### PR TITLE
Simplify IndexLimits extern

### DIFF
--- a/gapis/gfxapi/gles/api/draw_commands.api
+++ b/gapis/gfxapi/gles/api/draw_commands.api
@@ -106,10 +106,13 @@ sub void DrawElements(ref!Context    ctx,
     if (id != 0) {
       // Element array buffer bound - indices is an offset on the buffer.
       index_data := ctx.Instances.Buffers[id].Data
-      offset := as!u32(as!u64(indices))
+      offset := as!s32(as!u64(indices))
 
       // Read the vertices
-      limits := IndexLimits(as!u8*(index_data), indices_type, offset, count)
+      index_size := IndexSize(indices_type)
+      index_start := min(offset, len(index_data)) // Clamp offset
+      index_end := min(offset+as!s32(index_size*count), len(index_data)) // Clamp count
+      limits := IndexLimits(index_data[index_start:index_end], as!s32(index_size))
       ReadVertexArrays(ctx, limits.first + as!u32(base_vertex), limits.count, as!u32(instance_count))
 
       // No need to read the indices - they're already in a GPU-side buffer.
@@ -118,7 +121,8 @@ sub void DrawElements(ref!Context    ctx,
       index_data := as!u8*(indices)
 
       // Read the vertices
-      limits := IndexLimits(index_data, indices_type, 0, count)
+      index_size := IndexSize(indices_type)
+      limits := IndexLimits(index_data[0:index_size*count], as!s32(index_size))
       ReadVertexArrays(ctx, limits.first + as!u32(base_vertex), limits.count, as!u32(instance_count))
 
       // Read the indices

--- a/gapis/gfxapi/gles/externs.go
+++ b/gapis/gfxapi/gles/externs.go
@@ -67,15 +67,11 @@ func (e externs) GetAndroidNativeBufferExtra(Voidᵖ) *AndroidNativeBufferExtra 
 	return FindAndroidNativeBufferExtra(e.a.Extras())
 }
 
-func (e externs) elSize(ty GLenum) uint64 {
-	return uint64(DataTypeSize(ty))
-}
-
-func (e externs) calcIndexLimits(data U8ᵖ, ty GLenum, offset, count uint32) resolve.IndexRange {
-	elSize := e.elSize(ty)
-	id := data.Slice(uint64(offset), uint64(offset)+uint64(count)*elSize, e.s).ResourceID(e.ctx, e.s)
+func (e externs) calcIndexLimits(data U8ˢ, indexSize int) resolve.IndexRange {
+	id := data.ResourceID(e.ctx, e.s)
+	count := int(data.Count) / int(indexSize)
 	littleEndian := e.s.MemoryLayout.GetEndian() == device.LittleEndian
-	limits, err := resolve.IndexLimits(e.ctx, id, int(count), int(elSize), littleEndian)
+	limits, err := resolve.IndexLimits(e.ctx, id, count, indexSize, littleEndian)
 	if err != nil {
 		if errors.Cause(err) == context.Canceled {
 			// TODO: Propagate error
@@ -87,8 +83,8 @@ func (e externs) calcIndexLimits(data U8ᵖ, ty GLenum, offset, count uint32) re
 	return *limits
 }
 
-func (e externs) IndexLimits(data U8ᵖ, ty GLenum, offset, count uint32) u32Limits {
-	limits := e.calcIndexLimits(data, ty, offset, count)
+func (e externs) IndexLimits(data U8ˢ, indexSize int32) u32Limits {
+	limits := e.calcIndexLimits(data, int(indexSize))
 	return u32Limits{First: limits.First, Count: limits.Count}
 }
 

--- a/gapis/gfxapi/gles/gles.api
+++ b/gapis/gfxapi/gles/gles.api
@@ -676,7 +676,7 @@ sub u32 IndexSize(GLenum indices_type) {
 }
 
 @internal class u32Limits { u32 first u32 count }
-extern u32Limits IndexLimits(u8* indices, GLenum indices_type, u32 offset, u32 count)
+extern u32Limits IndexLimits(u8[] indices, s32 sizeof_index)
 
 /////////////////////////////////////////////////////////////////
 // Desktop GL


### PR DESCRIPTION
Make the IndexLimits extern simpler and safer by passing slice.
This ensures we do not do out-of-bounds indexing inside it.