### PR TITLE
Handle our own UI-thread queuing for a snappier UI.

### DIFF
--- a/gapic/src/main/com/google/gapid/views/MemoryView.java
+++ b/gapic/src/main/com/google/gapid/views/MemoryView.java
@@ -222,7 +222,7 @@ public class MemoryView extends Composite
     selections.setDataType(uiState.dataType);
     memoryPanel.setModel(uiState.getMemoryModel(memoryData));
     memoryScroll.updateMinSize();
-    getDisplay().asyncExec(() -> goToAddress(address));
+    scheduleIfNotDisposed(memoryScroll, () -> goToAddress(address));
     selections.updateSelectedObservation(address);
   }
 

--- a/gapic/src/main/com/google/gapid/widgets/Widgets.java
+++ b/gapic/src/main/com/google/gapid/widgets/Widgets.java
@@ -118,12 +118,12 @@ public class Widgets {
       if (enqueue(() -> ifNotDisposed(widget, run))) {
         long start = System.currentTimeMillis();
         widget.getDisplay().asyncExec(() -> {
-          Runnable[] todo = drainQueue();
-          if (todo.length > 1 && LOG.isLoggable(Level.FINE)) {
+          Runnable[] work = drainQueue();
+          if (work.length > 1 && LOG.isLoggable(Level.FINE)) {
             LOG.log(Level.FINE, "Processing a batch of {0} runnables after a delay of {1}ms",
-                new Object[] { todo.length, System.currentTimeMillis() - start });
+                new Object[] { work.length, System.currentTimeMillis() - start });
           }
-          for (Runnable r : todo) {
+          for (Runnable r : work) {
             r.run();
           }
         });
@@ -141,9 +141,9 @@ public class Widgets {
 
   private static Runnable[] drainQueue() {
     synchronized (queue) {
-      Runnable[] todo = queue.toArray(new Runnable[queue.size()]);
+      Runnable[] work = queue.toArray(new Runnable[queue.size()]);
       queue.clear();
-      return todo;
+      return work;
     }
   }
 

--- a/gapic/src/main/com/google/gapid/widgets/Widgets.java
+++ b/gapic/src/main/com/google/gapid/widgets/Widgets.java
@@ -15,6 +15,7 @@
  */
 package com.google.gapid.widgets;
 
+import com.google.common.collect.Lists;
 import com.google.gapid.models.Models;
 import com.google.gapid.server.Client;
 
@@ -63,13 +64,18 @@ import org.eclipse.swt.widgets.Tree;
 import org.eclipse.swt.widgets.Widget;
 
 import java.util.Comparator;
+import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * Widget utilities.
  */
 public class Widgets {
+  private static final Logger LOG = Logger.getLogger(Widgets.class.getName());
+
   public final Theme theme;
   public final CopyPaste copypaste;
   public final LoadingIndicator loading;
@@ -109,7 +115,35 @@ public class Widgets {
 
   public static void scheduleIfNotDisposed(Widget widget, Runnable run) {
     if (!widget.isDisposed()) {
-      widget.getDisplay().asyncExec(() -> ifNotDisposed(widget, run));
+      if (enqueue(() -> ifNotDisposed(widget, run))) {
+        long start = System.currentTimeMillis();
+        widget.getDisplay().asyncExec(() -> {
+          Runnable[] todo = drainQueue();
+          if (todo.length > 1 && LOG.isLoggable(Level.FINE)) {
+            LOG.log(Level.FINE, "Processing a batch of {0} runnables after a delay of {1}ms",
+                new Object[] { todo.length, System.currentTimeMillis() - start });
+          }
+          for (Runnable r : todo) {
+            r.run();
+          }
+        });
+      }
+    }
+  }
+
+  private static final List<Runnable> queue = Lists.newArrayList();
+  private static boolean enqueue(Runnable run) {
+    synchronized (queue) {
+      queue.add(run);
+      return queue.size() == 1;
+    }
+  }
+
+  private static Runnable[] drainQueue() {
+    synchronized (queue) {
+      Runnable[] todo = queue.toArray(new Runnable[queue.size()]);
+      queue.clear();
+      return todo;
     }
   }
 


### PR DESCRIPTION
It is common for multiple updates to be queued from the RPC threads in
quick succession. This caused some 2+ seconds delays as the UI thread
seems to only process one queued item at a time. Instead, batch up all
queued request and execute them together as soon as the UI thread gives
us control to do so.