### PR TITLE
Filter the replay target based on memory layout.

### DIFF
--- a/gapis/gfxapi/gles/replay.go
+++ b/gapis/gfxapi/gles/replay.go
@@ -80,8 +80,9 @@ type imgRes struct {
 func (a api) CanReplayOnLocalAndroidDevice(context.Context) bool { return false }
 
 // CanReplayOn returns true if the API can be replayed on the specified device.
+// The given layout is the memory_layout that was recorded in the capture
 // GLES can currently cannot replay on Android devices.
-func (a api) CanReplayOn(ctx context.Context, i *device.Instance) bool {
+func (a api) CanReplayOn(ctx context.Context, i *device.Instance, l *device.MemoryLayout) bool {
 	return i.GetConfiguration().GetOS().GetKind() != device.Android
 }
 

--- a/gapis/gfxapi/vulkan/replay.go
+++ b/gapis/gfxapi/vulkan/replay.go
@@ -44,9 +44,15 @@ var (
 func (a api) CanReplayOnLocalAndroidDevice(context.Context) bool { return true }
 
 // CanReplayOn returns true if the API can be replayed on the specified device.
+// The given layout is the memory_layout that was recorded in the capture
 // Vulkan can currently only replay on Android devices.
-func (a api) CanReplayOn(ctx context.Context, i *device.Instance) bool {
-	return i.GetConfiguration().GetOS().GetKind() == device.Android
+func (a api) CanReplayOn(ctx context.Context, i *device.Instance, l *device.MemoryLayout) bool {
+	for _, abi := range i.GetConfiguration().GetABIs() {
+		if *abi.GetMemoryLayout() == *l {
+			return true
+		}
+	}
+	return false
 }
 
 // makeAttachementReadable is a transformation marking all color/depth/stencil attachment

--- a/gapis/replay/interfaces.go
+++ b/gapis/replay/interfaces.go
@@ -32,8 +32,9 @@ type Support interface {
 	CanReplayOnLocalAndroidDevice(context.Context) bool
 
 	// CanReplayOn returns true if the API can be replayed on the specified
-	// device.
-	CanReplayOn(context.Context, *device.Instance) bool
+	// device. The MemoryLayout is the memory layout that was in the capture
+	// file.
+	CanReplayOn(context.Context, *device.Instance, *device.MemoryLayout) bool
 }
 
 // QueryIssues is the interface implemented by types that can verify the replay

--- a/gapis/service/service.go
+++ b/gapis/service/service.go
@@ -61,12 +61,16 @@ type Service interface {
 	// GetDevices returns the full list of replay devices avaliable to the server.
 	// These include local replay devices and any connected Android devices.
 	// This list may change over time, as devices are connected and disconnected.
+	// If both connected Android and Local replay devices are found,
+	// the local Android devices will be returned first.
 	GetDevices(ctx context.Context) ([]*path.Device, error)
 
 	// GetDevicesForReplay returns the list of replay devices avaliable to the
 	// server that are capable of replaying the given capture.
 	// These include local replay devices and any connected Android devices.
 	// This list may change over time, as devices are connected and disconnected.
+	// If both connected Android and Local replay devices are found,
+	// the local Android devices will be returned first.
 	GetDevicesForReplay(ctx context.Context, p *path.Capture) ([]*path.Device, error)
 
 	// GetFramebufferAttachment returns the ImageInfo identifier describing the


### PR DESCRIPTION
This allows us to replay Vulkan applications on Desktop if they were
captured on desktop without any user intervention.