### PR TITLE
Fix bug in Mid-Execution capture for Vulkan Semaphores

### DIFF
--- a/core/vulkan/vk_virtual_swapchain/cc/swapchain.cpp
+++ b/core/vulkan/vk_virtual_swapchain/cc/swapchain.cpp
@@ -276,6 +276,7 @@ vkQueuePresentKHR(VkQueue queue, const VkPresentInfoKHR *pPresentInfo) {
   // We submit to the queue the commands set up by the virtual swapchain.
   // This will start a copy operation from the image to the swapchain
   // buffers.
+  uint32_t res = VK_SUCCESS;
   std::vector<VkPipelineStageFlags> pipeline_stages(
       pPresentInfo->waitSemaphoreCount, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT);
   for (size_t i = 0; i < pPresentInfo->swapchainCount; ++i) {
@@ -295,12 +296,12 @@ vkQueuePresentKHR(VkQueue queue, const VkPresentInfoKHR *pPresentInfo) {
         nullptr                                           // pSemaphores
     };
 
-    GetGlobalContext().GetQueueData(queue)->vkQueueSubmit(
+    res |= GetGlobalContext().GetQueueData(queue)->vkQueueSubmit(
         queue, 1, &submitInfo, swp->GetFence(image_index));
     swp->NotifySubmitted(image_index);
   }
 
-  return VK_SUCCESS;
+  return VkResult(res);
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL vkQueueSubmit(VkQueue queue,

--- a/gapii/cc/vulkan_extras.inl
+++ b/gapii/cc/vulkan_extras.inl
@@ -46,7 +46,7 @@ void SpyOverride_RecreateQueue(VkDevice, uint32_t, uint32_t, VkQueue*) {}
 void SpyOverride_RecreateVkCmdBindPipeline(VkCommandBuffer, uint32_t, VkPipeline) {}
 void SpyOverride_RecreateVkCommandBuffer(VkDevice, const VkCommandBufferAllocateInfo*, const VkCommandBufferBeginInfo*, VkCommandBuffer*) {}
 void SpyOverride_RecreateVkEndCommandBuffer(VkCommandBuffer) {}
-void SpyOverride_RecreateSemaphore(VkDevice, const VkSemaphoreCreateInfo*, VkSemaphore*) {}
+void SpyOverride_RecreateSemaphore(VkDevice, const VkSemaphoreCreateInfo*, uint32_t, VkSemaphore*) {}
 void SpyOverride_RecreateFence(VkDevice, const VkFenceCreateInfo*, VkFence*) {}
 void SpyOverride_RecreateCommandPool(VkDevice, const VkCommandPoolCreateInfo*, VkCommandPool*) {}
 void SpyOverride_RecreatePipelineCache(VkDevice, const VkPipelineCacheCreateInfo*, VkPipelineCache*) {}

--- a/gapii/cc/vulkan_mid_execution.cpp
+++ b/gapii/cc/vulkan_mid_execution.cpp
@@ -617,6 +617,9 @@ void VulkanSpy::EnumerateVulkanResources(CallObserver* observer) {
 
             if (image.second->mBoundMemory &&
                 info.mSamples == VkSampleCountFlagBits::VK_SAMPLE_COUNT_1_BIT &&
+                // Don't capture images with undefined layout. The resulting data
+                // itself will be undefined.
+                imageLayout != VkImageLayout::VK_IMAGE_LAYOUT_UNDEFINED &&
                 !image.second->mIsSwapchainImage &&
                 image.second->mImageAspect == VkImageAspectFlagBits::VK_IMAGE_ASPECT_COLOR_BIT) {
 
@@ -884,6 +887,7 @@ void VulkanSpy::EnumerateVulkanResources(CallObserver* observer) {
         for (auto& semaphore: Semaphores) {
             RecreateSemaphore(observer, semaphore.second->mDevice,
                                         &create_info,
+                                        semaphore.second->mSignaled,
                                         &semaphore.second->mVulkanHandle);
         }
     }

--- a/gapis/gfxapi/vulkan/vulkan.api
+++ b/gapis/gfxapi/vulkan/vulkan.api
@@ -2777,9 +2777,16 @@ cmd VkResult vkQueueSubmit(
 
   for i in (0 .. submitCount) {
     info := submitInfo[i]
-    read(info.pWaitSemaphores[0:info.waitSemaphoreCount])
+    wait_semaphores := info.pWaitSemaphores[0:info.waitSemaphoreCount]
+    for j in (0 .. info.waitSemaphoreCount) {
+      Semaphores[wait_semaphores[j]].Signaled = false
+    }
     read(info.pWaitDstStageMask[0:info.waitSemaphoreCount])
-    read(info.pSignalSemaphores[0:info.signalSemaphoreCount])
+
+    signal_semaphores := info.pSignalSemaphores[0:info.signalSemaphoreCount]
+    for j in (0 .. info.signalSemaphoreCount) {
+      Semaphores[signal_semaphores[j]].Signaled = true
+    }
 
     command_buffers := info.pCommandBuffers[0:info.commandBufferCount]
 
@@ -3200,6 +3207,7 @@ cmd VkResult vkWaitForFences(
 cmd void RecreateSemaphore(
     VkDevice                     device,
     const VkSemaphoreCreateInfo* pCreateInfo,
+    VkBool32                     signaled,
     VkSemaphore*                 pSemaphore) {
   read(pCreateInfo[0:1])
   write(pSemaphore[0:1])
@@ -7117,7 +7125,7 @@ cmd VkResult vkAcquireNextImageKHR(
     u32*           pImageIndex) {
   _ = pImageIndex[0]
   pImageIndex[0] = ?
-
+  Semaphores[semaphore].Signaled = true
   return ?
 }
 
@@ -7132,7 +7140,10 @@ cmd VkResult vkQueuePresentKHR(
   // TODO: handle pNext
 
   if (info.pWaitSemaphores != null) {
-    read(info.pWaitSemaphores[0:info.waitSemaphoreCount])
+    wait_semaphores := info.pWaitSemaphores[0:info.waitSemaphoreCount]
+    for i in (0 .. info.waitSemaphoreCount) {
+      Semaphores[wait_semaphores[i]].Signaled = false
+    }
   }
   swapchains := info.pSwapchains[0:info.swapchainCount]
   imageIndices := info.pImageIndices[0:info.swapchainCount]
@@ -8015,6 +8026,8 @@ enum RecordingState {
 @internal class SemaphoreObject {
   @unused VkDevice    Device
   @unused VkSemaphore VulkanHandle
+  @unused VkQueue     LastQueue
+  @unused bool        Signaled
 }
 
 @internal class EventObject {


### PR DESCRIPTION
If a semaphore was captured in the "Signaled" state, on recreate
we would create it in the unsignaled state. Now we track
what state it is in, and signal it if it was signaled before.