### PR TITLE
More include path fixes

### DIFF
--- a/gapii/cc/call_observer.h
+++ b/gapii/cc/call_observer.h
@@ -17,9 +17,9 @@
 #ifndef GAPII_CALL_OBSERVER_H
 #define GAPII_CALL_OBSERVER_H
 
-#include "abort_exception.h"
-#include "gles_types.h"
-#include "slice.h"
+#include "gapii/cc/abort_exception.h"
+#include "gapii/cc/gles_types.h"
+#include "gapii/cc/slice.h"
 
 #include "core/cc/coder/atom.h"
 #include "core/cc/interval_list.h"

--- a/gapii/cc/deqp.cpp
+++ b/gapii/cc/deqp.cpp
@@ -23,9 +23,9 @@
 #include <memory>
 #include <iostream>
 
-#include "abort_exception.h"
-#include "call_observer.h"
-#include "gles_types.h"
+#include "gapii/cc/abort_exception.h"
+#include "gapii/cc/call_observer.h"
+#include "gapii/cc/gles_types.h"
 
 namespace null_driver {
 

--- a/gapii/cc/deqp.h
+++ b/gapii/cc/deqp.h
@@ -17,8 +17,8 @@
 #ifndef GAPII_DEQP_H
 #define GAPII_DEQP_H
 
-#include "core_spy.h"
-#include "gles_spy.h"
+#include "gapii/cc/core_spy.h"
+#include "gapii/cc/gles_spy.h"
 #include "return_handler.h"
 
 #include "core/cc/null_writer.h"

--- a/gapii/cc/gles_context.cpp
+++ b/gapii/cc/gles_context.cpp
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include "gles_spy.h"
+#include "gapii/cc/gles_spy.h"
 
 #include <iostream>
 #include <string>

--- a/gapii/cc/gles_extras.cpp
+++ b/gapii/cc/gles_extras.cpp
@@ -16,7 +16,7 @@
 
 #include "core/cc/encoder.h"
 #include "core/cc/coder/gles.h"
-#include "gles_spy.h"
+#include "gapii/cc/gles_spy.h"
 
 #define ANDROID_NATIVE_MAKE_CONSTANT(a,b,c,d) \
     (((unsigned)(a)<<24)|((unsigned)(b)<<16)|((unsigned)(c)<<8)|(unsigned)(d))

--- a/gapii/cc/gles_spy_externs.cpp
+++ b/gapii/cc/gles_spy_externs.cpp
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#include "gles_spy.h"
-#include "call_observer.h"
+#include "gapii/cc/gles_spy.h"
+#include "gapii/cc/call_observer.h"
 
 namespace gapii {
 

--- a/gapii/cc/spy.cpp
+++ b/gapii/cc/spy.cpp
@@ -16,8 +16,8 @@
 
 #include "connection_header.h"
 #include "connection_stream.h"
-#include "gles_exports.h"
-#include "spy.h"
+#include "gapii/cc/gles_exports.h"
+#include "gapii/cc/spy.h"
 
 #include "core/cc/encoder.h"
 #include "core/cc/gl/formats.h"

--- a/gapii/cc/spy.h
+++ b/gapii/cc/spy.h
@@ -16,9 +16,9 @@
 
 #ifndef GAPII_SPY_H
 #define GAPII_SPY_H
-#include "core_spy.h"
-#include "vulkan_spy.h"
-#include "gles_spy.h"
+#include "gapii/cc/core_spy.h"
+#include "gapii/cc/vulkan_spy.h"
+#include "gapii/cc/gles_spy.h"
 
 #include <memory>
 #include <unordered_map>

--- a/gapii/cc/spy_disable_precompiled_shaders.cpp
+++ b/gapii/cc/spy_disable_precompiled_shaders.cpp
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#include "spy.h"
-#include "call_observer.h"
+#include "gapii/cc/spy.h"
+#include "gapii/cc/call_observer.h"
 
 #include "core/cc/coder/gles.h"
 

--- a/gapii/cc/vulkan_layer_extras.h
+++ b/gapii/cc/vulkan_layer_extras.h
@@ -37,11 +37,11 @@
 #ifndef GAPII_VULKAN_LAYER_EXTRAS_H
 #define GAPII_VULKAN_LAYER_EXTRAS_H
 
-#include "vulkan_exports.h"
-#include "vulkan_extras.h"
-#include "vulkan_types.h"
-#include "vulkan_imports.h"
-#include "vulkan_spy.h"
+#include "gapii/cc/vulkan_exports.h"
+#include "gapii/cc/vulkan_extras.h"
+#include "gapii/cc/vulkan_types.h"
+#include "gapii/cc/vulkan_imports.h"
+#include "gapii/cc/vulkan_spy.h"
 
 namespace gapii {
 namespace {

--- a/gapis/gfxapi/gles/templates/api_exports.cpp.tmpl
+++ b/gapis/gfxapi/gles/templates/api_exports.cpp.tmpl
@@ -27,10 +27,10 @@
   {{AssertType $ "API"}}
   {{Template "C++.Copyright"}}
 ¶
-#include "gles_exports.h"
-#include "{{Global "API"}}_imports.h"
-#include "{{Global "API"}}_types.h"
-#include "spy.h"
+#include "gapii/cc/gles_exports.h"
+#include "gapii/cc/{{Global "API"}}_imports.h"
+#include "gapii/cc/{{Global "API"}}_types.h"
+#include "gapii/cc/spy.h"
 ¶
 #include "core/cc/get_{{Global "API"}}_proc_address.h"
 #include "core/cc/log.h"

--- a/gapis/gfxapi/templates/api_spy.cpp.tmpl
+++ b/gapis/gfxapi/templates/api_spy.cpp.tmpl
@@ -82,7 +82,7 @@
 */}}
 {{define "FileHeaders"}}
 ¶
-  #include "abort_exception.h"
+  #include "gapii/cc/abort_exception.h"
   #include "{{Global "API"}}_imports.h"
   #include "{{Global "API"}}_types.h"
 ¶

--- a/gapis/gfxapi/templates/api_spy.h.tmpl
+++ b/gapis/gfxapi/templates/api_spy.h.tmpl
@@ -38,11 +38,11 @@
   #include "{{Global "API"}}_types.h"
 ¶
 {{if (eq (Global "API") "gles")}}
-  #include "spy_base.h"
+  #include "gapii/cc/spy_base.h"
 {{else}}
-  #include "gles_spy.h"
+  #include "gapii/cc/gles_spy.h"
 {{end}}
-  #include "call_observer.h"
+  #include "gapii/cc/call_observer.h"
 ¶
   #define __STDC_FORMAT_MACROS
   #include <inttypes.h>
@@ -70,7 +70,7 @@
   «protected:»
     {{$imports}} mImports;
 ¶
-    #include "{{Global "API"}}_extras.inl"
+    #include "gapii/cc/{{Global "API"}}_extras.inl"
   };
 ¶
   // Inline methods
@@ -90,7 +90,7 @@
     return mImports;
   }
 ¶
