### PR TITLE
Some optimizations for traces with 100s of shaders/textures.

### DIFF
--- a/gapic/src/main/com/google/gapid/util/GeoUtils.java
+++ b/gapic/src/main/com/google/gapid/util/GeoUtils.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.gapid.util;
+
+import org.eclipse.swt.graphics.Point;
+import org.eclipse.swt.graphics.Rectangle;
+
+/**
+ * Utilities for {@link Point points}, {@link Rectangle rectangles}, etc.
+ */
+public class GeoUtils {
+  private GeoUtils() {
+  }
+
+  public static int left(Rectangle r) {
+    return r.x;
+  }
+
+  public static int right(Rectangle r) {
+    return r.x + r.width;
+  }
+
+  public static int top(Rectangle r) {
+    return r.y;
+  }
+
+  public static int bottom(Rectangle r) {
+    return r.y + r.height;
+  }
+
+  public static int horCenter(Rectangle r) {
+    return r.x + r.width / 2;
+  }
+
+  public static int vertCenter(Rectangle r) {
+    return r.y + r.height / 2;
+  }
+
+  public static Point topLeft(Rectangle r) {
+    return new Point(r.x, r.y);
+  }
+
+  public static Point topRight(Rectangle r) {
+    return new Point(r.x + r.width, r.y);
+  }
+
+  public static Point bottomLeft(Rectangle r) {
+    return new Point(r.x, r.y + r.height);
+  }
+
+  public static Point bottomRight(Rectangle r) {
+    return new Point(r.x + r.width, r.y + r.height);
+  }
+}

--- a/gapic/src/main/com/google/gapid/util/Tables.java
+++ b/gapic/src/main/com/google/gapid/util/Tables.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.gapid.util;
+
+import static com.google.gapid.util.GeoUtils.bottom;
+import static java.util.Collections.emptySet;
+
+import com.google.common.collect.Sets;
+
+import org.eclipse.swt.widgets.Table;
+import org.eclipse.swt.widgets.TableItem;
+
+import java.util.Set;
+
+/**
+ * Utilities for dealing with {@link Table Tables} and {@link TableItem TableItems}.
+ */
+public class Tables {
+  private Tables() {
+  }
+
+  /**
+   * @return the {@link TableItem TableItems} that are currently visible in the table.
+   */
+  public static Set<TableItem> getVisibleItems(Table table) {
+    int items = table.getItemCount();
+    if (items == 0) {
+      return emptySet();
+    }
+
+    int tableBottom = bottom(table.getClientArea());
+    Set<TableItem> visible = Sets.newIdentityHashSet();
+    for (int index = table.getTopIndex(); index < items; index++) {
+      TableItem item = table.getItem(index);
+      visible.add(table.getItem(index));
+      if (bottom(item.getBounds()) > tableBottom) {
+        break;
+      }
+    }
+    return visible;
+  }
+}

--- a/gapic/src/main/com/google/gapid/util/Trees.java
+++ b/gapic/src/main/com/google/gapid/util/Trees.java
@@ -15,11 +15,11 @@
  */
 package com.google.gapid.util;
 
+import static com.google.gapid.util.GeoUtils.bottom;
 import static java.util.Collections.emptySet;
 
 import com.google.common.collect.Sets;
 
-import org.eclipse.swt.graphics.Rectangle;
 import org.eclipse.swt.widgets.Tree;
 import org.eclipse.swt.widgets.TreeItem;
 
@@ -43,8 +43,7 @@ public class Trees {
       return (tree.getItemCount() != 0) ? null : emptySet();
     }
 
