### PR TITLE
Fix the remaining incorrect dispose handlers.

### DIFF
--- a/gapic/src/main/com/google/gapid/widgets/ImagePanel.java
+++ b/gapic/src/main/com/google/gapid/widgets/ImagePanel.java
@@ -167,6 +167,8 @@ public class ImagePanel extends Composite {
         }
       }
     });
+
+    addListener(SWT.Dispose, e -> backgroundSelection.dispose());
   }
 
   protected void setPreviewPixel(Pixel pixel) {
@@ -257,12 +259,6 @@ public class ImagePanel extends Composite {
     }
     status.setLevelCount(0);
     imageComponent.setImageData(level);
-  }
-
-  @Override
-  public void dispose() {
-    backgroundSelection.dispose();
-    super.dispose();
   }
 
   private void loadLevel(int index) {

--- a/gapic/src/main/com/google/gapid/widgets/LoadableImageWidget.java
+++ b/gapic/src/main/com/google/gapid/widgets/LoadableImageWidget.java
@@ -38,6 +38,7 @@ public class LoadableImageWidget extends Canvas {
 
     setSize(Thumbnails.THUMB_SIZE, Thumbnails.THUMB_SIZE);
     addListener(SWT.Paint, e -> paint(e.gc));
+    addListener(SWT.Dispose, e -> image.dispose());
   }
 
   public static LoadableImageWidget forImageData(
@@ -86,12 +87,6 @@ public class LoadableImageWidget extends Canvas {
     gc.drawImage(toDraw, 0, 0, imageSize.width, imageSize.height,
         (size.width - imageSize.width) / 2, (size.height - imageSize.height) / 2,
         imageSize.width, imageSize.height);
-  }
-
-  @Override
-  public void dispose() {
-    image.dispose();
-    super.dispose();
   }
 
   @Override

--- a/gapic/src/main/com/google/gapid/widgets/QuickColorPiker.java
+++ b/gapic/src/main/com/google/gapid/widgets/QuickColorPiker.java
@@ -87,11 +87,7 @@ public class QuickColorPiker extends Canvas {
     };
     addMouseListener(mouseHandler);
     addMouseMoveListener(mouseHandler);
-  }
-
-  @Override
-  public void dispose() {
-    image.dispose();
+    addListener(SWT.Dispose, e -> image.dispose());
   }
 
   @Override


### PR DESCRIPTION
Overriding the .dispose() method is not the right way to do it.
Instead, listening to the SWT.Dispose event is required.