### PR TITLE
Instead of a Yes/No replay prioritize the replay devices.

### DIFF
--- a/gapis/gfxapi/gles/replay.go
+++ b/gapis/gfxapi/gles/replay.go
@@ -66,15 +66,16 @@ type framebufferRequest struct {
 	wireframeOverlay bool
 }
 
-// CanReplayOnLocalAndroidDevice returns true if the API can be replayed on a
-// locally connected Android device.
-func (a api) CanReplayOnLocalAndroidDevice(context.Context) bool { return false }
+// GetReplayPriority returns a uint32 representing the preference for
+// replaying this trace on the given device.
+// A lower number represents a higher priority, and Zero represents
+// an inability for the trace to be replayed on the given device.
+func (a api) GetReplayPriority(ctx context.Context, i *device.Instance, l *device.MemoryLayout) uint32 {
+	if i.GetConfiguration().GetOS().GetKind() != device.Android {
+		return 1
+	}
 
-// CanReplayOn returns true if the API can be replayed on the specified device.
-// The given layout is the memory_layout that was recorded in the capture
-// GLES can currently cannot replay on Android devices.
-func (a api) CanReplayOn(ctx context.Context, i *device.Instance, l *device.MemoryLayout) bool {
-	return i.GetConfiguration().GetOS().GetKind() != device.Android
+	return 2
 }
 
 func (a api) Replay(

--- a/gapis/gfxapi/vulkan/replay.go
+++ b/gapis/gfxapi/vulkan/replay.go
@@ -39,20 +39,17 @@ var (
 	_ = replay.Support(api{})
 )
 
-// CanReplayOnLocalAndroidDevice returns true if the API can be replayed on a
-// locally connected Android device.
-func (a api) CanReplayOnLocalAndroidDevice(context.Context) bool { return true }
-
-// CanReplayOn returns true if the API can be replayed on the specified device.
-// The given layout is the memory_layout that was recorded in the capture
-// Vulkan can currently only replay on Android devices.
-func (a api) CanReplayOn(ctx context.Context, i *device.Instance, l *device.MemoryLayout) bool {
+// GetReplayPriority returns a uint32 representing the preference for
+// replaying this trace on the given device.
+// A lower number represents a higher priority, and Zero represents
+// an inability for the trace to be replayed on the given device.
+func (a api) GetReplayPriority(ctx context.Context, i *device.Instance, l *device.MemoryLayout) uint32 {
 	for _, abi := range i.GetConfiguration().GetABIs() {
 		if *abi.GetMemoryLayout() == *l {
-			return true
+			return 1
 		}
 	}
-	return false
+	return 0
 }
 
 // makeAttachementReadable is a transformation marking all color/depth/stencil attachment

--- a/gapis/replay/interfaces.go
+++ b/gapis/replay/interfaces.go
@@ -27,14 +27,11 @@ import (
 // Support is the optional interface implemented by APIs that can describe
 // replay support for particular devices and device types.
 type Support interface {
-	// CanReplayOnLocalAndroidDevice returns true if the API can be replayed on
-	// a locally connected Android device.
-	CanReplayOnLocalAndroidDevice(context.Context) bool
-
-	// CanReplayOn returns true if the API can be replayed on the specified
-	// device. The MemoryLayout is the memory layout that was in the capture
-	// file.
-	CanReplayOn(context.Context, *device.Instance, *device.MemoryLayout) bool
+	// GetReplayPriority returns a uint32 representing the preference for
+	// replaying this trace on the given device.
+	// A lower number represents a higher priority, and Zero represents
+	// an inability for the trace to be replayed on the given device.
+	GetReplayPriority(context.Context, *device.Instance, *device.MemoryLayout) uint32
 }
 
 // QueryIssues is the interface implemented by types that can verify the replay


### PR DESCRIPTION
This lets us handle the case where we have multi-api traces.
We can still replay on Device, even though in the general case
we want to replay GLES on Host.