### PR TITLE
Vulkan:Bring back depth buffer

### DIFF
--- a/core/stream/fmts/d.go
+++ b/core/stream/fmts/d.go
@@ -25,6 +25,14 @@ var (
 		}},
 	}
 
+	D_U24_NORM = &stream.Format{
+		Components: []*stream.Component{{
+			DataType: &stream.U24,
+			Sampling: stream.LinearNormalized,
+			Channel:  stream.Channel_Depth,
+		}},
+	}
+
 	D_F32 = &stream.Format{
 		Components: []*stream.Component{{
 			DataType: &stream.F32,

--- a/gapis/gfxapi/vulkan/resources.go
+++ b/gapis/gfxapi/vulkan/resources.go
@@ -129,18 +129,24 @@ func getImageFormatFromVulkanFormat(vkfmt VkFormat) (*image.Format, error) {
 	}
 }
 
+// Returns the corresponding depth format for the given Vulkan format. If the given Vulkan
+// format contains a stencil field, returns a format which matches only with the tightly
+// packed depth field of the given Vulkan format.
 func getDepthImageFormatFromVulkanFormat(vkfmt VkFormat) (*image.Format, error) {
 	switch vkfmt {
 	case VkFormat_VK_FORMAT_D32_SFLOAT_S8_UINT:
-		return image.NewUncompressed("VK_FORMAT_D32_SFLOAT_S8_UINT", fmts.DS_F32U8), nil
+		// Only the depth field is considered, and assume the data is tightly packed.
+		return image.NewUncompressed("VK_FORMAT_D32_SFLOAT_S8_UINT", fmts.D_F32), nil
 	case VkFormat_VK_FORMAT_D32_SFLOAT:
 		return image.NewUncompressed("VK_FORMAT_D32_SFLOAT", fmts.D_F32), nil
 	case VkFormat_VK_FORMAT_D16_UNORM:
 		return image.NewUncompressed("VK_FORMAT_D16_UNORM", fmts.D_U16_NORM), nil
 	case VkFormat_VK_FORMAT_D16_UNORM_S8_UINT:
-		return image.NewUncompressed("VK_FORMAT_D16_UNORM_S8_UINT", fmts.DS_NU16U8), nil
+		// Only the depth field is considered, and assume the data is tightly packed.
+		return image.NewUncompressed("VK_FORMAT_D16_UNORM_S8_UINT", fmts.D_U16_NORM), nil
 	case VkFormat_VK_FORMAT_D24_UNORM_S8_UINT:
-		return image.NewUncompressed("VK_FORMAT_D24_UNORM_S8_UINT", fmts.DS_NU24U8), nil
+		// Only the depth field is considered, and assume the data is tightly packed.
+		return image.NewUncompressed("VK_FORMAT_D24_UNORM_S8_UINT", fmts.D_U24_NORM), nil
 	default:
 		return nil, &unsupportedVulkanFormatError{Format: vkfmt}
 	}


### PR DESCRIPTION
Because when copying depth/stencil image with aspect mask for only depth
field, the result data is packed tightly. We should treat the data from
those images as pure depth data, instead of depth+stencil data.

Resolve issue #122 