### PR TITLE
Fix flaky TestSignalTryWait test.

### DIFF
--- a/core/event/task/signal_test.go
+++ b/core/event/task/signal_test.go
@@ -49,7 +49,7 @@ func TestSignalTryWait(t *testing.T) {
 	ctx := log.Testing(t)
 	signal, fire := task.NewSignal()
 	fire(ctx)
-	assert.With(ctx).That(signal.TryWait(ctx, 0)).Equals(true)
+	assert.With(ctx).That(signal.TryWait(ctx, ExpectBlocking)).Equals(true)
 }
 
 func TestSignalTryWaitTimeout(t *testing.T) {


### PR DESCRIPTION
0 duration timeout results in non-deterministic result.

Fixes: #183 