### PR TITLE
Fixed shadertools.

### DIFF
--- a/gapis/shadertools/cc/libmanager.cpp
+++ b/gapis/shadertools/cc/libmanager.cpp
@@ -280,12 +280,12 @@ const char* getDisassembleText(uint32_t* spirv_binary, size_t length) {
 
   spvtools::SpirvTools tools(SPV_ENV_VULKAN_1_0);
   std::string disassembly;
-  const auto result = tools.Disassemble(
+  const bool result = tools.Disassemble(
     spirv_vec, &disassembly,
     (SPV_BINARY_TO_TEXT_OPTION_FRIENDLY_NAMES |
      SPV_BINARY_TO_TEXT_OPTION_INDENT));
 
-  if (result < 0) {
+  if (!result) {
     return nullptr;
   }
 


### PR DESCRIPTION
My last fix was wrong. It assumed that the auto return was of type
spv_result as it had previously been compared with SPV_SUCCESS. These
were both incorrect, as tools.Disassemble returns a bool.