### PR TITLE
Fix the case where one verb is a strict prefix of another.

### DIFF
--- a/core/app/verbs.go
+++ b/core/app/verbs.go
@@ -83,6 +83,13 @@ func (v *Verb) Invoke(ctx context.Context, args []string) error {
 	}
 	verb := args[0]
 	matches := v.Filter(verb)
+	for _, verbs := range matches {
+		if verbs.Name == verb {
+			matches = []*Verb{verbs}
+			break
+		}
+	}
+
 	switch len(matches) {
 	case 1:
 		v.selected = matches[0]


### PR DESCRIPTION
Previously we would declare the verbs ambiguous, now if
the user types a full verb-name then succeed.