### PR TITLE
Fix TreeViewer keyboard node expansion handling.

### DIFF
--- a/gapic/src/main/com/google/gapid/views/AtomTree.java
+++ b/gapic/src/main/com/google/gapid/views/AtomTree.java
@@ -21,7 +21,8 @@ import static com.google.gapid.util.Loadable.MessageType.Error;
 import static com.google.gapid.util.Ranges.count;
 import static com.google.gapid.util.Ranges.first;
 import static com.google.gapid.util.Ranges.last;
-import static com.google.gapid.widgets.Widgets.createTree;
+import static com.google.gapid.widgets.Widgets.createTreeForViewer;
+import static com.google.gapid.widgets.Widgets.createTreeViewer;
 import static com.google.gapid.widgets.Widgets.expandOnDoubleClick;
 import static com.google.gapid.widgets.Widgets.scheduleIfNotDisposed;
 
@@ -114,10 +115,10 @@ public class AtomTree extends Composite implements Tab, Capture.Listener, AtomSt
 
     SearchBox search = new SearchBox(this);
     loading = new LoadablePanel<Tree>(this, widgets,
-        loadingParent -> createTree(loadingParent, SWT.H_SCROLL | SWT.V_SCROLL | SWT.VIRTUAL));
+        p -> createTreeForViewer(p, SWT.H_SCROLL | SWT.V_SCROLL | SWT.VIRTUAL));
     Tree tree = loading.getContents();
     tree.setLinesVisible(true);
-    viewer = new TreeViewer(tree);
+    viewer = createTreeViewer(tree);
     imageProvider = new ImageProvider(models.thumbs, viewer, widgets.loading);
     viewer.setUseHashlookup(true);
     viewer.setContentProvider(new AtomContentProvider(viewer));

--- a/gapic/src/main/com/google/gapid/views/LogView.java
+++ b/gapic/src/main/com/google/gapid/views/LogView.java
@@ -15,18 +15,24 @@
  */
 package com.google.gapid.views;
 
+import static com.google.gapid.widgets.Widgets.createTree;
+
 import com.google.gapid.proto.log.Log;
 import com.google.gapid.util.Logging;
 import com.google.gapid.util.Pods;
 import com.google.gapid.widgets.Theme;
 import com.google.gapid.widgets.Widgets;
-
 import com.google.protobuf.Timestamp;
+
 import org.eclipse.jface.resource.JFaceResources;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.layout.FillLayout;
-import org.eclipse.swt.widgets.*;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Control;
+import org.eclipse.swt.widgets.Tree;
+import org.eclipse.swt.widgets.TreeColumn;
+import org.eclipse.swt.widgets.TreeItem;
 
 import java.util.Calendar;
 import java.util.Date;
