### PR TITLE
Update the atom selection, if needed, when the context changes.

### DIFF
--- a/gapic/src/main/com/google/gapid/models/ApiContext.java
+++ b/gapic/src/main/com/google/gapid/models/ApiContext.java
@@ -15,6 +15,8 @@
  */
 package com.google.gapid.models;
 
+import static com.google.gapid.util.Ranges.commands;
+import static com.google.gapid.util.Ranges.first;
 import static com.google.gapid.util.Ranges.last;
 import static java.util.Arrays.stream;
 
@@ -185,6 +187,11 @@ public class ApiContext extends CaptureDependentModel<ApiContext.FilteringContex
         public boolean contains(long index) {
           return true;
         }
+
+        @Override
+        public CommandRange findClosest(CommandRange range) {
+          return range;
+        }
       };
     }
 
@@ -202,6 +209,20 @@ public class ApiContext extends CaptureDependentModel<ApiContext.FilteringContex
 
     public boolean contains(long index) {
       return Ranges.contains(context.getRangesList(), index) >= 0;
+    }
+
+    public CommandRange findClosest(CommandRange range) {
+      int index = Ranges.contains(context.getRangesList(), last(range));
+      if (index >= 0) {
+        return commands(last(range), 1);
+      } else if (index == -1) {
+        // The given range ends before any of our commands.
+        return (context.getRangesCount() == 0) ? null : commands(first(context.getRanges(0)), 1);
+      } else {
+        // Return the end of the range just before the given range.
+        // ...] [i - 1] range [i] [...   (i = -index - 1)
+        return commands(last(context.getRanges((-index - 1) - 1)), 1);
+      }
     }
 
     @Override

--- a/gapic/src/main/com/google/gapid/models/AtomStream.java
+++ b/gapic/src/main/com/google/gapid/models/AtomStream.java
@@ -43,7 +43,7 @@ import java.util.logging.Logger;
 /**
  * Model containing the API commands (atoms) of the capture.
  */
-public class AtomStream extends CaptureDependentModel<AtomList> {
+public class AtomStream extends CaptureDependentModel<AtomList> implements ApiContext.Listener {
   private static final Logger LOG = Logger.getLogger(AtomStream.class.getName());
 
   private final ApiContext context;
@@ -53,6 +53,8 @@ public class AtomStream extends CaptureDependentModel<AtomList> {
   public AtomStream(Shell shell, Client client, Capture capture, ApiContext context) {
     super(LOG, shell, client, capture);
     this.context = context;
+
+    context.addListener(this);
   }
 
   @Override
@@ -81,6 +83,17 @@ public class AtomStream extends CaptureDependentModel<AtomList> {
     listeners.fire().onAtomsLoaded();
     if (selection != null) {
       listeners.fire().onAtomsSelected(selection);
+    }
+  }
+
+  @Override
+  public void onContextSelected(FilteringContext ctx) {
+    if (selection != null && !ctx.contains(selection)) {
+      if (ctx.contains(last(selection))) {
+        selectAtoms(last(selection), 1, false);
+      } else {
+        selectAtoms(ctx.findClosest(selection), false);
+      }
     }
   }
 


### PR DESCRIPTION
The current atom selection is already maintained when changing contexts.
However, if a context is selected that does not contain the current
selection, the selection needs to be updated for the new context.