-  #include "{{Global "API"}}_inlines.inl"
+  #include "gapii/cc/{{Global "API"}}_inlines.inl"
 ¶
   »} // namespace gapii
 ¶

--- a/gapis/gfxapi/vulkan/templates/api_exports.cpp.tmpl
+++ b/gapis/gfxapi/vulkan/templates/api_exports.cpp.tmpl
@@ -67,10 +67,10 @@
   {{AssertType $ "API"}}
   {{Template "C++.Copyright"}}
 ¶
-  #include "{{Global "API"}}_types.h"
-  #include "{{Global "API"}}_spy.h"
-  #include "{{Global "API"}}_exports.h"
-  #include "spy.h"
+  #include "gapii/cc/{{Global "API"}}_types.h"
+  #include "gapii/cc/{{Global "API"}}_spy.h"
+  #include "gapii/cc/{{Global "API"}}_exports.h"
+  #include "gapii/cc/spy.h"
 ¶
   #include "core/cc/get_{{Global "API"}}_proc_address.h"
   #include "core/cc/lock.h"

--- a/gapis/gfxapi/vulkan/templates/vk_spy_helpers.cpp.tmpl
+++ b/gapis/gfxapi/vulkan/templates/vk_spy_helpers.cpp.tmpl
@@ -25,12 +25,12 @@
 
 {{Template "C++.Copyright"}}
 ¶
-#include "vulkan_exports.h"
-#include "vulkan_extras.h"
-#include "vulkan_types.h"
-#include "vulkan_layer_extras.h"
-#include "vulkan_imports.h"
-#include "vulkan_spy.h"
+#include "gapii/cc/vulkan_exports.h"
+#include "gapii/cc/vulkan_extras.h"
+#include "gapii/cc/vulkan_types.h"
+#include "gapii/cc/vulkan_layer_extras.h"
+#include "gapii/cc/vulkan_imports.h"
+#include "gapii/cc/vulkan_spy.h"
 ¶
 extern "C" {«
 // For this to function on Android the entry-point names for GetDeviceProcAddr

--- a/tools/codergen/template/cpp_binary.tmpl
+++ b/tools/codergen/template/cpp_binary.tmpl
@@ -15,7 +15,7 @@
  */}}
 
 {{define "Cpp.IncludeType"}}
-  {{File.Include (print "<core/cc/coder/" (index (File.ModuleOf .).Directives "cpp") ".h>") }}
+  {{File.Include (print "\"core/cc/coder/" (index (File.ModuleOf .).Directives "cpp") ".h\"") }}
 {{end}}
 
 {{define "Cpp.Include.Primitive"}}{{end}}
@@ -42,13 +42,13 @@
 
 {{define "Cpp.Include.Slice"}}
   {{template "Cpp.Include" .ValueType}}
-  {{File.Include "<core/cc/vector.h>"}}
+  {{File.Include "\"core/cc/vector.h\""}}
 {{end}}
 
 {{define "Cpp.Include.Map"}}
   {{template "Cpp.Include" .KeyType}}
   {{template "Cpp.Include" .ValueType}}
-  {{File.Include "<core/cc/map.h>"}}
+  {{File.Include "\"core/cc/map.h\""}}
 {{end}}
 
 {{define "Cpp.Include"}}{{end}}
@@ -268,7 +268,7 @@
   ¶
   ¶
   {{if and (File.Directive "Schema" true) (len .Structs)}}
-#include "{{.Namespace}}.h"¶
+#include "core/cc/coder/{{.Namespace}}.h"¶
 
 #include "core/cc/schema.h"¶
   {{end}}


### PR DESCRIPTION
Using the search path rather than a relative one means files don't have to be in the same dir, like when they are auto generated