### PR TITLE
Split FramebufferAttachment.ObjectName to two fields.

### DIFF
--- a/gapii/cc/spy.cpp
+++ b/gapii/cc/spy.cpp
@@ -528,16 +528,13 @@ bool Spy::getFramebufferAttachmentSize(uint32_t& width, uint32_t& height) {
         return false;
     }
 
-    switch (attachment->second.mObjectType) {
+    switch (attachment->second.mType) {
         case GL_TEXTURE: {
-            auto t = ctx->mSharedObjects.mTextures.find(attachment->second.mObjectName);
-            if (t == ctx->mSharedObjects.mTextures.end()) {
-                return false;
-            }
-            switch (t->second->mKind) {
+            auto t = attachment->second.mTexture;
+            switch (t->mKind) {
                 case GLenum::GL_TEXTURE_2D: {
-                    auto l = t->second->mTexture2D.find(attachment->second.mTextureLevel);
-                    if (l == t->second->mTexture2D.end()) {
+                    auto l = t->mTexture2D.find(attachment->second.mTextureLevel);
+                    if (l == t->mTexture2D.end()) {
                         return false;
                     }
                     width = uint32_t(l->second.mWidth);
@@ -545,8 +542,8 @@ bool Spy::getFramebufferAttachmentSize(uint32_t& width, uint32_t& height) {
                     return true;
                 }
                 case GLenum::GL_TEXTURE_CUBE_MAP: {
-                    auto l = t->second->mCubemap.find(attachment->second.mTextureLevel);
-                    if (l == t->second->mCubemap.end()) {
+                    auto l = t->mCubemap.find(attachment->second.mTextureLevel);
+                    if (l == t->mCubemap.end()) {
                         return false;
                     }
                     auto f = l->second.mFaces.find(attachment->second.mTextureCubeMapFace);
@@ -560,12 +557,9 @@ bool Spy::getFramebufferAttachmentSize(uint32_t& width, uint32_t& height) {
             }
         }
         case GL_RENDERBUFFER: {
-            auto r = ctx->mSharedObjects.mRenderbuffers.find(attachment->second.mObjectName);
-            if (r == ctx->mSharedObjects.mRenderbuffers.end()) {
-                return false;
-            }
-            width = uint32_t(r->second->mWidth);
-            height = uint32_t(r->second->mHeight);
+            auto r = attachment->second.mRenderbuffer;
+            width = uint32_t(r->mWidth);
+            height = uint32_t(r->mHeight);
             return true;
         }
     }

--- a/gapis/gfxapi/gles/api/framebuffer.api
+++ b/gapis/gfxapi/gles/api/framebuffer.api
@@ -48,12 +48,13 @@ class Framebuffer {
 @internal
 class FramebufferAttachment {
   // Table 21.16: Framebuffer (state per attachment point)
-  GLenum    ObjectType         = GL_NONE
-  GLuint    ObjectName         = 0
-  GLint     TextureLevel       = 0
-  GLenum    TextureCubeMapFace = GL_NONE
-  GLint     TextureLayer       = 0
-  GLboolean Layered            = GL_FALSE
+  GLenum           Type = GL_NONE
+  ref!Texture      Texture
+  ref!Renderbuffer Renderbuffer
+  GLint            TextureLevel       = 0
+  GLenum           TextureCubeMapFace = GL_NONE
+  GLint            TextureLayer       = 0
+  GLboolean        Layered            = GL_FALSE
 /* TODO
   GLenum ColorEncoding
   GLenum ComponentType
@@ -69,6 +70,7 @@ class FramebufferAttachment {
 
 @internal
 class Renderbuffer {
+  RenderbufferId ID
   @unused u8[] Data
 
   // Table 21.17: Renderbuffer (state per renderbuffer object)
@@ -214,7 +216,7 @@ cmd void glBindRenderbuffer(GLenum target, RenderbufferId renderbuffer) {
     }
   }
   if !(renderbuffer in ctx.SharedObjects.Renderbuffers) {
-    ctx.SharedObjects.Renderbuffers[renderbuffer] = new!Renderbuffer()
+    ctx.SharedObjects.Renderbuffers[renderbuffer] = new!Renderbuffer(ID: renderbuffer)
   }
 }
 
@@ -552,8 +554,8 @@ cmd void glFramebufferRenderbuffer(GLenum         framebuffer_target,
 
   attachment := FramebufferAttachment()
   if (renderbuffer != 0) {
-    attachment.ObjectType = GL_RENDERBUFFER
-    attachment.ObjectName = as!GLuint(renderbuffer)
+    attachment.Type = GL_RENDERBUFFER
+    attachment.Renderbuffer = ctx.SharedObjects.Renderbuffers[renderbuffer]
   }
   SetFramebufferAttachment(framebuffer_target, framebuffer_attachment, attachment)
 }
@@ -569,8 +571,8 @@ sub void FramebufferTexture(GLenum target, GLenum attachment, TextureId texture,
   attachment_info := FramebufferAttachment()
   if (texture != 0) {
     if !(texture in ctx.SharedObjects.Textures) { glErrorInvalidValue() }
-    attachment_info.ObjectType = GL_TEXTURE
-    attachment_info.ObjectName = as!GLuint(texture)
+    attachment_info.Type = GL_TEXTURE
+    attachment_info.Texture = ctx.SharedObjects.Textures[texture]
     attachment_info.TextureLevel = level
     attachment_info.Layered = 0 // TODO
   }
@@ -631,8 +633,8 @@ sub void FramebufferTexture2D(GLenum    framebuffer_target,
     }
     // TODO: Handle texture 0
     if ctx.SharedObjects.Textures[texture].Kind != kind { glErrorInvalidOperation() }
-    attachment.ObjectType = GL_TEXTURE
-    attachment.ObjectName = as!GLuint(texture)
+    attachment.Type = GL_TEXTURE
+    attachment.Texture = ctx.SharedObjects.Textures[texture]
     attachment.TextureLevel = level
     attachment.TextureCubeMapFace = switch (texture_target) {
       case GL_TEXTURE_CUBE_MAP_NEGATIVE_X, GL_TEXTURE_CUBE_MAP_NEGATIVE_Y,
@@ -658,8 +660,8 @@ cmd void glFramebufferTextureLayer(GLenum    target,
   attachment_info := FramebufferAttachment()
   if (texture != 0) {
     if !(texture in ctx.SharedObjects.Textures) { glErrorInvalidValue() }
-    attachment_info.ObjectType = GL_TEXTURE
-    attachment_info.ObjectName = as!GLuint(texture)
+    attachment_info.Type = GL_TEXTURE
+    attachment_info.Texture = ctx.SharedObjects.Textures[texture]
     attachment_info.TextureLevel = level
     attachment_info.TextureLayer = layer
   }
@@ -695,7 +697,7 @@ cmd void glGenRenderbuffers(GLsizei count, RenderbufferId* renderbuffers) {
   ctx := GetContext()
   for i in (0 .. count) {
     id := as!RenderbufferId(?)
-    ctx.SharedObjects.Renderbuffers[id] = new!Renderbuffer()
+    ctx.SharedObjects.Renderbuffers[id] = new!Renderbuffer(ID: id)
     r[i] = id
   }
 }
@@ -755,14 +757,19 @@ cmd void glGetFramebufferAttachmentParameteriv(GLenum framebuffer_target,
     }
   }
 
-  if (a.ObjectType == GL_NONE) &&
+  if (a.Type == GL_NONE) &&
       (parameter != GL_FRAMEBUFFER_ATTACHMENT_OBJECT_NAME) && (parameter != GL_FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE) {
     glErrorInvalidOperation()
   }
   value[0] = switch (parameter) {
     // TODO: Several format-related cases are still missing.
-    case GL_FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE:           as!GLint(a.ObjectType)
-    case GL_FRAMEBUFFER_ATTACHMENT_OBJECT_NAME:           as!GLint(a.ObjectName)
+    case GL_FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE:           as!GLint(a.Type)
+    case GL_FRAMEBUFFER_ATTACHMENT_OBJECT_NAME:
+      switch a.Type {
+        case GL_NONE:         as!GLint(0)
+        case GL_TEXTURE:      as!GLint(a.Texture.ID)
+        case GL_RENDERBUFFER: as!GLint(a.Renderbuffer.ID)
+      }
     case GL_FRAMEBUFFER_ATTACHMENT_TEXTURE_LEVEL:         as!GLint(a.TextureLevel)
     case GL_FRAMEBUFFER_ATTACHMENT_TEXTURE_CUBE_MAP_FACE: as!GLint(a.TextureCubeMapFace)
     case GL_FRAMEBUFFER_ATTACHMENT_LAYERED:               as!GLint(a.Layered)

--- a/gapis/gfxapi/gles/gles.api
+++ b/gapis/gfxapi/gles/gles.api
@@ -439,7 +439,7 @@ sub void ApplyStaticContextState(ref!Context ctx, ref!StaticContextState staticS
 
     ctx.Objects.Framebuffers[0] = new!Framebuffer(ReadBuffer: GL_BACK)
     ctx.SharedObjects.Buffers[0] = new!Buffer()
-    ctx.SharedObjects.Renderbuffers[0] = new!Renderbuffer()
+    ctx.SharedObjects.Renderbuffers[0] = new!Renderbuffer(ID:0)
     ctx.Objects.TransformFeedbacks[0] = new!TransformFeedback()
     ctx.Objects.VertexArrays[0] = NewVertexArray(ctx)
     ctx.TextureUnits[GL_TEXTURE0] = new!TextureUnit()
@@ -454,26 +454,26 @@ sub void ApplyStaticContextState(ref!Context ctx, ref!StaticContextState staticS
     ctx.Objects.DefaultTextures.TextureCubeMapArray = new!Texture(Kind: GL_TEXTURE_CUBE_MAP_ARRAY)
     ctx.Objects.DefaultTextures.TextureExternalOes = new!Texture(Kind: GL_TEXTURE_EXTERNAL_OES)
 
-    ctx.SharedObjects.Renderbuffers[color_id] = new!Renderbuffer()
-    ctx.SharedObjects.Renderbuffers[depth_id] = new!Renderbuffer()
-    ctx.SharedObjects.Renderbuffers[stencil_id] = new!Renderbuffer()
+    ctx.SharedObjects.Renderbuffers[color_id] = new!Renderbuffer(ID: color_id)
+    ctx.SharedObjects.Renderbuffers[depth_id] = new!Renderbuffer(ID: depth_id)
+    ctx.SharedObjects.Renderbuffers[stencil_id] = new!Renderbuffer(ID: stencil_id)
 
     backbuffer := ctx.Objects.Framebuffers[0]
     backbuffer.ColorAttachments[0] = FramebufferAttachment(
-      ObjectName:          as!GLuint(color_id),
-      ObjectType:          GL_RENDERBUFFER,
+      Type:                GL_RENDERBUFFER,
+      Renderbuffer:        ctx.SharedObjects.Renderbuffers[color_id],
       TextureCubeMapFace:  GL_NONE,
     )
 
     backbuffer.DepthAttachment = FramebufferAttachment(
-      ObjectName:          as!GLuint(depth_id),
-      ObjectType:          GL_RENDERBUFFER,
+      Type:                GL_RENDERBUFFER,
+      Renderbuffer:        ctx.SharedObjects.Renderbuffers[depth_id],
       TextureCubeMapFace:  GL_NONE,
     )
 
     backbuffer.StencilAttachment = FramebufferAttachment(
-      ObjectName:          as!GLuint(stencil_id),
-      ObjectType:          GL_RENDERBUFFER,
+      Type:                GL_RENDERBUFFER,
+      Renderbuffer:        ctx.SharedObjects.Renderbuffers[stencil_id],
       TextureCubeMapFace:  GL_NONE,
     )
 
@@ -507,9 +507,9 @@ sub void ApplyStaticContextState(ref!Context ctx, ref!StaticContextState staticS
 sub void ApplyDynamicContextState(ref!Context ctx, ref!DynamicContextState dynamicState) {
   if (dynamicState != null) {
     backbuffer := ctx.Objects.Framebuffers[0]
-    color_id := as!RenderbufferId(backbuffer.ColorAttachments[0].ObjectName)
-    depth_id := as!RenderbufferId(backbuffer.DepthAttachment.ObjectName)
-    stencil_id := as!RenderbufferId(backbuffer.StencilAttachment.ObjectName)
+    color_id := backbuffer.ColorAttachments[0].Renderbuffer.ID
+    depth_id := backbuffer.DepthAttachment.Renderbuffer.ID
+    stencil_id := backbuffer.StencilAttachment.Renderbuffer.ID
 
     color_buffer := ctx.SharedObjects.Renderbuffers[color_id]
     color_buffer.Width = dynamicState.BackbufferWidth

--- a/gapis/gfxapi/gles/state.go
+++ b/gapis/gfxapi/gles/state.go
@@ -58,17 +58,11 @@ func (s *State) getFramebufferAttachmentInfo(att gfxapi.FramebufferAttachment) (
 		return 0, 0, 0, fmt.Errorf("Framebuffer attachment %v unsupported by gles", att)
 	}
 
-	if a.ObjectType == GLenum_GL_NONE {
+	switch a.Type {
+	case GLenum_GL_NONE:
 		return 0, 0, 0, fmt.Errorf("%s is not bound", att)
-	}
-
-	switch a.ObjectType {
 	case GLenum_GL_TEXTURE:
-		id := TextureId(a.ObjectName)
-		t, ok := c.SharedObjects.Textures[id]
-		if !ok {
-			return 0, 0, 0, fmt.Errorf("Invalid texture attachment %v", id)
-		}
+		t := a.Texture
 		switch t.Kind {
 		case GLenum_GL_TEXTURE_2D:
 			l := t.Texture2D[a.TextureLevel]
@@ -81,13 +75,9 @@ func (s *State) getFramebufferAttachmentInfo(att gfxapi.FramebufferAttachment) (
 			return 0, 0, 0, fmt.Errorf("Unknown texture kind %v", t.Kind)
 		}
 	case GLenum_GL_RENDERBUFFER:
-		id := RenderbufferId(a.ObjectName)
-		r, ok := c.SharedObjects.Renderbuffers[id]
-		if !ok {
-			return 0, 0, 0, fmt.Errorf("Renderbuffer %v not found", id)
-		}
+		r := a.Renderbuffer
 		return uint32(r.Width), uint32(r.Height), r.InternalFormat, nil
 	default:
-		return 0, 0, 0, fmt.Errorf("Unknown framebuffer attachment type %T", a.ObjectType)
+		return 0, 0, 0, fmt.Errorf("Unknown framebuffer attachment type %T", a.Type)
 	}
 }


### PR DESCRIPTION
Use two fields (Renderbuffer/Texture) to replace the 'union' field.

Also replace the ID with object reference.

This makes the attachment easier to follow in the state block
and easier to work with in the code.