### PR TITLE
Added a mode to gapit to only trace a single API.

### DIFF
--- a/cmd/gapit/flags.go
+++ b/cmd/gapit/flags.go
@@ -167,6 +167,7 @@ type (
 		Capture struct {
 			Frames int `help:"only capture the given number of frames. 0 for all"`
 		}
+		API string `help: "only capture the given API valid options are gles and vulkan"`
 	}
 	PackagesFlags struct {
 		DeviceFlags

--- a/cmd/gapit/trace.go
+++ b/cmd/gapit/trace.go
@@ -49,12 +49,19 @@ func init() {
 	})
 }
 
+// These are hard-coded and need to be kept in sync with the api_index
+// in the *.api files.
+const coreAPI = uint32(1 << 0)
+const glesAPI = uint32(1 << 1)
+const vulkanAPI = uint32(1 << 2)
+
 func (verb *traceVerb) Run(ctx context.Context, flags flag.FlagSet) error {
 	options := client.Options{
 		ObserveFrameFrequency: uint32(verb.Observe.Frames),
 		ObserveDrawFrequency:  uint32(verb.Observe.Draws),
 		StartFrame:            uint32(verb.Start.At.Frame),
 		FramesToCapture:       uint32(verb.Capture.Frames),
+		APIs:                  uint32(0xFFFFFFFF),
 		APK:                   verb.APK,
 	}
 
@@ -66,6 +73,17 @@ func (verb *traceVerb) Run(ctx context.Context, flags flag.FlagSet) error {
 	}
 	if verb.Start.Defer {
 		options.Flags |= client.DeferStart
+	}
+
+	switch verb.API {
+	case "vulkan":
+		options.APIs = coreAPI | vulkanAPI
+	case "gles":
+		options.APIs = coreAPI | glesAPI
+	case "":
+		options.APIs = uint32(0xFFFFFFFF)
+	default:
+		return fmt.Errorf("Unknown API %s", verb.API)
 	}
 
 	if !verb.Local.App.IsEmpty() {

--- a/gapii/cc/call_observer.h
+++ b/gapii/cc/call_observer.h
@@ -42,7 +42,7 @@ class CallObserver {
 public:
     typedef memory_pb::Observation Observation;
 
-    CallObserver(SpyBase* spy_p);
+    CallObserver(SpyBase* spy_p, uint8_t api);
 
     ~CallObserver();
 
@@ -142,8 +142,10 @@ private:
     // pool and we are supposed to observe application pool.
     template <class T>
     bool shouldObserve(const Slice<T>& slice) const {
-        return mObserveApplicationPool && slice.isApplicationPool();
+        return isActive() && mObserveApplicationPool && slice.isApplicationPool();
     }
+
+    bool isActive() const;
 
     // Make a slice on a new Pool.
     template <typename T>
@@ -172,6 +174,9 @@ private:
 
     // Record GL error which was raised during this call.
     GLenum_Error mError;
+
+    // The current API that this call-observer is observing.
+    uint8_t mApi;
 };
 
 template <typename T>

--- a/gapii/cc/connection_header.cpp
+++ b/gapii/cc/connection_header.cpp
@@ -27,6 +27,7 @@ ConnectionHeader::ConnectionHeader()
     , mObserveDrawFrequency(0)
     , mStartFrame(0)
     , mNumFrames(0)
+    , mAPIs(0xFFFFFFFF)
     , mFlags(0) {}
 
 bool ConnectionHeader::read(core::StreamReader* reader) {
@@ -49,7 +50,7 @@ bool ConnectionHeader::read(core::StreamReader* reader) {
     }
 
     const int kMinSupportedVersion = 2;
-    const int kMaxSupportedVersion = 4;
+    const int kMaxSupportedVersion = 5;
 
     if (mVersion < kMinSupportedVersion || mVersion > kMaxSupportedVersion) {
         GAPID_WARNING("Unsupported ConnectionHeader version %d. Only understand [%d to %d].",
@@ -65,6 +66,11 @@ bool ConnectionHeader::read(core::StreamReader* reader) {
     if (mVersion >= 4) {
         if (!reader->read(mStartFrame) ||
             !reader->read(mNumFrames)) {
+            return false;
+        }
+    }
+    if (mVersion >= 5) {
+        if (!reader->read(mAPIs)) {
             return false;
         }
     }

--- a/gapii/cc/connection_header.h
+++ b/gapii/cc/connection_header.h
@@ -52,6 +52,7 @@ public:
     uint32_t mObserveDrawFrequency;         // non-zero == enabled. Version: 2+
     uint32_t mStartFrame;                   // non-zero == Frame to start at. version 4+
     uint32_t mNumFrames;                    // non-zero == Number of frames to capture. version 4+
+    uint32_t mAPIs;                         // Bitset of APIS to enable. version 5+
     uint32_t mFlags;                        // Combination of FLAG_XX bits. Version: 3+
 };
 

--- a/gapii/cc/spy.cpp
+++ b/gapii/cc/spy.cpp
@@ -107,6 +107,7 @@ const uint32_t kStartMidExecutionCapture =  0xdeadbeef;
 
 const int32_t  kSuspendIndefinitely = -1;
 
+const uint8_t kCoreAPI = 0;
 core::Mutex gMutex;  // Guards gSpy.
 std::unique_ptr<gapii::Spy> gSpy;
 
@@ -133,7 +134,7 @@ Spy* Spy::get() {
         if (!s->try_to_enter()) {
             GAPID_FATAL("Couldn't enter on init?!")
         }
-        CallObserver observer(s);
+        CallObserver observer(s, kCoreAPI);
         s->lock(&observer, "writeHeader");
         s->writeHeader();
         s->unlock();
@@ -180,13 +181,14 @@ Spy::Spy()
     } else {
         GAPID_WARNING("Failed to read connection header");
     }
-
+    set_valid_apis(header.mAPIs);
+    GAPID_ERROR("APIS %08x", header.mAPIs);
     GAPID_INFO("GAPII connection established. Settings:");
     GAPID_INFO("Observe framebuffer every %d frames", mObserveFrameFrequency);
     GAPID_INFO("Observe framebuffer every %d draws", mObserveDrawFrequency);
     GAPID_INFO("Disable precompiled shaders: %s", mDisablePrecompiledShaders ? "true" : "false");
 
-    CallObserver observer(this);
+    CallObserver observer(this, kCoreAPI);
 
     mEncoder = gapii::PackEncoder::create(conn);
 

--- a/gapii/cc/spy_base.cpp
+++ b/gapii/cc/spy_base.cpp
@@ -33,6 +33,7 @@ SpyBase::SpyBase()
     , mCommandStartEndCounter(0)
     , mExpectedNextCommandStartCounterValue(0)
     , mNullEncoder(PackEncoder::noop())
+    , mWatchedApis(0xFFFFFFFF)
 #ifdef COHERENT_TRACKING_ENABLED
     , mMemoryTracker()
 #endif // TARGET_OS

--- a/gapii/cc/spy_base.h
+++ b/gapii/cc/spy_base.h
@@ -95,8 +95,8 @@ public:
     // Returns the transimission encoder.
     // TODO(qining): To support multithreaded uses, mutex is required to manage
     // the access to this encoder.
-    std::shared_ptr<gapii::PackEncoder> getEncoder() {
-        return is_suspended() ? mNullEncoder : mEncoder;
+    std::shared_ptr<gapii::PackEncoder> getEncoder(uint8_t api) {
+        return should_trace(api) ? mEncoder : mNullEncoder;
     }
 
     // Returns true if we should observe application pool.
@@ -116,6 +116,11 @@ public:
     bool is_suspended() const { return mIsSuspended; }
 
     void set_suspended(bool suspended) { mIsSuspended = suspended; }
+
+    bool should_trace(uint8_t api) {
+        return !is_suspended() && (mWatchedApis & (1 << api)) != 0;
+    }
+    void set_valid_apis(uint32_t apis) { mWatchedApis = apis; }
 protected:
     static const size_t kMaxExtras = 16; // Per atom
 
@@ -228,6 +233,11 @@ private:
 
     // True if we should not be currently tracing, false if we should be tracing.
     bool mIsSuspended;
+
+    // This is the list of all Apis that are considered for tracing. This is a
+    // bit set of apis where bit (1 << api) is set if a particular api
+    // should be traced.
+    uint32_t mWatchedApis;
 };
 
 // finds a key in the map and returns the value. If no value is present

--- a/gapii/client/capture.go
+++ b/gapii/client/capture.go
@@ -55,6 +55,8 @@ type Options struct {
 	StartFrame uint32
 	// If non-zero, then only n frames will be captured.
 	FramesToCapture uint32
+	// A bitmask of the APIs to capture in a trace.
+	APIs uint32
 	// Combination of FlagXX bits.
 	Flags Flags
 	// APK is an apk to install before tracing

--- a/gapii/client/header.go
+++ b/gapii/client/header.go
@@ -23,17 +23,18 @@ import (
 
 var magic = [4]byte{'s', 'p', 'y', '0'}
 
-const version = 4
+const version = 5
 
 // The GAPII header is defined as:
 //
 // struct ConnectionHeader {
 //   uint8_t  mMagic[4];                     // 's', 'p', 'y', '0'
-//   uint32_t mVersion;                      // 2 or 3
+//   uint32_t mVersion;                      // 2+
 //   uint32_t mObserveFrameFrequency;        // non-zero == enabled. Version: 2+
 //   uint32_t mObserveDrawFrequency;         // non-zero == enabled. Version: 2+
 //   uint32_t mStartFrame;                   // non-zero == Frame to start at. version 4+
 //   uint32_t mNumFrames;                    // non-zero == Number of frames to capture. version 4+
+//   uint32_t mAPIs;                         // Bitset of APIS to enable. version 5+
 //   uint32_t mFlags;                        // Combination of FLAG_XX bits. Version: 3+
 // };
 //
@@ -51,6 +52,7 @@ func sendHeader(out io.Writer, options Options) error {
 	w.Uint32(options.ObserveDrawFrequency)
 	w.Uint32(options.StartFrame)
 	w.Uint32(options.FramesToCapture)
+	w.Uint32(options.APIs)
 	w.Uint32(uint32(options.Flags))
 	return w.Error()
 }

--- a/gapis/gfxapi/gles/templates/api_exports.cpp.tmpl
+++ b/gapis/gfxapi/gles/templates/api_exports.cpp.tmpl
@@ -42,6 +42,8 @@
 ¶
 using namespace gapii;
 ¶
+const uint8_t GlesAPI = {{$.Index}};
+¶
 extern "C" {«
   {{range $c := AllCommands $}}
     {{if not (GetAnnotation $c "synthetic")}}
@@ -104,7 +106,7 @@ const Symbol kGLESExports[] = {
           GAPID_DEBUG("{{$name}}() -- done");
           {{if not (IsVoid $c.Return.Type)}}return _result_;{{else}}return;{{end}}
         }
-        CallObserver observer(s);
+        CallObserver observer(s, GlesAPI);
         s->lock(&observer, "{{$name}}");
         {{if not (IsVoid $c.Return.Type)}}auto _result_ = §{{end}}
         s->{{$name}}({{Macro "C++.CallArguments" $c | Strings "&observer" | JoinWith ", "}});

--- a/gapis/gfxapi/vulkan/templates/api_exports.cpp.tmpl
+++ b/gapis/gfxapi/vulkan/templates/api_exports.cpp.tmpl
@@ -20,6 +20,8 @@
 {{/* ---- Overrides ---- */}}
 {{Global "C++.EnumTypeOverride" "uint32_t"}}
 
+{{Global "ApiIndex" $.Index}}
+
 {{$filename := print (Global "API") "_exports.h" }}
 {{$ | Macro "ExportHeader" | Reflow 4 | Write $filename}}
 
@@ -131,7 +133,7 @@
       GAPID_FATAL("Unexpected re-entrant call to vulkan function");
       return {{if not (IsVoid $.Return.Type)}}{{Template "C++.Null" $.Return.Type}}{{end}};
     }
-    CallObserver observer(s);
+    CallObserver observer(s, {{Global "ApiIndex"}});
     s->lock(&observer, "{{$name}}");
     {{if not (IsVoid $.Return.Type)}} auto _result_ = §{{end}}
     s->{{$name}}({{Macro "C++.CallArguments" $ | Strings "&observer" | JoinWith ", "}});


### PR DESCRIPTION
This will allow us to filter out traced commands during trace.
Specifically this means we don't have to care about GLES during a
vulkan trace.