### PR TITLE
Get gapit trace -local-app working for Vulkan on Windows.

### DIFF
--- a/core/cc/log.h
+++ b/core/cc/log.h
@@ -46,6 +46,12 @@
 #define GAPID_STR(S) GAPID_STR2(S)
 #define GAPID_STR2(S) #S
 
+#if TARGET_OS == GAPID_OS_WINDOWS
+  #define PRIsize "Iu"
+#else
+  #define PRIsize "zu"
+#endif
+
 // Template meta-programming (tmp) used to strip absolute path from __FILE__.
 // The main difficulty is that we need to make copy of the string since
 // any live reference to __FILE__ will keep the whole path in the binary.

--- a/core/vulkan/cc/include/vulkan/vk_layer.h
+++ b/core/vulkan/cc/include/vulkan/vk_layer.h
@@ -43,7 +43,9 @@
 #pragma once
 
 #include "vulkan.h"
-#if defined(__GNUC__) && __GNUC__ >= 4
+#if defined (_WIN32)
+#define VK_LAYER_EXPORT  __declspec(dllexport)
+#elif defined(__GNUC__) && __GNUC__ >= 4
 #define VK_LAYER_EXPORT __attribute__((visibility("default")))
 #elif defined(__SUNPRO_C) && (__SUNPRO_C >= 0x590)
 #define VK_LAYER_EXPORT __attribute__((visibility("default")))

--- a/gapii/cc/vulkan_layer_extras.h
+++ b/gapii/cc/vulkan_layer_extras.h
@@ -117,7 +117,9 @@ typedef struct {
 #define VK_VERSION_MINOR(version) (((uint32_t)(version) >> 12) & 0x3ff)
 #define VK_VERSION_PATCH(version) ((uint32_t)(version) & 0xfff)
 
-#if defined(__GNUC__) && __GNUC__ >= 4
+#if defined (_WIN32)
+#define VK_LAYER_EXPORT  __declspec(dllexport)
+#elif defined(__GNUC__) && __GNUC__ >= 4
 #define VK_LAYER_EXPORT __attribute__((visibility("default")))
 #elif defined(__SUNPRO_C) && (__SUNPRO_C >= 0x590)
 #define VK_LAYER_EXPORT __attribute__((visibility("default")))

--- a/gapii/vulkan/vk_graphics_spy/cc/CMakeBuild.cmake
+++ b/gapii/vulkan/vk_graphics_spy/cc/CMakeBuild.cmake
@@ -31,7 +31,7 @@ foreach(abi ${ANDROID_ACTIVE_ABI_LIST})
     )
 endforeach()
 
-if(NOT DISABLED_CXX AND NOT WIN32) # TODO: Windows build not currently supported
+if(NOT DISABLED_CXX) # TODO: Windows build not currently supported
     # This should only be needed on Android
     add_library(VkLayerGraphicsSpy SHARED ${sources})
     target_compile_options(VkLayerGraphicsSpy PRIVATE -fno-exceptions -fno-rtti)

--- a/gapir/cc/stack.cpp
+++ b/gapir/cc/stack.cpp
@@ -145,7 +145,7 @@ BaseType Stack::getTopType() {
 
     if (mTop == 0 || mTop > mStack.size()) {
         mValid = false;
-        GAPID_WARNING("GetTopType with invalid stack head: %u (size: %zu)", mTop, mStack.size());
+        GAPID_WARNING("GetTopType with invalid stack head: %u (size: %" PRIsize ")", mTop, mStack.size());
         return BaseType::Bool;
     }
 

--- a/gapis/gfxapi/templates/cpp_common.tmpl
+++ b/gapis/gfxapi/templates/cpp_common.tmpl
@@ -981,7 +981,7 @@
   {{else if IsS64           $}}%" PRId64 "
   {{else if IsInt           $}}%d
   {{else if IsUint          $}}%u
-  {{else if IsSize          $}}%zu
+  {{else if IsSize          $}}%" PRIsize "
   {{else if IsEnum          $}}0x%X
   {{else}}{{Error "C++.PrintfFormatCode passed unsupported type: %s" $.Name}}
   {{end}}

--- a/gapis/gfxapi/templates/vulkan_gfx_api_extras.tmpl
+++ b/gapis/gfxapi/templates/vulkan_gfx_api_extras.tmpl
@@ -315,7 +315,7 @@ uint32_t getMemoryTypeIndex(
     auto pPhysicalDeviceMemoryProperties = stack->pop<VkPhysicalDeviceMemoryProperties*>();
     auto device = stack->pop<VkDevice>();
     if (stack->isValid()) {
-      GAPID_INFO("replayAllocateImageMemory(%zu, %zu, %p", device, image, pMemory);
+      GAPID_INFO("replayAllocateImageMemory(%" PRIsize ", %" PRIsize ", %p", device, image, pMemory);
 
       VkMemoryRequirements image_mem_reqs;
       auto GetImageMemReqFuncPtr = mVkDeviceFunctionStubs[device].vkGetImageMemoryRequirements;
@@ -348,7 +348,7 @@ bool Vulkan::replayGetFenceStatus(Stack* stack, bool pushReturn) {
     auto fence = stack->pop<uint64_t>();
     auto device = static_cast<size_val>(stack->pop<size_val>());
     if (stack->isValid()) {
-        GAPID_INFO("vkGetFenceStatus(%zu, %" PRIu64 ")", device, fence);
+        GAPID_INFO("vkGetFenceStatus(%" PRIsize ", %" PRIu64 ")", device, fence);
         if (mVkDeviceFunctionStubs.find(device) != mVkDeviceFunctionStubs.end() &&
         mVkDeviceFunctionStubs[device].vkGetFenceStatus) {
             VkResult return_value;

--- a/gapis/gfxapi/vulkan/vulkan.api
+++ b/gapis/gfxapi/vulkan/vulkan.api
@@ -40,6 +40,7 @@ api_index 2
 
 import "android/vulkan_android.api"
 import "linux/vulkan_linux.api"
+import "windows/vulkan_windows.api"
 import "synthetic.api"
 
 ///////////////

--- a/gapis/gfxapi/vulkan/windows/vulkan_windows.api
+++ b/gapis/gfxapi/vulkan/windows/vulkan_windows.api
@@ -37,7 +37,7 @@ class VkWin32SurfaceCreateInfoKHR {
 }
 
 @extension("VK_KHR_win32_surface")
-@instance
+@indirect("VkInstance")
 cmd VkResult vkCreateWin32SurfaceKHR(
         VkInstance                              instance,
         const VkWin32SurfaceCreateInfoKHR*      pCreateInfo,
@@ -47,7 +47,7 @@ cmd VkResult vkCreateWin32SurfaceKHR(
 }
 
 @extension("VK_KHR_win32_surface")
-@physical_device
+@indirect("VkPhysicalDevice", "VkInstance")
 cmd VkResult vkGetPhysicalDeviceWin32PresentationSupportKHR(
         VkPhysicalDevice                        physicalDevice,
         u32                                     queueFamilyIndex) {


### PR DESCRIPTION
This allows us to trace Windows applications that use Vulkan.
Still TODO: Get Vulkan replay up and running on Windows.