### PR TITLE
Gracefully handle unhandled texture types.

### DIFF
--- a/gapis/gfxapi/gfxapi.proto
+++ b/gapis/gfxapi/gfxapi.proto
@@ -50,6 +50,10 @@ enum ResourceType {
 	ShaderResource = 5;
 	// ProgramResource represents the Program resource type
 	ProgramResource = 6;
+	// UninitializedTextureResource represents texture resource type
+	// which has been generated but was never assigned dimensions.
+	// TODO: Clean up texture handling as per issue #237
+	UninitializedTextureResource = 7;
 }
 
 // FramebufferAttachment values indicate the type of frame buffer attachment.

--- a/gapis/gfxapi/gles/resources.go
+++ b/gapis/gfxapi/gles/resources.go
@@ -51,13 +51,16 @@ func (t *Texture) Order() uint64 {
 }
 
 // ResourceType returns the type of this resource.
-func (t *Texture) ResourceType() gfxapi.ResourceType {
+func (t *Texture) ResourceType(ctx context.Context) gfxapi.ResourceType {
 	switch t.Kind {
+	case GLenum_GL_NONE:
+		return gfxapi.ResourceType_UninitializedTextureResource
 	case GLenum_GL_TEXTURE_2D:
 		return gfxapi.ResourceType_Texture2DResource
 	case GLenum_GL_TEXTURE_CUBE_MAP:
 		return gfxapi.ResourceType_CubemapResource
 	default:
+		log.E(ctx, "Unknown texture resource type: %v", t.Kind)
 		return gfxapi.ResourceType_UnknownResource
 	}
 }
@@ -146,7 +149,7 @@ func (s *Shader) Order() uint64 {
 }
 
 // ResourceType returns the type of this resource.
-func (s *Shader) ResourceType() gfxapi.ResourceType {
+func (s *Shader) ResourceType(ctx context.Context) gfxapi.ResourceType {
 	return gfxapi.ResourceType_ShaderResource
 }
 
@@ -181,7 +184,7 @@ func (shader *Shader) SetResourceData(ctx context.Context, at *path.Command,
 	}
 	resourceID := resourceIDs[shader]
 
-	resource := resources.Find(shader.ResourceType(), resourceID)
+	resource := resources.Find(shader.ResourceType(ctx), resourceID)
 	if resource == nil {
 		return fmt.Errorf("Couldn't find resource")
 	}
@@ -244,7 +247,7 @@ func (p *Program) Order() uint64 {
 }
 
 // ResourceType returns the type of this resource.
-func (p *Program) ResourceType() gfxapi.ResourceType {
+func (p *Program) ResourceType(ctx context.Context) gfxapi.ResourceType {
 	return gfxapi.ResourceType_ProgramResource
 }
 

--- a/gapis/gfxapi/resource.go
+++ b/gapis/gfxapi/resource.go
@@ -37,7 +37,7 @@ type Resource interface {
 	Order() uint64
 
 	// ResourceType returns the type of this resource.
-	ResourceType() ResourceType
+	ResourceType(ctx context.Context) ResourceType
 
 	// ResourceData returns the resource data given the current state.
 	ResourceData(ctx context.Context, s *State) (interface{}, error)

--- a/gapis/gfxapi/vulkan/resources.go
+++ b/gapis/gfxapi/vulkan/resources.go
@@ -60,7 +60,7 @@ func (t *ImageObject) Order() uint64 {
 }
 
 // ResourceType returns the type of this resource.
-func (t *ImageObject) ResourceType() gfxapi.ResourceType {
+func (t *ImageObject) ResourceType(ctx context.Context) gfxapi.ResourceType {
 	if uint32(t.Info.Flags)&uint32(VkImageCreateFlagBits_VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT) != 0 {
 		return gfxapi.ResourceType_CubemapResource
 	} else {
@@ -251,7 +251,7 @@ func (s *ShaderModuleObject) Order() uint64 {
 }
 
 // ResourceType returns the type of this resource.
-func (s *ShaderModuleObject) ResourceType() gfxapi.ResourceType {
+func (s *ShaderModuleObject) ResourceType(ctx context.Context) gfxapi.ResourceType {
 	return gfxapi.ResourceType_ShaderResource
 }
 
@@ -274,7 +274,7 @@ func (shader *ShaderModuleObject) SetResourceData(ctx context.Context, at *path.
 	}
 	resourceID := resourceIDs[shader]
 
-	resource := resources.Find(shader.ResourceType(), resourceID)
+	resource := resources.Find(shader.ResourceType(ctx), resourceID)
 	if resource == nil {
 		return fmt.Errorf("Couldn't find resource")
 	}

--- a/gapis/resolve/resources.go
+++ b/gapis/resolve/resources.go
@@ -81,7 +81,7 @@ func (r *ResourcesResolvable) Resolve(ctx context.Context) (interface{}, error) 
 
 	types := map[gfxapi.ResourceType]*service.ResourcesByType{}
 	for _, r := range resources {
-		ty := r.resource.ResourceType()
+		ty := r.resource.ResourceType(ctx)
 		handle := r.resource.ResourceHandle()
 		label := r.resource.ResourceLabel()
 		order := r.resource.Order()


### PR DESCRIPTION
This ensures that one unhandled texture does not break all previews.