### PR TITLE
Vulkan:Ensure Read observation for recreate cmd blit image

### DIFF
--- a/gapis/gfxapi/vulkan/vulkan.api
+++ b/gapis/gfxapi/vulkan/vulkan.api
@@ -6207,7 +6207,7 @@ cmd void RecreateCmdBlitImage(
     u32                regionCount,
     const VkImageBlit* pRegions,
     VkFilter           filter) {
-  _ = pRegions[0:regionCount]
+  read(pRegions[0:regionCount])
 }
 
 @threadSafety("app")


### PR DESCRIPTION
`_ = pRegions[0:count]` does not ensure a read observation.