### PR TITLE
Allow Go version above the requirement to be used

### DIFF
--- a/cmd/do/do.go
+++ b/cmd/do/do.go
@@ -125,7 +125,7 @@ func init() {
 		hostExeExt = ".exe"
 	}
 
-	if got := strings.TrimLeft(runtime.Version(), "go"); got != requiredGoVersion {
+	if got := strings.TrimLeft(runtime.Version(), "go"); got < requiredGoVersion {
 		fmt.Fprintf(os.Stderr, "Requires Go version '%s', got '%s'", requiredGoVersion, got)
 		os.Exit(1)
 	}


### PR DESCRIPTION
Currently, the code reject any version that isn't `1.8`:
```
Requires Go version '1.8', got '1.8.1'
```

This string comparison isn't perfect (it will be wrong again when go `1.10` comes out), but at least it fixes the issue until someone write a correct version comparison test *(I don't know what the proper way of doing this in go is; looking it up, it looks like [that lib](https://github.com/blang/semver) might be good, but I'm not going to make the decision of suggesting we import that lib into this project)*.