### PR TITLE
Resolve all resources for a single frame at a time.

### DIFF
--- a/gapis/gfxapi/gles/resources.go
+++ b/gapis/gfxapi/gles/resources.go
@@ -63,7 +63,7 @@ func (t *Texture) ResourceType() gfxapi.ResourceType {
 }
 
 // ResourceData returns the resource data given the current state.
-func (t *Texture) ResourceData(ctx context.Context, s *gfxapi.State, resources gfxapi.ResourceMap) (interface{}, error) {
+func (t *Texture) ResourceData(ctx context.Context, s *gfxapi.State) (interface{}, error) {
 	ctx = log.Enter(ctx, "Texture.Resource()")
 	switch t.Kind {
 	case GLenum_GL_TEXTURE_2D:
@@ -143,7 +143,7 @@ func (s *Shader) ResourceType() gfxapi.ResourceType {
 }
 
 // ResourceData returns the resource data given the current state.
-func (s *Shader) ResourceData(ctx context.Context, t *gfxapi.State, resources gfxapi.ResourceMap) (interface{}, error) {
+func (s *Shader) ResourceData(ctx context.Context, t *gfxapi.State) (interface{}, error) {
 	ctx = log.Enter(ctx, "Shader.Resource()")
 	var ty gfxapi.ShaderType
 	switch s.ShaderType {
@@ -241,7 +241,7 @@ func (p *Program) ResourceType() gfxapi.ResourceType {
 }
 
 // ResourceData returns the resource data given the current state.
-func (p *Program) ResourceData(ctx context.Context, s *gfxapi.State, resources gfxapi.ResourceMap) (interface{}, error) {
+func (p *Program) ResourceData(ctx context.Context, s *gfxapi.State) (interface{}, error) {
 	ctx = log.Enter(ctx, "Program.Resource()")
 	state := GetState(s)
 	context := state.Contexts.Get(state.CurrentThread)

--- a/gapis/gfxapi/resource.go
+++ b/gapis/gfxapi/resource.go
@@ -40,7 +40,7 @@ type Resource interface {
 	ResourceType() ResourceType
 
 	// ResourceData returns the resource data given the current state.
-	ResourceData(ctx context.Context, s *State, resources ResourceMap) (interface{}, error)
+	ResourceData(ctx context.Context, s *State) (interface{}, error)
 
 	// SetResourceData sets resource data in a new capture.
 	SetResourceData(ctx context.Context, at *path.Command, data interface{}, resources ResourceMap, edits ReplaceCallback) error

--- a/gapis/gfxapi/vulkan/resources.go
+++ b/gapis/gfxapi/vulkan/resources.go
@@ -176,7 +176,7 @@ func setCubemapFace(img *image.Info2D, cubeMap *gfxapi.CubemapLevel, layerIndex 
 }
 
 // ResourceData returns the resource data given the current state.
-func (t *ImageObject) ResourceData(ctx context.Context, s *gfxapi.State, resources gfxapi.ResourceMap) (interface{}, error) {
+func (t *ImageObject) ResourceData(ctx context.Context, s *gfxapi.State) (interface{}, error) {
 	ctx = log.Enter(ctx, "ImageObject.Resource()")
 
 	vkFmt := t.Info.Format
@@ -256,7 +256,7 @@ func (s *ShaderModuleObject) ResourceType() gfxapi.ResourceType {
 }
 
 // ResourceData returns the resource data given the current state.
-func (s *ShaderModuleObject) ResourceData(ctx context.Context, t *gfxapi.State, resources gfxapi.ResourceMap) (interface{}, error) {
+func (s *ShaderModuleObject) ResourceData(ctx context.Context, t *gfxapi.State) (interface{}, error) {
 	ctx = log.Enter(ctx, "Shader.ResourceData()")
 	words := s.Words.Read(ctx, nil, t, nil)
 	source := shadertools.DisassembleSpirvBinary(words)

--- a/gapis/resolve/resolvables.proto
+++ b/gapis/resolve/resolvables.proto
@@ -77,6 +77,10 @@ message ResourceDataResolvable {
 	path.ResourceData path = 1;
 }
 
+message AllResourceDataResolvable {
+	path.Command after = 1;
+}
+
 message ResourceMetaResolvable {
 	path.ID id = 1;
 	path.Command after = 2;


### PR DESCRIPTION
This means for getting texture thumbnails for example,
we run a single replay rather than one replay for each image.