### PR TITLE
Use (first,count) to represent index ranges.

### DIFF
--- a/gapii/cc/gles_spy_externs.cpp
+++ b/gapii/cc/gles_spy_externs.cpp
@@ -29,6 +29,9 @@ MsgID GlesSpy::newMsg(CallObserver*, uint32_t, const char*) { return 0; }
 void GlesSpy::addTag(CallObserver*, uint32_t, const char*) {}
 
 u32Limits GlesSpy::IndexLimits(CallObserver*, uint8_t* indices, uint32_t indices_type, uint32_t offset, uint32_t count) {
+    if (count == 0) {
+        return u32Limits(0, 0);
+    }
     uint32_t low = ~(uint32_t)0;
     uint32_t high = 0;
     switch (indices_type) {
@@ -57,7 +60,7 @@ u32Limits GlesSpy::IndexLimits(CallObserver*, uint8_t* indices, uint32_t indices
             break;
         }
     }
-    return u32Limits(low, high);
+    return u32Limits(low, high+1-low);
 }
 
 void GlesSpy::onGlError(CallObserver* observer, GLenum_Error err) {

--- a/gapis/gfxapi/gles/api/draw_commands.api
+++ b/gapis/gfxapi/gles/api/draw_commands.api
@@ -110,7 +110,7 @@ sub void DrawElements(ref!Context    ctx,
 
       // Read the vertices
       limits := IndexLimits(as!u8*(index_data), indices_type, offset, count)
-      ReadVertexArrays(ctx, limits.first + as!u32(base_vertex), (limits.last - limits.first) + 1, as!u32(instance_count))
+      ReadVertexArrays(ctx, limits.first + as!u32(base_vertex), limits.count, as!u32(instance_count))
 
       // No need to read the indices - they're already in a GPU-side buffer.
     } else {
@@ -119,7 +119,7 @@ sub void DrawElements(ref!Context    ctx,
 
       // Read the vertices
       limits := IndexLimits(index_data, indices_type, 0, count)
-      ReadVertexArrays(ctx, limits.first + as!u32(base_vertex), (limits.last - limits.first) + 1, as!u32(instance_count))
+      ReadVertexArrays(ctx, limits.first + as!u32(base_vertex), limits.count, as!u32(instance_count))
 
       // Read the indices
       read(index_data[0:count * IndexSize(indices_type)])

--- a/gapis/gfxapi/gles/externs.go
+++ b/gapis/gfxapi/gles/externs.go
@@ -71,7 +71,7 @@ func (e externs) elSize(ty GLenum) uint64 {
 	return uint64(DataTypeSize(ty))
 }
 
-func (e externs) calcIndexLimits(data U8ᵖ, ty GLenum, offset, count uint32) resolve.MinMax {
+func (e externs) calcIndexLimits(data U8ᵖ, ty GLenum, offset, count uint32) resolve.IndexRange {
 	elSize := e.elSize(ty)
 	id := data.Slice(uint64(offset), uint64(offset)+uint64(count)*elSize, e.s).ResourceID(e.ctx, e.s)
 	littleEndian := e.s.MemoryLayout.GetEndian() == device.LittleEndian
@@ -79,7 +79,7 @@ func (e externs) calcIndexLimits(data U8ᵖ, ty GLenum, offset, count uint32) re
 	if err != nil {
 		if errors.Cause(err) == context.Canceled {
 			// TODO: Propagate error
-			return resolve.MinMax{}
+			return resolve.IndexRange{}
 		} else {
 			panic(fmt.Errorf("Could not calculate index limits: %v", err))
 		}
@@ -89,7 +89,7 @@ func (e externs) calcIndexLimits(data U8ᵖ, ty GLenum, offset, count uint32) re
 
 func (e externs) IndexLimits(data U8ᵖ, ty GLenum, offset, count uint32) u32Limits {
 	limits := e.calcIndexLimits(data, ty, offset, count)
-	return u32Limits{First: limits.Min, Last: limits.Max}
+	return u32Limits{First: limits.First, Count: limits.Count}
 }
 
 func (e externs) substr(str string, start, end int32) string {

--- a/gapis/gfxapi/gles/gles.api
+++ b/gapis/gfxapi/gles/gles.api
@@ -675,7 +675,7 @@ sub u32 IndexSize(GLenum indices_type) {
   }
 }
 
-@internal class u32Limits { u32 first u32 last }
+@internal class u32Limits { u32 first u32 count }
 extern u32Limits IndexLimits(u8* indices, GLenum indices_type, u32 offset, u32 count)
 
 /////////////////////////////////////////////////////////////////


### PR DESCRIPTION
The (min,max) did not work well for empty set.

Fixes #134