### PR TITLE
Let's not rely on lexograpical ordering of files at link time

### DIFF
--- a/gapis/gfxapi/gles/metadata.go
+++ b/gapis/gfxapi/gles/metadata.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"reflect"
 
-	_ "github.com/google/gapid/gapil/snippets"
 	"github.com/google/gapid/framework/binary"
 	"github.com/google/gapid/framework/binary/registry"
 	"github.com/google/gapid/gapis/atom"
@@ -52,10 +51,8 @@ func AddMetadata(n *registry.Namespace) {
 	})
 }
 
-// Note gles_binary.go must initialize first. We really on the Go's
-// lexigraphical provision; that is "metadata.go" > "gles_binary.go"
-// for correct order of initialization.
 func init() {
+	binary_init()
 	AddMetadata(Namespace)
 	if err := atom.AddSnippetsFromBase64String(
 		Namespace, embedded[snippets_base64_file]); err != nil {

--- a/gapis/gfxapi/vulkan/vulkan_binary_metatadata.go
+++ b/gapis/gfxapi/vulkan/vulkan_binary_metatadata.go
@@ -48,10 +48,8 @@ func AddMetadata(n *registry.Namespace) {
 	})
 }
 
-// Note vulkan_binary.go must initialize first. We really on the Go's
-// lexigraphical provision; that is "metadata.go" > "vulkan_binary.go"
-// for correct order of initialization.
 func init() {
+	binary_init()
 	AddMetadata(Namespace)
 	if err := atom.AddSnippetsFromBase64String(
 		Namespace, embedded[snippets_base64_file]); err != nil {

--- a/tools/codergen/template/go_binary.tmpl
+++ b/tools/codergen/template/go_binary.tmpl
@@ -384,6 +384,16 @@ func doDecode{{.Name}}(d binary.Decoder, o *{{.Name}}) error {»¶
     {{end}}
     ¶
     func init() {»¶
+      binary_init()
+    «}¶
+    ¶
+    var binary_init_done = false¶
+    ¶
+    func binary_init() {»¶
+      if binary_init_done {»¶
+        return¶
+      «}¶
+      binary_init_done = true¶
       {{if not .IsTest}}
         registry.Global.AddFallbacks(Namespace)¶
       {{end}}


### PR DESCRIPTION
With this change it does not matter which init function happens first, binary_init happens just once and before it's needed