### PR TITLE
Texture thumbnail fixes.

### DIFF
--- a/core/image/uncompressed.go
+++ b/core/image/uncompressed.go
@@ -72,7 +72,7 @@ func (f *FmtUncompressed) resize(data []byte, srcW, srcH, dstW, dstH int) ([]byt
 	if err != nil {
 		return nil, err
 	}
-	return Convert(data, dstW, dstH, RGBA_F32, RGBA_F32)
+	return Convert(data, dstW, dstH, RGBA_F32, format)
 }
 
 func (f *FmtUncompressed) convert(data []byte, width, height int, dstFmt *Format) ([]byte, error) {

--- a/core/stream/convert.go
+++ b/core/stream/convert.go
@@ -115,7 +115,7 @@ func resolveImplicitMappings(count int, mappings []mapping, srcFmt *Format, srcD
 			}
 		case Channel_Luminance:
 			if c := srcFmt.GetSingleColorComponent(); c != nil {
-				// A format with a signle color channel is equivalent to a luninance format.
+				// A format with a single color channel is equivalent to a luninance format.
 				m.src = buf{srcData, c, srcFmt.BitOffsets()[c], uint32(srcFmt.Stride()) * 8}
 			}
 			// TODO: RGB->Luminance conversion (#276)

--- a/core/stream/convert.go
+++ b/core/stream/convert.go
@@ -114,10 +114,11 @@ func resolveImplicitMappings(count int, mappings []mapping, srcFmt *Format, srcD
 				m.src = buf0
 			}
 		case Channel_Luminance:
-			if c := srcFmt.HasSingleColorComponent(); c != nil {
+			if c := srcFmt.GetSingleColorComponent(); c != nil {
+				// A format with a signle color channel is equivalent to a luninance format.
 				m.src = buf{srcData, c, srcFmt.BitOffsets()[c], uint32(srcFmt.Stride()) * 8}
 			}
-			// TODO: RGB->Luminance conversion
+			// TODO: RGB->Luminance conversion (#276)
 		}
 	}
 	return mappings

--- a/core/stream/convert.go
+++ b/core/stream/convert.go
@@ -113,6 +113,11 @@ func resolveImplicitMappings(count int, mappings []mapping, srcFmt *Format, srcD
 			} else if srcFmt.HasColorComponent() {
 				m.src = buf0
 			}
+		case Channel_Luminance:
+			if c := srcFmt.HasSingleColorComponent(); c != nil {
+				m.src = buf{srcData, c, srcFmt.BitOffsets()[c], uint32(srcFmt.Stride()) * 8}
+			}
+			// TODO: RGB->Luminance conversion
 		}
 	}
 	return mappings

--- a/core/stream/format.go
+++ b/core/stream/format.go
@@ -129,6 +129,21 @@ func (f *Format) HasColorComponent() bool {
 	return false
 }
 
+// HasSingleColorComponent returns a component if the format contains a single
+// color component, otherwise nil. See ColorChannels for channels considered colors.
+func (f *Format) HasSingleColorComponent() *Component {
+	var c *Component = nil
+	for _, t := range f.Components {
+		if t.Channel.IsColor() {
+			if c != nil {
+				return nil
+			}
+			c = t
+		}
+	}
+	return c
+}
+
 // HasVectorComponent returns true if the format contains a vector component.
 // See VectorChannels for channels considered vectors.
 func (f *Format) HasVectorComponent() bool {

--- a/core/stream/format.go
+++ b/core/stream/format.go
@@ -129,9 +129,9 @@ func (f *Format) HasColorComponent() bool {
 	return false
 }
 
-// HasSingleColorComponent returns a component if the format contains a single
+// GetSingleColorComponent returns a component if the format contains a single
 // color component, otherwise nil. See ColorChannels for channels considered colors.
-func (f *Format) HasSingleColorComponent() *Component {
+func (f *Format) GetSingleColorComponent() *Component {
 	var c *Component = nil
 	for _, t := range f.Components {
 		if t.Channel.IsColor() {


### PR DESCRIPTION
- Fixes a bug in the resize code for uncompressed formats
- If luminance channel is requested of a format that doesn't have a luminance channel, but has a single (other) color channel, use that channel as luminance.