### PR TITLE
Do not flip z in generated GLSL

### DIFF
--- a/gapis/shadertools/cc/libmanager.cpp
+++ b/gapis/shadertools/cc/libmanager.cpp
@@ -232,6 +232,7 @@ code_with_debug_info_t* convertGlsl(const char* input, size_t length, const opti
   cross_options.version = 330;
   cross_options.es = false;
   cross_options.force_temporary = false;
+  cross_options.vertex.fixup_clipspace = false;
   glsl.set_options(cross_options);
   std::string source = glsl.compile().c_str();
 


### PR DESCRIPTION
This is vulkan specific hack in SPRIV-Cross.
We do not want it for GLSL to GLSL translation.