### PR TITLE
Vulkan:Emit SIGTRAP in memory tracker before passing to underlying handler

### DIFF
--- a/core/memory_tracker/cc/memory_tracker.cpp
+++ b/core/memory_tracker/cc/memory_tracker.cpp
@@ -114,6 +114,9 @@ bool MemoryTracker::ClearTrackingRangesImpl() {
 void MemoryTracker::HandleSegfaultImpl(int sig, siginfo_t* info, void* unused) {
   void* fault_addr = info->si_addr;
   if (!IsInRanges(reinterpret_cast<uintptr_t>(fault_addr), ranges_)) {
+#ifndef NDEBUG
+    raise(SIGTRAP);
+#endif // NDEBUG
     return (*orig_action_.sa_sigaction)(sig, info, unused);
   }
 
@@ -125,6 +128,9 @@ void MemoryTracker::HandleSegfaultImpl(int sig, siginfo_t* info, void* unused) {
   if (!dirty_pages_.Record(page_addr)) {
     // The dirty page table does not have enough space pre-allocated,
     // fallback to the original handler.
+#ifndef NDEBUG
+    raise(SIGTRAP);
+#endif // NDEBUG
     return (*orig_action_.sa_sigaction)(sig, info, unused);
   }
   mprotect(page_addr, page_size_, PROT_READ | PROT_WRITE);


### PR DESCRIPTION
In Debug build, if a non-tracking-coherent memory triggers SIGSEGV
signal, raise the SIGTRAP signal for debugger to capture, before passing
the SIGSEGV signal to the underlying segfault handler.

In this way, when debugging tracing with memory tracker enabled, even if
the debugger is set to skip SIGSEGV signals (since it is triggered too
often), it can still capture the invalid memory accesses.