### PR TITLE
Replace most atom.NoID uses with derived ID.

### DIFF
--- a/gapis/atom/atom.go
+++ b/gapis/atom/atom.go
@@ -16,6 +16,7 @@ package atom
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/google/gapid/framework/binary"
 	"github.com/google/gapid/framework/binary/schema"
@@ -53,6 +54,24 @@ type ID uint64
 
 // NoID is used when you have to pass an ID, but don't have one to use.
 const NoID = ID(1<<63 - 1) // use max int64 for the benefit of java
+
+// DerivedID is used to annotate generated extra atoms.
+// They are used purely for debugging when printing logs.
+func DerivedID(id ID) ID {
+	return id | derivedBit
+}
+
+const derivedBit = ID(1 << 62)
+
+func (id ID) String() string {
+	if id == NoID {
+		return "(NoID)"
+	} else if (id & derivedBit) != 0 {
+		return fmt.Sprintf("%v*", uint64(id & ^derivedBit))
+	} else {
+		return fmt.Sprintf("%v", uint64(id))
+	}
+}
 
 // AtomCast is automatically called by the generated decoders.
 func AtomCast(obj binary.Object) Atom {

--- a/gapis/atom/atom.go
+++ b/gapis/atom/atom.go
@@ -55,9 +55,9 @@ type ID uint64
 // NoID is used when you have to pass an ID, but don't have one to use.
 const NoID = ID(1<<63 - 1) // use max int64 for the benefit of java
 
-// DerivedID is used to annotate generated extra atoms.
-// They are used purely for debugging when printing logs.
-func DerivedID(id ID) ID {
+// Derived is used to create an ID which is used for generated extra atoms.
+// It is used purely for debugging (to print the related original atom ID).
+func (id ID) Derived() ID {
 	return id | derivedBit
 }
 

--- a/gapis/atom/transform/file_log.go
+++ b/gapis/atom/transform/file_log.go
@@ -40,11 +40,7 @@ func NewFileLog(ctx context.Context, name string) *FileLog {
 
 func (t *FileLog) Transform(ctx context.Context, id atom.ID, a atom.Atom, out Writer) {
 	if a.API() != nil {
-		if id != atom.NoID {
-			t.file.WriteString(fmt.Sprintf("%v: %v\n", id, a))
-		} else {
-			t.file.WriteString(fmt.Sprintf("%v\n", a))
-		}
+		t.file.WriteString(fmt.Sprintf("%v: %v\n", id, a))
 	} else {
 		t.file.WriteString(fmt.Sprintf("%T\n", a))
 	}

--- a/gapis/gfxapi/gles/compat.go
+++ b/gapis/gfxapi/gles/compat.go
@@ -165,7 +165,7 @@ func compat(ctx context.Context, device *device.Instance) (transform.Transformer
 		s := out.State()
 		id := nextBufferID
 		tmp := atom.Must(atom.AllocData(ctx, s, id))
-		out.MutateAndWrite(ctx, atom.DerivedID(i), NewGlGenBuffers(1, tmp.Ptr()).AddWrite(tmp.Data()))
+		out.MutateAndWrite(ctx, i.Derived(), NewGlGenBuffers(1, tmp.Ptr()).AddWrite(tmp.Data()))
 		nextBufferID--
 		return id
 	}
@@ -228,7 +228,7 @@ func compat(ctx context.Context, device *device.Instance) (transform.Transformer
 			if att.Type == GLenum_GL_TEXTURE {
 				tex := att.Texture
 				if tex.EGLImage != GLeglImageOES(memory.Nullptr) {
-					dID := atom.DerivedID(i)
+					dID := i.Derived()
 					t := newTweaker(ctx, out, dID)
 					s := out.State()
 					t.glBindFramebuffer_Read(c.BoundDrawFramebuffer)
@@ -250,7 +250,7 @@ func compat(ctx context.Context, device *device.Instance) (transform.Transformer
 
 	var t transform.Transformer
 	t = transform.Transform("compat", func(ctx context.Context, i atom.ID, a atom.Atom, out transform.Writer) {
-		dID := atom.DerivedID(i)
+		dID := i.Derived()
 		s := out.State()
 		switch a := a.(type) {
 		case *EglMakeCurrent: // TODO: Check for GLX, CGL, WGL...
@@ -1080,7 +1080,7 @@ func moveClientVBsToVAs(
 
 	// Apply the memory observations that were made by the draw call now.
 	// We need to do this as the glBufferData calls below will require the data.
-	dID := atom.DerivedID(i)
+	dID := i.Derived()
 	out.MutateAndWrite(ctx, dID, replay.Custom(func(ctx context.Context, s *gfxapi.State, b *builder.Builder) error {
 		a.Extras().Observations().ApplyReads(s.Memory[memory.ApplicationPool])
 		return nil

--- a/gapis/gfxapi/gles/compat.go
+++ b/gapis/gfxapi/gles/compat.go
@@ -161,11 +161,11 @@ func compat(ctx context.Context, device *device.Instance) (transform.Transformer
 
 	scratchBuffers := map[interface{}]scratchBuffer{}
 	nextBufferID := BufferId(0xffff0000)
-	newBuffer := func(out transform.Writer) BufferId {
+	newBuffer := func(i atom.ID, out transform.Writer) BufferId {
 		s := out.State()
 		id := nextBufferID
 		tmp := atom.Must(atom.AllocData(ctx, s, id))
-		out.MutateAndWrite(ctx, atom.NoID, NewGlGenBuffers(1, tmp.Ptr()).AddWrite(tmp.Data()))
+		out.MutateAndWrite(ctx, atom.DerivedID(i), NewGlGenBuffers(1, tmp.Ptr()).AddWrite(tmp.Data()))
 		nextBufferID--
 		return id
 	}
@@ -228,7 +228,8 @@ func compat(ctx context.Context, device *device.Instance) (transform.Transformer
 			if att.Type == GLenum_GL_TEXTURE {
 				tex := att.Texture
 				if tex.EGLImage != GLeglImageOES(memory.Nullptr) {
-					t := newTweaker(ctx, out)
+					dID := atom.DerivedID(i)
+					t := newTweaker(ctx, out, dID)
 					s := out.State()
 					t.glBindFramebuffer_Read(c.BoundDrawFramebuffer)
 					t.glReadBuffer(GLenum_GL_COLOR_ATTACHMENT0 + GLenum(name))
@@ -239,8 +240,8 @@ func compat(ctx context.Context, device *device.Instance) (transform.Transformer
 						data = atom.Must(atom.Alloc(ctx, s, img.Data.Count)).Ptr()
 						eglImageData[tex.EGLImage] = data
 					}
-					out.MutateAndWrite(ctx, i, NewGlReadPixels(0, 0, img.Width, img.Height, img.DataFormat, img.DataType, data))
-					out.MutateAndWrite(ctx, i, NewGlGetError(0))
+					out.MutateAndWrite(ctx, dID, NewGlReadPixels(0, 0, img.Width, img.Height, img.DataFormat, img.DataType, data))
+					out.MutateAndWrite(ctx, dID, NewGlGetError(0))
 					t.revert()
 				}
 			}
@@ -249,6 +250,7 @@ func compat(ctx context.Context, device *device.Instance) (transform.Transformer
 
 	var t transform.Transformer
 	t = transform.Transform("compat", func(ctx context.Context, i atom.ID, a atom.Atom, out transform.Writer) {
+		dID := atom.DerivedID(i)
 		s := out.State()
 		switch a := a.(type) {
 		case *EglMakeCurrent: // TODO: Check for GLX, CGL, WGL...
@@ -293,8 +295,8 @@ func compat(ctx context.Context, device *device.Instance) (transform.Transformer
 				// Satisfy the target by creating and binding a single VAO
 				// which we will use instead of the default VAO (id 0).
 				tmp := atom.Must(atom.AllocData(ctx, s, VertexArrayId(DefaultVertexArrayId)))
-				out.MutateAndWrite(ctx, atom.NoID, NewGlGenVertexArrays(1, tmp.Ptr()).AddWrite(tmp.Data()))
-				out.MutateAndWrite(ctx, atom.NoID, NewGlBindVertexArray(DefaultVertexArrayId))
+				out.MutateAndWrite(ctx, dID, NewGlGenVertexArrays(1, tmp.Ptr()).AddWrite(tmp.Data()))
+				out.MutateAndWrite(ctx, dID, NewGlBindVertexArray(DefaultVertexArrayId))
 			}
 			return
 		}
@@ -316,20 +318,20 @@ func compat(ctx context.Context, device *device.Instance) (transform.Transformer
 			if a.Buffer != 0 && !c.SharedObjects.Buffers.Contains(a.Buffer) {
 				// glGenBuffers() was not used to generate the buffer. Legal in GLES 2.
 				tmp := atom.Must(atom.AllocData(ctx, s, a.Buffer))
-				out.MutateAndWrite(ctx, atom.NoID, NewGlGenBuffers(1, tmp.Ptr()).AddRead(tmp.Data()))
+				out.MutateAndWrite(ctx, dID, NewGlGenBuffers(1, tmp.Ptr()).AddRead(tmp.Data()))
 			}
 
 		case *GlBindTexture:
 			if a.Texture != 0 && !c.SharedObjects.Textures.Contains(a.Texture) {
 				// glGenTextures() was not used to generate the texture. Legal in GLES 2.
 				tmp := atom.Must(atom.AllocData(ctx, s, VertexArrayId(a.Texture)))
-				out.MutateAndWrite(ctx, atom.NoID, NewGlGenTextures(1, tmp.Ptr()).AddRead(tmp.Data()))
+				out.MutateAndWrite(ctx, dID, NewGlGenTextures(1, tmp.Ptr()).AddRead(tmp.Data()))
 			}
 
 			if a.Target == GLenum_GL_TEXTURE_EXTERNAL_OES && target.eglImageExternal == unsupported {
 				// TODO: Implement full support for external images.
 				// Remap external textures to plain 2D textures - this matches GLSL compat.
-				out.MutateAndWrite(ctx, atom.NoID, NewGlBindTexture(GLenum_GL_TEXTURE_2D, a.Texture))
+				out.MutateAndWrite(ctx, i, NewGlBindTexture(GLenum_GL_TEXTURE_2D, a.Texture))
 				return
 			}
 
@@ -346,7 +348,7 @@ func compat(ctx context.Context, device *device.Instance) (transform.Transformer
 					// NB: This leaks state change upstream.
 					// In particular, when the tweaker saves and then restores vertex array binding,
 					// it will restore it to DefaultVertexArrayId instead of 0.  It is harmless.
-					out.MutateAndWrite(ctx, atom.NoID, NewGlBindVertexArray(DefaultVertexArrayId))
+					out.MutateAndWrite(ctx, i, NewGlBindVertexArray(DefaultVertexArrayId))
 					return
 				}
 			}
@@ -355,7 +357,7 @@ func compat(ctx context.Context, device *device.Instance) (transform.Transformer
 			if a.Array == VertexArrayId(0) {
 				if target.vertexArrayObjects == required &&
 					contexts[c].vertexArrayObjects != required {
-					out.MutateAndWrite(ctx, atom.NoID, NewGlBindVertexArray(DefaultVertexArrayId))
+					out.MutateAndWrite(ctx, i, NewGlBindVertexArray(DefaultVertexArrayId))
 					return
 				}
 			}
@@ -383,31 +385,31 @@ func compat(ctx context.Context, device *device.Instance) (transform.Transformer
 				// Look for pre-existing buffer we can reuse.
 				buffer, ok := scratchBuffers[key]
 				if !ok {
-					buffer.id = newBuffer(out)
+					buffer.id = newBuffer(dID, out)
 					scratchBuffers[key] = buffer
 				}
 
 				// Bind the scratch buffer to GL_COPY_WRITE_BUFFER
 				origCopyWriteBuffer := c.BoundBuffers.CopyWriteBuffer
-				out.MutateAndWrite(ctx, atom.NoID, NewGlBindBuffer(GLenum_GL_COPY_WRITE_BUFFER, buffer.id))
+				out.MutateAndWrite(ctx, dID, NewGlBindBuffer(GLenum_GL_COPY_WRITE_BUFFER, buffer.id))
 
 				if buffer.size < a.Size {
 					// Resize the scratch buffer
-					out.MutateAndWrite(ctx, atom.NoID, NewGlBufferData(GLenum_GL_COPY_WRITE_BUFFER, a.Size, memory.Nullptr, GLenum_GL_DYNAMIC_COPY))
+					out.MutateAndWrite(ctx, dID, NewGlBufferData(GLenum_GL_COPY_WRITE_BUFFER, a.Size, memory.Nullptr, GLenum_GL_DYNAMIC_COPY))
 					buffer.size = a.Size
 					scratchBuffers[key] = buffer
 				}
 
 				// Copy out the misaligned data to the scratch buffer in the
 				// GL_COPY_WRITE_BUFFER binding.
-				out.MutateAndWrite(ctx, atom.NoID, NewGlBindBuffer(a.Target, a.Buffer))
-				out.MutateAndWrite(ctx, atom.NoID, NewGlCopyBufferSubData(a.Target, GLenum_GL_COPY_WRITE_BUFFER, a.Offset, 0, a.Size))
+				out.MutateAndWrite(ctx, dID, NewGlBindBuffer(a.Target, a.Buffer))
+				out.MutateAndWrite(ctx, dID, NewGlCopyBufferSubData(a.Target, GLenum_GL_COPY_WRITE_BUFFER, a.Offset, 0, a.Size))
 
 				// We can now bind the range with correct alignment.
 				out.MutateAndWrite(ctx, i, NewGlBindBufferRange(a.Target, a.Index, buffer.id, 0, a.Size))
 
 				// Restore old GL_COPY_WRITE_BUFFER binding.
-				out.MutateAndWrite(ctx, atom.NoID, NewGlBindBuffer(GLenum_GL_COPY_WRITE_BUFFER, origCopyWriteBuffer))
+				out.MutateAndWrite(ctx, dID, NewGlBindBuffer(GLenum_GL_COPY_WRITE_BUFFER, origCopyWriteBuffer))
 
 				return
 			}
@@ -516,7 +518,7 @@ func compat(ctx context.Context, device *device.Instance) (transform.Transformer
 				if clientVAsBound(c, clientVAs) {
 					first := uint32(a.FirstIndex)
 					count := uint32(a.IndicesCount)
-					t := newTweaker(ctx, out)
+					t := newTweaker(ctx, out, dID)
 					defer t.revert()
 					moveClientVBsToVAs(ctx, t, clientVAs, first, count, i, a, s, c, out)
 				}
@@ -525,7 +527,7 @@ func compat(ctx context.Context, device *device.Instance) (transform.Transformer
 		case *GlDrawElements:
 			if target.vertexArrayObjects == required {
 				e := externs{ctx: ctx, a: a, s: s}
-				t := newTweaker(ctx, out)
+				t := newTweaker(ctx, out, dID)
 				defer t.revert()
 
 				ib := c.Objects.VertexArrays[c.BoundVertexArray].ElementArrayBuffer
@@ -543,7 +545,7 @@ func compat(ctx context.Context, device *device.Instance) (transform.Transformer
 					size, base := DataTypeSize(a.IndicesType)*int(a.IndicesCount), memory.Pointer(a.Indices)
 					glBufferData := NewGlBufferData(GLenum_GL_ELEMENT_ARRAY_BUFFER, GLsizeiptr(size), memory.Pointer(base), GLenum_GL_STATIC_DRAW)
 					glBufferData.extras = a.extras
-					out.MutateAndWrite(ctx, atom.NoID, glBufferData)
+					out.MutateAndWrite(ctx, dID, glBufferData)
 
 					if clientVB {
 						// Some of the vertex arrays for the glDrawElements call is in
@@ -598,7 +600,7 @@ func compat(ctx context.Context, device *device.Instance) (transform.Transformer
 		case *GlTexStorage1DEXT:
 			{
 				a := *a
-				textureCompat.convertFormat(a.Target, &a.Internalformat, nil, nil, out)
+				textureCompat.convertFormat(a.Target, &a.Internalformat, nil, nil, out, i)
 				if !version.IsES { // Strip suffix on desktop.
 					a := NewGlTexStorage1D(a.Target, a.Levels, a.Internalformat, a.Width)
 					out.MutateAndWrite(ctx, i, a)
@@ -610,14 +612,14 @@ func compat(ctx context.Context, device *device.Instance) (transform.Transformer
 		case *GlTexStorage2D:
 			{
 				a := *a
-				textureCompat.convertFormat(a.Target, &a.Internalformat, nil, nil, out)
+				textureCompat.convertFormat(a.Target, &a.Internalformat, nil, nil, out, i)
 				out.MutateAndWrite(ctx, i, &a)
 				return
 			}
 		case *GlTexStorage2DEXT:
 			{
 				a := *a
-				textureCompat.convertFormat(a.Target, &a.Internalformat, nil, nil, out)
+				textureCompat.convertFormat(a.Target, &a.Internalformat, nil, nil, out, i)
 				if !version.IsES { // Strip suffix on desktop.
 					a := NewGlTexStorage2D(a.Target, a.Levels, a.Internalformat, a.Width, a.Height)
 					out.MutateAndWrite(ctx, i, a)
@@ -629,21 +631,21 @@ func compat(ctx context.Context, device *device.Instance) (transform.Transformer
 		case *GlTexStorage2DMultisample:
 			{
 				a := *a
-				textureCompat.convertFormat(a.Target, &a.Internalformat, nil, nil, out)
+				textureCompat.convertFormat(a.Target, &a.Internalformat, nil, nil, out, i)
 				out.MutateAndWrite(ctx, i, &a)
 				return
 			}
 		case *GlTexStorage3D:
 			{
 				a := *a
-				textureCompat.convertFormat(a.Target, &a.Internalformat, nil, nil, out)
+				textureCompat.convertFormat(a.Target, &a.Internalformat, nil, nil, out, i)
 				out.MutateAndWrite(ctx, i, &a)
 				return
 			}
 		case *GlTexStorage3DEXT:
 			{
 				a := *a
-				textureCompat.convertFormat(a.Target, &a.Internalformat, nil, nil, out)
+				textureCompat.convertFormat(a.Target, &a.Internalformat, nil, nil, out, i)
 				if !version.IsES { // Strip suffix on desktop.
 					a := NewGlTexStorage3D(a.Target, a.Levels, a.Internalformat, a.Width, a.Height, a.Depth)
 					out.MutateAndWrite(ctx, i, a)
@@ -655,14 +657,14 @@ func compat(ctx context.Context, device *device.Instance) (transform.Transformer
 		case *GlTexStorage3DMultisample:
 			{
 				a := *a
-				textureCompat.convertFormat(a.Target, &a.Internalformat, nil, nil, out)
+				textureCompat.convertFormat(a.Target, &a.Internalformat, nil, nil, out, i)
 				out.MutateAndWrite(ctx, i, &a)
 				return
 			}
 		case *GlTexStorage3DMultisampleOES:
 			{
 				a := *a
-				textureCompat.convertFormat(a.Target, &a.Internalformat, nil, nil, out)
+				textureCompat.convertFormat(a.Target, &a.Internalformat, nil, nil, out, i)
 				if !version.IsES { // Strip suffix on desktop.
 					a := NewGlTexStorage3DMultisample(a.Target, a.Samples, a.Internalformat, a.Width, a.Height, a.Depth, a.Fixedsamplelocations)
 					out.MutateAndWrite(ctx, i, a)
@@ -675,7 +677,7 @@ func compat(ctx context.Context, device *device.Instance) (transform.Transformer
 			{
 				a := *a
 				internalformat := GLenum(a.Internalformat)
-				textureCompat.convertFormat(a.Target, &internalformat, &a.Format, &a.Type, out)
+				textureCompat.convertFormat(a.Target, &internalformat, &a.Format, &a.Type, out, i)
 				a.Internalformat = GLint(internalformat)
 				out.MutateAndWrite(ctx, i, &a)
 				return
@@ -684,7 +686,7 @@ func compat(ctx context.Context, device *device.Instance) (transform.Transformer
 			{
 				a := *a
 				internalformat := GLenum(a.Internalformat)
-				textureCompat.convertFormat(a.Target, &internalformat, &a.Format, &a.Type, out)
+				textureCompat.convertFormat(a.Target, &internalformat, &a.Format, &a.Type, out, i)
 				a.Internalformat = GLint(internalformat)
 				out.MutateAndWrite(ctx, i, &a)
 				return
@@ -692,7 +694,7 @@ func compat(ctx context.Context, device *device.Instance) (transform.Transformer
 		case *GlTexImage3DOES:
 			{
 				a := *a
-				textureCompat.convertFormat(a.Target, &a.Internalformat, &a.Format, &a.Type, out)
+				textureCompat.convertFormat(a.Target, &a.Internalformat, &a.Format, &a.Type, out, i)
 				if !version.IsES { // Strip suffix on desktop.
 					extras := a.extras
 					a := NewGlTexImage3D(a.Target, a.Level, GLint(a.Internalformat), a.Width, a.Height, a.Depth, a.Border, a.Format, a.Type, memory.Pointer(a.Pixels))
@@ -706,21 +708,21 @@ func compat(ctx context.Context, device *device.Instance) (transform.Transformer
 		case *GlTexSubImage2D:
 			{
 				a := *a
-				textureCompat.convertFormat(a.Target, nil, &a.Format, &a.Type, out)
+				textureCompat.convertFormat(a.Target, nil, &a.Format, &a.Type, out, i)
 				out.MutateAndWrite(ctx, i, &a)
 				return
 			}
 		case *GlTexSubImage3D:
 			{
 				a := *a
-				textureCompat.convertFormat(a.Target, nil, &a.Format, &a.Type, out)
+				textureCompat.convertFormat(a.Target, nil, &a.Format, &a.Type, out, i)
 				out.MutateAndWrite(ctx, i, &a)
 				return
 			}
 		case *GlTexSubImage3DOES:
 			{
 				a := *a
-				textureCompat.convertFormat(a.Target, nil, &a.Format, &a.Type, out)
+				textureCompat.convertFormat(a.Target, nil, &a.Format, &a.Type, out, i)
 				if !version.IsES { // Strip suffix on desktop.
 					extras := a.extras
 					a := NewGlTexSubImage3D(a.Target, a.Level, a.Xoffset, a.Yoffset, a.Zoffset, a.Width, a.Height, a.Depth, a.Format, a.Type, memory.Pointer(a.Pixels))
@@ -734,50 +736,50 @@ func compat(ctx context.Context, device *device.Instance) (transform.Transformer
 		case *GlCopyTexImage2D:
 			{
 				a := *a
-				textureCompat.convertFormat(a.Target, &a.Internalformat, nil, nil, out)
+				textureCompat.convertFormat(a.Target, &a.Internalformat, nil, nil, out, i)
 				out.MutateAndWrite(ctx, i, &a)
 				return
 			}
 
 		case *GlTexParameterIivOES:
 			out.MutateAndWrite(ctx, i, a)
-			textureCompat.postTexParameter(a.Target, a.Pname, out)
+			textureCompat.postTexParameter(a.Target, a.Pname, out, i)
 			return
 		case *GlTexParameterIuivOES:
 			out.MutateAndWrite(ctx, i, a)
-			textureCompat.postTexParameter(a.Target, a.Pname, out)
+			textureCompat.postTexParameter(a.Target, a.Pname, out, i)
 			return
 		case *GlTexParameterIiv:
 			out.MutateAndWrite(ctx, i, a)
-			textureCompat.postTexParameter(a.Target, a.Pname, out)
+			textureCompat.postTexParameter(a.Target, a.Pname, out, i)
 			return
 		case *GlTexParameterIuiv:
 			out.MutateAndWrite(ctx, i, a)
-			textureCompat.postTexParameter(a.Target, a.Pname, out)
+			textureCompat.postTexParameter(a.Target, a.Pname, out, i)
 			return
 		case *GlTexParameterf:
 			out.MutateAndWrite(ctx, i, a)
-			textureCompat.postTexParameter(a.Target, a.Parameter, out)
+			textureCompat.postTexParameter(a.Target, a.Parameter, out, i)
 			return
 		case *GlTexParameterfv:
 			out.MutateAndWrite(ctx, i, a)
-			textureCompat.postTexParameter(a.Target, a.Pname, out)
+			textureCompat.postTexParameter(a.Target, a.Pname, out, i)
 			return
 		case *GlTexParameteri:
 			out.MutateAndWrite(ctx, i, a)
-			textureCompat.postTexParameter(a.Target, a.Parameter, out)
+			textureCompat.postTexParameter(a.Target, a.Parameter, out, i)
 			return
 		case *GlTexParameteriv:
 			out.MutateAndWrite(ctx, i, a)
-			textureCompat.postTexParameter(a.Target, a.Pname, out)
+			textureCompat.postTexParameter(a.Target, a.Pname, out, i)
 			return
 		case *GlTexParameterIivEXT:
 			out.MutateAndWrite(ctx, i, a)
-			textureCompat.postTexParameter(a.Target, a.Pname, out)
+			textureCompat.postTexParameter(a.Target, a.Pname, out, i)
 			return
 		case *GlTexParameterIuivEXT:
 			out.MutateAndWrite(ctx, i, a)
-			textureCompat.postTexParameter(a.Target, a.Pname, out)
+			textureCompat.postTexParameter(a.Target, a.Pname, out, i)
 			return
 
 		case *GlProgramBinary:
@@ -940,9 +942,9 @@ func compat(ctx context.Context, device *device.Instance) (transform.Transformer
 				if a.Target == GLenum_GL_FRAMEBUFFER || a.Target == GLenum_GL_DRAW_FRAMEBUFFER {
 					origSrgb := c.FragmentOperations.FramebufferSrgb
 					if a.Framebuffer == 0 {
-						out.MutateAndWrite(ctx, atom.NoID, NewGlDisable(GLenum_GL_FRAMEBUFFER_SRGB))
+						out.MutateAndWrite(ctx, dID, NewGlDisable(GLenum_GL_FRAMEBUFFER_SRGB))
 					} else {
-						out.MutateAndWrite(ctx, atom.NoID, NewGlEnable(GLenum_GL_FRAMEBUFFER_SRGB))
+						out.MutateAndWrite(ctx, dID, NewGlEnable(GLenum_GL_FRAMEBUFFER_SRGB))
 					}
 					// Change the replay driver state, but keep our mutated state,
 					// so we know what to do the next time we see glBindFramebuffer.
@@ -988,7 +990,7 @@ func compat(ctx context.Context, device *device.Instance) (transform.Transformer
 					for i := 0; i < int(uniform.ArraySize); i++ {
 						name := fmt.Sprintf("%v[%v]", strings.TrimSuffix(uniform.Name, "[0]"), i)
 						loc := uniform.Location + UniformLocation(i) // TODO: Does not have to be consecutive
-						out.MutateAndWrite(ctx, atom.NoID, NewGlGetUniformLocation(a.Program, name, loc))
+						out.MutateAndWrite(ctx, dID, NewGlGetUniformLocation(a.Program, name, loc))
 					}
 				}
 				return
@@ -1078,7 +1080,8 @@ func moveClientVBsToVAs(
 
 	// Apply the memory observations that were made by the draw call now.
 	// We need to do this as the glBufferData calls below will require the data.
-	out.MutateAndWrite(ctx, atom.NoID, replay.Custom(func(ctx context.Context, s *gfxapi.State, b *builder.Builder) error {
+	dID := atom.DerivedID(i)
+	out.MutateAndWrite(ctx, dID, replay.Custom(func(ctx context.Context, s *gfxapi.State, b *builder.Builder) error {
 		a.Extras().Observations().ApplyReads(s.Memory[memory.ApplicationPool])
 		return nil
 	}))
@@ -1091,7 +1094,7 @@ func moveClientVBsToVAs(
 		base := memory.Pointer{Address: rng.First, Pool: memory.ApplicationPool}
 		size := GLsizeiptr(rng.Count)
 		t.GlBindBuffer_ArrayBuffer(ids[i])
-		out.MutateAndWrite(ctx, atom.NoID, NewGlBufferData(GLenum_GL_ARRAY_BUFFER, size, base, GLenum_GL_STATIC_DRAW))
+		out.MutateAndWrite(ctx, dID, NewGlBufferData(GLenum_GL_ARRAY_BUFFER, size, base, GLenum_GL_STATIC_DRAW))
 	}
 
 	// Redirect all the vertex attrib arrays to point to the array-buffer data.
@@ -1103,7 +1106,7 @@ func moveClientVBsToVAs(
 				i := interval.IndexOf(&rngs, a.Data.Address)
 				t.GlBindBuffer_ArrayBuffer(ids[i])
 				a.Data = NewVertexPointer(a.Data.Address - rngs[i].First) // Offset
-				out.MutateAndWrite(ctx, atom.NoID, &a)
+				out.MutateAndWrite(ctx, dID, &a)
 			}
 		}
 	}

--- a/gapis/gfxapi/gles/find_issues.go
+++ b/gapis/gfxapi/gles/find_issues.go
@@ -99,7 +99,7 @@ func (t *findIssues) Transform(ctx context.Context, i atom.ID, a atom.Atom, out 
 	mutatorsGlError := t.lastGlError
 	out.MutateAndWrite(ctx, i, a)
 
-	dID := atom.DerivedID(i)
+	dID := i.Derived()
 	s := GetState(t.state)
 	c := s.getContext()
 	if c == nil {

--- a/gapis/gfxapi/gles/find_issues.go
+++ b/gapis/gfxapi/gles/find_issues.go
@@ -99,6 +99,7 @@ func (t *findIssues) Transform(ctx context.Context, i atom.ID, a atom.Atom, out 
 	mutatorsGlError := t.lastGlError
 	out.MutateAndWrite(ctx, i, a)
 
+	dID := atom.DerivedID(i)
 	s := GetState(t.state)
 	c := s.getContext()
 	if c == nil {
@@ -106,7 +107,7 @@ func (t *findIssues) Transform(ctx context.Context, i atom.ID, a atom.Atom, out 
 	}
 
 	// Check the result of glGetError after every command.
-	out.MutateAndWrite(ctx, atom.NoID, replay.Custom(func(ctx context.Context, s *gfxapi.State, b *builder.Builder) error {
+	out.MutateAndWrite(ctx, dID, replay.Custom(func(ctx context.Context, s *gfxapi.State, b *builder.Builder) error {
 		ptr := b.AllocateTemporaryMemory(4)
 		b.Call(funcInfoGlGetError)
 		b.Store(ptr)
@@ -192,8 +193,8 @@ func (t *findIssues) Transform(ctx context.Context, i atom.ID, a atom.Atom, out 
 		tmp := atom.Must(atom.Alloc(ctx, t.state, buflen))
 
 		infoLog := make([]byte, 2048)
-		out.MutateAndWrite(ctx, atom.NoID, NewGlGetShaderInfoLog(a.Shader, buflen, memory.Nullptr, tmp.Ptr()))
-		out.MutateAndWrite(ctx, atom.NoID, replay.Custom(func(ctx context.Context, s *gfxapi.State, b *builder.Builder) error {
+		out.MutateAndWrite(ctx, dID, NewGlGetShaderInfoLog(a.Shader, buflen, memory.Nullptr, tmp.Ptr()))
+		out.MutateAndWrite(ctx, dID, replay.Custom(func(ctx context.Context, s *gfxapi.State, b *builder.Builder) error {
 			b.ReserveMemory(tmp.Range())
 			b.Post(value.ObservedPointer(tmp.Address()), buflen, func(r pod.Reader, err error) error {
 				if err != nil {
@@ -206,8 +207,8 @@ func (t *findIssues) Transform(ctx context.Context, i atom.ID, a atom.Atom, out 
 		}))
 
 		source := make([]byte, 2048)
-		out.MutateAndWrite(ctx, atom.NoID, NewGlGetShaderSource(a.Shader, buflen, memory.Nullptr, tmp.Ptr()))
-		out.MutateAndWrite(ctx, atom.NoID, replay.Custom(func(ctx context.Context, s *gfxapi.State, b *builder.Builder) error {
+		out.MutateAndWrite(ctx, dID, NewGlGetShaderSource(a.Shader, buflen, memory.Nullptr, tmp.Ptr()))
+		out.MutateAndWrite(ctx, dID, replay.Custom(func(ctx context.Context, s *gfxapi.State, b *builder.Builder) error {
 			b.ReserveMemory(tmp.Range())
 			b.Post(value.ObservedPointer(tmp.Address()), buflen, func(r pod.Reader, err error) error {
 				if err != nil {
@@ -219,8 +220,8 @@ func (t *findIssues) Transform(ctx context.Context, i atom.ID, a atom.Atom, out 
 			return nil
 		}))
 
-		out.MutateAndWrite(ctx, atom.NoID, NewGlGetShaderiv(a.Shader, GLenum_GL_COMPILE_STATUS, tmp.Ptr()))
-		out.MutateAndWrite(ctx, atom.NoID, replay.Custom(func(ctx context.Context, s *gfxapi.State, b *builder.Builder) error {
+		out.MutateAndWrite(ctx, dID, NewGlGetShaderiv(a.Shader, GLenum_GL_COMPILE_STATUS, tmp.Ptr()))
+		out.MutateAndWrite(ctx, dID, replay.Custom(func(ctx context.Context, s *gfxapi.State, b *builder.Builder) error {
 			b.ReserveMemory(tmp.Range())
 			b.Post(value.ObservedPointer(tmp.Address()), 4, func(r pod.Reader, err error) error {
 				if err != nil {
@@ -242,9 +243,9 @@ func (t *findIssues) Transform(ctx context.Context, i atom.ID, a atom.Atom, out 
 	case *GlLinkProgram:
 		const buflen = 2048
 		tmp := atom.Must(atom.Alloc(ctx, t.state, 4+buflen))
-		out.MutateAndWrite(ctx, atom.NoID, NewGlGetProgramiv(a.Program, GLenum_GL_LINK_STATUS, tmp.Ptr()))
-		out.MutateAndWrite(ctx, atom.NoID, NewGlGetProgramInfoLog(a.Program, buflen, memory.Nullptr, tmp.Offset(4)))
-		out.MutateAndWrite(ctx, atom.NoID, replay.Custom(func(ctx context.Context, s *gfxapi.State, b *builder.Builder) error {
+		out.MutateAndWrite(ctx, dID, NewGlGetProgramiv(a.Program, GLenum_GL_LINK_STATUS, tmp.Ptr()))
+		out.MutateAndWrite(ctx, dID, NewGlGetProgramInfoLog(a.Program, buflen, memory.Nullptr, tmp.Offset(4)))
+		out.MutateAndWrite(ctx, dID, replay.Custom(func(ctx context.Context, s *gfxapi.State, b *builder.Builder) error {
 			b.ReserveMemory(tmp.Range())
 			b.Post(value.ObservedPointer(tmp.Address()), 4+buflen, func(r pod.Reader, err error) error {
 				if err != nil {

--- a/gapis/gfxapi/gles/read_framebuffer.go
+++ b/gapis/gfxapi/gles/read_framebuffer.go
@@ -85,7 +85,7 @@ func (t *readFramebuffer) Color(id atom.ID, width, height, bufferIdx uint32, res
 			outH = int32(height)
 		)
 
-		dID := atom.DerivedID(id)
+		dID := id.Derived()
 		t := newTweaker(ctx, out, dID)
 
 		t.glBindFramebuffer_Read(c.BoundDrawFramebuffer)
@@ -139,7 +139,7 @@ func postColorData(ctx context.Context,
 	unsizedFormat, ty := getUnsizedFormatAndType(sizedFormat)
 	imgFmt := getImageFormatOrPanic(unsizedFormat, ty)
 
-	dID := atom.DerivedID(id)
+	dID := id.Derived()
 	t := newTweaker(ctx, out, dID)
 	t.setPixelStorage(PixelStorageState{PackAlignment: 1, UnpackAlignment: 1}, 0, 0)
 

--- a/gapis/gfxapi/gles/read_framebuffer.go
+++ b/gapis/gfxapi/gles/read_framebuffer.go
@@ -62,7 +62,7 @@ func (t *readFramebuffer) Depth(id atom.ID, res replay.Result) {
 			return
 		}
 
-		postColorData(ctx, s, int32(width), int32(height), format, out, res)
+		postColorData(ctx, s, int32(width), int32(height), format, out, id, res)
 	})
 }
 
@@ -85,7 +85,8 @@ func (t *readFramebuffer) Color(id atom.ID, width, height, bufferIdx uint32, res
 			outH = int32(height)
 		)
 
-		t := newTweaker(ctx, out)
+		dID := atom.DerivedID(id)
+		t := newTweaker(ctx, out, dID)
 
 		t.glBindFramebuffer_Read(c.BoundDrawFramebuffer)
 
@@ -93,7 +94,7 @@ func (t *readFramebuffer) Color(id atom.ID, width, height, bufferIdx uint32, res
 		//       replay. Note that glReadBuffer was only introduced in
 		//       OpenGL ES 3.0, and that GL_FRONT is not a legal enum value.
 		if c.BoundDrawFramebuffer == 0 {
-			out.MutateAndWrite(ctx, atom.NoID, replay.Custom(func(ctx context.Context, s *gfxapi.State, b *builder.Builder) error {
+			out.MutateAndWrite(ctx, dID, replay.Custom(func(ctx context.Context, s *gfxapi.State, b *builder.Builder) error {
 				// TODO: We assume here that the default framebuffer is
 				//       single-buffered. Once we support double-buffering we
 				//       need to decide whether to read from GL_FRONT or GL_BACK.
@@ -105,7 +106,7 @@ func (t *readFramebuffer) Color(id atom.ID, width, height, bufferIdx uint32, res
 		}
 
 		if inW == outW && inH == outH {
-			postColorData(ctx, s, outW, outH, fmt, out, res)
+			postColorData(ctx, s, outW, outH, fmt, out, id, res)
 		} else {
 			t.glScissor(0, 0, GLsizei(inW), GLsizei(inH))
 			framebufferID := t.glGenFramebuffer()
@@ -113,14 +114,14 @@ func (t *readFramebuffer) Color(id atom.ID, width, height, bufferIdx uint32, res
 			renderbufferID := t.glGenRenderbuffer()
 			t.glBindRenderbuffer(renderbufferID)
 
-			mutateAndWriteEach(ctx, out,
+			mutateAndWriteEach(ctx, out, dID,
 				NewGlRenderbufferStorage(GLenum_GL_RENDERBUFFER, fmt, GLsizei(outW), GLsizei(outH)),
 				NewGlFramebufferRenderbuffer(GLenum_GL_DRAW_FRAMEBUFFER, GLenum_GL_COLOR_ATTACHMENT0, GLenum_GL_RENDERBUFFER, renderbufferID),
 				NewGlBlitFramebuffer(0, 0, GLint(inW), GLint(inH), 0, 0, GLint(outW), GLint(outH), GLbitfield_GL_COLOR_BUFFER_BIT, GLenum_GL_LINEAR),
 			)
 			t.glBindFramebuffer_Read(framebufferID)
 
-			postColorData(ctx, s, outW, outH, fmt, out, res)
+			postColorData(ctx, s, outW, outH, fmt, out, id, res)
 		}
 
 		t.revert()
@@ -132,17 +133,19 @@ func postColorData(ctx context.Context,
 	width, height int32,
 	sizedFormat GLenum,
 	out transform.Writer,
+	id atom.ID,
 	res replay.Result) {
 
 	unsizedFormat, ty := getUnsizedFormatAndType(sizedFormat)
 	imgFmt := getImageFormatOrPanic(unsizedFormat, ty)
 
-	t := newTweaker(ctx, out)
+	dID := atom.DerivedID(id)
+	t := newTweaker(ctx, out, dID)
 	t.setPixelStorage(PixelStorageState{PackAlignment: 1, UnpackAlignment: 1}, 0, 0)
 
 	imageSize := imgFmt.Size(int(width), int(height))
 	tmp := atom.Must(atom.Alloc(ctx, s, uint64(imageSize)))
-	out.MutateAndWrite(ctx, atom.NoID, replay.Custom(func(ctx context.Context, s *gfxapi.State, b *builder.Builder) error {
+	out.MutateAndWrite(ctx, dID, replay.Custom(func(ctx context.Context, s *gfxapi.State, b *builder.Builder) error {
 		// TODO: We use Call() directly here because we are calling glReadPixels
 		// with depth formats which are not legal for GLES. Once we're replaying
 		// on-device again, we need to take a look at methods for reading the
@@ -179,9 +182,9 @@ func postColorData(ctx context.Context,
 	t.revert()
 }
 
-func mutateAndWriteEach(ctx context.Context, out transform.Writer, atoms ...atom.Atom) {
+func mutateAndWriteEach(ctx context.Context, out transform.Writer, id atom.ID, atoms ...atom.Atom) {
 	for _, a := range atoms {
-		out.MutateAndWrite(ctx, atom.NoID, a)
+		out.MutateAndWrite(ctx, id, a)
 	}
 }
 

--- a/gapis/gfxapi/gles/texture_compat.go
+++ b/gapis/gfxapi/gles/texture_compat.go
@@ -104,7 +104,7 @@ func (tc *textureCompat) writeCompatSwizzle(ctx context.Context, t *Texture, par
 		}
 	}
 	if compat != curr {
-		out.MutateAndWrite(ctx, atom.DerivedID(id), NewGlTexParameteri(target, parameter, GLint(compat)))
+		out.MutateAndWrite(ctx, id.Derived(), NewGlTexParameteri(target, parameter, GLint(compat)))
 	}
 }
 
@@ -205,7 +205,7 @@ func (tc *textureCompat) postTexParameter(target, parameter GLenum, out transfor
 // the given glCompressedTexImage2D.
 func decompressTexImage2D(ctx context.Context, i atom.ID, a *GlCompressedTexImage2D, s *gfxapi.State, out transform.Writer) error {
 	ctx = log.Enter(ctx, "decompressTexImage2D")
-	dID := atom.DerivedID(i)
+	dID := i.Derived()
 	c := GetContext(s)
 
 	data := a.Data
@@ -252,7 +252,7 @@ func decompressTexImage2D(ctx context.Context, i atom.ID, a *GlCompressedTexImag
 // the given glCompressedTexSubImage2D.
 func decompressTexSubImage2D(ctx context.Context, i atom.ID, a *GlCompressedTexSubImage2D, s *gfxapi.State, out transform.Writer) error {
 	ctx = log.Enter(ctx, "decompressTexSubImage2D")
-	dID := atom.DerivedID(i)
+	dID := i.Derived()
 	c := GetContext(s)
 
 	data := a.Data

--- a/gapis/gfxapi/gles/tweaker.go
+++ b/gapis/gfxapi/gles/tweaker.go
@@ -36,7 +36,7 @@ type tweaker struct {
 func newTweaker(ctx context.Context, out transform.Writer, id atom.ID) *tweaker {
 	s := out.State()
 	c := GetContext(s)
-	dID := atom.DerivedID(id)
+	dID := id.Derived()
 	return &tweaker{ctx: ctx, out: out, s: s, c: c, dID: dID}
 }
 

--- a/gapis/gfxapi/gles/undefined_framebuffer.go
+++ b/gapis/gfxapi/gles/undefined_framebuffer.go
@@ -76,7 +76,7 @@ func drawUndefinedFramebuffer(ctx context.Context, id atom.ID, a atom.Atom, devi
 	// 2D vertices positions for a full screen 2D triangle strip.
 	positions := []float32{-1., -1., 1., -1., -1., 1., 1., 1.}
 
-	dID := atom.DerivedID(id)
+	dID := id.Derived()
 	t := newTweaker(ctx, out, id)
 
 	// Temporarily change rasterizing/blending state and enable VAP 0.

--- a/gapis/gfxapi/gles/undefined_framebuffer.go
+++ b/gapis/gfxapi/gles/undefined_framebuffer.go
@@ -37,18 +37,18 @@ func undefinedFramebuffer(ctx context.Context, device *device.Instance) transfor
 		}
 		if eglMakeCurrent, ok := a.(*EglMakeCurrent); ok && !seenSurfaces[eglMakeCurrent.Draw] {
 			// Render the undefined pattern for new contexts.
-			drawUndefinedFramebuffer(ctx, a, device, s, c, out)
+			drawUndefinedFramebuffer(ctx, i, a, device, s, c, out)
 			seenSurfaces[eglMakeCurrent.Draw] = true
 		}
 		if a.AtomFlags().IsEndOfFrame() {
 			if c != nil && !c.Info.PreserveBuffersOnSwap {
-				drawUndefinedFramebuffer(ctx, a, device, s, c, out)
+				drawUndefinedFramebuffer(ctx, i, a, device, s, c, out)
 			}
 		}
 	})
 }
 
-func drawUndefinedFramebuffer(ctx context.Context, a atom.Atom, device *device.Instance, s *gfxapi.State, c *Context, out transform.Writer) error {
+func drawUndefinedFramebuffer(ctx context.Context, id atom.ID, a atom.Atom, device *device.Instance, s *gfxapi.State, c *Context, out transform.Writer) error {
 	const (
 		aScreenCoordsLocation AttributeLocation = 0
 
@@ -76,7 +76,8 @@ func drawUndefinedFramebuffer(ctx context.Context, a atom.Atom, device *device.I
 	// 2D vertices positions for a full screen 2D triangle strip.
 	positions := []float32{-1., -1., 1., -1., -1., 1., 1., 1.}
 
-	t := newTweaker(ctx, out)
+	dID := atom.DerivedID(id)
+	t := newTweaker(ctx, out, id)
 
 	// Temporarily change rasterizing/blending state and enable VAP 0.
 	t.glDisable(GLenum_GL_BLEND)
@@ -88,19 +89,19 @@ func drawUndefinedFramebuffer(ctx context.Context, a atom.Atom, device *device.I
 
 	programID := t.makeProgram(vertexShaderSource, fragmentShaderSource)
 
-	out.MutateAndWrite(ctx, atom.NoID, NewGlBindAttribLocation(programID, aScreenCoordsLocation, "aScreenCoords"))
-	out.MutateAndWrite(ctx, atom.NoID, NewGlLinkProgram(programID))
+	out.MutateAndWrite(ctx, dID, NewGlBindAttribLocation(programID, aScreenCoordsLocation, "aScreenCoords"))
+	out.MutateAndWrite(ctx, dID, NewGlLinkProgram(programID))
 	t.glUseProgram(programID)
 
 	bufferID := t.glGenBuffer()
 	t.GlBindBuffer_ArrayBuffer(bufferID)
 
 	tmp := t.AllocData(positions)
-	out.MutateAndWrite(ctx, atom.NoID, NewGlBufferData(GLenum_GL_ARRAY_BUFFER, GLsizeiptr(4*len(positions)), tmp.Ptr(), GLenum_GL_STATIC_DRAW).
+	out.MutateAndWrite(ctx, dID, NewGlBufferData(GLenum_GL_ARRAY_BUFFER, GLsizeiptr(4*len(positions)), tmp.Ptr(), GLenum_GL_STATIC_DRAW).
 		AddRead(tmp.Data()))
 
-	out.MutateAndWrite(ctx, atom.NoID, NewGlVertexAttribPointer(aScreenCoordsLocation, 2, GLenum_GL_FLOAT, GLboolean(0), 0, memory.Nullptr))
-	out.MutateAndWrite(ctx, atom.NoID, NewGlDrawArrays(GLenum_GL_TRIANGLE_STRIP, 0, 4))
+	out.MutateAndWrite(ctx, dID, NewGlVertexAttribPointer(aScreenCoordsLocation, 2, GLenum_GL_FLOAT, GLboolean(0), 0, memory.Nullptr))
+	out.MutateAndWrite(ctx, dID, NewGlDrawArrays(GLenum_GL_TRIANGLE_STRIP, 0, 4))
 
 	t.revert()
 

--- a/gapis/gfxapi/gles/wireframe.go
+++ b/gapis/gfxapi/gles/wireframe.go
@@ -35,7 +35,7 @@ func wireframe(ctx context.Context) transform.Transformer {
 	return transform.Transform("Wireframe", func(ctx context.Context, i atom.ID, a atom.Atom, out transform.Writer) {
 		if dc, ok := a.(drawCall); ok {
 			s := out.State()
-			dID := atom.DerivedID(i)
+			dID := i.Derived()
 			t := newTweaker(ctx, out, dID)
 			t.glEnable(GLenum_GL_LINE_SMOOTH)
 			t.glEnable(GLenum_GL_BLEND)
@@ -62,7 +62,7 @@ func wireframeOverlay(ctx context.Context, id atom.ID) transform.Transformer {
 				s := out.State()
 				out.MutateAndWrite(ctx, i, dc)
 
-				dID := atom.DerivedID(id)
+				dID := id.Derived()
 				t := newTweaker(ctx, out, dID)
 				t.glEnable(GLenum_GL_POLYGON_OFFSET_LINE)
 				t.glPolygonOffset(-1, -1)
@@ -87,7 +87,7 @@ func wireframeOverlay(ctx context.Context, id atom.ID) transform.Transformer {
 
 func drawWireframe(ctx context.Context, i atom.ID, dc drawCall, s *gfxapi.State, out transform.Writer) error {
 	c := GetContext(s)
-	dID := atom.DerivedID(i)
+	dID := i.Derived()
 
 	indices, drawMode, err := dc.getIndices(ctx, c, s)
 	if err != nil {

--- a/gapis/gfxapi/gles/wireframe.go
+++ b/gapis/gfxapi/gles/wireframe.go
@@ -35,7 +35,8 @@ func wireframe(ctx context.Context) transform.Transformer {
 	return transform.Transform("Wireframe", func(ctx context.Context, i atom.ID, a atom.Atom, out transform.Writer) {
 		if dc, ok := a.(drawCall); ok {
 			s := out.State()
-			t := newTweaker(ctx, out)
+			dID := atom.DerivedID(i)
+			t := newTweaker(ctx, out, dID)
 			t.glEnable(GLenum_GL_LINE_SMOOTH)
 			t.glEnable(GLenum_GL_BLEND)
 			t.glBlendFunc(GLenum_GL_SRC_ALPHA, GLenum_GL_ONE_MINUS_SRC_ALPHA)
@@ -59,9 +60,10 @@ func wireframeOverlay(ctx context.Context, id atom.ID) transform.Transformer {
 		if i == id {
 			if dc, ok := a.(drawCall); ok {
 				s := out.State()
-				out.MutateAndWrite(ctx, atom.NoID, dc)
+				out.MutateAndWrite(ctx, i, dc)
 
-				t := newTweaker(ctx, out)
+				dID := atom.DerivedID(id)
+				t := newTweaker(ctx, out, dID)
 				t.glEnable(GLenum_GL_POLYGON_OFFSET_LINE)
 				t.glPolygonOffset(-1, -1)
 				t.glEnable(GLenum_GL_BLEND)
@@ -85,6 +87,7 @@ func wireframeOverlay(ctx context.Context, id atom.ID) transform.Transformer {
 
 func drawWireframe(ctx context.Context, i atom.ID, dc drawCall, s *gfxapi.State, out transform.Writer) error {
 	c := GetContext(s)
+	dID := atom.DerivedID(i)
 
 	indices, drawMode, err := dc.getIndices(ctx, c, s)
 	if err != nil {
@@ -105,7 +108,7 @@ func drawWireframe(ctx context.Context, i atom.ID, dc drawCall, s *gfxapi.State,
 	// Unbind the index buffer
 	tmp := atom.Must(atom.Alloc(ctx, s, uint64(len(wireframeData))))
 	oldIndexBufferID := c.Objects.VertexArrays[c.BoundVertexArray].ElementArrayBuffer
-	out.MutateAndWrite(ctx, atom.NoID,
+	out.MutateAndWrite(ctx, dID,
 		NewGlBindBuffer(GLenum_GL_ELEMENT_ARRAY_BUFFER, 0).
 			AddRead(tmp.Range(), resID))
 
@@ -114,7 +117,7 @@ func drawWireframe(ctx context.Context, i atom.ID, dc drawCall, s *gfxapi.State,
 		drawMode, GLsizei(len(indices)), wireframeDataType, tmp.Ptr()))
 
 	// Rebind the old index buffer
-	out.MutateAndWrite(ctx, atom.NoID, NewGlBindBuffer(
+	out.MutateAndWrite(ctx, dID, NewGlBindBuffer(
 		GLenum_GL_ELEMENT_ARRAY_BUFFER, oldIndexBufferID))
 
 	return nil

--- a/gapis/replay/batch.go
+++ b/gapis/replay/batch.go
@@ -208,6 +208,6 @@ func (w *adapter) MutateAndWrite(ctx context.Context, i atom.ID, a atom.Atom) {
 		w.builder.CommitAtom()
 	} else {
 		w.builder.RevertAtom(err)
-		log.W(ctx, "Failed to write atom %d (%T) for replay: %v", i, a, err)
+		log.W(ctx, "Failed to write atom %v (%T) for replay: %v", i, a, err)
 	}
 }


### PR DESCRIPTION
Derived ID has a high bit set to indicate it is generated atom.

The derived ID has no semantic value and it is just for debugging.