### PR TITLE
Reduce log verbosity of gapit video.

### DIFF
--- a/cmd/gapit/sxs_video.go
+++ b/cmd/gapit/sxs_video.go
@@ -107,7 +107,7 @@ func (verb *videoVerb) sxsVideoSource(ctx context.Context, atoms []atom.Atom, ca
 		}(v)
 	}
 	wg.Wait()
-	log.I(ctx, "Frames rendered in %v", time.Since(start))
+	log.D(ctx, "Frames rendered in %v", time.Since(start))
 	for _, v := range videoFrames {
 		if v.renderError != nil {
 			return nil, v.renderError


### PR DESCRIPTION
Many things were logged at error level when they should not be.
(avconv outputs data to stdout and logs to stderr)