### PR TITLE
Move device.Host to its own package.

### DIFF
--- a/cmd/gapis/main.go
+++ b/cmd/gapis/main.go
@@ -25,8 +25,8 @@ import (
 	"github.com/google/gapid/core/event/task"
 	"github.com/google/gapid/core/log"
 	"github.com/google/gapid/core/os/android/adb"
-	"github.com/google/gapid/core/os/device"
 	"github.com/google/gapid/core/os/device/bind"
+	"github.com/google/gapid/core/os/device/host"
 	"github.com/google/gapid/gapis/database"
 	"github.com/google/gapid/gapis/replay"
 	"github.com/google/gapid/gapis/server"
@@ -81,7 +81,7 @@ func run(ctx context.Context) error {
 
 	return server.Listen(ctx, *rpc, server.Config{
 		Info: &service.ServerInfo{
-			Name:         device.Host(ctx).Name,
+			Name:         host.Instance(ctx).Name,
 			VersionMajor: uint32(version.Major),
 			VersionMinor: uint32(version.Minor),
 			Features:     features,

--- a/cmd/robot/build.go
+++ b/cmd/robot/build.go
@@ -27,7 +27,7 @@ import (
 	"github.com/google/gapid/core/git"
 	"github.com/google/gapid/core/log"
 	"github.com/google/gapid/core/net/grpcutil"
-	"github.com/google/gapid/core/os/device"
+	"github.com/google/gapid/core/os/device/host"
 	"github.com/google/gapid/test/robot/build"
 	"google.golang.org/grpc"
 )
@@ -141,7 +141,7 @@ func (u *buildUploader) prepare(ctx context.Context, conn *grpc.ClientConn) erro
 	}
 	log.I(ctx, "Dectected build type %s", typ)
 	u.store = build.NewRemote(ctx, conn)
-	host := device.Host(ctx)
+	host := host.Instance(ctx)
 	u.info = &build.Information{
 		Type:        typ,
 		Branch:      buildFlags.branch,

--- a/core/app/layout/layout.go
+++ b/core/app/layout/layout.go
@@ -20,6 +20,7 @@ import (
 	"github.com/google/gapid/core/fault"
 	"github.com/google/gapid/core/log"
 	"github.com/google/gapid/core/os/device"
+	"github.com/google/gapid/core/os/device/host"
 	"github.com/google/gapid/core/os/file"
 )
 
@@ -74,15 +75,15 @@ func (l pkgLayout) Strings(ctx context.Context) (file.Path, error) {
 }
 
 func (l pkgLayout) Gapit(ctx context.Context) (file.Path, error) {
-	return l.File(ctx, device.Host(ctx).Configuration.ABIs[0], "gapit")
+	return l.File(ctx, host.Instance(ctx).Configuration.ABIs[0], "gapit")
 }
 
 func (l pkgLayout) Gapir(ctx context.Context) (file.Path, error) {
-	return l.File(ctx, device.Host(ctx).Configuration.ABIs[0], "gapir")
+	return l.File(ctx, host.Instance(ctx).Configuration.ABIs[0], "gapir")
 }
 
 func (l pkgLayout) Gapis(ctx context.Context) (file.Path, error) {
-	return l.File(ctx, device.Host(ctx).Configuration.ABIs[0], "gapis")
+	return l.File(ctx, host.Instance(ctx).Configuration.ABIs[0], "gapis")
 }
 
 func (l pkgLayout) GapidApk(ctx context.Context, abi *device.ABI) (file.Path, error) {
@@ -111,7 +112,7 @@ func abiDirectory(ctx context.Context, abi *device.ABI) (string, error) {
 }
 
 func (l binLayout) File(ctx context.Context, abi *device.ABI, name string) (file.Path, error) {
-	if abi.OS == device.Host(ctx).Configuration.OS.Kind {
+	if abi.OS == host.Instance(ctx).Configuration.OS.Kind {
 		return l.root.Join(name), nil
 	}
 	dir, err := abiDirectory(ctx, abi)

--- a/core/os/device/CMakeFiles.cmake
+++ b/core/os/device/CMakeFiles.cmake
@@ -33,12 +33,6 @@ set(files
     gpu.go
     gpu_test.go
     hardware.go
-    host.go
-    host_c.go
-    host_darwin.go
-    host_linux.go
-    host_test.go
-    host_windows.go
     id.go
     instance.go
     instance_test.go
@@ -51,4 +45,5 @@ set(files
 set(dirs
     bind
     deviceinfo
+    host
 )

--- a/core/os/device/bind/bind.go
+++ b/core/os/device/bind/bind.go
@@ -18,22 +18,22 @@ import (
 	"context"
 	"sync"
 
-	"github.com/google/gapid/core/os/device"
+	"github.com/google/gapid/core/os/device/host"
 )
 
 var (
 	hostMutex sync.Mutex
-	host      Device
+	hostDev   Device
 )
 
 // Host returns the Device to the host.
 func Host(ctx context.Context) Device {
 	hostMutex.Lock()
 	defer hostMutex.Unlock()
-	if host == nil {
-		host = &Simple{
-			To: device.Host(ctx),
+	if hostDev == nil {
+		hostDev = &Simple{
+			To: host.Instance(ctx),
 		}
 	}
-	return host
+	return hostDev
 }

--- a/core/os/device/deviceinfo/cc/CMakeBuild.cmake
+++ b/core/os/device/deviceinfo/cc/CMakeBuild.cmake
@@ -50,7 +50,6 @@ if(NOT DISABLED_CXX)
     endif()
 
     target_include_directories(deviceinfo PUBLIC "${PROTO_CC_OUT}")
-    target_include_directories(deviceinfo PUBLIC "${PROTO_CC_OUT}/github.com/google/gapid")
     target_include_directories(deviceinfo PUBLIC "${CMAKE_SOURCE_DIR}/external/protobuf/src")
 
     find_package(GL REQUIRED)

--- a/core/os/device/host/CMakeBuild.cmake
+++ b/core/os/device/host/CMakeBuild.cmake
@@ -12,5 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-build_subdirectory(deviceinfo)
-build_subdirectory(host)
+cgo_dependency(deviceinfo)

--- a/core/os/device/host/CMakeFiles.cmake
+++ b/core/os/device/host/CMakeFiles.cmake
@@ -12,5 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-build_subdirectory(deviceinfo)
-build_subdirectory(host)
+# Generated globbing source file
+# This file will be automatically regenerated if deleted, do not edit by hand.
+# If you add a new file to the directory, just delete this file, run any cmake
+# build and the file will be recreated, check in the new version.
+
+set(files
+    host.go
+    host_c.go
+    host_darwin.go
+    host_linux.go
+    host_test.go
+    host_windows.go
+)
+set(dirs
+)

--- a/core/os/device/host/host.go
+++ b/core/os/device/host/host.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package device
+package host
 
 import (
 	"context"
@@ -20,15 +20,17 @@ import (
 	"sync"
 
 	"github.com/golang/protobuf/proto"
+	"github.com/google/gapid/core/os/device"
 )
 
 var (
-	host     Instance
+	host     device.Instance
 	hostOnce sync.Once
 )
 
-// Host returns the device information for the host computer running the code.
-func Host(ctx context.Context) *Instance {
+// Instance returns the device information for the host computer running the
+// code.
+func Instance(ctx context.Context) *device.Instance {
 	hostOnce.Do(func() {
 		buf, err := getHostDevice()
 		if err != nil {

--- a/core/os/device/host/host_c.go
+++ b/core/os/device/host/host_c.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package device
+package host
 
 // #cgo LDFLAGS: -ldeviceinfo -lprotobuf -lprotobuf_lite -lstdc++ -lpthread -lm -lcityhash
 // #include "core/os/device/deviceinfo/cc/instance.h"

--- a/core/os/device/host/host_darwin.go
+++ b/core/os/device/host/host_darwin.go
@@ -14,7 +14,7 @@
 
 // +build darwin
 
-package device
+package host
 
 // #cgo LDFLAGS: -framework Cocoa -framework OpenGL
 import "C"

--- a/core/os/device/host/host_linux.go
+++ b/core/os/device/host/host_linux.go
@@ -14,7 +14,7 @@
 
 // +build linux
 
-package device
+package host
 
 // #cgo LDFLAGS: -lGL -lX11
 import "C"

--- a/core/os/device/host/host_test.go
+++ b/core/os/device/host/host_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package device_test
+package host_test
 
 import (
 	"sync"
@@ -22,21 +22,22 @@ import (
 	"github.com/google/gapid/core/data/id"
 	"github.com/google/gapid/core/log"
 	"github.com/google/gapid/core/os/device"
+	"github.com/google/gapid/core/os/device/host"
 )
 
 func TestHost(t *testing.T) {
 	ctx := log.Testing(t)
-	host := device.Host(ctx)
+	h := host.Instance(ctx)
 	assert.For(ctx, "Host.ID").
-		That(host.Id.ID()).NotEquals(id.ID{})
+		That(h.Id.ID()).NotEquals(id.ID{})
 	assert.For(ctx, "Host.Name").
-		That(host.Name).NotEquals("")
+		That(h.Name).NotEquals("")
 	assert.For(ctx, "Host.Configuration.OS.Kind").
-		That(host.Configuration.OS.Kind).NotEquals(device.UnknownOS)
+		That(h.Configuration.OS.Kind).NotEquals(device.UnknownOS)
 	assert.For(ctx, "Host.Configuration.Hardware.CPU").
-		ThatString(host.Configuration.Hardware.CPU.Name).NotEquals("")
+		ThatString(h.Configuration.Hardware.CPU.Name).NotEquals("")
 	assert.For(ctx, "Host.Configuration.Hardware.GPU").
-		ThatString(host.Configuration.Hardware.GPU.Name).NotEquals("")
+		ThatString(h.Configuration.Hardware.GPU.Name).NotEquals("")
 }
 
 func TestHostConcurrent(t *testing.T) {
@@ -47,7 +48,7 @@ func TestHostConcurrent(t *testing.T) {
 		i := i
 		wg.Add(1)
 		go func() {
-			hosts[i] = device.Host(ctx)
+			hosts[i] = host.Instance(ctx)
 			wg.Done()
 		}()
 	}

--- a/core/os/device/host/host_windows.go
+++ b/core/os/device/host/host_windows.go
@@ -14,7 +14,7 @@
 
 // +build windows
 
-package device
+package host
 
 // #cgo LDFLAGS: -lopengl32 -lgdi32
 import "C"

--- a/core/os/device/instance_test.go
+++ b/core/os/device/instance_test.go
@@ -20,11 +20,12 @@ import (
 	"github.com/google/gapid/core/assert"
 	"github.com/google/gapid/core/log"
 	"github.com/google/gapid/core/os/device"
+	"github.com/google/gapid/core/os/device/host"
 )
 
 func TestSamePhysicalDevice(t *testing.T) {
 	ctx := log.Testing(t)
-	a := device.Host(ctx)
+	a := host.Instance(ctx)
 	var b *device.Instance
 	c := a
 	log.I(ctx, "%#+v %#+v", a, b)

--- a/gapir/client/session.go
+++ b/gapir/client/session.go
@@ -28,6 +28,7 @@ import (
 	"github.com/google/gapid/core/os/android/adb"
 	"github.com/google/gapid/core/os/device"
 	"github.com/google/gapid/core/os/device/bind"
+	"github.com/google/gapid/core/os/device/host"
 	"github.com/google/gapid/core/os/file"
 	"github.com/google/gapid/core/os/process"
 	"github.com/google/gapid/core/os/shell"
@@ -66,7 +67,7 @@ func (s *session) init(ctx context.Context, d bind.Device, abi *device.ABI) erro
 	defer close(s.inited)
 
 	var err error
-	if device.Host(ctx).SameAs(d.Instance()) {
+	if host.Instance(ctx).SameAs(d.Instance()) {
 		err = s.newHost(ctx, d)
 	} else if d, ok := d.(adb.Device); ok {
 		err = s.newADB(ctx, d, abi)

--- a/gapis/client/process.go
+++ b/gapis/client/process.go
@@ -22,6 +22,7 @@ import (
 	"github.com/google/gapid/core/log"
 	"github.com/google/gapid/core/net/grpcutil"
 	"github.com/google/gapid/core/os/device"
+	"github.com/google/gapid/core/os/device/host"
 	"github.com/google/gapid/core/os/file"
 	"github.com/google/gapid/core/os/process"
 	"github.com/google/gapid/framework/binary/registry"
@@ -46,7 +47,7 @@ func init() {
 	}
 	// Search standard package structure
 	packagePath := file.Abs(".")
-	switch device.Host(context.Background()).Configuration.OS.Kind {
+	switch host.Instance(context.Background()).Configuration.OS.Kind {
 	case device.Windows:
 		packagePath = packagePath.Join("windows")
 	case device.OSX:

--- a/test/robot/replay/client.go
+++ b/test/robot/replay/client.go
@@ -21,7 +21,7 @@ import (
 	"github.com/google/gapid/core/app/layout"
 	"github.com/google/gapid/core/data/stash"
 	"github.com/google/gapid/core/log"
-	"github.com/google/gapid/core/os/device"
+	"github.com/google/gapid/core/os/device/host"
 	"github.com/google/gapid/core/os/file"
 	"github.com/google/gapid/core/os/shell"
 	"github.com/google/gapid/test/robot/job"
@@ -36,7 +36,7 @@ type client struct {
 // Run starts new replay client if any hardware is available.
 func Run(ctx context.Context, store *stash.Client, manager Manager, tempDir file.Path) error {
 	c := &client{store: store, manager: manager, tempDir: tempDir}
-	host := device.Host(ctx)
+	host := host.Instance(ctx)
 	return manager.Register(ctx, host, host, c.replay)
 }
 

--- a/test/robot/report/client.go
+++ b/test/robot/report/client.go
@@ -21,7 +21,7 @@ import (
 	"github.com/google/gapid/core/app/layout"
 	"github.com/google/gapid/core/data/stash"
 	"github.com/google/gapid/core/log"
-	"github.com/google/gapid/core/os/device"
+	"github.com/google/gapid/core/os/device/host"
 	"github.com/google/gapid/core/os/file"
 	"github.com/google/gapid/core/os/shell"
 	"github.com/google/gapid/test/robot/job"
@@ -36,7 +36,7 @@ type client struct {
 // Run starts new report client if any hardware is available.
 func Run(ctx context.Context, store *stash.Client, manager Manager, tempDir file.Path) error {
 	c := &client{store: store, manager: manager, tempDir: tempDir}
-	host := device.Host(ctx)
+	host := host.Instance(ctx)
 	return manager.Register(ctx, host, host, c.report)
 }
 

--- a/test/robot/trace/client.go
+++ b/test/robot/trace/client.go
@@ -25,8 +25,8 @@ import (
 	"github.com/google/gapid/core/data/stash"
 	"github.com/google/gapid/core/log"
 	"github.com/google/gapid/core/os/android/adb"
-	"github.com/google/gapid/core/os/device"
 	"github.com/google/gapid/core/os/device/bind"
+	"github.com/google/gapid/core/os/device/host"
 	"github.com/google/gapid/core/os/file"
 	"github.com/google/gapid/core/os/shell"
 	"github.com/google/gapid/test/robot/job"
@@ -64,7 +64,7 @@ func (c *client) getRunner(d bind.Device) (r *runner, existing bool) {
 
 // TODO: not assume all android devices are valid trace targets
 func (c *client) OnDeviceAdded(ctx context.Context, d bind.Device) {
-	host := device.Host(ctx)
+	host := host.Instance(ctx)
 	inst := d.Instance()
 
 	r, existing := c.getRunner(d)


### PR DESCRIPTION
Getting the host info involves cgo magic which is heavyweight.

As the device package is pulled in everywhere moving out the
host logic removes a bunch of cgo work from much of the codebase.