### PR TITLE
Fix include of memory tracker

### DIFF
--- a/gapii/cc/spy_base.cpp
+++ b/gapii/cc/spy_base.cpp
@@ -20,10 +20,6 @@
 #include "core/cc/log.h"
 #include "core/cc/thread.h"
 
-#if (TARGET_OS == GAPID_OS_LINUX) || (TARGET_OS == GAPID_OS_ANDROID)
-#include <core/memory_tracker/cc/memory_tracker.h>
-#endif // TARGET_OS
-
 #define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 

--- a/gapii/cc/spy_base.h
+++ b/gapii/cc/spy_base.h
@@ -34,7 +34,7 @@
 #include "core/cc/coder/atom.h"
 
 #if (TARGET_OS == GAPID_OS_LINUX) || (TARGET_OS == GAPID_OS_ANDROID)
-#include <core/memory_tracker/cc/memory_tracker.h>
+#include "core/memory_tracker/cc/memory_tracker.h"
 #endif // TARGET_OS
 
 #include <stdint.h>


### PR DESCRIPTION
Included twice
Using <> instead of “”