### PR TITLE
If Vulkan is requested but not available, don't create a valid renderer.

### DIFF
--- a/gapir/cc/android/vulkan_renderer.cpp
+++ b/gapir/cc/android/vulkan_renderer.cpp
@@ -27,6 +27,7 @@ public:
 
     virtual Api* api() override;
 
+    virtual bool isValid() override;
 private:
     Vulkan mApi;
 };
@@ -40,6 +41,10 @@ VulkanRendererImpl::~VulkanRendererImpl() {
 
 Api* VulkanRendererImpl::api() {
   return &mApi;
+}
+
+bool VulkanRendererImpl::isValid() {
+ return mApi.mFunctionStubs.vkCreateInstance != nullptr;
 }
 
 } // anonymous namespace

--- a/gapir/cc/context.cpp
+++ b/gapir/cc/context.cpp
@@ -105,10 +105,12 @@ bool Context::interpret() {
             if (api_index == gapir::Vulkan::INDEX) {
                 // There is only one vulkan "renderer" so we create it when requested.
                 mBoundVulkanRenderer = VulkanRenderer::create();
-                Api* api = mBoundVulkanRenderer->api();
-                interpreter->setRendererFunctions(api->index(), &api->mFunctions);
-                GAPID_INFO("Bound Vulkan renderer");
-                return true;
+                if (mBoundVulkanRenderer->isValid()) {
+                    Api* api = mBoundVulkanRenderer->api();
+                    interpreter->setRendererFunctions(api->index(), &api->mFunctions);
+                    GAPID_INFO("Bound Vulkan renderer");
+                    return true;
+                }
             }
             return false;
         };

--- a/gapir/cc/gles_renderer.h
+++ b/gapir/cc/gles_renderer.h
@@ -68,6 +68,8 @@ public:
 
     // Returns the version of the renderer's graphics context.
     virtual const char* version() = 0;
+
+    virtual bool isValid() { return true; }
 };
 
 inline GlesRenderer::Backbuffer::Format::Format()

--- a/gapir/cc/linux/vulkan_renderer.cpp
+++ b/gapir/cc/linux/vulkan_renderer.cpp
@@ -27,6 +27,7 @@ public:
 
     virtual Api* api() override;
 
+    virtual bool isValid() override;
 private:
     Vulkan mApi;
 };
@@ -42,10 +43,15 @@ Api* VulkanRendererImpl::api() {
   return &mApi;
 }
 
+bool VulkanRendererImpl::isValid() {
+ return mApi.mFunctionStubs.vkCreateInstance != nullptr;
+}
+
 } // anonymous namespace
 
 VulkanRenderer* VulkanRenderer::create() {
     return new VulkanRendererImpl();
 }
+
 
 }  // namespace gapir

--- a/gapir/cc/osx/vulkan_renderer.mm
+++ b/gapir/cc/osx/vulkan_renderer.mm
@@ -27,6 +27,7 @@ public:
 
     virtual Api* api() override;
 
+    virtual bool isValid() override;
 private:
     Vulkan mApi;
 };
@@ -41,10 +42,15 @@ Api* VulkanRendererImpl::api() {
   return &mApi;
 }
 
+bool VulkanRendererImpl::isValid() {
+ return mApi.mFunctionStubs.vkCreateInstance != nullptr;
+}
+
 } // anonymous namespace
 
 VulkanRenderer* VulkanRenderer::create() {
     return new VulkanRendererImpl();
 }
+
 
 }  // namespace gapir

--- a/gapir/cc/renderer.h
+++ b/gapir/cc/renderer.h
@@ -32,6 +32,8 @@ public:
     virtual Api* api() = 0;
 
     template <typename T> inline T* getApi();
+
+    virtual bool isValid() = 0;
 };
 
 template <typename T>

--- a/gapir/cc/vulkan_renderer.h
+++ b/gapir/cc/vulkan_renderer.h
@@ -30,6 +30,9 @@ public:
 
     // Returns the renderer's API.
     virtual Api* api() = 0;
+
+    // Return true if this is a valid api for this system.
+    virtual bool isValid() = 0;
 };
 
 }  // namespace gapir

--- a/gapir/cc/windows/vulkan_renderer.cpp
+++ b/gapir/cc/windows/vulkan_renderer.cpp
@@ -27,6 +27,7 @@ public:
 
     virtual Api* api() override;
 
+    virtual bool isValid() override;
 private:
     Vulkan mApi;
 };
@@ -40,6 +41,10 @@ VulkanRendererImpl::~VulkanRendererImpl() {
 
 Api* VulkanRendererImpl::api() {
   return &mApi;
+}
+
+bool VulkanRendererImpl::isValid() {
+ return mApi.mFunctionStubs.vkCreateInstance != nullptr;
 }
 
 } // anonymous namespace


### PR DESCRIPTION
This will output an error message instead of failing mysteriously
on the first call.