### PR TITLE
Handle glDebugMessageCallback

### DIFF
--- a/core/cc/linux/get_gles_proc_address.cpp
+++ b/core/cc/linux/get_gles_proc_address.cpp
@@ -28,24 +28,24 @@ void* getGlesProcAddress(const char *name, bool bypassLocal) {
         static DlLoader libgl("libGL.so");
         if (GPAPROC gpa = reinterpret_cast<GPAPROC>(libgl.lookup("glXGetProcAddress"))) {
             if (void* proc = gpa(name)) {
-                GAPID_DEBUG("GetGlesProcAddress(%s, %d) -> 0x%x (via libGL glXGetProcAddress)", name, bypassLocal, proc);
+                GAPID_VERBOSE("GetGlesProcAddress(%s, %d) -> 0x%x (via libGL glXGetProcAddress)", name, bypassLocal, proc);
                 return proc;
             }
         }
         if (void* proc = libgl.lookup(name)) {
-            GAPID_DEBUG("GetGlesProcAddress(%s, %d) -> 0x%x (from libGL dlsym)", name, bypassLocal, proc);
+            GAPID_VERBOSE("GetGlesProcAddress(%s, %d) -> 0x%x (from libGL dlsym)", name, bypassLocal, proc);
             return proc;
         }
     } else {
         static DlLoader local(nullptr);
         if (GPAPROC gpa = reinterpret_cast<GPAPROC>(local.lookup("glXGetProcAddress"))) {
             if (void* proc = gpa(name)) {
-                GAPID_DEBUG("GetGlesProcAddress(%s, %d) -> 0x%x (via local glXGetProcAddress)", name, bypassLocal, proc);
+                GAPID_VERBOSE("GetGlesProcAddress(%s, %d) -> 0x%x (via local glXGetProcAddress)", name, bypassLocal, proc);
                 return proc;
             }
         }
         if (void* proc = local.lookup(name)) {
-            GAPID_DEBUG("GetGlesProcAddress(%s, %d) -> 0x%x (from local dlsym)", name, bypassLocal, proc);
+            GAPID_VERBOSE("GetGlesProcAddress(%s, %d) -> 0x%x (from local dlsym)", name, bypassLocal, proc);
             return proc;
         }
     }

--- a/gapis/gfxapi/gles/compat.go
+++ b/gapis/gfxapi/gles/compat.go
@@ -802,6 +802,13 @@ func compat(ctx context.Context, device *device.Instance) (transform.Transformer
 				return // Not supported in the core profile of OpenGL.
 			}
 
+		case *GlDebugMessageCallback,
+			*GlDebugMessageControl,
+			*GlDebugMessageCallbackKHR,
+			*GlDebugMessageControlKHR:
+			// Ignore - the callback function address is invalid in replay.
+			return
+
 		case *GlGetBooleani_v,
 			*GlGetBooleanv,
 			*GlGetFloatv,


### PR DESCRIPTION
We need to ignore in compat as it will crash gapir (at random point in the driver if/when it tries to use it)

On the other hand it is really useful, so wire it to so gapir reports messages from driver.