-    Rectangle bounds = tree.getClientArea();
-    int treeBottom = bounds.y + bounds.height;
+    int treeBottom = bottom(tree.getClientArea());
     Set<TreeItem> visible = Sets.newIdentityHashSet();
     if (!getVisibleItems(top, treeBottom, visible)) {
       do {
@@ -60,8 +59,7 @@ public class Trees {
    */
   private static boolean getVisibleItems(TreeItem item, int treeBottom, Set<TreeItem> visible) {
     visible.add(item);
-    Rectangle bounds = item.getBounds();
-    if (bounds.y + bounds.height > treeBottom) {
+    if (bottom(item.getBounds()) > treeBottom) {
       return true;
     }
 

--- a/gapic/src/main/com/google/gapid/views/AtomTree.java
+++ b/gapic/src/main/com/google/gapid/views/AtomTree.java
@@ -17,6 +17,8 @@ package com.google.gapid.views;
 
 import static com.google.gapid.image.Images.noAlpha;
 import static com.google.gapid.models.Thumbnails.THUMB_SIZE;
+import static com.google.gapid.util.GeoUtils.right;
+import static com.google.gapid.util.GeoUtils.vertCenter;
 import static com.google.gapid.util.Loadable.MessageType.Error;
 import static com.google.gapid.util.Ranges.count;
 import static com.google.gapid.util.Ranges.first;
@@ -264,7 +266,7 @@ public class AtomTree extends Composite implements Tab, Capture.Listener, AtomSt
                   }
                 }
               });
-        }, new Point(bounds.x + bounds.width + 2, bounds.y + bounds.height / 2 - THUMB_SIZE / 2));
+        }, new Point(right(bounds) + 2, vertCenter(bounds) - THUMB_SIZE / 2));
       }
 
       private ListenableFuture<ImageData> loadImage(FilteredGroup group) {

--- a/gapic/src/main/com/google/gapid/views/MemoryView.java
+++ b/gapic/src/main/com/google/gapid/views/MemoryView.java
@@ -15,6 +15,7 @@
  */
 package com.google.gapid.views;
 
+import static com.google.gapid.util.GeoUtils.top;
 import static com.google.gapid.util.Loadable.MessageType.Error;
 import static com.google.gapid.util.Loadable.MessageType.Info;
 import static com.google.gapid.util.Paths.command;
@@ -599,7 +600,7 @@ public class MemoryView extends Composite
 
       gc.setFont(font);
       Rectangle clip = gc.getClipping();
-      BigInteger startY = yOffset.add(BigInteger.valueOf(clip.y));
+      BigInteger startY = yOffset.add(BigInteger.valueOf(top(clip)));
       long startRow = startY.divide(lineHeightBig)
           .max(BigInteger.ZERO).min(BigInteger.valueOf(model.getLineCount() - 1)).longValueExact();
       long endRow = startY.add(BigInteger.valueOf(clip.height + lineHeight - 1))

--- a/gapic/src/main/com/google/gapid/views/ShaderView.java
+++ b/gapic/src/main/com/google/gapid/views/ShaderView.java
@@ -158,7 +158,8 @@ public class ShaderView extends Composite
     panel.addListener(SWT.Selection, e -> getProgramSource((Data)e.data,
         program -> scheduleIfNotDisposed(uniforms, () -> uniforms.setUniforms(program)),
         panel::setSource));
-    addListener(SWT.Dispose, e -> models.settings.shaderSplitterWeights = splitter.getWeights());
+    splitter.addListener(
+        SWT.Dispose, e -> models.settings.shaderSplitterWeights = splitter.getWeights());
     return splitter;
   }
 

--- a/gapic/src/main/com/google/gapid/views/ThumbnailScrubber.java
+++ b/gapic/src/main/com/google/gapid/views/ThumbnailScrubber.java
@@ -17,6 +17,8 @@ package com.google.gapid.views;
 
 import static com.google.gapid.image.Images.noAlpha;
 import static com.google.gapid.models.Thumbnails.THUMB_SIZE;
+import static com.google.gapid.util.GeoUtils.left;
+import static com.google.gapid.util.GeoUtils.right;
 import static com.google.gapid.util.Loadable.MessageType.Error;
 import static com.google.gapid.util.Loadable.MessageType.Info;
 import static com.google.gapid.util.Ranges.commands;
@@ -354,9 +356,9 @@ public class ThumbnailScrubber extends Composite
 
       Rectangle clip = gc.getClipping();
       Point size = (imageSize == null) ? new Point(THUMB_SIZE, THUMB_SIZE) : imageSize;
