### PR TITLE
The dead code elimination transformer needs to be first.

### DIFF
--- a/gapis/atom/transform/transforms.go
+++ b/gapis/atom/transform/transforms.go
@@ -54,6 +54,11 @@ func (l *Transforms) Add(t ...Transformer) {
 	}
 }
 
+// Prepend adds the given transformer to the beginning of the transform chain.
+func (l *Transforms) Prepend(t Transformer) {
+	*l = append([]Transformer{t}, *l...)
+}
+
 // Transform is a helper for building simple Transformers that are implemented
 // by function f. name is used to identify the transform when logging.
 func Transform(name string, f func(ctx log.Context, id atom.ID, atom atom.Atom, output Writer)) Transformer {

--- a/gapis/gfxapi/gles/replay.go
+++ b/gapis/gfxapi/gles/replay.go
@@ -120,6 +120,7 @@ func (a api) Replay(
 	readFramebuffer := newReadFramebuffer(ctx)
 
 	optimize := true
+	wire := false
 
 	for _, req := range requests {
 		switch req := req.(type) {
@@ -149,8 +150,7 @@ func (a api) Replay(
 			cfg := cfg.(drawConfig)
 			switch cfg.wireframeMode {
 			case replay.WireframeMode_All:
-				// TODO: Add only once
-				transforms.Add(wireframe(ctx))
+				wire = true
 			case replay.WireframeMode_Overlay:
 				transforms.Add(wireframeOverlay(ctx, req.after))
 			}
@@ -160,6 +160,10 @@ func (a api) Replay(
 	if optimize && !config.DisableDeadCodeElimination {
 		atoms = atom.NewList() // DeadAtomRemoval generates atoms.
 		transforms.Prepend(deadCodeElimination)
+	}
+
+	if wire {
+		transforms.Add(wireframe(ctx))
 	}
 
 	if issues != nil {

--- a/gapis/gfxapi/gles/replay.go
+++ b/gapis/gfxapi/gles/replay.go
@@ -159,7 +159,7 @@ func (a api) Replay(
 
 	if optimize && !config.DisableDeadCodeElimination {
 		atoms = atom.NewList() // DeadAtomRemoval generates atoms.
-		transforms.Add(deadCodeElimination)
+		transforms.Prepend(deadCodeElimination)
 	}
 
 	if issues != nil {


### PR DESCRIPTION
Fixes the wireframe and wireframe overlay replay modes.