### PR TITLE
Split GL objects to shared and non-shared.

### DIFF
--- a/gapii/cc/spy.cpp
+++ b/gapii/cc/spy.cpp
@@ -518,8 +518,8 @@ bool Spy::getFramebufferAttachmentSize(uint32_t& width, uint32_t& height) {
       return false;
     }
 
-    auto framebuffer = ctx->mInstances.mFramebuffers.find(ctx->mBoundReadFramebuffer);
-    if (framebuffer == ctx->mInstances.mFramebuffers.end()) {
+    auto framebuffer = ctx->mObjects.mFramebuffers.find(ctx->mBoundReadFramebuffer);
+    if (framebuffer == ctx->mObjects.mFramebuffers.end()) {
         return false;
     }
 
@@ -530,8 +530,8 @@ bool Spy::getFramebufferAttachmentSize(uint32_t& width, uint32_t& height) {
 
     switch (attachment->second.mObjectType) {
         case GL_TEXTURE: {
-            auto t = ctx->mInstances.mTextures.find(attachment->second.mObjectName);
-            if (t == ctx->mInstances.mTextures.end()) {
+            auto t = ctx->mSharedObjects.mTextures.find(attachment->second.mObjectName);
+            if (t == ctx->mSharedObjects.mTextures.end()) {
                 return false;
             }
             switch (t->second->mKind) {
@@ -560,8 +560,8 @@ bool Spy::getFramebufferAttachmentSize(uint32_t& width, uint32_t& height) {
             }
         }
         case GL_RENDERBUFFER: {
-            auto r = ctx->mInstances.mRenderbuffers.find(attachment->second.mObjectName);
-            if (r == ctx->mInstances.mRenderbuffers.end()) {
+            auto r = ctx->mSharedObjects.mRenderbuffers.find(attachment->second.mObjectName);
+            if (r == ctx->mSharedObjects.mRenderbuffers.end()) {
                 return false;
             }
             width = uint32_t(r->second->mWidth);

--- a/gapis/gfxapi/gles/api/asynchronous_queries.api
+++ b/gapis/gfxapi/gles/api/asynchronous_queries.api
@@ -52,7 +52,7 @@ cmd void glDeleteQueries(GLsizei count, const QueryId* queries) {
   for i in (0 .. count) {
     id := q[i]
     if id != 0 {
-      delete(ctx.Instances.Queries, id)
+      delete(ctx.Objects.Queries, id)
     }
   }
 }
@@ -89,7 +89,7 @@ cmd void glGenQueries(GLsizei count, QueryId* queries) {
   for i in (0 .. count) {
     id := as!QueryId(?)
     // TODO: This should only reserve the name, but not create the object.
-    ctx.Instances.Queries[id] = new!Query()
+    ctx.Objects.Queries[id] = new!Query()
     q[i] = id
   }
 }
@@ -158,5 +158,5 @@ cmd GLboolean glIsQuery(QueryId query) {
   minRequiredVersion(3, 0)
 
   ctx := GetContext()
-  return as!GLboolean(query in ctx.Instances.Queries)
+  return as!GLboolean(query in ctx.Objects.Queries)
 }

--- a/gapis/gfxapi/gles/api/buffer_objects.api
+++ b/gapis/gfxapi/gles/api/buffer_objects.api
@@ -49,7 +49,7 @@ sub ref!Buffer GetBoundBufferOrError(GLenum target) {
     }
     case GL_ELEMENT_ARRAY_BUFFER: {
       // minRequiredVersion(2, 0)
-      ctx.Instances.VertexArrays[ctx.BoundVertexArray].ElementArrayBuffer
+      ctx.Objects.VertexArrays[ctx.BoundVertexArray].ElementArrayBuffer
     }
     case GL_COPY_READ_BUFFER: {
       // minRequiredVersion(3, 0)
@@ -101,7 +101,7 @@ sub ref!Buffer GetBoundBufferOrError(GLenum target) {
     }
   }
   if id == 0 { glErrorInvalidOperation() }
-  return ctx.Instances.Buffers[id]
+  return ctx.SharedObjects.Buffers[id]
 }
 
 @Doc("https://www.khronos.org/opengles/sdk/docs/man/xhtml/glBindBuffer.xml","OpenGL ES 2.0")
@@ -116,7 +116,7 @@ cmd void glBindBuffer(GLenum target, BufferId buffer) {
       ctx.BoundBuffers.ArrayBuffer = buffer
     }
     case GL_ELEMENT_ARRAY_BUFFER: {
-      ctx.Instances.VertexArrays[ctx.BoundVertexArray].ElementArrayBuffer = buffer
+      ctx.Objects.VertexArrays[ctx.BoundVertexArray].ElementArrayBuffer = buffer
     }
     case GL_COPY_READ_BUFFER: {
       minRequiredVersion(3, 0)
@@ -168,8 +168,8 @@ cmd void glBindBuffer(GLenum target, BufferId buffer) {
   }
 
   // Create the buffer if need (after checking whether the enum is valid)
-  if !(buffer in ctx.Instances.Buffers) {
-    ctx.Instances.Buffers[buffer] = new!Buffer()
+  if !(buffer in ctx.SharedObjects.Buffers) {
+    ctx.SharedObjects.Buffers[buffer] = new!Buffer()
   }
 }
 
@@ -179,8 +179,8 @@ cmd void glBindBuffer(GLenum target, BufferId buffer) {
 cmd void glBindBufferBase(GLenum target, GLuint index, BufferId buffer) {
   minRequiredVersion(3, 0)
   ctx := GetContext()
-  size := switch (buffer in ctx.Instances.Buffers) {
-    case true:  ctx.Instances.Buffers[buffer].Size
+  size := switch (buffer in ctx.SharedObjects.Buffers) {
+    case true:  ctx.SharedObjects.Buffers[buffer].Size
     case false: as!GLsizeiptr(0)
   }
   BindBufferRange(target, index, buffer, 0, size)
@@ -236,8 +236,8 @@ sub void BindBufferRange(GLenum     target,
   }
 
   // Create the buffer if need (after checking whether the enum is valid)
-  if !(buffer in ctx.Instances.Buffers) {
-    ctx.Instances.Buffers[buffer] = new!Buffer()
+  if !(buffer in ctx.SharedObjects.Buffers) {
+    ctx.SharedObjects.Buffers[buffer] = new!Buffer()
   }
 }
 
@@ -315,7 +315,7 @@ cmd void glDeleteBuffers(GLsizei count, const BufferId* buffers) {
   for i in (0 .. count) {
     id := b[i]
     if id != 0 {
-      delete(ctx.Instances.Buffers, id)
+      delete(ctx.SharedObjects.Buffers, id)
     }
   }
 }
@@ -332,7 +332,7 @@ cmd void glGenBuffers(GLsizei count, BufferId* buffers) {
   ctx := GetContext()
   for i in (0 .. count) {
     id := as!BufferId(?)
-    ctx.Instances.Buffers[id] = new!Buffer()
+    ctx.SharedObjects.Buffers[id] = new!Buffer()
     b[i] = id
   }
 }
@@ -431,7 +431,7 @@ cmd GLboolean glIsBuffer(BufferId buffer) {
   minRequiredVersion(1, 0)
 
   ctx := GetContext()
-  return as!GLboolean(buffer in ctx.Instances.Buffers)
+  return as!GLboolean(buffer in ctx.SharedObjects.Buffers)
 }
 
 // This command only exits in desktop GL - but we need the signature in compat.

--- a/gapis/gfxapi/gles/api/debug.api
+++ b/gapis/gfxapi/gles/api/debug.api
@@ -247,48 +247,48 @@ sub void ObjectLabel(GLenum identifier, GLuint name, GLsizei length, const GLcha
   ctx := GetContext()
   switch (identifier) {
     case GL_TEXTURE: {
-      if !(as!TextureId(name) in ctx.Instances.Textures) { glErrorInvalidOperation() }
-      ctx.Instances.Textures[as!TextureId(name)].Label = str
+      if !(as!TextureId(name) in ctx.SharedObjects.Textures) { glErrorInvalidOperation() }
+      ctx.SharedObjects.Textures[as!TextureId(name)].Label = str
     }
     case GL_FRAMEBUFFER: {
-      if !(as!FramebufferId(name) in ctx.Instances.Framebuffers) { glErrorInvalidOperation() }
-      ctx.Instances.Framebuffers[as!FramebufferId(name)].Label = str
+      if !(as!FramebufferId(name) in ctx.Objects.Framebuffers) { glErrorInvalidOperation() }
+      ctx.Objects.Framebuffers[as!FramebufferId(name)].Label = str
     }
     case GL_RENDERBUFFER: {
-      if !(as!RenderbufferId(name) in ctx.Instances.Renderbuffers) { glErrorInvalidOperation() }
-      ctx.Instances.Renderbuffers[as!RenderbufferId(name)].Label = str
+      if !(as!RenderbufferId(name) in ctx.SharedObjects.Renderbuffers) { glErrorInvalidOperation() }
+      ctx.SharedObjects.Renderbuffers[as!RenderbufferId(name)].Label = str
     }
     case GL_BUFFER: {
-      if !(as!BufferId(name) in ctx.Instances.Buffers) { glErrorInvalidOperation() }
-      ctx.Instances.Buffers[as!BufferId(name)].Label = str
+      if !(as!BufferId(name) in ctx.SharedObjects.Buffers) { glErrorInvalidOperation() }
+      ctx.SharedObjects.Buffers[as!BufferId(name)].Label = str
     }
     case GL_SHADER: {
-      if !(as!ShaderId(name) in ctx.Instances.Shaders) { glErrorInvalidOperation() }
-      ctx.Instances.Shaders[as!ShaderId(name)].Label = str
+      if !(as!ShaderId(name) in ctx.SharedObjects.Shaders) { glErrorInvalidOperation() }
+      ctx.SharedObjects.Shaders[as!ShaderId(name)].Label = str
     }
     case GL_PROGRAM: {
-      if !(as!ProgramId(name) in ctx.Instances.Programs) { glErrorInvalidOperation() }
-      ctx.Instances.Programs[as!ProgramId(name)].Label = str
+      if !(as!ProgramId(name) in ctx.SharedObjects.Programs) { glErrorInvalidOperation() }
+      ctx.SharedObjects.Programs[as!ProgramId(name)].Label = str
     }
     case GL_VERTEX_ARRAY: {
-      if !(as!VertexArrayId(name) in ctx.Instances.VertexArrays) { glErrorInvalidOperation() }
-      ctx.Instances.VertexArrays[as!VertexArrayId(name)].Label = str
+      if !(as!VertexArrayId(name) in ctx.Objects.VertexArrays) { glErrorInvalidOperation() }
+      ctx.Objects.VertexArrays[as!VertexArrayId(name)].Label = str
     }
     case GL_QUERY: {
-      if !(as!QueryId(name) in ctx.Instances.Queries) { glErrorInvalidOperation() }
-      ctx.Instances.Queries[as!QueryId(name)].Label = str
+      if !(as!QueryId(name) in ctx.Objects.Queries) { glErrorInvalidOperation() }
+      ctx.Objects.Queries[as!QueryId(name)].Label = str
     }
     case GL_SAMPLER: {
-      if !(as!SamplerId(name) in ctx.Instances.Samplers) { glErrorInvalidOperation() }
-      ctx.Instances.Samplers[as!SamplerId(name)].Label = str
+      if !(as!SamplerId(name) in ctx.SharedObjects.Samplers) { glErrorInvalidOperation() }
+      ctx.SharedObjects.Samplers[as!SamplerId(name)].Label = str
     }
     case GL_TRANSFORM_FEEDBACK: {
-      if !(as!TransformFeedbackId(name) in ctx.Instances.TransformFeedbacks) { glErrorInvalidOperation() }
-      ctx.Instances.TransformFeedbacks[as!TransformFeedbackId(name)].Label = str
+      if !(as!TransformFeedbackId(name) in ctx.Objects.TransformFeedbacks) { glErrorInvalidOperation() }
+      ctx.Objects.TransformFeedbacks[as!TransformFeedbackId(name)].Label = str
     }
     case GL_PROGRAM_PIPELINE: {
-      if !(as!PipelineId(name) in ctx.Instances.Pipelines) { glErrorInvalidOperation() }
-      ctx.Instances.Pipelines[as!PipelineId(name)].Label = str
+      if !(as!PipelineId(name) in ctx.Objects.Pipelines) { glErrorInvalidOperation() }
+      ctx.Objects.Pipelines[as!PipelineId(name)].Label = str
     }
     default: {
       glErrorInvalidEnum(identifier)

--- a/gapis/gfxapi/gles/api/draw_commands.api
+++ b/gapis/gfxapi/gles/api/draw_commands.api
@@ -102,10 +102,10 @@ sub void DrawElements(ref!Context    ctx,
   if instance_count < 0 { glErrorInvalidValue() } // SPEC: missing in pdf
   if indices_count > 0 {
     count := as!u32(indices_count)
-    id := ctx.Instances.VertexArrays[ctx.BoundVertexArray].ElementArrayBuffer
+    id := ctx.Objects.VertexArrays[ctx.BoundVertexArray].ElementArrayBuffer
     if (id != 0) {
       // Element array buffer bound - indices is an offset on the buffer.
-      index_data := ctx.Instances.Buffers[id].Data
+      index_data := ctx.SharedObjects.Buffers[id].Data
       offset := as!s32(as!u64(indices))
 
       // Read the vertices

--- a/gapis/gfxapi/gles/api/extensions.api
+++ b/gapis/gfxapi/gles/api/extensions.api
@@ -371,7 +371,7 @@ cmd void glDeleteQueriesEXT(GLsizei count, const QueryId* queries) {
   for i in (0 .. count) {
     id := q[i]
     if id != 0 {
-      delete(ctx.Instances.Queries, id)
+      delete(ctx.Objects.Queries, id)
     }
   }
 }
@@ -907,7 +907,7 @@ cmd void glGenQueriesEXT(GLsizei count, QueryId* queries) {
   ctx := GetContext()
   for i in (0 .. count) {
     id := as!QueryId(?)
-    ctx.Instances.Queries[id] = new!Query()
+    ctx.Objects.Queries[id] = new!Query()
     q[i] = id
   }
 }
@@ -1480,7 +1480,7 @@ cmd GLboolean glIsQueryEXT(QueryId query) {
   requiresExtension2(GL_EXT_disjoint_timer_query, GL_EXT_occlusion_query_boolean)
 
   ctx := GetContext()
-  return as!GLboolean(query in ctx.Instances.Queries)
+  return as!GLboolean(query in ctx.Objects.Queries)
 }
 
 @Doc("https://www.khronos.org/registry/gles/extensions/APPLE/APPLE_sync.txt", "GL_APPLE_sync")
@@ -1523,48 +1523,48 @@ cmd void glLabelObjectEXT(GLenum type, GLuint object, GLsizei length, const GLch
   ctx := GetContext()
   switch (type) {
     case GL_TEXTURE: {
-      if !(as!TextureId(object) in ctx.Instances.Textures) { glErrorInvalidOperation() }
-      ctx.Instances.Textures[as!TextureId(object)].Label = str
+      if !(as!TextureId(object) in ctx.SharedObjects.Textures) { glErrorInvalidOperation() }
+      ctx.SharedObjects.Textures[as!TextureId(object)].Label = str
     }
     case GL_FRAMEBUFFER: {
-      if !(as!FramebufferId(object) in ctx.Instances.Framebuffers) { glErrorInvalidOperation() }
-      ctx.Instances.Framebuffers[as!FramebufferId(object)].Label = str
+      if !(as!FramebufferId(object) in ctx.Objects.Framebuffers) { glErrorInvalidOperation() }
+      ctx.Objects.Framebuffers[as!FramebufferId(object)].Label = str
     }
     case GL_RENDERBUFFER: {
-      if !(as!RenderbufferId(object) in ctx.Instances.Renderbuffers) { glErrorInvalidOperation() }
-      ctx.Instances.Renderbuffers[as!RenderbufferId(object)].Label = str
+      if !(as!RenderbufferId(object) in ctx.SharedObjects.Renderbuffers) { glErrorInvalidOperation() }
+      ctx.SharedObjects.Renderbuffers[as!RenderbufferId(object)].Label = str
     }
     case GL_BUFFER_OBJECT_EXT: {
-      if !(as!BufferId(object) in ctx.Instances.Buffers) { glErrorInvalidOperation() }
-      ctx.Instances.Buffers[as!BufferId(object)].Label = str
+      if !(as!BufferId(object) in ctx.SharedObjects.Buffers) { glErrorInvalidOperation() }
+      ctx.SharedObjects.Buffers[as!BufferId(object)].Label = str
     }
     case GL_SHADER_OBJECT_EXT: {
-      if !(as!ShaderId(object) in ctx.Instances.Shaders) { glErrorInvalidOperation() }
-      ctx.Instances.Shaders[as!ShaderId(object)].Label = str
+      if !(as!ShaderId(object) in ctx.SharedObjects.Shaders) { glErrorInvalidOperation() }
+      ctx.SharedObjects.Shaders[as!ShaderId(object)].Label = str
     }
     case GL_PROGRAM_OBJECT_EXT: {
-      if !(as!ProgramId(object) in ctx.Instances.Programs) { glErrorInvalidOperation() }
-      ctx.Instances.Programs[as!ProgramId(object)].Label = str
+      if !(as!ProgramId(object) in ctx.SharedObjects.Programs) { glErrorInvalidOperation() }
+      ctx.SharedObjects.Programs[as!ProgramId(object)].Label = str
     }
     case GL_VERTEX_ARRAY_OBJECT_EXT: {
-      if !(as!VertexArrayId(object) in ctx.Instances.VertexArrays) { glErrorInvalidOperation() }
-      ctx.Instances.VertexArrays[as!VertexArrayId(object)].Label = str
+      if !(as!VertexArrayId(object) in ctx.Objects.VertexArrays) { glErrorInvalidOperation() }
+      ctx.Objects.VertexArrays[as!VertexArrayId(object)].Label = str
     }
     case GL_QUERY_OBJECT_EXT: {
-      if !(as!QueryId(object) in ctx.Instances.Queries) { glErrorInvalidOperation() }
-      ctx.Instances.Queries[as!QueryId(object)].Label = str
+      if !(as!QueryId(object) in ctx.Objects.Queries) { glErrorInvalidOperation() }
+      ctx.Objects.Queries[as!QueryId(object)].Label = str
     }
     case GL_SAMPLER: {
-      if !(as!SamplerId(object) in ctx.Instances.Samplers) { glErrorInvalidOperation() }
-      ctx.Instances.Samplers[as!SamplerId(object)].Label = str
+      if !(as!SamplerId(object) in ctx.SharedObjects.Samplers) { glErrorInvalidOperation() }
+      ctx.SharedObjects.Samplers[as!SamplerId(object)].Label = str
     }
     case GL_TRANSFORM_FEEDBACK: {
-      if !(as!TransformFeedbackId(object) in ctx.Instances.TransformFeedbacks) { glErrorInvalidOperation() }
-      ctx.Instances.TransformFeedbacks[as!TransformFeedbackId(object)].Label = str
+      if !(as!TransformFeedbackId(object) in ctx.Objects.TransformFeedbacks) { glErrorInvalidOperation() }
+      ctx.Objects.TransformFeedbacks[as!TransformFeedbackId(object)].Label = str
     }
     case GL_PROGRAM_PIPELINE_OBJECT_EXT: {
-      if !(as!PipelineId(object) in ctx.Instances.Pipelines) { glErrorInvalidOperation() }
-      ctx.Instances.Pipelines[as!PipelineId(object)].Label = str
+      if !(as!PipelineId(object) in ctx.Objects.Pipelines) { glErrorInvalidOperation() }
+      ctx.Objects.Pipelines[as!PipelineId(object)].Label = str
     }
     default: {
       glErrorInvalidEnum(type)

--- a/gapis/gfxapi/gles/api/extras.api
+++ b/gapis/gfxapi/gles/api/extras.api
@@ -58,7 +58,7 @@ extern ref!ProgramInfo GetProgramInfoExtra(ProgramId programId)
 sub void ApplyProgramInfoExtra(ProgramId programId, ref!ProgramInfo info) {
   if (info != null) {
     ctx := GetContext()
-    program := ctx.Instances.Programs[programId]
+    program := ctx.SharedObjects.Programs[programId]
     program.LinkStatus = info.LinkStatus
     program.InfoLog = info.InfoLog
     program.ActiveAttributes = null

--- a/gapis/gfxapi/gles/api/framebuffer.api
+++ b/gapis/gfxapi/gles/api/framebuffer.api
@@ -126,12 +126,12 @@ sub ref!Framebuffer GetBoundFramebufferOrErrorInvalidEnum(GLenum framebuffer_tar
     case GL_DRAW_FRAMEBUFFER: ctx.BoundDrawFramebuffer
     case GL_READ_FRAMEBUFFER: ctx.BoundReadFramebuffer
   }
-  return ctx.Instances.Framebuffers[framebufferId]
+  return ctx.Objects.Framebuffers[framebufferId]
 }
 
 sub bool IsDefaultFramebuffer(ref!Framebuffer framebuffer) {
   ctx := GetContext()
-  return framebuffer == ctx.Instances.Framebuffers[0]
+  return framebuffer == ctx.Objects.Framebuffers[0]
 }
 
 sub void SetFramebufferAttachment(GLenum                framebuffer_target,
@@ -192,8 +192,8 @@ cmd void glBindFramebuffer(GLenum target, FramebufferId framebuffer) {
       glErrorInvalidEnum(target)
     }
   }
-  if !(framebuffer in ctx.Instances.Framebuffers) {
-    ctx.Instances.Framebuffers[framebuffer] = new!Framebuffer()
+  if !(framebuffer in ctx.Objects.Framebuffers) {
+    ctx.Objects.Framebuffers[framebuffer] = new!Framebuffer()
   }
 }
 
@@ -213,8 +213,8 @@ cmd void glBindRenderbuffer(GLenum target, RenderbufferId renderbuffer) {
       glErrorInvalidEnum(target)
     }
   }
-  if !(renderbuffer in ctx.Instances.Renderbuffers) {
-    ctx.Instances.Renderbuffers[renderbuffer] = new!Renderbuffer()
+  if !(renderbuffer in ctx.SharedObjects.Renderbuffers) {
+    ctx.SharedObjects.Renderbuffers[renderbuffer] = new!Renderbuffer()
   }
 }
 
@@ -447,7 +447,7 @@ cmd void glDeleteFramebuffers(GLsizei count, const FramebufferId* framebuffers) 
   for i in (0 .. count) {
     id := f[i]
     if id != 0 {
-      delete(ctx.Instances.Framebuffers, id)
+      delete(ctx.Objects.Framebuffers, id)
       if id == ctx.BoundReadFramebuffer {
         ctx.BoundReadFramebuffer = 0
       }
@@ -471,7 +471,7 @@ cmd void glDeleteRenderbuffers(GLsizei count, const RenderbufferId* renderbuffer
   for i in (0 .. count) {
     id := r[i]
     if id != 0 {
-      delete(ctx.Instances.Renderbuffers, id)
+      delete(ctx.SharedObjects.Renderbuffers, id)
     }
   }
 }
@@ -548,7 +548,7 @@ cmd void glFramebufferRenderbuffer(GLenum         framebuffer_target,
   ctx := GetContext()
   if renderbuffer_target != GL_RENDERBUFFER { glErrorInvalidEnum(renderbuffer_target) }
   // SPEC: Only PDF spec mentions this:
-  if (renderbuffer != 0) && !(renderbuffer in ctx.Instances.Renderbuffers) { glErrorInvalidOperation() }
+  if (renderbuffer != 0) && !(renderbuffer in ctx.SharedObjects.Renderbuffers) { glErrorInvalidOperation() }
 
   attachment := FramebufferAttachment()
   if (renderbuffer != 0) {
@@ -568,7 +568,7 @@ sub void FramebufferTexture(GLenum target, GLenum attachment, TextureId texture,
   ctx := GetContext()
   attachment_info := FramebufferAttachment()
   if (texture != 0) {
-    if !(texture in ctx.Instances.Textures) { glErrorInvalidValue() }
+    if !(texture in ctx.SharedObjects.Textures) { glErrorInvalidValue() }
     attachment_info.ObjectType = GL_TEXTURE
     attachment_info.ObjectName = as!GLuint(texture)
     attachment_info.TextureLevel = level
@@ -616,7 +616,7 @@ sub void FramebufferTexture2D(GLenum    framebuffer_target,
   ctx := GetContext()
   attachment := FramebufferAttachment()
   if (texture != 0) {
-    if !(texture in ctx.Instances.Textures) { glErrorInvalidOperation() }
+    if !(texture in ctx.SharedObjects.Textures) { glErrorInvalidOperation() }
     kind := switch (texture_target) {
       case GL_TEXTURE_2D:
         GL_TEXTURE_2D
@@ -630,7 +630,7 @@ sub void FramebufferTexture2D(GLenum    framebuffer_target,
         as!GLenum(0)
     }
     // TODO: Handle texture 0
-    if ctx.Instances.Textures[texture].Kind != kind { glErrorInvalidOperation() }
+    if ctx.SharedObjects.Textures[texture].Kind != kind { glErrorInvalidOperation() }
     attachment.ObjectType = GL_TEXTURE
     attachment.ObjectName = as!GLuint(texture)
     attachment.TextureLevel = level
@@ -657,7 +657,7 @@ cmd void glFramebufferTextureLayer(GLenum    target,
   ctx := GetContext()
   attachment_info := FramebufferAttachment()
   if (texture != 0) {
-    if !(texture in ctx.Instances.Textures) { glErrorInvalidValue() }
+    if !(texture in ctx.SharedObjects.Textures) { glErrorInvalidValue() }
     attachment_info.ObjectType = GL_TEXTURE
     attachment_info.ObjectName = as!GLuint(texture)
     attachment_info.TextureLevel = level
@@ -678,7 +678,7 @@ cmd void glGenFramebuffers(GLsizei count, FramebufferId* framebuffers) {
   ctx := GetContext()
   for i in (0 .. count) {
     id := as!FramebufferId(?)
-    ctx.Instances.Framebuffers[id] = new!Framebuffer()
+    ctx.Objects.Framebuffers[id] = new!Framebuffer()
     f[i] = id
   }
 }
@@ -695,7 +695,7 @@ cmd void glGenRenderbuffers(GLsizei count, RenderbufferId* renderbuffers) {
   ctx := GetContext()
   for i in (0 .. count) {
     id := as!RenderbufferId(?)
-    ctx.Instances.Renderbuffers[id] = new!Renderbuffer()
+    ctx.SharedObjects.Renderbuffers[id] = new!Renderbuffer()
     r[i] = id
   }
 }
@@ -829,7 +829,7 @@ cmd void glGetRenderbufferParameteriv(GLenum target, GLenum parameter, GLint* va
   ctx := GetContext()
   id := ctx.BoundRenderbuffer
   if id == 0 { glErrorInvalidOperation() } // PDF spec
-  rb := ctx.Instances.Renderbuffers[id]
+  rb := ctx.SharedObjects.Renderbuffers[id]
   values[0] = switch (parameter) {
     case GL_RENDERBUFFER_WIDTH:           as!GLint(rb.Width)
     case GL_RENDERBUFFER_HEIGHT:          as!GLint(rb.Height)
@@ -912,7 +912,7 @@ cmd GLboolean glIsFramebuffer(FramebufferId framebuffer) {
   minRequiredVersion(2, 0)
 
   ctx := GetContext()
-  return as!GLboolean(framebuffer in ctx.Instances.Framebuffers)
+  return as!GLboolean(framebuffer in ctx.Objects.Framebuffers)
 }
 
 @Doc("https://www.khronos.org/opengles/sdk/docs/man/xhtml/glIsRenderbuffer.xml","OpenGL ES 2.0")
@@ -923,7 +923,7 @@ cmd GLboolean glIsRenderbuffer(RenderbufferId renderbuffer) {
   minRequiredVersion(2, 0)
 
   ctx := GetContext()
-  return as!GLboolean(renderbuffer in ctx.Instances.Renderbuffers)
+  return as!GLboolean(renderbuffer in ctx.SharedObjects.Renderbuffers)
 }
 
 @Doc("https://www.khronos.org/opengles/sdk/docs/man3/html/glReadBuffer.xhtml","OpenGL ES 3.0")
@@ -1094,7 +1094,7 @@ sub void RenderbufferStorageMultisample(GLenum target, GLsizei samples, GLenum i
 
   id := ctx.BoundRenderbuffer
   if id == 0 { glErrorInvalidOperation() }
-  rb := ctx.Instances.Renderbuffers[id]
+  rb := ctx.SharedObjects.Renderbuffers[id]
   rb.InternalFormat = internalformat
   rb.Width = width
   rb.Height = height

--- a/gapis/gfxapi/gles/api/programs_and_shaders.api
+++ b/gapis/gfxapi/gles/api/programs_and_shaders.api
@@ -243,8 +243,8 @@ sub void writeString(GLsizei  buffer_size,
 }
 
 sub void checkShader(ref!Context ctx, ShaderId shader) {
-  if (!shader in ctx.Instances.Shaders) {
-    if (!as!ProgramId(shader) in ctx.Instances.Programs) {
+  if (!shader in ctx.SharedObjects.Shaders) {
+    if (!as!ProgramId(shader) in ctx.SharedObjects.Programs) {
       glErrorInvalidValue()
     } else {
       glErrorInvalidOperation()
@@ -253,8 +253,8 @@ sub void checkShader(ref!Context ctx, ShaderId shader) {
 }
 
 sub void checkProgram(ref!Context ctx, ProgramId program) {
-  if (!program in ctx.Instances.Programs) {
-    if (!as!ShaderId(program) in ctx.Instances.Shaders) {
+  if (!program in ctx.SharedObjects.Programs) {
+    if (!as!ShaderId(program) in ctx.SharedObjects.Shaders) {
       glErrorInvalidValue()
     } else {
       glErrorInvalidOperation()
@@ -264,20 +264,20 @@ sub void checkProgram(ref!Context ctx, ProgramId program) {
 
 sub void reapShader(ref!Context ctx, ShaderId shaderId, ref!Shader shader) {
   if (shader.DeleteStatus && shader.RefCount == 0) {
-    delete(ctx.Instances.Shaders, shaderId)
+    delete(ctx.SharedObjects.Shaders, shaderId)
   }
 }
 
 sub void reapProgram(ref!Context ctx, ProgramId program) {
   if (program != 0) {
-    p := ctx.Instances.Programs[program]
+    p := ctx.SharedObjects.Programs[program]
     if (p.DeleteStatus) {
       for _ , _ , v in p.Shaders {
-        s := ctx.Instances.Shaders[v]
+        s := ctx.SharedObjects.Shaders[v]
         s.RefCount -= 1
         reapShader(ctx, v, s)
       }
-      delete(ctx.Instances.Programs, program)
+      delete(ctx.SharedObjects.Programs, program)
     }
   }
 }
@@ -285,7 +285,7 @@ sub void reapProgram(ref!Context ctx, ProgramId program) {
 sub void SetProgramUniform(ProgramId program, UniformLocation location, u8[] value, GLenum type) {
   ctx := GetContext()
   checkProgram(ctx, program)
-  p := ctx.Instances.Programs[program]
+  p := ctx.SharedObjects.Programs[program]
   if location != -1 { // -1 is silently ignored.
     if !(location in p.Uniforms) { glErrorInvalidOperation() }
     // TODO: Remove the temporary.
@@ -320,8 +320,8 @@ cmd void glAttachShader(ProgramId program, ShaderId shader) {
   checkShader(ctx, shader)
   checkProgram(ctx, program)
 
-  p := ctx.Instances.Programs[program]
-  s := ctx.Instances.Shaders[shader]
+  p := ctx.SharedObjects.Programs[program]
+  s := ctx.SharedObjects.Shaders[shader]
   if s.Type in p.Shaders { glErrorInvalidOperation() } // shader already attached
   p.Shaders[s.Type] = shader
   s.RefCount += 1
@@ -338,7 +338,7 @@ cmd void glBindAttribLocation(ProgramId program, AttributeLocation location, str
   ctx := GetContext()
   checkProgram(ctx, program)
   if location >= as!AttributeLocation(ctx.Constants.MaxVertexAttribs) { glErrorInvalidValue() }
-  p := ctx.Instances.Programs[program]
+  p := ctx.SharedObjects.Programs[program]
   p.AttributeBindings[name] = location
 }
 
@@ -371,7 +371,7 @@ cmd ProgramId glCreateProgram() {
 
   ctx := GetContext()
   id := ?
-  ctx.Instances.Programs[id] = new!Program(ID: id)
+  ctx.SharedObjects.Programs[id] = new!Program(ID: id)
   return id
 }
 
@@ -398,8 +398,8 @@ cmd ShaderId glCreateShader(GLenum type) {
 
   ctx := GetContext()
   id := ?
-  ctx.Instances.Shaders[id] = new!Shader(ID: id,ShaderType:  type)
-  s := ctx.Instances.Shaders[id]
+  ctx.SharedObjects.Shaders[id] = new!Shader(ID: id,ShaderType:  type)
+  s := ctx.SharedObjects.Shaders[id]
   s.Type = type
   return id
 }
@@ -437,7 +437,7 @@ cmd void glDeleteProgram(ProgramId program) {
   if program != 0 {
     ctx := GetContext()
     checkProgram(ctx, program)
-    ctx.Instances.Programs[program].DeleteStatus = true
+    ctx.SharedObjects.Programs[program].DeleteStatus = true
     // Do not reap while the program is in use.
     if ctx.BoundProgram != program {
       reapProgram(ctx, program)
@@ -463,8 +463,8 @@ cmd void glDeleteShader(ShaderId shader) {
   if shader != 0 {
     ctx := GetContext()
     checkShader(ctx, shader)
-    if shader in ctx.Instances.Shaders { // TODO: Remove once we have go aborts.
-      s := ctx.Instances.Shaders[shader]
+    if shader in ctx.SharedObjects.Shaders { // TODO: Remove once we have go aborts.
+      s := ctx.SharedObjects.Shaders[shader]
       s.DeleteStatus = true
       reapShader(ctx, shader, s)
     }
@@ -483,8 +483,8 @@ cmd void glDetachShader(ProgramId program, ShaderId shader) {
   checkShader(ctx, shader)
   checkProgram(ctx, program)
 
-  s := ctx.Instances.Shaders[shader]
-  p := ctx.Instances.Programs[program]
+  s := ctx.SharedObjects.Shaders[shader]
+  p := ctx.SharedObjects.Programs[program]
   if (!(s.Type in p.Shaders)) || (p.Shaders[s.Type] != shader) { glErrorInvalidOperation() }
   delete(p.Shaders, s.Type)
   s.RefCount -= 1
@@ -530,7 +530,7 @@ cmd void glGetActiveAttrib(ProgramId      program,
 
   ctx := GetContext()
   checkProgram(ctx, program)
-  p := ctx.Instances.Programs[program]
+  p := ctx.SharedObjects.Programs[program]
   if !(index in p.ActiveAttributes) { glErrorInvalidValue() }
 
   writeString(buffer_size, buffer_bytes_written, name)
@@ -555,7 +555,7 @@ cmd void glGetActiveUniform(ProgramId    program,
   ctx := GetContext()
   checkProgram(ctx, program)
   if buffer_size < 0 { glErrorInvalidValue() }
-  p := ctx.Instances.Programs[program]
+  p := ctx.SharedObjects.Programs[program]
   if !(index in p.ActiveUniforms) { glErrorInvalidValue() }
 
   writeString(buffer_size, buffer_bytes_written, name)
@@ -637,7 +637,7 @@ cmd void glGetAttachedShaders(ProgramId program,
   ctx := GetContext()
   checkProgram(ctx, program)
   if buffer_length < 0 { glErrorInvalidValue() }
-  p := ctx.Instances.Programs[program]
+  p := ctx.SharedObjects.Programs[program]
   l := min(as!s32(buffer_length), len(p.Shaders))
   if shaders_length_written != null {
     shaders_length_written[0] = as!GLsizei(l)
@@ -980,7 +980,7 @@ cmd void glGetShaderiv(ShaderId shader, GLenum parameter, GLint* value) {
 
   ctx := GetContext()
   checkShader(ctx, shader)
-  s := ctx.Instances.Shaders[shader]
+  s := ctx.SharedObjects.Shaders[shader]
   value[0] = switch (parameter) {
     case GL_SHADER_TYPE:          as!GLint(s.Type)
     case GL_DELETE_STATUS:        switch (s.DeleteStatus) { case true: 1 case false: 0 }
@@ -1113,7 +1113,7 @@ cmd GLboolean glIsProgram(ProgramId program) {
   minRequiredVersion(2, 0)
 
   ctx := GetContext()
-  return as!GLboolean(program in ctx.Instances.Programs)
+  return as!GLboolean(program in ctx.SharedObjects.Programs)
 }
 
 @Doc("https://www.khronos.org/opengles/sdk/docs/man31/html/glIsProgramPipeline.xhtml","OpenGL ES 3.1")
@@ -1132,7 +1132,7 @@ cmd GLboolean glIsShader(ShaderId shader) {
   minRequiredVersion(2, 0)
 
   ctx := GetContext()
-  return as!GLboolean(shader in ctx.Instances.Shaders)
+  return as!GLboolean(shader in ctx.SharedObjects.Shaders)
 }
 
 @custom
@@ -1235,7 +1235,7 @@ cmd void glProgramBinary(ProgramId   program,
 sub void ProgramBinary(ProgramId program, GLenum binaryFormat, const void* binary, GLsizei length) {
   ctx := GetContext()
   checkProgram(ctx, program)
-  p := ctx.Instances.Programs[program]
+  p := ctx.SharedObjects.Programs[program]
   switch (binaryFormat) {
     case GL_Z400_BINARY_AMD: {
       p.Binary = clone(as!u8[](binary[0:length]))
@@ -1843,7 +1843,7 @@ cmd void glShaderSource(ShaderId             shader,
   ctx := GetContext()
   checkShader(ctx, shader)
 
-  s := ctx.Instances.Shaders[shader]
+  s := ctx.SharedObjects.Shaders[shader]
   s.Source = as!string(null)
   if length == null {
     for i in (0 .. count) {
@@ -2286,7 +2286,7 @@ cmd void glUseProgram(ProgramId program) {
   }
 
   // TODO: Remove the check once we have go aborts.
-  if (program == 0) || (program in ctx.Instances.Programs) {
+  if (program == 0) || (program in ctx.SharedObjects.Programs) {
 
     // Lazy delete. See glDeleteProgram.
     if (ctx.BoundProgram != program) {

--- a/gapis/gfxapi/gles/api/state_queries.api
+++ b/gapis/gfxapi/gles/api/state_queries.api
@@ -404,7 +404,7 @@ sub void GetStateVariable!T(GLenum name, bool isIndexed, GLuint index, T* v) {
     }
     case GL_ELEMENT_ARRAY_BUFFER_BINDING: {
       minRequiredVersion(2, 0)
-      v[0] = as!T(ctx.Instances.VertexArrays[ctx.BoundVertexArray].ElementArrayBuffer)
+      v[0] = as!T(ctx.Objects.VertexArrays[ctx.BoundVertexArray].ElementArrayBuffer)
     }
     case GL_FRAGMENT_INTERPOLATION_OFFSET_BITS: {
       minRequiredVersion(3, 2)
@@ -1432,7 +1432,7 @@ sub void GetStateVariable!T(GLenum name, bool isIndexed, GLuint index, T* v) {
       minRequiredVersion(3, 1)
       if isIndexed {
         i := as!VertexBufferBindingIndex(index)
-        v[0] = as!T(ctx.Instances.VertexArrays[ctx.BoundVertexArray].VertexBufferBindings[i].Divisor)
+        v[0] = as!T(ctx.Objects.VertexArrays[ctx.BoundVertexArray].VertexBufferBindings[i].Divisor)
       } else {
         glErrorInvalidEnum(name)
       }
@@ -1441,7 +1441,7 @@ sub void GetStateVariable!T(GLenum name, bool isIndexed, GLuint index, T* v) {
       minRequiredVersion(3, 1)
       if isIndexed {
         i := as!VertexBufferBindingIndex(index)
-        v[0] = as!T(ctx.Instances.VertexArrays[ctx.BoundVertexArray].VertexBufferBindings[i].Offset)
+        v[0] = as!T(ctx.Objects.VertexArrays[ctx.BoundVertexArray].VertexBufferBindings[i].Offset)
       } else {
         glErrorInvalidEnum(name)
       }
@@ -1450,7 +1450,7 @@ sub void GetStateVariable!T(GLenum name, bool isIndexed, GLuint index, T* v) {
       minRequiredVersion(3, 1)
       if isIndexed {
         i := as!VertexBufferBindingIndex(index)
-        v[0] = as!T(ctx.Instances.VertexArrays[ctx.BoundVertexArray].VertexBufferBindings[i].Stride)
+        v[0] = as!T(ctx.Objects.VertexArrays[ctx.BoundVertexArray].VertexBufferBindings[i].Stride)
       } else {
         glErrorInvalidEnum(name)
       }

--- a/gapis/gfxapi/gles/api/synchronization.api
+++ b/gapis/gfxapi/gles/api/synchronization.api
@@ -34,7 +34,7 @@ cmd GLenum glClientWaitSync(GLsync sync, GLbitfield syncFlags, GLuint64 timeout)
 sub void ClientWaitSync(GLsync sync, GLbitfield syncFlags, GLuint64 timeout) {
   supportsBits(syncFlags, GL_SYNC_FLUSH_COMMANDS_BIT)
   ctx := GetContext()
-  if !(sync in ctx.Instances.SyncObjects) { glErrorInvalidValue() }
+  if !(sync in ctx.SharedObjects.SyncObjects) { glErrorInvalidValue() }
   if (GL_SYNC_FLUSH_COMMANDS_BIT in syncFlags) {
   }
   _ = timeout // TODO
@@ -51,8 +51,8 @@ cmd void glDeleteSync(GLsync sync) {
 sub void DeleteSync(GLsync sync) {
   if sync != null {
     ctx := GetContext()
-    if !(sync in ctx.Instances.SyncObjects) { glErrorInvalidValue() }
-    delete(ctx.Instances.SyncObjects, sync)
+    if !(sync in ctx.SharedObjects.SyncObjects) { glErrorInvalidValue() }
+    delete(ctx.SharedObjects.SyncObjects, sync)
   }
 }
 
@@ -71,7 +71,7 @@ sub void FenceSync(GLenum condition, GLbitfield syncFlags, GLsync sync) {
   if syncFlags != as!GLbitfield(0) { glErrorInvalidValue() }
   ctx := GetContext()
   if (sync != null) {
-    ctx.Instances.SyncObjects[sync] = new!SyncObject()
+    ctx.SharedObjects.SyncObjects[sync] = new!SyncObject()
   }
 }
 
@@ -111,7 +111,7 @@ cmd GLboolean glIsSync(GLsync sync) {
 
 sub GLboolean IsSync(GLsync sync) {
   ctx := GetContext()
-  return as!GLboolean(sync in ctx.Instances.SyncObjects)
+  return as!GLboolean(sync in ctx.SharedObjects.SyncObjects)
 }
 
 @Doc("https://www.khronos.org/opengles/sdk/docs/man3/html/glWaitSync.xhtml","OpenGL ES 3.0")
@@ -124,7 +124,7 @@ cmd void glWaitSync(GLsync sync, GLbitfield syncFlags, GLuint64 timeout) {
 
 sub void WaitSync(GLsync sync, GLbitfield syncFlags, GLuint64 timeout) {
   ctx := GetContext()
-  if !(sync in ctx.Instances.SyncObjects) { glErrorInvalidOperation() }
+  if !(sync in ctx.SharedObjects.SyncObjects) { glErrorInvalidOperation() }
   if timeout != 0xFFFFFFFFFFFFFFFF { glErrorInvalidValue() } // GL_TIMEOUT_IGNORED
   if syncFlags != as!GLbitfield(0) { glErrorInvalidValue() }
 }

--- a/gapis/gfxapi/gles/api/textures_and_samplers.api
+++ b/gapis/gfxapi/gles/api/textures_and_samplers.api
@@ -149,69 +149,69 @@ sub ref!Texture GetBoundTextureForUnit(ref!Context ctx, GLenum unit, GLenum targ
     case GL_TEXTURE_2D: {
       // minRequiredVersion(2, 0)
       switch (tu.Binding2d != 0) {
-        case true:  ctx.Instances.Textures[tu.Binding2d]
-        case false: ctx.Instances.DefaultTextures.Texture2d
+        case true:  ctx.SharedObjects.Textures[tu.Binding2d]
+        case false: ctx.Objects.DefaultTextures.Texture2d
       }
     }
     case GL_TEXTURE_EXTERNAL_OES: {
       // minRequiredVersion(2, 0)
       switch (tu.BindingExternalOes != 0) {
-        case true:  ctx.Instances.Textures[tu.BindingExternalOes]
-        case false: ctx.Instances.DefaultTextures.TextureExternalOes
+        case true:  ctx.SharedObjects.Textures[tu.BindingExternalOes]
+        case false: ctx.Objects.DefaultTextures.TextureExternalOes
       }
     }
     case GL_TEXTURE_2D_ARRAY: {
       // minRequiredVersion(3, 0)
       switch (tu.Binding2dArray != 0) {
-        case true:  ctx.Instances.Textures[tu.Binding2dArray]
-        case false: ctx.Instances.DefaultTextures.Texture2dArray
+        case true:  ctx.SharedObjects.Textures[tu.Binding2dArray]
+        case false: ctx.Objects.DefaultTextures.Texture2dArray
       }
     }
     case GL_TEXTURE_2D_MULTISAMPLE: {
       // minRequiredVersion(3, 1)
       switch (tu.Binding2dMultisample != 0) {
-        case true:  ctx.Instances.Textures[tu.Binding2dMultisample]
-        case false: ctx.Instances.DefaultTextures.Texture2dMultisample
+        case true:  ctx.SharedObjects.Textures[tu.Binding2dMultisample]
+        case false: ctx.Objects.DefaultTextures.Texture2dMultisample
       }
     }
     case GL_TEXTURE_2D_MULTISAMPLE_ARRAY: {
       // minRequiredVersion(3, 2)
       switch (tu.Binding2dMultisampleArray != 0) {
-        case true:  ctx.Instances.Textures[tu.Binding2dMultisampleArray]
-        case false: ctx.Instances.DefaultTextures.Texture2dMultisampleArray
+        case true:  ctx.SharedObjects.Textures[tu.Binding2dMultisampleArray]
+        case false: ctx.Objects.DefaultTextures.Texture2dMultisampleArray
       }
     }
     case GL_TEXTURE_3D: {
       // minRequiredVersion(3, 0)
       switch (tu.Binding3d != 0) {
-        case true:  ctx.Instances.Textures[tu.Binding3d]
-        case false: ctx.Instances.DefaultTextures.Texture3d
+        case true:  ctx.SharedObjects.Textures[tu.Binding3d]
+        case false: ctx.Objects.DefaultTextures.Texture3d
       }
     }
     case GL_TEXTURE_BUFFER: {
       // minRequiredVersion(3, 2)
       switch (tu.BindingBuffer != 0) {
-        case true:  ctx.Instances.Textures[tu.BindingBuffer]
-        case false: ctx.Instances.DefaultTextures.TextureBuffer
+        case true:  ctx.SharedObjects.Textures[tu.BindingBuffer]
+        case false: ctx.Objects.DefaultTextures.TextureBuffer
       }
     }
     case GL_TEXTURE_CUBE_MAP, GL_TEXTURE_CUBE_MAP_POSITIVE_X, GL_TEXTURE_CUBE_MAP_POSITIVE_Y, GL_TEXTURE_CUBE_MAP_POSITIVE_Z, GL_TEXTURE_CUBE_MAP_NEGATIVE_X, GL_TEXTURE_CUBE_MAP_NEGATIVE_Y, GL_TEXTURE_CUBE_MAP_NEGATIVE_Z: {
       // minRequiredVersion(2, 0)
       switch (tu.BindingCubeMap != 0) {
-        case true:  ctx.Instances.Textures[tu.BindingCubeMap]
-        case false: ctx.Instances.DefaultTextures.TextureCubeMap
+        case true:  ctx.SharedObjects.Textures[tu.BindingCubeMap]
+        case false: ctx.Objects.DefaultTextures.TextureCubeMap
       }
     }
     case GL_TEXTURE_CUBE_MAP_ARRAY: {
       // minRequiredVersion(3, 2)
       switch (tu.BindingCubeMapArray != 0) {
-        case true:  ctx.Instances.Textures[tu.BindingCubeMapArray]
-        case false: ctx.Instances.DefaultTextures.TextureCubeMapArray
+        case true:  ctx.SharedObjects.Textures[tu.BindingCubeMapArray]
+        case false: ctx.Objects.DefaultTextures.TextureCubeMapArray
       }
     }
     default: {
       // glErrorInvalidEnum(target)
-      ctx.Instances.DefaultTextures.Texture2d
+      ctx.Objects.DefaultTextures.Texture2d
     }
   }
 }
@@ -348,21 +348,21 @@ cmd void glBindTexture(GLenum target, TextureId texture) {
 
   // TODO: Do not initialize if the enum is not valid.
   if (texture != 0) {
-    if !(texture in ctx.Instances.Textures) {
+    if !(texture in ctx.SharedObjects.Textures) {
       if target == GL_TEXTURE_EXTERNAL_OES {
-        ctx.Instances.Textures[texture] = new!Texture(
+        ctx.SharedObjects.Textures[texture] = new!Texture(
           ID:         texture,
           WrapS:      GL_CLAMP_TO_EDGE,
           WrapT:      GL_CLAMP_TO_EDGE,
           MinFilter:  GL_LINEAR)
       } else {
-        ctx.Instances.Textures[texture] = new!Texture(
+        ctx.SharedObjects.Textures[texture] = new!Texture(
           ID: texture,
         )
       }
     }
 
-    t := ctx.Instances.Textures[texture]
+    t := ctx.SharedObjects.Textures[texture]
     if t.Kind == as!GLenum(0) {
       t.Kind = target
     } else {
@@ -831,7 +831,7 @@ cmd void glDeleteSamplers(GLsizei count, const SamplerId* samplers) {
   for i in (0 .. count) {
     id := s[i]
     if id != 0 {
-      delete(ctx.Instances.Samplers, id)
+      delete(ctx.SharedObjects.Samplers, id)
     }
   }
 }
@@ -849,7 +849,7 @@ cmd void glDeleteTextures(GLsizei count, const TextureId* textures) {
   for i in (0 .. count) {
     id := t[i]
     if id != 0 {
-      delete(ctx.Instances.Textures, id)
+      delete(ctx.SharedObjects.Textures, id)
     }
     // TODO: Unbind from all texture units.
   }
@@ -865,7 +865,7 @@ cmd void glGenSamplers(GLsizei count, SamplerId* samplers) {
   ctx := GetContext()
   for i in (0 .. count) {
     id := as!SamplerId(?)
-    ctx.Instances.Samplers[id] = new!Sampler()
+    ctx.SharedObjects.Samplers[id] = new!Sampler()
     s[i] = id
   }
 }
@@ -882,7 +882,7 @@ cmd void glGenTextures(GLsizei count, TextureId* textures) {
   ctx := GetContext()
   for i in (0 .. count) {
     id := as!TextureId(?)
-    ctx.Instances.Textures[id] = new!Texture(ID: id)
+    ctx.SharedObjects.Textures[id] = new!Texture(ID: id)
     t[i] = id
   }
 }
@@ -912,7 +912,7 @@ cmd void glGenerateMipmap(GLenum target) {
 
 sub void GetSamplerParameterv!T(SamplerId sampler, GLenum pname, T* params) {
   ctx := GetContext()
-  s := ctx.Instances.Samplers[sampler]
+  s := ctx.SharedObjects.Samplers[sampler]
   switch (pname) {
     case GL_TEXTURE_COMPARE_FUNC: params[0] = as!T(s.CompareFunc)
     case GL_TEXTURE_COMPARE_MODE: params[0] = as!T(s.CompareMode)
@@ -1213,7 +1213,7 @@ cmd GLboolean glIsSampler(SamplerId sampler) {
   minRequiredVersion(3, 0)
 
   ctx := GetContext()
-  return as!GLboolean(sampler in ctx.Instances.Samplers)
+  return as!GLboolean(sampler in ctx.SharedObjects.Samplers)
 }
 
 @Doc("https://www.khronos.org/opengles/sdk/docs/man/xhtml/glIsTexture.xml","OpenGL ES 2.0")
@@ -1224,7 +1224,7 @@ cmd GLboolean glIsTexture(TextureId texture) {
   minRequiredVersion(1, 0)
 
   ctx := GetContext()
-  return as!GLboolean(texture in ctx.Instances.Textures)
+  return as!GLboolean(texture in ctx.SharedObjects.Textures)
 }
 
 @Doc("https://www.khronos.org/opengles/sdk/docs/man/xhtml/glPixelStorei.xml","OpenGL ES 2.0")
@@ -1294,7 +1294,7 @@ cmd void glPixelStorei(GLenum parameter, GLint value) {
 
 sub void SamplerParameterv!T(SamplerId sampler, GLenum pname, T params) {
   ctx := GetContext()
-  s := ctx.Instances.Samplers[sampler]
+  s := ctx.SharedObjects.Samplers[sampler]
   switch (pname) {
     case GL_TEXTURE_COMPARE_FUNC: s.CompareFunc = as!GLenum(params[0])
     case GL_TEXTURE_COMPARE_MODE: s.CompareMode = as!GLenum(params[0])
@@ -2020,7 +2020,7 @@ cmd void glTexSubImage2D(GLenum         target,
   dst_offset := uncompressedImageSize(as!GLsizei(xoffset), 1, format, type) + dst_stride * as!u32(yoffset)
   src_data := switch (pbo == 0) {
     case true:  as!u8*(data)[0:src_size]
-    case false: ctx.Instances.Buffers[pbo].Data[as!u64(data):as!u64(data) + as!u64(src_size)]
+    case false: ctx.SharedObjects.Buffers[pbo].Data[as!u64(data):as!u64(data) + as!u64(src_size)]
   }
   line_bytes := uncompressedImageSize(width, 1, format, type)
 

--- a/gapis/gfxapi/gles/api/transform_feedback.api
+++ b/gapis/gfxapi/gles/api/transform_feedback.api
@@ -23,7 +23,7 @@ class TransformFeedback {
 
 sub ref!TransformFeedback GetBoundTransformFeedback() {
   ctx := GetContext()
-  return ctx.Instances.TransformFeedbacks[ctx.BoundTransformFeedback]
+  return ctx.Objects.TransformFeedbacks[ctx.BoundTransformFeedback]
 }
 
 @Doc("https://www.khronos.org/opengles/sdk/docs/man3/html/glBeginTransformFeedback.xhtml","OpenGL ES 3.0")
@@ -56,8 +56,8 @@ cmd void glBindTransformFeedback(GLenum target, TransformFeedbackId id) {
     }
   }
   ctx := GetContext()
-  if !(id in ctx.Instances.TransformFeedbacks) {
-    ctx.Instances.TransformFeedbacks[id] = new!TransformFeedback()
+  if !(id in ctx.Objects.TransformFeedbacks) {
+    ctx.Objects.TransformFeedbacks[id] = new!TransformFeedback()
   }
   ctx.BoundTransformFeedback = id
 }
@@ -72,7 +72,7 @@ cmd void glDeleteTransformFeedbacks(GLsizei n, const TransformFeedbackId* ids) {
   for i in (0 .. n) {
     id := tfs[i]
     if id != 0 {
-      ctx.Instances.TransformFeedbacks[id] = null
+      ctx.Objects.TransformFeedbacks[id] = null
     }
   }
 }
@@ -95,7 +95,7 @@ cmd void glGenTransformFeedbacks(GLsizei n, TransformFeedbackId* ids) {
   ctx := GetContext()
   for i in (0 .. n) {
     id := as!TransformFeedbackId(?)
-    ctx.Instances.TransformFeedbacks[id] = new!TransformFeedback()
+    ctx.Objects.TransformFeedbacks[id] = new!TransformFeedback()
     tfs[i] = id
   }
 }
@@ -123,7 +123,7 @@ cmd void glGetTransformFeedbackVarying(ProgramId program,
 cmd GLboolean glIsTransformFeedback(TransformFeedbackId id) {
   minRequiredVersion(3, 0)
   ctx := GetContext()
-  return as!GLboolean(id in ctx.Instances.TransformFeedbacks)
+  return as!GLboolean(id in ctx.Objects.TransformFeedbacks)
 }
 
 @Doc("https://www.khronos.org/opengles/sdk/docs/man3/html/glPauseTransformFeedback.xhtml","OpenGL ES 3.0")

--- a/gapis/gfxapi/gles/api/vertex_arrays.api
+++ b/gapis/gfxapi/gles/api/vertex_arrays.api
@@ -77,7 +77,7 @@ sub ref!VertexArray NewVertexArray(ref!Context ctx) {
 
 // Logic shared by glGetVertexAttrib* commands.
 sub u64 GetVertexAttrib(ref!Context ctx, AttributeLocation index, GLenum pname) {
-  vao := ctx.Instances.VertexArrays[ctx.BoundVertexArray]
+  vao := ctx.Objects.VertexArrays[ctx.BoundVertexArray]
   array := vao.VertexAttributeArrays[index]
   // TODO: Uncomment all the version checks
   return switch (pname) {
@@ -125,7 +125,7 @@ sub void ReadVertexArrays(ref!Context ctx, u32 first_index, u32 index_count, u32
   if (index_count > 0) && (instance_count > 0) {
     // Only the default vertex array can contain client data pointer.
     if ctx.BoundVertexArray == 0 {
-      vao := ctx.Instances.VertexArrays[0]
+      vao := ctx.Objects.VertexArrays[0]
       for i in (0 .. as!AttributeLocation(ctx.Constants.MaxVertexAttribs)) {
         arr := vao.VertexAttributeArrays[i]
         if arr.Enabled == GL_TRUE {
@@ -166,8 +166,8 @@ cmd void glBindVertexArray(VertexArrayId array) {
 sub void BindVertexArray(VertexArrayId array) {
   ctx := GetContext()
   // TODO: if !((array == 0) || (array in ctx.UsedNames.VertexArrays)) { glErrorInvalidOperation() }
-  if !(array in ctx.Instances.VertexArrays) {
-    ctx.Instances.VertexArrays[array] = NewVertexArray(ctx)
+  if !(array in ctx.Objects.VertexArrays) {
+    ctx.Objects.VertexArrays[array] = NewVertexArray(ctx)
   }
   ctx.BoundVertexArray = array
 }
@@ -187,10 +187,10 @@ sub void BindVertexBuffer(ref!Context ctx, VertexBufferBindingIndex binding_inde
     }
   }
   // TODO: if !((buffer == 0) || (buffer in ctx.UsedNames.Buffers)) { glErrorInvalidOperation() } // SPEC: html is different
-  if !(buffer in ctx.Instances.Buffers) {
-    ctx.Instances.Buffers[buffer] = new!Buffer()
+  if !(buffer in ctx.SharedObjects.Buffers) {
+    ctx.SharedObjects.Buffers[buffer] = new!Buffer()
   }
-  vao := ctx.Instances.VertexArrays[ctx.BoundVertexArray]
+  vao := ctx.Objects.VertexArrays[ctx.BoundVertexArray]
   binding := vao.VertexBufferBindings[binding_index]
   binding.Buffer = buffer
   binding.Offset = offset
@@ -223,8 +223,8 @@ sub void DeleteVertexArrays(GLsizei count, const VertexArrayId* arrays) {
     // Silently ignore invalid ids
     if id != 0 {
       // TODO: ctx.UsedNames.VertexArrays[id] = false
-      if id in ctx.Instances.VertexArrays {
-        delete(ctx.Instances.VertexArrays, id)
+      if id in ctx.Objects.VertexArrays {
+        delete(ctx.Objects.VertexArrays, id)
         if ctx.BoundVertexArray == id {
           ctx.BoundVertexArray = 0
         }
@@ -241,7 +241,7 @@ cmd void glDisableVertexAttribArray(AttributeLocation location) {
   minRequiredVersion(2, 0)
   ctx := GetContext()
   if location >= as!AttributeLocation(ctx.Constants.MaxVertexAttribs) { glErrorInvalidValue() }
-  vao := ctx.Instances.VertexArrays[ctx.BoundVertexArray]
+  vao := ctx.Objects.VertexArrays[ctx.BoundVertexArray]
   vao.VertexAttributeArrays[location].Enabled = GL_FALSE
 }
 
@@ -253,7 +253,7 @@ cmd void glEnableVertexAttribArray(AttributeLocation location) {
   minRequiredVersion(2, 0)
   ctx := GetContext()
   if location >= as!AttributeLocation(ctx.Constants.MaxVertexAttribs) { glErrorInvalidValue() }
-  vao := ctx.Instances.VertexArrays[ctx.BoundVertexArray]
+  vao := ctx.Objects.VertexArrays[ctx.BoundVertexArray]
   vao.VertexAttributeArrays[location].Enabled = GL_TRUE
 }
 
@@ -317,7 +317,7 @@ cmd void glGetVertexAttribPointerv(AttributeLocation index, GLenum pname, void**
   ctx := GetContext()
   if index >= as!AttributeLocation(ctx.Constants.MaxVertexAttribs) { glErrorInvalidValue() }
   if pname != GL_VERTEX_ATTRIB_ARRAY_POINTER { glErrorInvalidEnum(pname) }
-  vao := ctx.Instances.VertexArrays[ctx.BoundVertexArray]
+  vao := ctx.Objects.VertexArrays[ctx.BoundVertexArray]
   pointer[0] = as!void*(vao.VertexAttributeArrays[index].Pointer)
 }
 
@@ -365,7 +365,7 @@ cmd GLboolean glIsVertexArray(VertexArrayId array) {
 
 sub GLboolean IsVertexArray(VertexArrayId array) {
   ctx := GetContext()
-  return as!GLboolean((array != 0) && (array in ctx.Instances.VertexArrays))
+  return as!GLboolean((array != 0) && (array in ctx.Objects.VertexArrays))
 }
 
 sub void VertexAttribF(AttributeLocation location, Vec4f value) {
@@ -478,7 +478,7 @@ sub void VertexAttribBinding(ref!Context ctx, AttributeLocation index, VertexBuf
   }
   // NB: Some callers may use the default VertexArray and some may not.
   //     Therefore the caller should do the check if it is needed.
-  vao := ctx.Instances.VertexArrays[ctx.BoundVertexArray]
+  vao := ctx.Objects.VertexArrays[ctx.BoundVertexArray]
   vao.VertexAttributeArrays[index].Binding = binding_index
 }
 
@@ -503,7 +503,7 @@ sub void VertexAttribDivisor(AttributeLocation index, GLuint divisor) {
   ctx := GetContext()
   binding_index := as!VertexBufferBindingIndex(index)
   VertexAttribBinding(ctx, index, binding_index)
-  vao := ctx.Instances.VertexArrays[ctx.BoundVertexArray]
+  vao := ctx.Objects.VertexArrays[ctx.BoundVertexArray]
   vao.VertexBufferBindings[binding_index].Divisor = divisor
 }
 
@@ -554,7 +554,7 @@ sub void VertexAttribFormat(ref!Context       ctx,
   if VersionGreaterOrEqual(ctx, 3, 1) {
     if relativeOffset > as!GLuint(ctx.Constants.MaxVertexAttribRelativeOffset) { glErrorInvalidValue() }
   }
-  vao := ctx.Instances.VertexArrays[ctx.BoundVertexArray]
+  vao := ctx.Objects.VertexArrays[ctx.BoundVertexArray]
   format := vao.VertexAttributeArrays[index]
   format.Size = size
   format.Type = type
@@ -650,7 +650,7 @@ sub void VertexAttribPointer(ref!Context       ctx,
     case true:  stride
     case false: as!GLsizei(vertexTypeSize * size)
   }
-  vao := ctx.Instances.VertexArrays[ctx.BoundVertexArray]
+  vao := ctx.Objects.VertexArrays[ctx.BoundVertexArray]
   vao.VertexAttributeArrays[index].Stride = stride
   vao.VertexAttributeArrays[index].Pointer = pointer
   if (ctx.BoundVertexArray == 0) && (boundArrayBuffer == 0) {
@@ -700,6 +700,6 @@ cmd void glVertexBindingDivisor(VertexBufferBindingIndex binding_index, GLuint d
   ctx := GetContext()
   if binding_index >= as!VertexBufferBindingIndex(ctx.Constants.MaxVertexAttribBindings) { glErrorInvalidValue() }
   if ctx.BoundVertexArray == 0 { glErrorInvalidOperation() }
-  vao := ctx.Instances.VertexArrays[ctx.BoundVertexArray]
+  vao := ctx.Objects.VertexArrays[ctx.BoundVertexArray]
   vao.VertexBufferBindings[binding_index].Divisor = divisor
 }

--- a/gapis/gfxapi/gles/compat_test.go
+++ b/gapis/gfxapi/gles/compat_test.go
@@ -187,7 +187,7 @@ func TestGlVertexAttribPointerCompatTest(t *testing.T) {
 		}
 		if _, ok := a.(*gles.GlDrawElements); ok {
 			ctx := gles.GetContext(s)
-			vao := ctx.Instances.VertexArrays[ctx.BoundVertexArray]
+			vao := ctx.Objects.VertexArrays[ctx.BoundVertexArray]
 			array := vao.VertexAttributeArrays[0]
 			binding := vao.VertexBufferBindings[array.Binding]
 			if binding.Buffer != 0 && array.Pointer.Address == 0 {

--- a/gapis/gfxapi/gles/custom_replay.go
+++ b/gapis/gfxapi/gles/custom_replay.go
@@ -91,7 +91,7 @@ func (i UniformBlockId) remap(a atom.Atom, s *gfxapi.State) (key interface{}, re
 	return struct {
 		p *Program
 		i UniformBlockId
-	}{ctx.Instances.Programs[program], i}, true
+	}{ctx.SharedObjects.Programs[program], i}, true
 }
 
 func (i VertexArrayId) remap(a atom.Atom, s *gfxapi.State) (key interface{}, remap bool) {
@@ -131,12 +131,12 @@ func (i UniformLocation) remap(a atom.Atom, s *gfxapi.State) (key interface{}, r
 	return struct {
 		p *Program
 		l UniformLocation
-	}{ctx.Instances.Programs[program], i}, true
+	}{ctx.SharedObjects.Programs[program], i}, true
 }
 
 func (i IndicesPointer) value(b *builder.Builder, a atom.Atom, s *gfxapi.State) value.Value {
 	c := GetContext(s)
-	if c.Instances.VertexArrays[c.BoundVertexArray].ElementArrayBuffer != 0 {
+	if c.Objects.VertexArrays[c.BoundVertexArray].ElementArrayBuffer != 0 {
 		return value.AbsolutePointer(i.Address)
 	} else {
 		return value.ObservedPointer(i.Address)

--- a/gapis/gfxapi/gles/draw_call.go
+++ b/gapis/gfxapi/gles/draw_call.go
@@ -54,7 +54,7 @@ func (a *GlDrawElements) getIndices(
 		GLenum_GL_UNSIGNED_SHORT: 2,
 		GLenum_GL_UNSIGNED_INT:   4,
 	}[a.IndicesType]
-	indexBufferID := c.Instances.VertexArrays[c.BoundVertexArray].ElementArrayBuffer
+	indexBufferID := c.Objects.VertexArrays[c.BoundVertexArray].ElementArrayBuffer
 	size := uint64(a.IndicesCount) * indexSize
 
 	var decoder pod.Reader
@@ -63,7 +63,7 @@ func (a *GlDrawElements) getIndices(
 		decoder = a.Indices.Slice(0, size, s).Decoder(ctx, s)
 	} else {
 		// Get the index buffer data from buffer, offset by the 'indices' pointer.
-		indexBuffer := c.Instances.Buffers[indexBufferID]
+		indexBuffer := c.SharedObjects.Buffers[indexBufferID]
 		if indexBuffer == nil {
 			return nil, 0, fmt.Errorf("Can not find buffer %v", indexBufferID)
 		}

--- a/gapis/gfxapi/gles/draw_call_mesh.go
+++ b/gapis/gfxapi/gles/draw_call_mesh.go
@@ -72,13 +72,13 @@ func drawCallMesh(ctx context.Context, dc drawCall, p *path.Mesh) (*gfxapi.Mesh,
 		return nil, &service.ErrDataUnavailable{Reason: messages.ErrMeshHasNoVertices()}
 	}
 
-	program, found := c.Instances.Programs[c.BoundProgram]
+	program, found := c.SharedObjects.Programs[c.BoundProgram]
 	if !found {
 		return nil, &service.ErrDataUnavailable{Reason: messages.ErrNoProgramBound()}
 	}
 
 	vb := &vertex.Buffer{}
-	va := c.Instances.VertexArrays[c.BoundVertexArray]
+	va := c.Objects.VertexArrays[c.BoundVertexArray]
 	for _, attr := range program.ActiveAttributes {
 		vaa := va.VertexAttributeArrays[attr.Location]
 		if vaa.Enabled == GLboolean_GL_FALSE {
@@ -96,7 +96,7 @@ func drawCallMesh(ctx context.Context, dc drawCall, p *path.Mesh) (*gfxapi.Mesh,
 			// upper bound doesn't really matter here, so long as it's big.
 			slice = U8ˢ(vaa.Pointer.Slice(0, 1<<30, s))
 		} else {
-			slice = c.Instances.Buffers[vbb.Buffer].Data
+			slice = c.SharedObjects.Buffers[vbb.Buffer].Data
 		}
 		data, err := vertexStreamData(ctx, vaa, vbb, count, slice, s)
 		if err != nil {

--- a/gapis/gfxapi/gles/find_issues.go
+++ b/gapis/gfxapi/gles/find_issues.go
@@ -165,7 +165,7 @@ func (t *findIssues) Transform(ctx context.Context, i atom.ID, a atom.Atom, out 
 
 	switch a := a.(type) {
 	case *GlShaderSource:
-		shader := c.Instances.Shaders[a.Shader]
+		shader := c.SharedObjects.Shaders[a.Shader]
 		var errs []error
 		var kind string
 		switch shader.Type {
@@ -228,7 +228,7 @@ func (t *findIssues) Transform(ctx context.Context, i atom.ID, a atom.Atom, out 
 				}
 				if r.Uint32() != uint32(GLboolean_GL_TRUE) {
 					originalSource := "<unknown>"
-					if shader := c.Instances.Shaders[a.Shader]; shader != nil {
+					if shader := c.SharedObjects.Shaders[a.Shader]; shader != nil {
 						originalSource = shader.Source
 					}
 					t.onIssue(a, i, service.Severity_ErrorLevel, fmt.Errorf("Shader %d failed to compile. Error:\n%v\nOriginal source:\n%s\nTranslated source:\n%s\n", a.Shader, ntbs(infoLog), originalSource, ntbs(source)))
@@ -255,11 +255,11 @@ func (t *findIssues) Transform(ctx context.Context, i atom.ID, a atom.Atom, out 
 				r.Data(msg)
 				if res != uint32(GLboolean_GL_TRUE) {
 					vss, fss := "<unknown>", "<unknown>"
-					if program := c.Instances.Programs[a.Program]; program != nil {
-						if shader := c.Instances.Shaders[program.Shaders[GLenum_GL_VERTEX_SHADER]]; shader != nil {
+					if program := c.SharedObjects.Programs[a.Program]; program != nil {
+						if shader := c.SharedObjects.Shaders[program.Shaders[GLenum_GL_VERTEX_SHADER]]; shader != nil {
 							vss = shader.Source
 						}
-						if shader := c.Instances.Shaders[program.Shaders[GLenum_GL_FRAGMENT_SHADER]]; shader != nil {
+						if shader := c.SharedObjects.Shaders[program.Shaders[GLenum_GL_FRAGMENT_SHADER]]; shader != nil {
 							fss = shader.Source
 						}
 					}

--- a/gapis/gfxapi/gles/gles.api
+++ b/gapis/gfxapi/gles/gles.api
@@ -320,20 +320,27 @@ class DefaultTextureObjects {
   ref!Texture TextureExternalOes
 }
 
+// Objects which are never shared between contexts.
 @internal
 class Objects {
-  map!(RenderbufferId, ref!Renderbuffer)           Renderbuffers
   DefaultTextureObjects                            DefaultTextures
-  map!(TextureId, ref!Texture)                     Textures
   map!(FramebufferId, ref!Framebuffer)             Framebuffers
-  map!(BufferId, ref!Buffer)                       Buffers
-  map!(SamplerId, ref!Sampler)                     Samplers
-  map!(ShaderId, ref!Shader)                       Shaders
-  map!(ProgramId, ref!Program)                     Programs
   @unused map!(PipelineId, ref!Pipeline)           Pipelines
   map!(VertexArrayId, ref!VertexArray)             VertexArrays
   map!(QueryId, ref!Query)                         Queries
   map!(TransformFeedbackId, ref!TransformFeedback) TransformFeedbacks
+}
+
+// Objects which can be shared between contexts.
+// See: Chapter 5 - "Shared Objects and Multiple Contexts"
+@internal
+class SharedObjects {
+  map!(RenderbufferId, ref!Renderbuffer)           Renderbuffers
+  map!(TextureId, ref!Texture)                     Textures
+  map!(BufferId, ref!Buffer)                       Buffers
+  map!(SamplerId, ref!Sampler)                     Samplers
+  map!(ShaderId, ref!Shader)                       Shaders
+  map!(ProgramId, ref!Program)                     Programs
   map!(GLsync, ref!SyncObject)                     SyncObjects
 }
 
@@ -386,7 +393,8 @@ class Context {
   PixelStorageState                                     PixelStorage
   MiscellaneousState                                    Miscellaneous
   map!(GLenum, QueryId)                                 ActiveQueries
-  Objects                                               Instances
+  Objects                                               Objects
+  SharedObjects                                         SharedObjects
   Constants                                             Constants
 }
 
@@ -429,28 +437,28 @@ sub void ApplyStaticContextState(ref!Context ctx, ref!StaticContextState staticS
     // First initialization for the context.
     ctx.Constants = staticState.Constants
 
-    ctx.Instances.Framebuffers[0] = new!Framebuffer(ReadBuffer: GL_BACK)
-    ctx.Instances.Buffers[0] = new!Buffer()
-    ctx.Instances.Renderbuffers[0] = new!Renderbuffer()
-    ctx.Instances.TransformFeedbacks[0] = new!TransformFeedback()
-    ctx.Instances.VertexArrays[0] = NewVertexArray(ctx)
+    ctx.Objects.Framebuffers[0] = new!Framebuffer(ReadBuffer: GL_BACK)
+    ctx.SharedObjects.Buffers[0] = new!Buffer()
+    ctx.SharedObjects.Renderbuffers[0] = new!Renderbuffer()
+    ctx.Objects.TransformFeedbacks[0] = new!TransformFeedback()
+    ctx.Objects.VertexArrays[0] = NewVertexArray(ctx)
     ctx.TextureUnits[GL_TEXTURE0] = new!TextureUnit()
 
-    ctx.Instances.DefaultTextures.Texture2d = new!Texture(Kind: GL_TEXTURE_2D)
-    ctx.Instances.DefaultTextures.Texture2dArray = new!Texture(Kind: GL_TEXTURE_2D_ARRAY)
-    ctx.Instances.DefaultTextures.Texture2dMultisample = new!Texture(Kind: GL_TEXTURE_2D_MULTISAMPLE)
-    ctx.Instances.DefaultTextures.Texture2dMultisampleArray = new!Texture(Kind: GL_TEXTURE_2D_MULTISAMPLE_ARRAY)
-    ctx.Instances.DefaultTextures.Texture3d = new!Texture(Kind: GL_TEXTURE_3D)
-    ctx.Instances.DefaultTextures.TextureBuffer = new!Texture(Kind: GL_TEXTURE_BUFFER)
-    ctx.Instances.DefaultTextures.TextureCubeMap = new!Texture(Kind: GL_TEXTURE_CUBE_MAP)
-    ctx.Instances.DefaultTextures.TextureCubeMapArray = new!Texture(Kind: GL_TEXTURE_CUBE_MAP_ARRAY)
-    ctx.Instances.DefaultTextures.TextureExternalOes = new!Texture(Kind: GL_TEXTURE_EXTERNAL_OES)
+    ctx.Objects.DefaultTextures.Texture2d = new!Texture(Kind: GL_TEXTURE_2D)
+    ctx.Objects.DefaultTextures.Texture2dArray = new!Texture(Kind: GL_TEXTURE_2D_ARRAY)
+    ctx.Objects.DefaultTextures.Texture2dMultisample = new!Texture(Kind: GL_TEXTURE_2D_MULTISAMPLE)
+    ctx.Objects.DefaultTextures.Texture2dMultisampleArray = new!Texture(Kind: GL_TEXTURE_2D_MULTISAMPLE_ARRAY)
+    ctx.Objects.DefaultTextures.Texture3d = new!Texture(Kind: GL_TEXTURE_3D)
+    ctx.Objects.DefaultTextures.TextureBuffer = new!Texture(Kind: GL_TEXTURE_BUFFER)
+    ctx.Objects.DefaultTextures.TextureCubeMap = new!Texture(Kind: GL_TEXTURE_CUBE_MAP)
+    ctx.Objects.DefaultTextures.TextureCubeMapArray = new!Texture(Kind: GL_TEXTURE_CUBE_MAP_ARRAY)
+    ctx.Objects.DefaultTextures.TextureExternalOes = new!Texture(Kind: GL_TEXTURE_EXTERNAL_OES)
 
-    ctx.Instances.Renderbuffers[color_id] = new!Renderbuffer()
-    ctx.Instances.Renderbuffers[depth_id] = new!Renderbuffer()
-    ctx.Instances.Renderbuffers[stencil_id] = new!Renderbuffer()
+    ctx.SharedObjects.Renderbuffers[color_id] = new!Renderbuffer()
+    ctx.SharedObjects.Renderbuffers[depth_id] = new!Renderbuffer()
+    ctx.SharedObjects.Renderbuffers[stencil_id] = new!Renderbuffer()
 
-    backbuffer := ctx.Instances.Framebuffers[0]
+    backbuffer := ctx.Objects.Framebuffers[0]
     backbuffer.ColorAttachments[0] = FramebufferAttachment(
       ObjectName:          as!GLuint(color_id),
       ObjectType:          GL_RENDERBUFFER,
@@ -498,28 +506,28 @@ sub void ApplyStaticContextState(ref!Context ctx, ref!StaticContextState staticS
 
 sub void ApplyDynamicContextState(ref!Context ctx, ref!DynamicContextState dynamicState) {
   if (dynamicState != null) {
-    backbuffer := ctx.Instances.Framebuffers[0]
+    backbuffer := ctx.Objects.Framebuffers[0]
     color_id := as!RenderbufferId(backbuffer.ColorAttachments[0].ObjectName)
     depth_id := as!RenderbufferId(backbuffer.DepthAttachment.ObjectName)
     stencil_id := as!RenderbufferId(backbuffer.StencilAttachment.ObjectName)
 
-    color_buffer := ctx.Instances.Renderbuffers[color_id]
+    color_buffer := ctx.SharedObjects.Renderbuffers[color_id]
     color_buffer.Width = dynamicState.BackbufferWidth
     color_buffer.Height = dynamicState.BackbufferHeight
     color_buffer.InternalFormat = dynamicState.BackbufferColorFmt
-    ctx.Instances.Renderbuffers[color_id] = color_buffer
+    ctx.SharedObjects.Renderbuffers[color_id] = color_buffer
 
-    depth_buffer := ctx.Instances.Renderbuffers[depth_id]
+    depth_buffer := ctx.SharedObjects.Renderbuffers[depth_id]
     depth_buffer.Width = dynamicState.BackbufferWidth
     depth_buffer.Height = dynamicState.BackbufferHeight
     depth_buffer.InternalFormat = dynamicState.BackbufferDepthFmt
-    ctx.Instances.Renderbuffers[depth_id] = depth_buffer
+    ctx.SharedObjects.Renderbuffers[depth_id] = depth_buffer
 
-    stencil_buffer := ctx.Instances.Renderbuffers[stencil_id]
+    stencil_buffer := ctx.SharedObjects.Renderbuffers[stencil_id]
     stencil_buffer.Width = dynamicState.BackbufferWidth
     stencil_buffer.Height = dynamicState.BackbufferHeight
     stencil_buffer.InternalFormat = dynamicState.BackbufferStencilFmt
-    ctx.Instances.Renderbuffers[stencil_id] = stencil_buffer
+    ctx.SharedObjects.Renderbuffers[stencil_id] = stencil_buffer
 
     if dynamicState.ResetViewportScissor {
       ctx.FragmentOperations.Scissor.Box.Width = dynamicState.BackbufferWidth

--- a/gapis/gfxapi/gles/links.go
+++ b/gapis/gfxapi/gles/links.go
@@ -49,7 +49,7 @@ func (o AttributeLocation) Link(ctx context.Context, p path.Node) (path.Node, er
 	if i == nil {
 		return nil, err
 	}
-	va, ok := c.Instances.VertexArrays[c.BoundVertexArray]
+	va, ok := c.Objects.VertexArrays[c.BoundVertexArray]
 	if !ok || !va.VertexAttributeArrays.Contains(o) {
 		return nil, nil
 	}
@@ -64,7 +64,7 @@ func (o AttributeLocation) Link(ctx context.Context, p path.Node) (path.Node, er
 // If nil, nil is returned then the path cannot be followed.
 func (o BufferId) Link(ctx context.Context, p path.Node) (path.Node, error) {
 	i, c, err := instances(ctx, p)
-	if i == nil || !c.Instances.Buffers.Contains(o) {
+	if i == nil || !c.SharedObjects.Buffers.Contains(o) {
 		return nil, err
 	}
 	return i.Field("Buffers").MapIndex(int64(o)), nil
@@ -74,7 +74,7 @@ func (o BufferId) Link(ctx context.Context, p path.Node) (path.Node, error) {
 // If nil, nil is returned then the path cannot be followed.
 func (o FramebufferId) Link(ctx context.Context, p path.Node) (path.Node, error) {
 	i, c, err := instances(ctx, p)
-	if i == nil || !c.Instances.Framebuffers.Contains(o) {
+	if i == nil || !c.Objects.Framebuffers.Contains(o) {
 		return nil, err
 	}
 	return i.Field("Framebuffers").MapIndex(int64(o)), nil
@@ -84,7 +84,7 @@ func (o FramebufferId) Link(ctx context.Context, p path.Node) (path.Node, error)
 // If nil, nil is returned then the path cannot be followed.
 func (o ProgramId) Link(ctx context.Context, p path.Node) (path.Node, error) {
 	i, c, err := instances(ctx, p)
-	if i == nil || !c.Instances.Programs.Contains(o) {
+	if i == nil || !c.SharedObjects.Programs.Contains(o) {
 		return nil, err
 	}
 	return i.Field("Programs").MapIndex(int64(o)), nil
@@ -94,7 +94,7 @@ func (o ProgramId) Link(ctx context.Context, p path.Node) (path.Node, error) {
 // If nil, nil is returned then the path cannot be followed.
 func (o QueryId) Link(ctx context.Context, p path.Node) (path.Node, error) {
 	i, c, err := instances(ctx, p)
-	if i == nil || !c.Instances.Queries.Contains(o) {
+	if i == nil || !c.Objects.Queries.Contains(o) {
 		return nil, err
 	}
 	return i.Field("Queries").MapIndex(int64(o)), nil
@@ -104,7 +104,7 @@ func (o QueryId) Link(ctx context.Context, p path.Node) (path.Node, error) {
 // If nil, nil is returned then the path cannot be followed.
 func (o RenderbufferId) Link(ctx context.Context, p path.Node) (path.Node, error) {
 	i, c, err := instances(ctx, p)
-	if i == nil || !c.Instances.Renderbuffers.Contains(o) {
+	if i == nil || !c.SharedObjects.Renderbuffers.Contains(o) {
 		return nil, err
 	}
 	return i.Field("Renderbuffers").MapIndex(int64(o)), nil
@@ -114,7 +114,7 @@ func (o RenderbufferId) Link(ctx context.Context, p path.Node) (path.Node, error
 // If nil, nil is returned then the path cannot be followed.
 func (o ShaderId) Link(ctx context.Context, p path.Node) (path.Node, error) {
 	i, c, err := instances(ctx, p)
-	if i == nil || !c.Instances.Shaders.Contains(o) {
+	if i == nil || !c.SharedObjects.Shaders.Contains(o) {
 		return nil, err
 	}
 	return i.Field("Shaders").MapIndex(int64(o)), nil
@@ -124,7 +124,7 @@ func (o ShaderId) Link(ctx context.Context, p path.Node) (path.Node, error) {
 // If nil, nil is returned then the path cannot be followed.
 func (o TextureId) Link(ctx context.Context, p path.Node) (path.Node, error) {
 	i, c, err := instances(ctx, p)
-	if i == nil || !c.Instances.Textures.Contains(o) {
+	if i == nil || !c.SharedObjects.Textures.Contains(o) {
 		return nil, err
 	}
 	return i.Field("Textures").MapIndex(int64(o)), nil
@@ -153,7 +153,7 @@ func (o UniformLocation) Link(ctx context.Context, p path.Node) (path.Node, erro
 		program = c.BoundProgram
 	}
 
-	prog, ok := c.Instances.Programs[program]
+	prog, ok := c.SharedObjects.Programs[program]
 	if !ok || !prog.Uniforms.Contains(o) {
 		return nil, nil
 	}
@@ -169,7 +169,7 @@ func (o UniformLocation) Link(ctx context.Context, p path.Node) (path.Node, erro
 // If nil, nil is returned then the path cannot be followed.
 func (o VertexArrayId) Link(ctx context.Context, p path.Node) (path.Node, error) {
 	i, c, err := instances(ctx, p)
-	if i == nil || !c.Instances.VertexArrays.Contains(o) {
+	if i == nil || !c.Objects.VertexArrays.Contains(o) {
 		return nil, err
 	}
 	return i.Field("VertexArrays").MapIndex(int64(o)), nil

--- a/gapis/gfxapi/gles/links.go
+++ b/gapis/gfxapi/gles/links.go
@@ -21,9 +21,9 @@ import (
 	"github.com/google/gapid/gapis/service/path"
 )
 
-// instances returns the path to the Instances field of the currently bound
+// objects returns the path to the Objects field of the currently bound
 // context, and the context at p.
-func instances(ctx context.Context, p path.Node) (*path.Field, *Context, error) {
+func objects(ctx context.Context, p path.Node) (*path.Field, *Context, error) {
 	if cmdPath := path.FindCommand(p); cmdPath != nil {
 		stateObj, err := resolve.APIState(ctx, cmdPath.StateAfter())
 		if err != nil {
@@ -37,7 +37,28 @@ func instances(ctx context.Context, p path.Node) (*path.Field, *Context, error) 
 		return cmdPath.StateAfter().
 			Field("Contexts").
 			MapIndex(uint64(state.CurrentThread)).
-			Field("Instances"), context, nil
+			Field("Objects"), context, nil
+	}
+	return nil, nil, nil
+}
+
+// sharedObjects returns the path to the SharedObjects field of the currently bound
+// context, and the context at p.
+func sharedObjects(ctx context.Context, p path.Node) (*path.Field, *Context, error) {
+	if cmdPath := path.FindCommand(p); cmdPath != nil {
+		stateObj, err := resolve.APIState(ctx, cmdPath.StateAfter())
+		if err != nil {
+			return nil, nil, err
+		}
+		state := stateObj.(*State)
+		context, ok := state.Contexts[state.CurrentThread]
+		if !ok {
+			return nil, nil, nil
+		}
+		return cmdPath.StateAfter().
+			Field("Contexts").
+			MapIndex(uint64(state.CurrentThread)).
+			Field("SharedObjects"), context, nil
 	}
 	return nil, nil, nil
 }
@@ -45,7 +66,7 @@ func instances(ctx context.Context, p path.Node) (*path.Field, *Context, error) 
 // Link returns the link to the attribute vertex array in the state block.
 // If nil, nil is returned then the path cannot be followed.
 func (o AttributeLocation) Link(ctx context.Context, p path.Node) (path.Node, error) {
-	i, c, err := instances(ctx, p)
+	i, c, err := objects(ctx, p)
 	if i == nil {
 		return nil, err
 	}
@@ -63,7 +84,7 @@ func (o AttributeLocation) Link(ctx context.Context, p path.Node) (path.Node, er
 // Link returns the link to the buffer object in the state block.
 // If nil, nil is returned then the path cannot be followed.
 func (o BufferId) Link(ctx context.Context, p path.Node) (path.Node, error) {
-	i, c, err := instances(ctx, p)
+	i, c, err := sharedObjects(ctx, p)
 	if i == nil || !c.SharedObjects.Buffers.Contains(o) {
 		return nil, err
 	}
@@ -73,7 +94,7 @@ func (o BufferId) Link(ctx context.Context, p path.Node) (path.Node, error) {
 // Link returns the link to the framebuffer object in the state block.
 // If nil, nil is returned then the path cannot be followed.
 func (o FramebufferId) Link(ctx context.Context, p path.Node) (path.Node, error) {
-	i, c, err := instances(ctx, p)
+	i, c, err := objects(ctx, p)
 	if i == nil || !c.Objects.Framebuffers.Contains(o) {
 		return nil, err
 	}
@@ -83,7 +104,7 @@ func (o FramebufferId) Link(ctx context.Context, p path.Node) (path.Node, error)
 // Link returns the link to the program in the state block.
 // If nil, nil is returned then the path cannot be followed.
 func (o ProgramId) Link(ctx context.Context, p path.Node) (path.Node, error) {
-	i, c, err := instances(ctx, p)
+	i, c, err := sharedObjects(ctx, p)
 	if i == nil || !c.SharedObjects.Programs.Contains(o) {
 		return nil, err
 	}
@@ -93,7 +114,7 @@ func (o ProgramId) Link(ctx context.Context, p path.Node) (path.Node, error) {
 // Link returns the link to the query object in the state block.
 // If nil, nil is returned then the path cannot be followed.
 func (o QueryId) Link(ctx context.Context, p path.Node) (path.Node, error) {
-	i, c, err := instances(ctx, p)
+	i, c, err := objects(ctx, p)
 	if i == nil || !c.Objects.Queries.Contains(o) {
 		return nil, err
 	}
@@ -103,7 +124,7 @@ func (o QueryId) Link(ctx context.Context, p path.Node) (path.Node, error) {
 // Link returns the link to the renderbuffer object in the state block.
 // If nil, nil is returned then the path cannot be followed.
 func (o RenderbufferId) Link(ctx context.Context, p path.Node) (path.Node, error) {
-	i, c, err := instances(ctx, p)
+	i, c, err := sharedObjects(ctx, p)
 	if i == nil || !c.SharedObjects.Renderbuffers.Contains(o) {
 		return nil, err
 	}
@@ -113,7 +134,7 @@ func (o RenderbufferId) Link(ctx context.Context, p path.Node) (path.Node, error
 // Link returns the link to the shader object in the state block.
 // If nil, nil is returned then the path cannot be followed.
 func (o ShaderId) Link(ctx context.Context, p path.Node) (path.Node, error) {
-	i, c, err := instances(ctx, p)
+	i, c, err := sharedObjects(ctx, p)
 	if i == nil || !c.SharedObjects.Shaders.Contains(o) {
 		return nil, err
 	}
@@ -123,7 +144,7 @@ func (o ShaderId) Link(ctx context.Context, p path.Node) (path.Node, error) {
 // Link returns the link to the texture object in the state block.
 // If nil, nil is returned then the path cannot be followed.
 func (o TextureId) Link(ctx context.Context, p path.Node) (path.Node, error) {
-	i, c, err := instances(ctx, p)
+	i, c, err := sharedObjects(ctx, p)
 	if i == nil || !c.SharedObjects.Textures.Contains(o) {
 		return nil, err
 	}
@@ -133,7 +154,7 @@ func (o TextureId) Link(ctx context.Context, p path.Node) (path.Node, error) {
 // Link returns the link to the uniform in the state block.
 // If nil, nil is returned then the path cannot be followed.
 func (o UniformLocation) Link(ctx context.Context, p path.Node) (path.Node, error) {
-	i, c, err := instances(ctx, p)
+	i, c, err := sharedObjects(ctx, p)
 	if i == nil {
 		return nil, err
 	}
@@ -168,7 +189,7 @@ func (o UniformLocation) Link(ctx context.Context, p path.Node) (path.Node, erro
 // Link returns the link to the vertex array in the state block.
 // If nil, nil is returned then the path cannot be followed.
 func (o VertexArrayId) Link(ctx context.Context, p path.Node) (path.Node, error) {
-	i, c, err := instances(ctx, p)
+	i, c, err := objects(ctx, p)
 	if i == nil || !c.Objects.VertexArrays.Contains(o) {
 		return nil, err
 	}

--- a/gapis/gfxapi/gles/replay.go
+++ b/gapis/gfxapi/gles/replay.go
@@ -259,8 +259,8 @@ func (t *destroyResourcesAtEOS) Flush(ctx context.Context, out transform.Writer)
 	}
 
 	// Delete all Renderbuffers.
-	renderbuffers := make([]RenderbufferId, 0, len(c.Instances.Renderbuffers)-3)
-	for renderbufferId := range c.Instances.Renderbuffers {
+	renderbuffers := make([]RenderbufferId, 0, len(c.SharedObjects.Renderbuffers)-3)
+	for renderbufferId := range c.SharedObjects.Renderbuffers {
 		// Skip virtual renderbuffers: backbuffer_color(-1), backbuffer_depth(-2), backbuffer_stencil(-3).
 		if renderbufferId < 0xf0000000 {
 			renderbuffers = append(renderbuffers, renderbufferId)
@@ -272,8 +272,8 @@ func (t *destroyResourcesAtEOS) Flush(ctx context.Context, out transform.Writer)
 	}
 
 	// Delete all Textures.
-	textures := make([]TextureId, 0, len(c.Instances.Textures))
-	for textureId := range c.Instances.Textures {
+	textures := make([]TextureId, 0, len(c.SharedObjects.Textures))
+	for textureId := range c.SharedObjects.Textures {
 		textures = append(textures, textureId)
 	}
 	if len(textures) > 0 {
@@ -282,8 +282,8 @@ func (t *destroyResourcesAtEOS) Flush(ctx context.Context, out transform.Writer)
 	}
 
 	// Delete all Framebuffers.
-	framebuffers := make([]FramebufferId, 0, len(c.Instances.Framebuffers))
-	for framebufferId := range c.Instances.Framebuffers {
+	framebuffers := make([]FramebufferId, 0, len(c.Objects.Framebuffers))
+	for framebufferId := range c.Objects.Framebuffers {
 		framebuffers = append(framebuffers, framebufferId)
 	}
 	if len(framebuffers) > 0 {
@@ -292,8 +292,8 @@ func (t *destroyResourcesAtEOS) Flush(ctx context.Context, out transform.Writer)
 	}
 
 	// Delete all Buffers.
-	buffers := make([]BufferId, 0, len(c.Instances.Buffers))
-	for bufferId := range c.Instances.Buffers {
+	buffers := make([]BufferId, 0, len(c.SharedObjects.Buffers))
+	for bufferId := range c.SharedObjects.Buffers {
 		buffers = append(buffers, bufferId)
 	}
 	if len(buffers) > 0 {
@@ -302,8 +302,8 @@ func (t *destroyResourcesAtEOS) Flush(ctx context.Context, out transform.Writer)
 	}
 
 	// Delete all VertexArrays.
-	vertexArrays := make([]VertexArrayId, 0, len(c.Instances.VertexArrays))
-	for vertexArrayId := range c.Instances.VertexArrays {
+	vertexArrays := make([]VertexArrayId, 0, len(c.Objects.VertexArrays))
+	for vertexArrayId := range c.Objects.VertexArrays {
 		vertexArrays = append(vertexArrays, vertexArrayId)
 	}
 	if len(vertexArrays) > 0 {
@@ -312,18 +312,18 @@ func (t *destroyResourcesAtEOS) Flush(ctx context.Context, out transform.Writer)
 	}
 
 	// Delete all Shaders.
-	for _, shaderId := range c.Instances.Shaders.KeysSorted() {
+	for _, shaderId := range c.SharedObjects.Shaders.KeysSorted() {
 		out.MutateAndWrite(ctx, id, NewGlDeleteShader(shaderId))
 	}
 
 	// Delete all Programs.
-	for _, programId := range c.Instances.Programs.KeysSorted() {
+	for _, programId := range c.SharedObjects.Programs.KeysSorted() {
 		out.MutateAndWrite(ctx, id, NewGlDeleteProgram(programId))
 	}
 
 	// Delete all Queries.
-	queries := make([]QueryId, 0, len(c.Instances.Queries))
-	for queryId := range c.Instances.Queries {
+	queries := make([]QueryId, 0, len(c.Objects.Queries))
+	for queryId := range c.Objects.Queries {
 		queries = append(queries, queryId)
 	}
 	if len(queries) > 0 {

--- a/gapis/gfxapi/gles/resources.go
+++ b/gapis/gfxapi/gles/resources.go
@@ -256,7 +256,7 @@ func (p *Program) ResourceData(ctx context.Context, s *gfxapi.State) (interface{
 
 	shaders := []*gfxapi.Shader{}
 	for shaderType, shaderID := range p.Shaders {
-		shader := context.Instances.Shaders.Get(shaderID)
+		shader := context.SharedObjects.Shaders.Get(shaderID)
 		if shader == nil {
 			continue
 		}

--- a/gapis/gfxapi/gles/state.go
+++ b/gapis/gfxapi/gles/state.go
@@ -35,7 +35,7 @@ func (s *State) getFramebufferAttachmentInfo(att gfxapi.FramebufferAttachment) (
 		return 0, 0, 0, fmt.Errorf("Context not initialized")
 	}
 
-	framebuffer, ok := c.Instances.Framebuffers[c.BoundReadFramebuffer]
+	framebuffer, ok := c.Objects.Framebuffers[c.BoundReadFramebuffer]
 	if !ok {
 		return 0, 0, 0, fmt.Errorf("No GL_FRAMEBUFFER bound")
 	}
@@ -65,7 +65,7 @@ func (s *State) getFramebufferAttachmentInfo(att gfxapi.FramebufferAttachment) (
 	switch a.ObjectType {
 	case GLenum_GL_TEXTURE:
 		id := TextureId(a.ObjectName)
-		t, ok := c.Instances.Textures[id]
+		t, ok := c.SharedObjects.Textures[id]
 		if !ok {
 			return 0, 0, 0, fmt.Errorf("Invalid texture attachment %v", id)
 		}
@@ -84,7 +84,7 @@ func (s *State) getFramebufferAttachmentInfo(att gfxapi.FramebufferAttachment) (
 		}
 	case GLenum_GL_RENDERBUFFER:
 		id := RenderbufferId(a.ObjectName)
-		r, ok := c.Instances.Renderbuffers[id]
+		r, ok := c.SharedObjects.Renderbuffers[id]
 		if !ok {
 			return 0, 0, 0, fmt.Errorf("Renderbuffer %v not found", id)
 		}

--- a/gapis/gfxapi/gles/stub_program.go
+++ b/gapis/gfxapi/gles/stub_program.go
@@ -38,11 +38,11 @@ func buildStubProgram(ctx context.Context, e *atom.Extras, s *gfxapi.State, prog
 	}
 	c := GetContext(s)
 	vertexShaderID := ShaderId(newUnusedID(ctx, 'S', func(x uint32) bool {
-		_, ok := c.Instances.Buffers[BufferId(x)]
+		_, ok := c.SharedObjects.Buffers[BufferId(x)]
 		return ok
 	}))
 	fragmentShaderID := ShaderId(newUnusedID(ctx, 'S', func(x uint32) bool {
-		_, ok := c.Instances.Buffers[BufferId(x)]
+		_, ok := c.SharedObjects.Buffers[BufferId(x)]
 		return ok || x == uint32(vertexShaderID)
 	}))
 	return append(

--- a/gapis/gfxapi/gles/texture_compat.go
+++ b/gapis/gfxapi/gles/texture_compat.go
@@ -214,7 +214,7 @@ func decompressTexImage2D(ctx context.Context, i atom.ID, a *GlCompressedTexImag
 	data := a.Data
 	if pb := c.BoundBuffers.PixelUnpackBuffer; pb != 0 {
 		base := a.Data.Address
-		data = TexturePointer(c.Instances.Buffers[pb].Data.Index(base, s))
+		data = TexturePointer(c.SharedObjects.Buffers[pb].Data.Index(base, s))
 		out.MutateAndWrite(ctx, atom.NoID, NewGlBindBuffer(GLenum_GL_PIXEL_UNPACK_BUFFER, 0))
 		defer out.MutateAndWrite(ctx, atom.NoID, NewGlBindBuffer(GLenum_GL_PIXEL_UNPACK_BUFFER, pb))
 	} else {
@@ -260,7 +260,7 @@ func decompressTexSubImage2D(ctx context.Context, i atom.ID, a *GlCompressedTexS
 	data := a.Data
 	if pb := c.BoundBuffers.PixelUnpackBuffer; pb != 0 {
 		base := a.Data.Address
-		data = TexturePointer(c.Instances.Buffers[pb].Data.Index(base, s))
+		data = TexturePointer(c.SharedObjects.Buffers[pb].Data.Index(base, s))
 		out.MutateAndWrite(ctx, atom.NoID, NewGlBindBuffer(GLenum_GL_PIXEL_UNPACK_BUFFER, 0))
 		defer out.MutateAndWrite(ctx, atom.NoID, NewGlBindBuffer(GLenum_GL_PIXEL_UNPACK_BUFFER, pb))
 	} else {

--- a/gapis/gfxapi/gles/tweaker.go
+++ b/gapis/gfxapi/gles/tweaker.go
@@ -162,7 +162,7 @@ func (t *tweaker) makeVertexArray(enabledLocations ...AttributeLocation) {
 		}
 	} else {
 		// GLES 2.0 does not have Vertex Array Objects, but the state is fairly simple.
-		vao := t.c.Instances.VertexArrays[t.c.BoundVertexArray]
+		vao := t.c.Objects.VertexArrays[t.c.BoundVertexArray]
 		// Disable all vertex attribute arrays
 		for location, origVertexAttrib := range vao.VertexAttributeArrays {
 			if origVertexAttrib.Enabled == GLboolean_GL_TRUE {
@@ -190,7 +190,7 @@ func (t *tweaker) makeVertexArray(enabledLocations ...AttributeLocation) {
 }
 
 func (t *tweaker) glGenBuffer() BufferId {
-	id := BufferId(newUnusedID(t.ctx, 'B', func(x uint32) bool { return t.c.Instances.Buffers[BufferId(x)] != nil }))
+	id := BufferId(newUnusedID(t.ctx, 'B', func(x uint32) bool { return t.c.SharedObjects.Buffers[BufferId(x)] != nil }))
 	tmp := t.AllocData(id)
 	t.doAndUndo(
 		NewGlGenBuffers(1, tmp.Ptr()).AddWrite(tmp.Data()),
@@ -199,7 +199,7 @@ func (t *tweaker) glGenBuffer() BufferId {
 }
 
 func (t *tweaker) glGenRenderbuffer() RenderbufferId {
-	id := RenderbufferId(newUnusedID(t.ctx, 'R', func(x uint32) bool { return t.c.Instances.Renderbuffers[RenderbufferId(x)] != nil }))
+	id := RenderbufferId(newUnusedID(t.ctx, 'R', func(x uint32) bool { return t.c.SharedObjects.Renderbuffers[RenderbufferId(x)] != nil }))
 	tmp := t.AllocData(id)
 	t.doAndUndo(
 		NewGlGenRenderbuffers(1, tmp.Ptr()).AddWrite(tmp.Data()),
@@ -208,7 +208,7 @@ func (t *tweaker) glGenRenderbuffer() RenderbufferId {
 }
 
 func (t *tweaker) glGenFramebuffer() FramebufferId {
-	id := FramebufferId(newUnusedID(t.ctx, 'F', func(x uint32) bool { return t.c.Instances.Framebuffers[FramebufferId(x)] != nil }))
+	id := FramebufferId(newUnusedID(t.ctx, 'F', func(x uint32) bool { return t.c.Objects.Framebuffers[FramebufferId(x)] != nil }))
 	tmp := t.AllocData(id)
 	t.doAndUndo(
 		NewGlGenFramebuffers(1, tmp.Ptr()).AddWrite(tmp.Data()),
@@ -217,7 +217,7 @@ func (t *tweaker) glGenFramebuffer() FramebufferId {
 }
 
 func (t *tweaker) glGenTexture() TextureId {
-	id := TextureId(newUnusedID(t.ctx, 'T', func(x uint32) bool { return t.c.Instances.Textures[TextureId(x)] != nil }))
+	id := TextureId(newUnusedID(t.ctx, 'T', func(x uint32) bool { return t.c.SharedObjects.Textures[TextureId(x)] != nil }))
 	tmp := t.AllocData(id)
 	t.doAndUndo(
 		NewGlGenTextures(1, tmp.Ptr()).AddWrite(tmp.Data()),
@@ -226,7 +226,7 @@ func (t *tweaker) glGenTexture() TextureId {
 }
 
 func (t *tweaker) glGenVertexArray() VertexArrayId {
-	id := VertexArrayId(newUnusedID(t.ctx, 'V', func(x uint32) bool { return t.c.Instances.VertexArrays[VertexArrayId(x)] != nil }))
+	id := VertexArrayId(newUnusedID(t.ctx, 'V', func(x uint32) bool { return t.c.Objects.VertexArrays[VertexArrayId(x)] != nil }))
 	tmp := t.AllocData(id)
 	t.doAndUndo(
 		NewGlGenVertexArrays(1, tmp.Ptr()).AddWrite(tmp.Data()),
@@ -236,7 +236,7 @@ func (t *tweaker) glGenVertexArray() VertexArrayId {
 
 func (t *tweaker) glCreateProgram() ProgramId {
 	id := ProgramId(newUnusedID(t.ctx, 'P', func(x uint32) bool {
-		return t.c.Instances.Programs[ProgramId(x)] != nil || t.c.Instances.Shaders[ShaderId(x)] != nil
+		return t.c.SharedObjects.Programs[ProgramId(x)] != nil || t.c.SharedObjects.Shaders[ShaderId(x)] != nil
 	}))
 	t.doAndUndo(
 		NewGlCreateProgram(id),
@@ -259,7 +259,7 @@ func (t *tweaker) makeProgram(vertexShaderSource, fragmentShaderSource string) P
 
 func (t *tweaker) glCreateShader(shaderType GLenum) ShaderId {
 	id := ShaderId(newUnusedID(t.ctx, 'S', func(x uint32) bool {
-		return t.c.Instances.Programs[ProgramId(x)] != nil || t.c.Instances.Shaders[ShaderId(x)] != nil
+		return t.c.SharedObjects.Programs[ProgramId(x)] != nil || t.c.SharedObjects.Shaders[ShaderId(x)] != nil
 	}))
 	// We need to mutate the state, as otherwise two consecutive calls can return the same ShaderId.
 	t.doAndUndo(
@@ -297,7 +297,7 @@ func (t *tweaker) GlBindBuffer_ArrayBuffer(id BufferId) {
 }
 
 func (t *tweaker) GlBindBuffer_ElementArrayBuffer(id BufferId) {
-	vao := t.c.Instances.VertexArrays[t.c.BoundVertexArray]
+	vao := t.c.Objects.VertexArrays[t.c.BoundVertexArray]
 	if o := vao.ElementArrayBuffer; o != id {
 		t.doAndUndo(
 			NewGlBindBuffer(GLenum_GL_ELEMENT_ARRAY_BUFFER, id),
@@ -322,7 +322,7 @@ func (t *tweaker) glBindFramebuffer_Read(id FramebufferId) {
 }
 
 func (t *tweaker) glReadBuffer(id GLenum) {
-	fb := t.c.Instances.Framebuffers[t.c.BoundReadFramebuffer]
+	fb := t.c.Objects.Framebuffers[t.c.BoundReadFramebuffer]
 	if o := fb.ReadBuffer; o != id {
 		t.doAndUndo(
 			NewGlReadBuffer(id),

--- a/gapis/gfxapi/gles/wireframe.go
+++ b/gapis/gfxapi/gles/wireframe.go
@@ -104,7 +104,7 @@ func drawWireframe(ctx context.Context, i atom.ID, dc drawCall, s *gfxapi.State,
 
 	// Unbind the index buffer
 	tmp := atom.Must(atom.Alloc(ctx, s, uint64(len(wireframeData))))
-	oldIndexBufferID := c.Instances.VertexArrays[c.BoundVertexArray].ElementArrayBuffer
+	oldIndexBufferID := c.Objects.VertexArrays[c.BoundVertexArray].ElementArrayBuffer
 	out.MutateAndWrite(ctx, atom.NoID,
 		NewGlBindBuffer(GLenum_GL_ELEMENT_ARRAY_BUFFER, 0).
 			AddRead(tmp.Range(), resID))


### PR DESCRIPTION
Separate the ID->object maps based on whether the object
can be shared between GL contexts or not.

Other then the change in gles.api, this is just a renaming commit.