-      int first = (int)((xOffset.longValueExact() + clip.x) / (size.x + 2 * MARGIN));
+      int first = (int)((xOffset.longValueExact() + left(clip)) / (size.x + 2 * MARGIN));
       int last = Math.min(datas.size(),
-          (int)((xOffset.longValueExact() + clip.x + clip.width + size.x - 1) / size.x));
+          (int)((xOffset.longValueExact() + right(clip) + size.x - 1) / size.x));
       int x = (int)(first * ((long)size.x + 2 * MARGIN) - xOffset.longValueExact());
 
       prepareImages(first, last);

--- a/gapic/src/main/com/google/gapid/views/WelcomeDialog.java
+++ b/gapic/src/main/com/google/gapid/views/WelcomeDialog.java
@@ -15,6 +15,7 @@
  */
 package com.google.gapid.views;
 
+import static com.google.gapid.util.GeoUtils.bottomLeft;
 import static com.google.gapid.views.TracerDialog.showOpenTraceDialog;
 import static com.google.gapid.views.TracerDialog.showTracingDialog;
 import static com.google.gapid.widgets.AboutDialog.showHelp;
@@ -32,8 +33,6 @@ import com.google.gapid.widgets.Widgets;
 import org.eclipse.jface.dialogs.IDialogConstants;
 import org.eclipse.jface.dialogs.TitleAreaDialog;
 import org.eclipse.swt.SWT;
-import org.eclipse.swt.graphics.Point;
-import org.eclipse.swt.graphics.Rectangle;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Button;
@@ -98,8 +97,7 @@ public class WelcomeDialog {
             }
             popup.addListener(SWT.Hide, ev -> scheduleIfNotDisposed(popup, popup::dispose));
 
-            Rectangle rect = ((Link)e.widget).getBounds();
-            popup.setLocation(container.toDisplay(new Point(rect.x, rect.y + rect.height)));
+            popup.setLocation(container.toDisplay(bottomLeft(((Link)e.widget).getBounds())));
             popup.setVisible(true);
           });
         }

--- a/gapic/src/main/com/google/gapid/widgets/LoadableImage.java
+++ b/gapic/src/main/com/google/gapid/widgets/LoadableImage.java
@@ -69,6 +69,7 @@ public class LoadableImage {
     }
     state = State.LOADING;
     listeners.fire().onLoadingStart();
