### PR TITLE
Add usage hints and cancel OOV thumbnails for better replay performance.

### DIFF
--- a/cmd/gapis/main.go
+++ b/cmd/gapis/main.go
@@ -62,9 +62,10 @@ func run(ctx context.Context) error {
 	logBroadcaster := log.Broadcast(log.GetHandler(ctx))
 	ctx = log.PutHandler(ctx, logBroadcaster)
 
-	m, r := replay.New(ctx), bind.NewRegistry()
-	ctx = replay.PutManager(ctx, m)
+	r := bind.NewRegistry()
 	ctx = bind.PutRegistry(ctx, r)
+	m := replay.New(ctx)
+	ctx = replay.PutManager(ctx, m)
 	ctx = database.Put(ctx, database.NewInMemory(ctx))
 
 	deviceScanDone, onDeviceScanDone := task.NewSignal()

--- a/cmd/gapit/video.go
+++ b/cmd/gapit/video.go
@@ -349,7 +349,7 @@ func (verb *videoVerb) encodeVideo(ctx context.Context, filepath string, vidFun 
 func getFrame(ctx context.Context, flags VideoFlags, cmd *path.Command, device *path.Device, client service.Service) (*image.NRGBA, error) {
 	ctx = log.V{"cmd": int(cmd.Index)}.Bind(ctx)
 	settings := &service.RenderSettings{MaxWidth: uint32(flags.Max.Width), MaxHeight: uint32(flags.Max.Height)}
-	iip, err := client.GetFramebufferAttachment(ctx, device, cmd, gfxapi.FramebufferAttachment_Color0, settings)
+	iip, err := client.GetFramebufferAttachment(ctx, device, cmd, gfxapi.FramebufferAttachment_Color0, settings, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/perf/bench.go
+++ b/cmd/perf/bench.go
@@ -397,7 +397,14 @@ func getFrame(ctx context.Context, session *session, cmd *path.Command) error {
 		MaxWidth:  uint32(session.bench.Input.MaxFrameWidth),
 		MaxHeight: uint32(session.bench.Input.MaxFrameHeight),
 	}
-	imgInfoPath, err := session.client.GetFramebufferAttachment(ctx, session.device, cmd, gfxapi.FramebufferAttachment_Color0, settings)
+	imgInfoPath, err := session.client.GetFramebufferAttachment(
+		ctx,
+		session.device,
+		cmd,
+		gfxapi.FramebufferAttachment_Color0,
+		settings,
+		nil,
+	)
 	if err != nil {
 		return err
 	}

--- a/gapic/src/main/com/google/gapid/models/Models.java
+++ b/gapic/src/main/com/google/gapid/models/Models.java
@@ -59,13 +59,12 @@ public class Models {
     Resources resources = new Resources(shell, client, capture);
     ApiState state = new ApiState(shell, client, follower, atoms);
     Reports reports = new Reports(shell, client, devices, capture);
-    Thumbnails thumbs = new Thumbnails(client, devices, capture, atoms);
+    Thumbnails thumbs = new Thumbnails(client, devices, atoms);
     return new Models(settings, follower, capture, devices, atoms, contexts, hierarchies, resources,
         state, reports, thumbs);
   }
 
   public void dispose() {
-    thumbs.dispose();
     settings.save();
   }
 }

--- a/gapic/src/main/com/google/gapid/models/Thumbnails.java
+++ b/gapic/src/main/com/google/gapid/models/Thumbnails.java
@@ -16,13 +16,9 @@
 package com.google.gapid.models;
 
 import static com.google.gapid.util.Paths.command;
-import static java.util.logging.Level.FINE;
 
-import com.google.common.collect.Lists;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
-import com.google.common.util.concurrent.SettableFuture;
-import com.google.gapid.Server.GapisInitException;
 import com.google.gapid.image.FetchedImage;
 import com.google.gapid.proto.service.Service;
 import com.google.gapid.proto.service.gfxapi.GfxAPI;
@@ -34,19 +30,10 @@ import com.google.gapid.util.Events.ListenerCollection;
 import org.eclipse.swt.graphics.ImageData;
 import org.eclipse.swt.internal.DPIUtil;
 
-import java.util.List;
-import java.util.PriorityQueue;
-import java.util.Queue;
-import java.util.concurrent.ExecutionException;
 import java.util.logging.Logger;
-import java.util.stream.Collectors;
 
 /**
- * Manages the loading of thumbnail previews. In order to keep the UI responsive and give other
- * requests to the server a chance to complete, a single thread is used to request thumbnail
- * previews, which require a replay, from the server. In essence, this prevents request starvation
- * to the server by de-prioritizing requests for thumbnails. Thumbnail requests are batched to take
- * advantage of the batching optimization the server does for replay requests.
+ * Manages the loading of thumbnail previews.
  */
 public class Thumbnails {
   protected static final Logger LOG = Logger.getLogger(ApiState.class.getName());
@@ -66,14 +53,11 @@ public class Thumbnails {
   private final Devices devices;
   private final AtomStream atoms;
   private final ListenerCollection<Listener> listeners = Events.listeners(Listener.class);
-  private final Queue<Thumbnail> queuedThumbnails = new PriorityQueue<>();
-  private final Thread processorThread;
 
-  public Thumbnails(Client client, Devices devices, Capture capture, AtomStream atoms) {
+  public Thumbnails(Client client, Devices devices, AtomStream atoms) {
     this.client = client;
     this.devices = devices;
     this.atoms = atoms;
-    this.processorThread = new ProcessorThread(client, queuedThumbnails);
 
     devices.addListener(new Devices.Listener() {
       @Override
@@ -81,27 +65,11 @@ public class Thumbnails {
         update();
       }
     });
-    capture.addListener(new Capture.Listener() {
-      @Override
-      public void onCaptureLoaded(GapisInitException error) {
-        if (error == null) {
-          update();
-        }
-      }
-    });
-    atoms.addListener(new AtomStream.Listener() {
-      @Override
-      public void onAtomsLoaded() {
-        update();
-      }
-    });
-
-    processorThread.start();
   }
 
   protected void update() {
     if (isReady()) {
-      listeners.fire().onThumnailsChanged();
+      listeners.fire().onThumbnailsChanged();
     }
   }
 
@@ -110,23 +78,8 @@ public class Thumbnails {
   }
 
   public ListenableFuture<ImageData> getThumbnail(long atomId, int size) {
-    Thumbnail result = new Thumbnail(atomId, getPath(atomId));
-    synchronized (queuedThumbnails) {
-      queuedThumbnails.add(result);
-      queuedThumbnails.notify();
-    }
-    return Futures.transform(result.result, image -> processImage(image, size));
-  }
-
-  public void dispose() {
-    synchronized (queuedThumbnails) {
-      while (!queuedThumbnails.isEmpty()) {
-        Thumbnail thumbnail = queuedThumbnails.remove();
-        thumbnail.pathFuture.cancel(true);
-        thumbnail.result.cancel(true);
-      }
-    }
-    processorThread.interrupt();
+    return Futures.transform(FetchedImage.loadLevel(FetchedImage.load(client, getPath(atomId)), 0),
+        image -> processImage(image, size));
   }
 
   private static ImageData processImage(ImageData image, int size) {
@@ -142,7 +95,8 @@ public class Thumbnails {
 
   private ListenableFuture<Path.ImageInfo> getPath(long atomId) {
     return client.getFramebufferAttachment(devices.getReplayDevice(),
-        command(atoms.getPath(), atomId), GfxAPI.FramebufferAttachment.Color0, RENDER_SETTINGS, HINTS);
+        command(atoms.getPath(), atomId), GfxAPI.FramebufferAttachment.Color0,
+        RENDER_SETTINGS, HINTS);
   }
 
   public void addListener(Listener listener) {
@@ -157,105 +111,6 @@ public class Thumbnails {
     /**
      * Event indicating that render settings have changed an thumbnails need to be updated.
      */
-    public default void onThumnailsChanged() { /* empty */ }
-  }
-
-  /**
-   * A queued thumbnail request and its result.
-   */
-  private static class Thumbnail implements Comparable<Thumbnail> {
-    public final long atomId;
-    public final ListenableFuture<Path.ImageInfo> pathFuture;
-    public final SettableFuture<ImageData> result;
-
-    public Thumbnail(long atomId, ListenableFuture<Path.ImageInfo> pathFuture) {
-      this.atomId = atomId;
-      this.pathFuture = pathFuture;
-      this.result = SettableFuture.create();
-    }
-
-    @Override
-    public int compareTo(Thumbnail o) {
-      return Long.compare(atomId, o.atomId);
-    }
-  }
-
-  /**
-   * Thread that requests and processes all thumbnail previews..
-   */
-  private static class ProcessorThread extends Thread {
-    private static final long BATCH_TIMEOUT_MS = 10;
-    private static final int BATCH_SIZE = 25;
-
-    private final Client client;
-    private final Queue<Thumbnail> queue;
-
-    public ProcessorThread(Client client, Queue<Thumbnail> queue) {
-      super(ProcessorThread.class.getName());
-      this.client = client;
-      this.queue = queue;
-      setDaemon(true);
-    }
-
-    @Override
-    public void run() {
-      while (true) {
-        List<Thumbnail> batch = Lists.newArrayList();
-        synchronized (queue) {
-          while (queue.isEmpty()) {
-            if (!await()) {
-              return;
-            }
-          }
-
-          for (long end = System.currentTimeMillis() + BATCH_TIMEOUT_MS;
-              batch.size() < BATCH_SIZE && end > System.currentTimeMillis(); ) {
-            while (!queue.isEmpty() && batch.size() < BATCH_SIZE) {
-              Thumbnail thumbnail = queue.remove();
-              if (!thumbnail.result.isCancelled()) {
-                batch.add(thumbnail);
-              }
-            }
-            if (batch.size() < BATCH_SIZE && !await()) {
-              return;
-            }
-          }
-        }
-        if (!process(batch)) {
-          return;
-        }
-      }
-    }
-
-    private boolean process(List<Thumbnail> batch) {
-      LOG.log(FINE, "Processing a batch of " + batch.size() + " thumbnails.");
-      long start = System.currentTimeMillis();
-      try {
-        Futures.whenAllComplete(batch.stream().map(thumbnail -> {
-          thumbnail.result.setFuture(
-              FetchedImage.loadLevel(FetchedImage.load(client, thumbnail.pathFuture), 0));
-          return thumbnail.result;
-        }).collect(Collectors.toList())).call(() -> null).get();
-      } catch (ExecutionException e) {
-        throw new AssertionError(); // "() -> null" above should not throw an exception.
-      } catch (InterruptedException e) {
-        LOG.log(FINE, "Aborting thumbnail fetching in process() due to interrupt");
-        return false;
-      }
-      long end = System.currentTimeMillis();
-      LOG.log(FINE,
-          "Took " + (end - start) + "ms to process a batch of " + batch.size() + " thumbnails.");
-      return true;
-    }
-
-    private boolean await() {
-      try {
-        queue.wait(BATCH_TIMEOUT_MS);
-        return true;
-      } catch (InterruptedException e) {
-        LOG.log(FINE, "Aborting thumbnail fetching in await() due to interrupt");
-        return false;
-      }
-    }
+    public default void onThumbnailsChanged() { /* empty */ }
   }
 }

--- a/gapic/src/main/com/google/gapid/models/Thumbnails.java
+++ b/gapic/src/main/com/google/gapid/models/Thumbnails.java
@@ -58,6 +58,9 @@ public class Thumbnails {
       .setMaxHeight(DPIUtil.autoScaleUp(THUMB_SIZE))
       .setWireframeMode(Service.WireframeMode.None)
       .build();
+  private static final Service.UsageHints HINTS = Service.UsageHints.newBuilder()
+      .setPreview(true)
+      .build();
 
   private final Client client;
   private final Devices devices;
@@ -139,7 +142,7 @@ public class Thumbnails {
 
   private ListenableFuture<Path.ImageInfo> getPath(long atomId) {
     return client.getFramebufferAttachment(devices.getReplayDevice(),
-        command(atoms.getPath(), atomId), GfxAPI.FramebufferAttachment.Color0, RENDER_SETTINGS);
+        command(atoms.getPath(), atomId), GfxAPI.FramebufferAttachment.Color0, RENDER_SETTINGS, HINTS);
   }
 
   public void addListener(Listener listener) {

--- a/gapic/src/main/com/google/gapid/server/Client.java
+++ b/gapic/src/main/com/google/gapid/server/Client.java
@@ -161,15 +161,16 @@ public class Client {
 
   public ListenableFuture<Path.ImageInfo> getFramebufferAttachment(Path.Device device,
       Path.Command after, GfxAPI.FramebufferAttachment attachment,
-      Service.RenderSettings settings) {
-    LOG.log(FINE, "RPC->getFramebufferAttachment({0}, {1}, {2}, {3})",
-        new Object[] { device, after, attachment, settings });
+      Service.RenderSettings settings, Service.UsageHints hints) {
+    LOG.log(FINE, "RPC->getFramebufferAttachment({0}, {1}, {2}, {3}, {4})",
+        new Object[] { device, after, attachment, settings, hints });
     return Futures.transformAsync(
         client.getFramebufferAttachment(GetFramebufferAttachmentRequest.newBuilder()
             .setDevice(device)
             .setAfter(after)
             .setAttachment(attachment)
             .setSettings(settings)
+            .setHints(hints)
             .build()),
         in -> Futures.immediateFuture(throwIfError(in.getImage(), in.getError()))
     );

--- a/gapic/src/main/com/google/gapid/util/Trees.java
+++ b/gapic/src/main/com/google/gapid/util/Trees.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (C) 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.gapid.util;
+
+import static java.util.Collections.emptySet;
+
+import com.google.common.collect.Sets;
+
+import org.eclipse.swt.graphics.Rectangle;
+import org.eclipse.swt.widgets.Tree;
+import org.eclipse.swt.widgets.TreeItem;
+
+import java.util.Set;
+
+/**
+ * Utilities for dealing with {@link Tree Trees} and {@link TreeItem TreeItems}.
+ */
+public class Trees {
+  private Trees() {
+  }
+
+  /**
+   * @return the {@link TreeItem TreeItems} that are currently visible in the tree.
+   */
+  public static Set<TreeItem> getVisibleItems(Tree tree) {
+    TreeItem top = tree.getTopItem();
+    if (top == null) {
+      // Work around bug where getTopItem() returns null when scrolling
+      // up past the top item (elastic scroll).
+      return (tree.getItemCount() != 0) ? null : emptySet();
+    }
+
+    Rectangle bounds = tree.getClientArea();
+    int treeBottom = bounds.y + bounds.height;
+    Set<TreeItem> visible = Sets.newIdentityHashSet();
+    if (!getVisibleItems(top, treeBottom, visible)) {
+      do {
+        top = getVisibleSiblings(top, treeBottom, visible);
+      } while (top != null);
+    }
+    return visible;
+  }
+
+  /**
+   * Adds the given item and all visible descendants into the given set.
+   * @return whether the bottom has been reached.
+   */
+  private static boolean getVisibleItems(TreeItem item, int treeBottom, Set<TreeItem> visible) {
+    visible.add(item);
+    Rectangle bounds = item.getBounds();
+    if (bounds.y + bounds.height > treeBottom) {
+      return true;
+    }
+
+    if (item.getExpanded()) {
+      for (TreeItem child : item.getItems()) {
+        if (getVisibleItems(child, treeBottom, visible)) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Adds all visible siblings (and their visible descendants) into the given set.
+   * @return the next parent or {@code null} if the bottom has been reached.
+   */
+  private static TreeItem getVisibleSiblings(TreeItem item, int treeBottom, Set<TreeItem> visible) {
+    TreeItem parent = item.getParentItem();
+    TreeItem[] siblings = (parent == null) ? item.getParent().getItems() : parent.getItems();
+    int idx = 0;
+    for (; idx < siblings.length && siblings[idx] != item; idx++) {
+      // Do nothing.
+    }
+    for (idx++; idx < siblings.length; idx++) {
+      if (getVisibleItems(siblings[idx], treeBottom, visible)) {
+        return null;
+      }
+    }
+    return parent;
+  }
+}

--- a/gapic/src/main/com/google/gapid/views/AtomTree.java
+++ b/gapic/src/main/com/google/gapid/views/AtomTree.java
@@ -62,6 +62,7 @@ import com.google.gapid.widgets.LoadingIndicator;
 import com.google.gapid.widgets.MeasuringViewLabelProvider;
 import com.google.gapid.widgets.SearchBox;
 import com.google.gapid.widgets.Theme;
+import com.google.gapid.widgets.VisibilityTrackingTreeViewer;
 import com.google.gapid.widgets.Widgets;
 
 import org.eclipse.jface.viewers.ILazyTreeContentProvider;
@@ -366,7 +367,7 @@ public class AtomTree extends Composite implements Tab, Capture.Listener, AtomSt
   }
 
   @Override
-  public void onThumnailsChanged() {
+  public void onThumbnailsChanged() {
     imageProvider.reset();
     viewer.refresh();
   }
@@ -442,7 +443,26 @@ public class AtomTree extends Composite implements Tab, Capture.Listener, AtomSt
       this.loading = loading;
     }
 
+    public void load(FilteredGroup group) {
+      LoadableImage image = getLoadableImage(group);
+      if (image != null) {
+        image.load();
+      }
+    }
+
+    public void unload(FilteredGroup group) {
+      LoadableImage image = getLoadableImage(group);
+      if (image != null) {
+        image.unload();
+      }
+    }
+
     public Image getImage(FilteredGroup group) {
+      LoadableImage image = getLoadableImage(group);
+      return (image == null) ? null : image.getImage();
+    }
+
+    private LoadableImage getLoadableImage(FilteredGroup group) {
       LoadableImage image = images.get(group);
       if (image == null) {
         if (!shouldShowImage(group) || !thumbs.isReady()) {
@@ -453,14 +473,7 @@ public class AtomTree extends Composite implements Tab, Capture.Listener, AtomSt
             viewer.getTree(), () -> loadImage(group), loading, this);
         images.put(group, image);
       }
-      return image.getImage();
-    }
-
-    public void onPaint(FilteredGroup group) {
-      LoadableImage image = images.get(group);
-      if (image != null) {
-        image.load();
-      }
+      return image;
     }
 
     @Override
@@ -492,7 +505,8 @@ public class AtomTree extends Composite implements Tab, Capture.Listener, AtomSt
   /**
    * Label provider for the command tree.
    */
-  private static class ViewLabelProvider extends MeasuringViewLabelProvider {
+  private static class ViewLabelProvider extends MeasuringViewLabelProvider
+      implements VisibilityTrackingTreeViewer.Listener {
     private final ImageProvider imageProvider;
 
     public ViewLabelProvider(TreeViewer viewer, Theme theme, ImageProvider imageProvider) {
@@ -525,18 +539,25 @@ public class AtomTree extends Composite implements Tab, Capture.Listener, AtomSt
       }
       return result;
     }
-
     @Override
     protected boolean isFollowable(Object element) {
       return element instanceof AtomNode;
     }
 
     @Override
-    protected void paint(Event event, Object element) {
+    public void onShow(TreeItem item) {
+      Object element = item.getData();
       if (element instanceof FilteredGroup) {
-        imageProvider.onPaint((FilteredGroup)element);
+        imageProvider.load((FilteredGroup)element);
       }
-      super.paint(event, element);
+    }
+
+    @Override
+    public void onHide(TreeItem item) {
+      Object element = item.getData();
+      if (element instanceof FilteredGroup) {
+        imageProvider.unload((FilteredGroup)element);
+      }
     }
   }
 }

--- a/gapic/src/main/com/google/gapid/views/AtomTree.java
+++ b/gapic/src/main/com/google/gapid/views/AtomTree.java
@@ -23,7 +23,7 @@ import static com.google.gapid.util.Ranges.first;
 import static com.google.gapid.util.Ranges.last;
 import static com.google.gapid.widgets.Widgets.createTreeForViewer;
 import static com.google.gapid.widgets.Widgets.createTreeViewer;
-import static com.google.gapid.widgets.Widgets.scheduleIfNotDisposed;
+import static com.google.gapid.widgets.Widgets.ifNotDisposed;
 
 import com.google.common.collect.Maps;
 import com.google.common.util.concurrent.Futures;
@@ -478,7 +478,7 @@ public class AtomTree extends Composite implements Tab, Capture.Listener, AtomSt
 
     @Override
     public void repaint() {
-      scheduleIfNotDisposed(viewer.getTree(), viewer::refresh);
+      ifNotDisposed(viewer.getControl(), viewer::refresh);
     }
 
     private static boolean shouldShowImage(FilteredGroup group) {

--- a/gapic/src/main/com/google/gapid/views/FramebufferView.java
+++ b/gapic/src/main/com/google/gapid/views/FramebufferView.java
@@ -33,6 +33,7 @@ import com.google.gapid.models.AtomStream;
 import com.google.gapid.models.Capture;
 import com.google.gapid.models.Devices;
 import com.google.gapid.models.Models;
+import com.google.gapid.proto.service.Service;
 import com.google.gapid.proto.service.Service.CommandRange;
 import com.google.gapid.proto.service.Service.RenderSettings;
 import com.google.gapid.proto.service.Service.WireframeMode;
@@ -83,6 +84,9 @@ public class FramebufferView extends Composite
   private static final RenderSettings RENDER_WIREFRAME = RenderSettings.newBuilder()
       .setMaxHeight(MAX_SIZE).setMaxWidth(MAX_SIZE)
       .setWireframeMode(WireframeMode.All)
+      .build();
+  private static final Service.UsageHints HINTS = Service.UsageHints.newBuilder()
+      .setPrimary(true)
       .build();
 
   private final Client client;
@@ -245,6 +249,6 @@ public class FramebufferView extends Composite
 
   private ListenableFuture<ImageInfo> getImageInfoPath(Path.Command atomPath) {
     return client.getFramebufferAttachment(
-        models.devices.getReplayDevice(), atomPath, target, renderSettings);
+        models.devices.getReplayDevice(), atomPath, target, renderSettings, HINTS);
   }
 }

--- a/gapic/src/main/com/google/gapid/views/TextureView.java
+++ b/gapic/src/main/com/google/gapid/views/TextureView.java
@@ -23,8 +23,8 @@ import static com.google.gapid.util.Ranges.last;
 import static com.google.gapid.widgets.Widgets.createComposite;
 import static com.google.gapid.widgets.Widgets.createTableColumn;
 import static com.google.gapid.widgets.Widgets.createTableViewer;
+import static com.google.gapid.widgets.Widgets.ifNotDisposed;
 import static com.google.gapid.widgets.Widgets.packColumns;
-import static com.google.gapid.widgets.Widgets.scheduleIfNotDisposed;
 import static com.google.gapid.widgets.Widgets.sorting;
 
 import com.google.common.collect.Lists;
@@ -528,7 +528,7 @@ public class TextureView extends Composite
 
     @Override
     public void repaint() {
-      scheduleIfNotDisposed(viewer.getTable(), viewer::refresh);
+      ifNotDisposed(viewer.getControl(), viewer::refresh);
     }
 
     private ListenableFuture<ImageData> loadImage(Data data) {

--- a/gapic/src/main/com/google/gapid/views/ThumbnailScrubber.java
+++ b/gapic/src/main/com/google/gapid/views/ThumbnailScrubber.java
@@ -322,7 +322,7 @@ public class ThumbnailScrubber extends Composite
     }
 
     @Override
-    public void onThumnailsChanged() {
+    public void onThumbnailsChanged() {
       for (Data data : datas) {
         if (data.image != null) {
           data.image.dispose();

--- a/gapic/src/main/com/google/gapid/widgets/LoadableImage.java
+++ b/gapic/src/main/com/google/gapid/widgets/LoadableImage.java
@@ -42,7 +42,7 @@ import java.util.logging.Logger;
 public class LoadableImage {
   protected static final Logger LOG = Logger.getLogger(LoadableImage.class.getName());
 
-  private final ListenerCollection<Listener> listeners = Events.listeners(Listener.class);
+  private final ListenerCollection<Listener> listeners = Events.silentListeners(Listener.class);
   private int loadCount = 0;
   protected final Widget widget;
   private final Supplier<ListenableFuture<Object>> futureSupplier;
@@ -207,8 +207,6 @@ public class LoadableImage {
     if (state == State.LOADING) {
       state = (result == null) ? State.FAILED : State.LOADED;
       image = result;
-      repaintable.repaint();
-      loading.cancelRedraw(repaintable);
       listeners.fire().onLoaded(result != null);
     } else if (result != null) {
       result.dispose();

--- a/gapic/src/main/com/google/gapid/widgets/VisibilityTrackingTreeViewer.java
+++ b/gapic/src/main/com/google/gapid/widgets/VisibilityTrackingTreeViewer.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (C) 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.gapid.widgets;
+
+import com.google.common.collect.Lists;
+import com.google.gapid.util.Trees;
+
+import org.eclipse.jface.viewers.IBaseLabelProvider;
+import org.eclipse.jface.viewers.IContentProvider;
+import org.eclipse.jface.viewers.TreeViewer;
+import org.eclipse.swt.widgets.Tree;
+import org.eclipse.swt.widgets.TreeItem;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * A {@link TreeViewer} that notifies the bound {@link IContentProvider} and
+ * {@link IBaseLabelProvider} of visibility changes if they also implement
+ * the {@link Listener} interface.
+ */
+public class VisibilityTrackingTreeViewer extends TreeViewer {
+  private Set<TreeItem> visible = new HashSet<>();
+  private Listener[] listeners;
+
+  public VisibilityTrackingTreeViewer(Tree tree) {
+    super(tree);
+    updateListeners();
+    tree.addPaintListener(e -> updateVisibility());
+  }
+
+  private void updateVisibility() {
+    if (listeners == null) {
+      return;
+    }
+
+    Set<TreeItem> seen = Trees.getVisibleItems(getTree());
+    if (seen == null) {
+      return; // No reliable data.
+    }
+    for (TreeItem item : visible) {
+      if (!seen.contains(item) && !item.isDisposed()) {
+        for (Listener listener : listeners) {
+          listener.onHide(item);
+        }
+      }
+    }
+    for (TreeItem item : seen) {
+      if (!visible.contains(item)) {
+        for (Listener listener : listeners) {
+          listener.onShow(item);
+        }
+      }
+    }
+    visible = seen;
+  }
+
+  @Override
+  public void setLabelProvider(IBaseLabelProvider labelProvider) {
+    super.setLabelProvider(labelProvider);
+    updateListeners();
+  }
+
+  @Override
+  public void setContentProvider(IContentProvider provider) {
+    super.setContentProvider(provider);
+    updateListeners();
+  }
+
+  private void updateListeners() {
+    List<Listener> found = Lists.newArrayList();
+    IContentProvider contentProvider = getContentProvider();
+    if (contentProvider instanceof Listener) {
+      found.add((Listener)contentProvider);
+    }
+
+    IBaseLabelProvider labelProvider = getLabelProvider();
+    if (labelProvider instanceof Listener) {
+      found.add((Listener)labelProvider);
+    }
+
+    listeners = found.isEmpty() ? null : found.toArray(new Listener[found.size()]);
+  }
+
+  /**
+   * The interface the {@link IContentProvider} and {@link IBaseLabelProvider} can
+   * implement to be notified about {@link TreeItem TreeItems} being made visible
+   * and hidden usually by scrolling.
+   */
+  public static interface Listener {
+    /**
+     * Called when the {@link TreeItem} is made visible.
+     */
+    public void onShow(TreeItem item);
+
+    /**
+     * Called when the {@link TreeItem} is made invisible.
+     */
+    public void onHide(TreeItem item);
+  }
+}

--- a/gapic/src/main/com/google/gapid/widgets/Widgets.java
+++ b/gapic/src/main/com/google/gapid/widgets/Widgets.java
@@ -488,7 +488,7 @@ public class Widgets {
   }
 
   public static TreeViewer createTreeViewer(Tree tree) {
-    TreeViewer viewer = new TreeViewer(tree);
+    TreeViewer viewer = new VisibilityTrackingTreeViewer(tree);
     viewer.setUseHashlookup(true);
     tree.addListener(SWT.KeyDown, e -> {
       switch (e.keyCode) {

--- a/gapis/client/client.go
+++ b/gapis/client/client.go
@@ -237,13 +237,15 @@ func (c *client) GetFramebufferAttachment(
 	dev *path.Device,
 	cmd *path.Command,
 	att gfxapi.FramebufferAttachment,
-	rs *service.RenderSettings) (*path.ImageInfo, error) {
+	rs *service.RenderSettings,
+	hints *service.UsageHints) (*path.ImageInfo, error) {
 
 	res, err := c.client.GetFramebufferAttachment(ctx, &service.GetFramebufferAttachmentRequest{
 		Device:     dev,
 		After:      cmd,
 		Attachment: att,
 		Settings:   rs,
+		Hints:      hints,
 	})
 	if err != nil {
 		return nil, err

--- a/gapis/replay/CMakeFiles.cmake
+++ b/gapis/replay/CMakeFiles.cmake
@@ -18,7 +18,7 @@
 # build and the file will be recreated, check in the new version.
 
 set(files
-    batcher.go
+    batch.go
     context.go
     custom.go
     doc.go

--- a/gapis/replay/events.go
+++ b/gapis/replay/events.go
@@ -20,5 +20,5 @@ import "github.com/google/gapid/core/os/device/bind"
 // replay activity.
 var Events struct {
 	// OnReplay is called when a replay batch is sent to a device.
-	OnReplay func(bind.Device, Intent, Config, []Request)
+	OnReplay func(bind.Device, Intent, Config)
 }

--- a/gapis/replay/interfaces.go
+++ b/gapis/replay/interfaces.go
@@ -38,9 +38,7 @@ type Support interface {
 }
 
 // QueryIssues is the interface implemented by types that can verify the replay
-// performs as expected and without errors. The returned chan will receive a
-// stream of issues detected while replaying the capture and the chan will close
-// after the last issue is sent (if any).
+// performs as expected and without errors.
 // If the capture includes FramebufferObservation atoms, this also includes
 // checking the replayed framebuffer matches (within reasonable error) the
 // framebuffer observed at capture time.
@@ -48,8 +46,7 @@ type QueryIssues interface {
 	QueryIssues(
 		ctx context.Context,
 		intent Intent,
-		mgr *Manager,
-		out chan<- Issue)
+		mgr *Manager) ([]Issue, error)
 }
 
 // QueryFramebufferAttachment is the interface implemented by types that can
@@ -63,7 +60,8 @@ type QueryFramebufferAttachment interface {
 		after atom.ID,
 		width, height uint32,
 		attachment gfxapi.FramebufferAttachment,
-		wireframeMode WireframeMode) (*image.Image2D, error)
+		wireframeMode WireframeMode,
+		hints *service.UsageHints) (*image.Image2D, error)
 }
 
 // Issue represents a single replay issue reported by QueryIssues.

--- a/gapis/replay/replay.go
+++ b/gapis/replay/replay.go
@@ -33,7 +33,7 @@ type Generator interface {
 		ctx context.Context,
 		intent Intent,
 		cfg Config,
-		requests []Request,
+		requests []RequestAndResult,
 		device *device.Instance,
 		capture *capture.Capture,
 		out transform.Writer) error
@@ -59,3 +59,13 @@ type Config interface{}
 // to insert a postback of the currently bound render-target content at a
 // specific atom.
 type Request interface{}
+
+// Result is the function called for the result of a request.
+// One of val and err must be nil.
+type Result func(val interface{}, err error)
+
+// RequestAndResult is a pair of Request and Result.
+type RequestAndResult struct {
+	Request Request
+	Result  Result
+}

--- a/gapis/replay/scheduler/CMakeFiles.cmake
+++ b/gapis/replay/scheduler/CMakeFiles.cmake
@@ -18,23 +18,9 @@
 # build and the file will be recreated, check in the new version.
 
 set(files
-    batcher.go
-    context.go
-    custom.go
-    doc.go
-    events.go
-    interfaces.go
-    manager.go
-    replay.go
-    replay.pb.go
-    replay.proto
+    scheduler.go
+    scheduler_test.go
 )
 set(dirs
-    asm
-    builder
-    executor
-    opcode
-    protocol
-    scheduler
-    value
+    
 )

--- a/gapis/replay/scheduler/scheduler.go
+++ b/gapis/replay/scheduler/scheduler.go
@@ -1,0 +1,248 @@
+// Copyright (C) 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package scheduler
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/google/gapid/core/event/task"
+)
+
+// Executor is the executor of Executables.
+// The executor can only work on one list of Executables at a time.
+type Executor func(context.Context, []Executable, Batch)
+
+// Executable holds a task and it's result.
+type Executable struct {
+	Task      Task        // The work to be done.
+	Cancelled task.Signal // Has this work been cancelled?
+	Result    Result      // The result callback.
+}
+
+// Result is the result of an executed Task.
+type Result func(val interface{}, err error)
+
+// Task represents a single unit or work.
+type Task interface{}
+
+// Batch describes the batching rules for a scheduled Task.
+type Batch struct {
+	// Precondition that needs to be satisfied before this batch will be
+	// executed.
+	// Can be a Time or Duration to indicate a time delay for batching.
+	// Can be a chan that is satisfied when closed.
+	// Can be nil for no precondition.
+	Precondition interface{}
+
+	// Key is used to batch together Tasks with the same key.
+	Key interface{}
+
+	// Priority is used to prioritize batches.
+	// The larger numbers represent higher priorities.
+	Priority int
+}
+
+// Scheduler schedules Tasks to Executors, batching where possible.
+type Scheduler struct {
+	pending  chan *job
+	exec     Executor
+	queueLen uint32
+}
+
+// New returns a new Scheduler that will execute Tasks with exec.
+func New(ctx context.Context, exec Executor) *Scheduler {
+	s := &Scheduler{exec: exec, pending: make(chan *job, 32)}
+	go s.run(ctx)
+	return s
+}
+
+// NumTasksQueued returns the number of queued tasks.
+func (s *Scheduler) NumTasksQueued() int { return int(s.queueLen) }
+
+// Schedule schedules task to be executed on exec.
+func (s *Scheduler) Schedule(ctx context.Context, t Task, b Batch) (val interface{}, err error) {
+	type res struct {
+		val interface{}
+		err error
+	}
+
+	out := make(chan res, 1)
+	c := task.ShouldStop(ctx)
+	r := func(val interface{}, err error) { out <- res{val, err} }
+
+	select {
+	case s.pending <- &job{executable: Executable{t, c, r}, batch: b}:
+	case <-c: // cancelled
+		return nil, task.StopReason(ctx)
+	}
+
+	select {
+	case r := <-out:
+		return r.val, r.err
+	case <-c: // cancelled
+		return nil, task.StopReason(ctx)
+	}
+}
+
+func (s *Scheduler) run(ctx context.Context) {
+	bins := map[Batch]*bin{}
+
+	const (
+		caseShouldStop = iota
+		casePending
+		casePreconditions
+	)
+
+	interrupts := make([]reflect.SelectCase, casePreconditions, 100)
+	interrupts[caseShouldStop] = reflect.SelectCase{
+		Dir:  reflect.SelectRecv,
+		Chan: reflect.ValueOf(task.ShouldStop(ctx)),
+	}
+	interrupts[casePending] = reflect.SelectCase{
+		Dir:  reflect.SelectRecv,
+		Chan: reflect.ValueOf(s.pending),
+	}
+
+	addJob := func(j *job) {
+		if b, ok := bins[j.batch]; ok {
+			b.jobs = append(b.jobs, j)
+		} else {
+			interrupt := reflect.SelectCase{
+				Dir:  reflect.SelectRecv,
+				Chan: preconditionChan(j.batch.Precondition),
+			}
+			bins[j.batch] = &bin{
+				batch:     j.batch,
+				jobs:      []*job{j},
+				interrupt: interrupt,
+			}
+			interrupts = append(interrupts, interrupt)
+		}
+		atomic.AddUint32(&s.queueLen, 1)
+	}
+
+	for !task.Stopped(ctx) {
+		i, v, ok := reflect.Select(interrupts)
+		switch i {
+		case caseShouldStop: // <-task.ShouldStop(ctx)
+			return
+		case casePending: // j := <-s.pending:
+			j := v.Interface().(*job)
+			// TODO: Check whether the task was already scheduled.
+			// If so, adjust priorites to the min, execute once and broadcast
+			// results.
+			addJob(j)
+		default: // precondition
+			if ok {
+				// Received a value on the chan instead of a the chan being closed.
+				// Once passed, the must always pass.
+				for _, b := range bins {
+					if b.interrupt == interrupts[i] {
+						b.interrupt.Chan = reflect.ValueOf(task.FiredSignal)
+					}
+				}
+			}
+			// Collect any remaining pending jobs
+			s.collect(addJob)
+			// Find the highest priority bin to execute.
+			var best *bin
+			for _, b := range bins {
+				if b.isReady() {
+					if best == nil || best.batch.Priority < b.batch.Priority {
+						best = b
+					}
+				}
+			}
+			// Execute the batch.
+			best.exec(ctx, s.exec)
+			// Drop the batch.
+			delete(bins, best.batch)
+			atomic.AddUint32(&s.queueLen, -uint32(len(best.jobs)))
+			// Rebuild interrupts.
+			interrupts = interrupts[:casePreconditions]
+			for _, b := range bins {
+				interrupts = append(interrupts, b.interrupt)
+			}
+		}
+	}
+}
+
+func (s *Scheduler) collect(f func(j *job)) {
+	for {
+		select {
+		case j := <-s.pending:
+			f(j)
+		default:
+			return
+		}
+	}
+}
+
+func preconditionChan(p interface{}) reflect.Value {
+	switch v := p.(type) {
+	case nil:
+		p = task.FiredSignal
+	case time.Time:
+		p = time.After(v.Sub(time.Now()))
+	case time.Duration:
+		p = time.After(v)
+	}
+	v := reflect.ValueOf(p)
+	if v.Kind() != reflect.Chan {
+		panic(fmt.Errorf("Precondition must be a Time, Duration or chan. Got %T", p))
+	}
+	return v
+}
+
+type bin struct {
+	batch     Batch
+	jobs      []*job
+	interrupt reflect.SelectCase
+}
+
+// isReady returns true if the bin is ready to be executed.
+func (b *bin) isReady() bool {
+	i, _, ok := reflect.Select([]reflect.SelectCase{
+		b.interrupt,
+		reflect.SelectCase{Dir: reflect.SelectDefault},
+	})
+	if ok {
+		// Received a value on the chan instead of a the chan being closed.
+		// Once passed, the must always pass.
+		b.interrupt.Chan = reflect.ValueOf(task.FiredSignal)
+	}
+	return i == 0
+}
+
+func (b *bin) exec(ctx context.Context, exec Executor) {
+	l := make([]Executable, 0, len(b.jobs))
+	for _, j := range b.jobs {
+		if !j.executable.Cancelled.Fired() {
+			l = append(l, j.executable)
+		}
+	}
+	exec(ctx, l, b.batch)
+}
+
+type job struct {
+	mutex      sync.Mutex
+	executable Executable
+	batch      Batch
+}

--- a/gapis/replay/scheduler/scheduler_test.go
+++ b/gapis/replay/scheduler/scheduler_test.go
@@ -1,0 +1,261 @@
+// Copyright (C) 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package scheduler
+
+import (
+	"context"
+	"sort"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/gapid/core/assert"
+	"github.com/google/gapid/core/event/task"
+	"github.com/google/gapid/core/log"
+)
+
+var delay = time.Millisecond * 100
+
+func waitForQueued(s *Scheduler, n int) {
+	for s.NumTasksQueued() != n {
+		time.Sleep(time.Millisecond)
+	}
+}
+
+type testExecutor struct {
+	got [][]int
+	val interface{}
+	err error
+}
+
+func (t *testExecutor) exec(ctx context.Context, l []Executable, b Batch) {
+	tasks := make([]int, len(l))
+	for i, e := range l {
+		tasks[i] = e.Task.(int)
+		e.Result(t.val, t.err)
+	}
+	sort.Ints(tasks)
+	t.got = append(t.got, tasks)
+}
+
+func setup(t *testing.T) (context.Context, *testExecutor, *Scheduler, *sync.WaitGroup) {
+	ctx := log.Testing(t)
+	e := &testExecutor{val: 321}
+	s := New(ctx, e.exec)
+	wg := &sync.WaitGroup{}
+	return ctx, e, s, wg
+}
+
+func TestSingle(t *testing.T) {
+	ctx, e, s, _ := setup(t)
+	val, err := s.Schedule(ctx, 123, Batch{})
+	assert.To(t).For("val").That(val).Equals(321)
+	assert.To(t).For("err").ThatError(err).Succeeded()
+	assert.To(t).For("got").ThatSlice(e.got).DeepEquals([][]int{[]int{123}})
+}
+
+func TestManyBatchedWithDuration(t *testing.T) {
+	ctx, e, s, wg := setup(t)
+	for i := 0; i < 5; i++ {
+		wg.Add(1)
+		go func(i int) {
+			val, err := s.Schedule(ctx, i, Batch{Precondition: delay})
+			assert.To(t).For("val %v", i).That(val).Equals(321)
+			assert.To(t).For("err %v", i).ThatError(err).Succeeded()
+			wg.Done()
+		}(i)
+	}
+	waitForQueued(s, 5)
+	wg.Wait()
+	assert.To(t).For("got").ThatSlice(e.got).DeepEquals([][]int{[]int{0, 1, 2, 3, 4}})
+}
+
+func TestManyBatchedWithTime(t *testing.T) {
+	ctx, e, s, wg := setup(t)
+	precondition := time.Now().Add(delay)
+	for i := 0; i < 5; i++ {
+		wg.Add(1)
+		go func(i int) {
+			val, err := s.Schedule(ctx, i, Batch{Precondition: precondition})
+			assert.To(t).For("val %v", i).That(val).Equals(321)
+			assert.To(t).For("err %v", i).ThatError(err).Succeeded()
+			wg.Done()
+		}(i)
+	}
+	waitForQueued(s, 5)
+	wg.Wait()
+	assert.To(t).For("got").ThatSlice(e.got).DeepEquals([][]int{[]int{0, 1, 2, 3, 4}})
+}
+
+func TestManyBatched(t *testing.T) {
+	ctx, e, s, wg := setup(t)
+	precondition, fence := task.NewSignal()
+	for i := 0; i < 5; i++ {
+		wg.Add(1)
+		go func(i int) {
+			val, err := s.Schedule(ctx, i, Batch{Precondition: precondition})
+			assert.To(t).For("val %v", i).That(val).Equals(321)
+			assert.To(t).For("err %v", i).ThatError(err).Succeeded()
+			wg.Done()
+		}(i)
+	}
+	waitForQueued(s, 5)
+	fence(ctx)
+	wg.Wait()
+	assert.To(t).For("got").ThatSlice(e.got).DeepEquals([][]int{[]int{0, 1, 2, 3, 4}})
+}
+
+func TestManySeparateKeys(t *testing.T) {
+	ctx, e, s, wg := setup(t)
+	precondition, fence := task.NewSignal()
+	for i := 0; i < 5; i++ {
+		wg.Add(1)
+		go func(i int) {
+			val, err := s.Schedule(ctx, i, Batch{Precondition: precondition, Key: i})
+			assert.To(t).For("val %v", i).That(val).Equals(321)
+			assert.To(t).For("err %v", i).ThatError(err).Succeeded()
+			wg.Done()
+		}(i)
+	}
+	waitForQueued(s, 5)
+	fence(ctx)
+	wg.Wait()
+	assert.To(t).For("got").ThatSlice(e.got).IsLength(5)
+}
+
+func TestManySeparatePreconditions(t *testing.T) {
+	ctx, e, s, _ := setup(t)
+	preconditionA, fenceA := task.NewSignal()
+	preconditionB, fenceB := task.NewSignal()
+	preconditionC, fenceC := task.NewSignal()
+	wgA, wgB, wgC := sync.WaitGroup{}, sync.WaitGroup{}, sync.WaitGroup{}
+	for i := 0; i < 3; i++ {
+		wgA.Add(1)
+		go func(i int) {
+			val, err := s.Schedule(ctx, 30+i, Batch{Precondition: preconditionA})
+			assert.To(t).For("val %v", i).That(val).Equals(321)
+			assert.To(t).For("err %v", i).ThatError(err).Succeeded()
+			wgA.Done()
+		}(i)
+	}
+	for i := 0; i < 2; i++ {
+		wgC.Add(1)
+		go func(i int) {
+			val, err := s.Schedule(ctx, 20+i, Batch{Precondition: preconditionC})
+			assert.To(t).For("val %v", i).That(val).Equals(321)
+			assert.To(t).For("err %v", i).ThatError(err).Succeeded()
+			wgC.Done()
+		}(i)
+	}
+	for i := 0; i < 1; i++ {
+		wgB.Add(1)
+		go func(i int) {
+			val, err := s.Schedule(ctx, 10+i, Batch{Precondition: preconditionB})
+			assert.To(t).For("val %v", i).That(val).Equals(321)
+			assert.To(t).For("err %v", i).ThatError(err).Succeeded()
+			wgB.Done()
+		}(i)
+	}
+
+	waitForQueued(s, 3+2+1)
+
+	fenceA(ctx)
+	wgA.Wait()
+	assert.To(t).For("got").ThatSlice(e.got).DeepEquals([][]int{
+		[]int{30, 31, 32},
+	})
+
+	fenceB(ctx)
+	wgB.Wait()
+	assert.To(t).For("got").ThatSlice(e.got).DeepEquals([][]int{
+		[]int{30, 31, 32},
+		[]int{10},
+	})
+
+	fenceC(ctx)
+	wgC.Wait()
+	assert.To(t).For("got").ThatSlice(e.got).DeepEquals([][]int{
+		[]int{30, 31, 32},
+		[]int{10},
+		[]int{20, 21},
+	})
+}
+
+func TestManySeparatePriorities(t *testing.T) {
+	ctx, e, s, wg := setup(t)
+	precondition, fence := task.NewSignal()
+	for i := 0; i < 3; i++ {
+		wg.Add(1)
+		go func(i int) {
+			val, err := s.Schedule(ctx, 30+i, Batch{Precondition: precondition, Priority: 3})
+			assert.To(t).For("val %v", i).That(val).Equals(321)
+			assert.To(t).For("err %v", i).ThatError(err).Succeeded()
+			wg.Done()
+		}(i)
+	}
+	for i := 0; i < 1; i++ {
+		wg.Add(1)
+		go func(i int) {
+			val, err := s.Schedule(ctx, 10+i, Batch{Precondition: precondition, Priority: 1})
+			assert.To(t).For("val %v", i).That(val).Equals(321)
+			assert.To(t).For("err %v", i).ThatError(err).Succeeded()
+			wg.Done()
+		}(i)
+	}
+	for i := 0; i < 2; i++ {
+		wg.Add(1)
+		go func(i int) {
+			val, err := s.Schedule(ctx, 20+i, Batch{Precondition: precondition, Priority: 2})
+			assert.To(t).For("val %v", i).That(val).Equals(321)
+			assert.To(t).For("err %v", i).ThatError(err).Succeeded()
+			wg.Done()
+		}(i)
+	}
+	waitForQueued(s, 3+1+2)
+	fence(ctx)
+	wg.Wait()
+	assert.To(t).For("got").ThatSlice(e.got).DeepEquals([][]int{
+		[]int{30, 31, 32},
+		[]int{20, 21},
+		[]int{10},
+	})
+}
+
+func TestCancel(t *testing.T) {
+	ctx, e, s, wg := setup(t)
+	for i := 0; i < 5; i++ {
+		wg.Add(1)
+		go func(i int) {
+			ctx, cancel := task.WithCancel(ctx)
+			if i&1 == 1 {
+				cancel()
+			}
+			val, err := s.Schedule(ctx, i, Batch{})
+			if err == nil {
+				assert.To(t).For("val %v", i).That(val).Equals(321)
+			} else {
+				assert.To(t).For("val %v", i).That(val).Equals(nil)
+			}
+			assert.To(t).For("err %v", i).That(err).Equals(task.StopReason(ctx))
+			wg.Done()
+		}(i)
+	}
+	wg.Wait()
+	sum := 0
+	for _, l := range e.got {
+		sum += len(l)
+	}
+	assert.To(t).For("sum").That(sum).Equals(3)
+}

--- a/gapis/resolve/framebuffer_attachment.go
+++ b/gapis/resolve/framebuffer_attachment.go
@@ -35,12 +35,14 @@ func FramebufferAttachment(
 	after *path.Command,
 	attachment gfxapi.FramebufferAttachment,
 	settings *service.RenderSettings,
+	hints *service.UsageHints,
 ) (*path.ImageInfo, error) {
 	id, err := database.Store(ctx, &FramebufferAttachmentResolvable{
 		device,
 		after,
 		attachment,
 		settings,
+		hints,
 	})
 	if err != nil {
 		return nil, err
@@ -84,6 +86,7 @@ func (r *FramebufferAttachmentResolvable) Resolve(ctx context.Context) (interfac
 		Height:        height,
 		Attachment:    r.Attachment,
 		WireframeMode: r.Settings.WireframeMode,
+		Hints:         r.Hints,
 	})
 	if err != nil {
 		return nil, err

--- a/gapis/resolve/framebuffer_attachment_data.go
+++ b/gapis/resolve/framebuffer_attachment_data.go
@@ -60,7 +60,17 @@ func (r *FramebufferAttachmentDataResolvable) Resolve(ctx context.Context) (inte
 
 	mgr := replay.GetManager(ctx)
 
-	res, err := query.QueryFramebufferAttachment(ctx, intent, mgr, atom.ID(r.After.Index), r.Width, r.Height, r.Attachment, wireframeMode)
+	res, err := query.QueryFramebufferAttachment(
+		ctx,
+		intent,
+		mgr,
+		atom.ID(r.After.Index),
+		r.Width,
+		r.Height,
+		r.Attachment,
+		wireframeMode,
+		r.Hints,
+	)
 	if err != nil {
 		if _, ok := err.(*service.ErrDataUnavailable); ok {
 			return nil, err

--- a/gapis/resolve/resolvables.proto
+++ b/gapis/resolve/resolvables.proto
@@ -33,6 +33,7 @@ message FramebufferAttachmentResolvable {
 	path.Command after = 2;
 	gfxapi.FramebufferAttachment attachment = 3;
 	service.RenderSettings settings = 4;
+	service.UsageHints hints = 5;
 }
 
 message FramebufferChangesResolvable {
@@ -46,6 +47,7 @@ message FramebufferAttachmentDataResolvable {
 	uint32 height = 4;
 	gfxapi.FramebufferAttachment attachment = 5;
 	service.WireframeMode wireframe_mode = 6;
+	service.UsageHints hints = 7;
 }
 
 // Get resolves the object, value or memory at Path.

--- a/gapis/server/grpc.go
+++ b/gapis/server/grpc.go
@@ -208,7 +208,14 @@ func (s *grpcServer) GetDevicesForReplay(ctx xctx.Context, req *service.GetDevic
 }
 
 func (s *grpcServer) GetFramebufferAttachment(ctx xctx.Context, req *service.GetFramebufferAttachmentRequest) (*service.GetFramebufferAttachmentResponse, error) {
-	image, err := s.handler.GetFramebufferAttachment(s.bindCtx(ctx), req.Device, req.After, req.Attachment, req.Settings)
+	image, err := s.handler.GetFramebufferAttachment(
+		s.bindCtx(ctx),
+		req.Device,
+		req.After,
+		req.Attachment,
+		req.Settings,
+		req.Hints,
+	)
 	if err := service.NewError(err); err != nil {
 		return &service.GetFramebufferAttachmentResponse{Res: &service.GetFramebufferAttachmentResponse_Error{Error: err}}, nil
 	}

--- a/gapis/server/server.go
+++ b/gapis/server/server.go
@@ -216,7 +216,8 @@ func (s *server) GetFramebufferAttachment(
 	device *path.Device,
 	after *path.Command,
 	attachment gfxapi.FramebufferAttachment,
-	settings *service.RenderSettings) (*path.ImageInfo, error) {
+	settings *service.RenderSettings,
+	hints *service.UsageHints) (*path.ImageInfo, error) {
 
 	// TODO: Path validation
 	// if err := device.Validate(); err != nil {
@@ -225,7 +226,7 @@ func (s *server) GetFramebufferAttachment(
 	// if err := after.Validate(); err != nil {
 	// 	return nil, err
 	// }
-	return resolve.FramebufferAttachment(ctx, device, after, attachment, settings)
+	return resolve.FramebufferAttachment(ctx, device, after, attachment, settings, hints)
 }
 
 func (s *server) Get(ctx context.Context, p *path.Any) (interface{}, error) {

--- a/gapis/service/service.go
+++ b/gapis/service/service.go
@@ -83,7 +83,8 @@ type Service interface {
 		device *path.Device,
 		after *path.Command,
 		attachment gfxapi.FramebufferAttachment,
-		settings *RenderSettings) (*path.ImageInfo, error)
+		settings *RenderSettings,
+		hints *UsageHints) (*path.ImageInfo, error)
 
 	// Get resolves and returns the object, value or memory at the path p.
 	Get(ctx context.Context, p *path.Any) (interface{}, error)

--- a/gapis/service/service.proto
+++ b/gapis/service/service.proto
@@ -29,35 +29,35 @@ option java_outer_classname = "Service";
 // WireframeMode is an enumerator of wireframe modes that can be used by
 // RenderSettings.
 enum WireframeMode {
-    // None indicates that nothing should be drawn in wireframe.
-    None = 0;
-    // Overlay indicates that the single draw call should be overlayed
-    // with the wireframe of the mesh.
-    Overlay = 1;
-    // All indicates that all draw calls should be displayed in wireframe.
-    All = 2;
+  // None indicates that nothing should be drawn in wireframe.
+  None = 0;
+  // Overlay indicates that the single draw call should be overlayed
+  // with the wireframe of the mesh.
+  Overlay = 1;
+  // All indicates that all draw calls should be displayed in wireframe.
+  All = 2;
 }
 
 // Severity defines the severity of a logging message.
 // The levels match the ones defined in rfc5424 for syslog.
 // They must be identical to the values in the logging package.
 enum Severity {
-    // EmergencyLevel indicates the system is unusable, no further data should be trusted.
-    EmergencyLevel = 0;
-    // AlertLevel indicates action must be taken immediately.
-    AlertLevel = 1;
-    // CriticalLevel indicates errors severe enough to terminate processing.
-    CriticalLevel = 2;
-    // ErrorLevel indicates non terminal failure conditions that may have an effect on results.
-    ErrorLevel = 3;
-    // WarningLevel indicates issues that might affect performance or compatibility, but could be ignored.
-    WarningLevel = 4;
-    // NoticeLevel indicates normal but significant conditions.
-    NoticeLevel = 5;
-    // InfoLevel indicates minor informational messages that should generally be ignored.
-    InfoLevel = 6;
-    // DebugLevel indicates verbose debug-level messages.
-    DebugLevel = 7;
+  // EmergencyLevel indicates the system is unusable, no further data should be trusted.
+  EmergencyLevel = 0;
+  // AlertLevel indicates action must be taken immediately.
+  AlertLevel = 1;
+  // CriticalLevel indicates errors severe enough to terminate processing.
+  CriticalLevel = 2;
+  // ErrorLevel indicates non terminal failure conditions that may have an effect on results.
+  ErrorLevel = 3;
+  // WarningLevel indicates issues that might affect performance or compatibility, but could be ignored.
+  WarningLevel = 4;
+  // NoticeLevel indicates normal but significant conditions.
+  NoticeLevel = 5;
+  // InfoLevel indicates minor informational messages that should generally be ignored.
+  InfoLevel = 6;
+  // DebugLevel indicates verbose debug-level messages.
+  DebugLevel = 7;
 }
 
 message ServerInfo {
@@ -241,10 +241,11 @@ message GetDevicesForReplayResponse {
 }
 
 message GetFramebufferAttachmentRequest {
-		path.Device device = 1;
-		path.Command after = 2;
-		gfxapi.FramebufferAttachment attachment = 3;
-		RenderSettings settings = 4;
+  path.Device device = 1;
+  path.Command after = 2;
+  gfxapi.FramebufferAttachment attachment = 3;
+  RenderSettings settings = 4;
+  UsageHints hints = 5;
 }
 
 message GetFramebufferAttachmentResponse {
@@ -418,6 +419,21 @@ message MemoryRange {
   uint64 base = 1;
   // The number of bytes that are in the memory range.
   uint64 size = 2;
+}
+
+// UsageHints hints to the server the intended usage of the result of a request.
+// This can be used to improve performance and responsiveness of the RPCs.
+message UsageHints {
+  // Preview indicates that the request has been made for a thumbnail or
+  // low-quality representation of the underlying data. Previews are considered
+  // non-critical and non-urgent; the server may consider scheduling other work
+  // ahead of previews, and possibly delay the processing of the request to
+  // batch together requests.
+  bool preview = 1;
+
+  // Primary indicates that the request has been made for the primary view.
+  // Primary requests are prioritized and are low-latency.
+  bool primary = 2;
 }
 
 // RenderSettings contains settings and flags to be used in replaying and

--- a/test/integration/service/service_test.go
+++ b/test/integration/service/service_test.go
@@ -65,10 +65,11 @@ func startServerAndGetGrpcClient(ctx context.Context, config server.Config) (ser
 
 func setup(t *testing.T) (context.Context, server.Server, func()) {
 	ctx := log.Testing(t)
-	m, r := replay.New(ctx), bind.NewRegistry()
+	r := bind.NewRegistry()
+	ctx = bind.PutRegistry(ctx, r)
+	m := replay.New(ctx)
 	ctx = replay.PutManager(ctx, m)
 	ctx = database.Put(ctx, database.NewInMemory(ctx))
-	ctx = bind.PutRegistry(ctx, r)
 
 	r.AddDevice(ctx, bind.Host(ctx))
 
@@ -202,7 +203,7 @@ func TestGetFramebufferAttachment(t *testing.T) {
 	after := capture.Commands().Index(swapAtomIndex)
 	attachment := gfxapi.FramebufferAttachment_Color0
 	settings := &service.RenderSettings{}
-	got, err := server.GetFramebufferAttachment(ctx, devices[0], after, attachment, settings)
+	got, err := server.GetFramebufferAttachment(ctx, devices[0], after, attachment, settings, nil)
 	assert.With(ctx).ThatError(err).Succeeded()
 	assert.With(ctx).That(got).IsNotNil()
 }


### PR DESCRIPTION
Controls replay priorities and batching delays.
Far better handling for RPC cancellation.
Much cleaner GAPIS replay internals.
GAPIC cancels thumbnail requests as they scroll out of view.
GAPIC no longer batches requests.