### PR TITLE
Vulkan:Fix MEC support for vkCmdExecuteCommands

### DIFF
--- a/gapii/cc/vulkan_mid_execution.cpp
+++ b/gapii/cc/vulkan_mid_execution.cpp
@@ -1453,6 +1453,7 @@ void VulkanSpy::EnumerateVulkanResources(CallObserver* observer) {
             &pool.mVulkanHandle);
     }
 
+    // Recreate and begin command buffers
     for (auto& commandBuffer: CommandBuffers) {
         auto& cmdBuff = *commandBuffer.second;
         VkCommandBufferAllocateInfo allocate_info {
@@ -1487,6 +1488,11 @@ void VulkanSpy::EnumerateVulkanResources(CallObserver* observer) {
         }
         RecreateVkCommandBuffer(observer, cmdBuff.mDevice,
                 &allocate_info, cmdBuff.mBeginInfo? &begin_info: nullptr, &cmdBuff.mVulkanHandle);
+    }
+
+    // Re-record commands and end for the command buffers
+    for (auto& commandBuffer: CommandBuffers) {
+        auto& cmdBuff = *commandBuffer.second;
 
         for (auto& recreate: cmdBuff.recreateCommands) {
             recreate(observer);


### PR DESCRIPTION
When the primary command buffer records `vkCmdExecuteCommands`, all the secondary command buffers should have been created (allocated) on the replay device.
So, this CL creates and begins all the command buffers first then records commands. This guarantees when `vkCmdExecuteCommands` is called, all the secondary command buffers do exist on the replay device.