@@ -69,7 +75,7 @@ public class LogView extends Composite implements Tab {
 
     messageIterator = Logging.getMessageIterator();
 
-    tree = new Tree(this, SWT.MULTI | SWT.H_SCROLL | SWT.V_SCROLL | SWT.FULL_SELECTION);
+    tree = createTree(this, SWT.MULTI | SWT.H_SCROLL | SWT.V_SCROLL | SWT.FULL_SELECTION);
     tree.setHeaderVisible(true);
     tree.setFont(JFaceResources.getFont(JFaceResources.TEXT_FONT));
     for (Column column : Column.values()) {

--- a/gapic/src/main/com/google/gapid/views/ReportView.java
+++ b/gapic/src/main/com/google/gapid/views/ReportView.java
@@ -17,7 +17,7 @@ package com.google.gapid.views;
 
 import static com.google.gapid.util.Loadable.MessageType.Error;
 import static com.google.gapid.util.Loadable.MessageType.Info;
-import static com.google.gapid.widgets.Widgets.createTree;
+import static com.google.gapid.widgets.Widgets.createTreeViewer;
 import static com.google.gapid.widgets.Widgets.expandOnDoubleClick;
 
 import com.google.common.base.Throwables;
@@ -80,7 +80,7 @@ public class ReportView extends Composite
     loading = LoadablePanel.create(this, widgets, panel -> new SashForm(panel, SWT.VERTICAL));
     SashForm splitter = loading.getContents();
 
-    viewer = new TreeViewer(createTree(splitter, SWT.H_SCROLL | SWT.V_SCROLL | SWT.VIRTUAL));
+    viewer = createTreeViewer(splitter, SWT.H_SCROLL | SWT.V_SCROLL | SWT.VIRTUAL);
     viewer.getTree().setLinesVisible(true);
     viewer.setUseHashlookup(true);
     viewer.setContentProvider(new ReportContentProvider(viewer, messages));

--- a/gapic/src/main/com/google/gapid/views/StateView.java
+++ b/gapic/src/main/com/google/gapid/views/StateView.java
@@ -19,7 +19,8 @@ import static com.google.gapid.util.Loadable.MessageType.Error;
 import static com.google.gapid.util.Loadable.MessageType.Info;
 import static com.google.gapid.util.Pods.pod;
 import static com.google.gapid.util.Pods.unpod;
-import static com.google.gapid.widgets.Widgets.createTree;
+import static com.google.gapid.widgets.Widgets.createTreeForViewer;
+import static com.google.gapid.widgets.Widgets.createTreeViewer;
 import static com.google.gapid.widgets.Widgets.expandOnDoubleClick;
 import static java.util.logging.Level.WARNING;
 
@@ -95,10 +96,10 @@ public class StateView extends Composite
     setLayout(new FillLayout(SWT.VERTICAL));
 
     loading = LoadablePanel.create(this, widgets,
-        panel -> createTree(panel, SWT.H_SCROLL | SWT.V_SCROLL | SWT.VIRTUAL | SWT.MULTI));
+        panel -> createTreeForViewer(panel, SWT.H_SCROLL | SWT.V_SCROLL | SWT.VIRTUAL | SWT.MULTI));
     Tree tree = loading.getContents();
     tree.setLinesVisible(true);
-    viewer = new TreeViewer(tree);
+    viewer = createTreeViewer(tree);
     viewer.setUseHashlookup(true);
     viewer.setContentProvider(new StateContentProvider(viewer));
     ViewLabelProvider labelProvider = new ViewLabelProvider(viewer, widgets.theme);

--- a/gapic/src/main/com/google/gapid/widgets/Widgets.java
+++ b/gapic/src/main/com/google/gapid/widgets/Widgets.java
@@ -23,6 +23,7 @@ import org.eclipse.jface.viewers.ColumnLabelProvider;
 import org.eclipse.jface.viewers.DoubleClickEvent;
 import org.eclipse.jface.viewers.IDoubleClickListener;
 import org.eclipse.jface.viewers.IStructuredSelection;
+import org.eclipse.jface.viewers.ITreeSelection;
 import org.eclipse.jface.viewers.TableViewer;
 import org.eclipse.jface.viewers.TableViewerColumn;
 import org.eclipse.jface.viewers.TreeViewer;
@@ -384,6 +385,10 @@ public class Widgets {
     return group;
   }
 
+  /**
+   * Do not use this if you intend to wrap the {@link Tree} in a {@link TreeViewer}. Instead use
+   * {@link #createTreeForViewer(Composite, int)} and then {@link #createTreeViewer(Tree)}.
+   */
   public static Tree createTree(Composite parent, int style) {
     Tree tree = new Tree(parent, style);
     tree.addListener(SWT.KeyDown, e -> {
@@ -397,6 +402,35 @@ public class Widgets {
       }
     });
     return tree;
+  }
+
+  /**
+   * Use this to create a {@link Tree} that you will later wrap in a {@link TreeViewer} using
+   * {@link #createTreeViewer(Tree)}, otherwise use {@link #createTree(Composite, int)}.
+   */
+  public static Tree createTreeForViewer(Composite parent, int style) {
+    Tree tree = new Tree(parent, style);
+    return tree;
+  }
+
+  public static TreeViewer createTreeViewer(Composite parent, int style) {
+    return createTreeViewer(createTreeForViewer(parent, style));
+  }
+
+  public static TreeViewer createTreeViewer(Tree tree) {
+    TreeViewer viewer = new TreeViewer(tree);
+    tree.addListener(SWT.KeyDown, e -> {
+      switch (e.keyCode) {
+        case SWT.ARROW_LEFT:
+        case SWT.ARROW_RIGHT:
+          ITreeSelection selection = viewer.getStructuredSelection();
+          if (selection.size() == 1) {
+            viewer.setExpandedState(selection.getFirstElement(), e.keyCode == SWT.ARROW_RIGHT);
+          }
+          break;
+      }
+    });
+    return viewer;
   }
 
   public static Composite createComposite(Composite parent, Layout layout) {


### PR DESCRIPTION
Fixes #105. The keyboard handling was interacting with the lower-level
tree instead of the TreeViewer, causing the dynamic node adding logic
to be skipped resulting in nodes with only a single child.