+    loading.scheduleForRedraw(repaintable);
 
     future = futureSupplier.get();
     Rpc.listen(future, new UiErrorCallback<Object, Object, Void>(widget, LOG) {
@@ -178,7 +179,7 @@ public class LoadableImage {
 
   public Image getImage() {
     switch (state) {
-      case NOT_STARTED:
+      case NOT_STARTED: return getLoadingImage();
       case LOADING: loading.scheduleForRedraw(repaintable); return getLoadingImage();
       case LOADED: return image;
       case FAILED: return loading.getErrorImage();

--- a/gapic/src/main/com/google/gapid/widgets/LoadingIndicator.java
+++ b/gapic/src/main/com/google/gapid/widgets/LoadingIndicator.java
@@ -82,7 +82,10 @@ public class LoadingIndicator {
   public void scheduleForRedraw(Repaintable c) {
     synchronized (componentsToRedraw) {
       if (componentsToRedraw.add(c) && componentsToRedraw.size() == 1) {
-        display.timerExec(MS_PER_FRAME, this::redrawAll);
+        display.timerExec(MS_PER_FRAME, () -> {
+          // Don't starve async runnables just for the animation.
+          display.asyncExec(this::redrawAll);
+        });
       }
     }
   }

--- a/gapic/src/main/com/google/gapid/widgets/VisibilityTrackingTableViewer.java
+++ b/gapic/src/main/com/google/gapid/widgets/VisibilityTrackingTableViewer.java
@@ -16,31 +16,31 @@
 package com.google.gapid.widgets;
 
 import com.google.common.collect.Lists;
-import com.google.gapid.util.Trees;
+import com.google.gapid.util.Tables;
 
 import org.eclipse.jface.viewers.IBaseLabelProvider;
 import org.eclipse.jface.viewers.IContentProvider;
-import org.eclipse.jface.viewers.TreeViewer;
-import org.eclipse.swt.widgets.Tree;
-import org.eclipse.swt.widgets.TreeItem;
+import org.eclipse.jface.viewers.TableViewer;
+import org.eclipse.swt.widgets.Table;
+import org.eclipse.swt.widgets.TableItem;
 
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
 /**
- * A {@link TreeViewer} that notifies the bound {@link IContentProvider} and
+ * A {@link TableViewer} that notifies bound {@link IContentProvider} and
  * {@link IBaseLabelProvider} of visibility changes if they also implement
  * the {@link Listener} interface.
  */
-public class VisibilityTrackingTreeViewer extends TreeViewer {
-  private Set<TreeItem> visible = Collections.emptySet();
+public class VisibilityTrackingTableViewer extends TableViewer {
+  private Set<TableItem> visible = Collections.emptySet();
   private Listener[] listeners;
 
-  public VisibilityTrackingTreeViewer(Tree tree) {
-    super(tree);
+  public VisibilityTrackingTableViewer(Table table) {
+    super(table);
     updateListeners();
-    tree.addPaintListener(e -> updateVisibility());
+    table.addPaintListener(e -> updateVisibility());
   }
 
   private void updateVisibility() {
@@ -48,18 +48,19 @@ public class VisibilityTrackingTreeViewer extends TreeViewer {
       return;
     }
 
-    Set<TreeItem> seen = Trees.getVisibleItems(getTree());
+    Set<TableItem> seen = Tables.getVisibleItems(getTable());
     if (seen == null) {
       return; // No reliable data.
     }
-    for (TreeItem item : visible) {
+
+    for (TableItem item : visible) {
       if (!seen.contains(item) && !item.isDisposed()) {
         for (Listener listener : listeners) {
           listener.onHide(item);
         }
       }
     }
-    for (TreeItem item : seen) {
+    for (TableItem item : seen) {
       if (!visible.contains(item)) {
         for (Listener listener : listeners) {
           listener.onShow(item);
@@ -105,18 +106,18 @@ public class VisibilityTrackingTreeViewer extends TreeViewer {
 
   /**
    * The interface the {@link IContentProvider} and {@link IBaseLabelProvider} can
-   * implement to be notified about {@link TreeItem TreeItems} being made visible
+   * implement to be notified about {@link TableItem TableItems} being made visible
    * and hidden usually by scrolling.
    */
   public static interface Listener {
     /**
-     * Called when the {@link TreeItem} is made visible.
+     * Called when the {@link TableItem} is made visible.
      */
-    public void onShow(TreeItem item);
+    public void onShow(TableItem item);
 
     /**
-     * Called when the {@link TreeItem} is made invisible.
+     * Called when the {@link TableItem} is made invisible.
      */
-    public void onHide(TreeItem item);
+    public void onHide(TableItem item);
   }
 }

--- a/gapis/resolve/resource_data.go
+++ b/gapis/resolve/resource_data.go
@@ -74,9 +74,10 @@ func buildResources(ctx context.Context, p *path.Command) (*ResolvedResources, e
 	for k, v := range resources {
 		res, err := v.ResourceData(ctx, state)
 		if err != nil {
-			return nil, fmt.Errorf("Could not get data for resource %v", k)
+			resourceData[k] = err;
+		} else {
+			resourceData[k] = res
 		}
-		resourceData[k] = res
 	}
 	return &ResolvedResources{idMap, resources, resourceData}, nil
 }
@@ -103,6 +104,9 @@ func (r *ResourceDataResolvable) Resolve(ctx context.Context) (interface{}, erro
 	}
 	id := r.Path.Id.ID()
 	if val, ok := res.resourceData[id]; ok {
+		if err, isErr := val.(error); isErr {
+			return nil, err
+		}
 		return val, nil
 	}
 


### PR DESCRIPTION
- Don't starve async scheduled runnables, if repaint is slow
- Only update the shader dropdown if required to do so
- Only load texture thumbnails that are visible
- Batch updates to the texture table