### PR TITLE
GAPIL framework support for annotate replacement.

### DIFF
--- a/gapil/analysis/CMakeFiles.cmake
+++ b/gapil/analysis/CMakeFiles.cmake
@@ -25,6 +25,7 @@ set(files
     class_value.go
     class_value_test.go
     enum_value.go
+    enum_value_test.go
     expressions.go
     map_value.go
     map_value_test.go
@@ -41,5 +42,5 @@ set(files
     value.go
 )
 set(dirs
-    
+
 )

--- a/gapil/analysis/enum_value_test.go
+++ b/gapil/analysis/enum_value_test.go
@@ -1,0 +1,186 @@
+// Copyright (C) 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package analysis_test
+
+import (
+	"testing"
+
+	"github.com/google/gapid/core/assert"
+	"github.com/google/gapid/core/log"
+	"github.com/google/gapid/gapil/analysis"
+)
+
+func TestEnumGlobalAnalysis(t *testing.T) {
+	ctx := log.Testing(t)
+
+	common := `
+    enum E{ A = 0x1  B = 0x2  C = 0x3 }
+	E G
+	`
+
+	for _, test := range []struct {
+		source   string
+		expected *analysis.EnumValue
+	}{
+		{``, &analysis.EnumValue{
+			Numbers: u64(0),
+			Labels:  map[uint64]string{},
+		}},
+		{`cmd void c(E e) { G = e }`, &analysis.EnumValue{
+			Numbers: u64Rng(0, 0xffffffffffffffff),
+			Labels:  map[uint64]string{},
+		}},
+		{`cmd void c(E e) {
+            switch e {
+              case A, B, C:
+                G = e
+            }
+          }`, &analysis.EnumValue{
+			Numbers: u64(0, 1, 2, 3),
+			Labels:  map[uint64]string{1: "A", 2: "B", 3: "C"},
+		}},
+	} {
+		ctx := log.V{"source": test.source}.Bind(ctx)
+		api, mappings, err := compile(ctx, common+" "+test.source)
+		assert.With(ctx).ThatError(err).Succeeded()
+		res := analysis.Analyze(api, mappings)
+		values := res.Globals[api.Globals[0]].(*analysis.EnumValue)
+		assert.For(ctx, "numbers").That(values.Numbers).DeepEquals(test.expected.Numbers)
+		assert.For(ctx, "labels").That(values.Labels).DeepEquals(test.expected.Labels)
+	}
+}
+
+func TestEnumParameterAnalysis(t *testing.T) {
+	ctx := log.Testing(t)
+
+	common := `
+    enum E{ A = 0x1  B = 0x2  C = 0x3 }
+	`
+
+	for _, test := range []struct {
+		source   string
+		expected *analysis.EnumValue
+	}{
+		{`cmd void c(E e) {
+            switch e {
+              case A, B, C: {}
+            }
+          }`, &analysis.EnumValue{
+			Numbers: anyU64,
+			Labels:  map[uint64]string{1: "A", 2: "B", 3: "C"},
+		}}, {`cmd void c(E e) {
+            if e == A {}
+            if e == B {}
+            if e == C {}
+          }`, &analysis.EnumValue{
+			Numbers: anyU64,
+			Labels:  map[uint64]string{1: "A", 2: "B", 3: "C"},
+		}},
+	} {
+		ctx := log.V{"source": test.source}.Bind(ctx)
+		api, mappings, err := compile(ctx, common+" "+test.source)
+		assert.With(ctx).ThatError(err).Succeeded()
+		res := analysis.Analyze(api, mappings)
+		values := res.Parameters[api.Functions[0].FullParameters[0]].(*analysis.EnumValue)
+		assert.For(ctx, "numbers").That(values.Numbers).DeepEquals(test.expected.Numbers)
+		assert.For(ctx, "labels").That(values.Labels).DeepEquals(test.expected.Labels)
+	}
+}
+
+func TestBitfieldGlobalAnalysis(t *testing.T) {
+	ctx := log.Testing(t)
+
+	common := `
+    bitfield E{ A = 0x1  B = 0x2  C = 0x4 }
+	E G
+	`
+
+	for _, test := range []struct {
+		source   string
+		expected *analysis.EnumValue
+	}{
+		{``, &analysis.EnumValue{
+			Numbers: u64(0),
+			Labels:  map[uint64]string{},
+		}},
+		{`cmd void c(E e) { G = e }`, &analysis.EnumValue{
+			Numbers: u64Rng(0, 0xffffffffffffffff),
+			Labels:  map[uint64]string{},
+		}},
+		{`cmd void c(E e) {
+            switch e {
+              case A, B, C:
+                G = e
+            }
+          }`, &analysis.EnumValue{
+			Numbers: u64(0, 1, 2, 4),
+			Labels:  map[uint64]string{1: "A", 2: "B", 4: "C"},
+		}},
+		{`cmd void c(E e) {
+            if (A in e) { G = A }
+            if (B in e) { G = B }
+            if (C in e) { G = C }
+          }`, &analysis.EnumValue{
+			Numbers: u64(0, 1, 2, 4),
+			Labels:  map[uint64]string{1: "A", 2: "B", 4: "C"},
+		}},
+	} {
+		ctx := log.V{"source": test.source}.Bind(ctx)
+		api, mappings, err := compile(ctx, common+" "+test.source)
+		assert.With(ctx).ThatError(err).Succeeded()
+		res := analysis.Analyze(api, mappings)
+		values := res.Globals[api.Globals[0]].(*analysis.EnumValue)
+		assert.For(ctx, "numbers").That(values.Numbers).DeepEquals(test.expected.Numbers)
+		assert.For(ctx, "labels").That(values.Labels).DeepEquals(test.expected.Labels)
+	}
+}
+
+func TestBitfieldParameterAnalysis(t *testing.T) {
+	ctx := log.Testing(t)
+
+	common := `
+    bitfield E{ A = 0x1  B = 0x2  C = 0x4 }
+	`
+
+	for _, test := range []struct {
+		source   string
+		expected *analysis.EnumValue
+	}{
+		{`cmd void c(E e) {
+            switch e {
+              case A, B, C: {}
+            }
+          }`, &analysis.EnumValue{
+			Numbers: anyU64,
+			Labels:  map[uint64]string{1: "A", 2: "B", 4: "C"},
+		}},
+		{`cmd void c(E e) {
+            if (A in e) { }
+            if (B in e) { }
+            if (C in e) { }
+          }`, &analysis.EnumValue{
+			Numbers: anyU64,
+			Labels:  map[uint64]string{1: "A", 2: "B", 4: "C"},
+		}},
+	} {
+		ctx := log.V{"source": test.source}.Bind(ctx)
+		api, mappings, err := compile(ctx, common+" "+test.source)
+		assert.With(ctx).ThatError(err).Succeeded()
+		res := analysis.Analyze(api, mappings)
+		values := res.Parameters[api.Functions[0].FullParameters[0]].(*analysis.EnumValue)
+		assert.For(ctx, "numbers").That(values.Numbers).DeepEquals(test.expected.Numbers)
+		assert.For(ctx, "labels").That(values.Labels).DeepEquals(test.expected.Labels)
+	}
+}

--- a/gapil/analysis/value.go
+++ b/gapil/analysis/value.go
@@ -233,8 +233,9 @@ func (s *scope) unknownOf(ty semantic.Type) (out Value) {
 
 	case *semantic.Enum:
 		return &EnumValue{
+			Ty:      ty,
 			Numbers: s.unknownOf(semantic.Uint64Type).(*UintValue),
-			Labels:  map[uint64]string{},
+			Labels:  Labels{},
 		}
 
 	case *semantic.Reference:
@@ -307,8 +308,9 @@ func (s *scope) defaultOf(ty semantic.Type) (out Value) {
 
 	case *semantic.Enum:
 		return &EnumValue{
+			Ty:      ty,
 			Numbers: s.defaultOf(semantic.Uint64Type).(*UintValue),
-			Labels:  map[uint64]string{},
+			Labels:  Labels{},
 		}
 
 	case *semantic.Reference:
@@ -391,8 +393,9 @@ func (s *scope) valueOf(n semantic.Expression) (out Value, setter func(Value)) {
 	case *semantic.EnumEntry:
 		v, _ := s.valueOf(semantic.Uint64Value(n.Value))
 		return &EnumValue{
+			Ty:      n.Owner().(*semantic.Enum),
 			Numbers: v.(*UintValue),
-			Labels:  map[uint64]string{uint64(n.Value): n.Name()},
+			Labels:  Labels{uint64(n.Value): n.Name()},
 		}, nil
 
 	case *semantic.Cast:

--- a/gapil/constset/CMakeFiles.cmake
+++ b/gapil/constset/CMakeFiles.cmake
@@ -18,21 +18,8 @@
 # build and the file will be recreated, check in the new version.
 
 set(files
-    api.go
-    constant_sets.go
-    format.go
-    functions.go
-    globals.go
-    list.go
-    literals.go
-    literals_test.go
-    names.go
-    strings.go
-    strings_examples_test.go
-    strings_test.go
-    template.go
-    types.go
+    constset.go
 )
 set(dirs
-
+    
 )

--- a/gapil/constset/constset.go
+++ b/gapil/constset/constset.go
@@ -1,0 +1,42 @@
+// Copyright (C) 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package constset provides structures for storing large numbers of
+// value-string pairs efficently.
+package constset
+
+// Pack holds the symbols and all constant sets.
+type Pack struct {
+	Symbols Symbols
+	Sets    []Set
+}
+
+// Symbols holds the symbol names.
+type Symbols string
+
+// Get returns the symbol for the entry e.
+func (s Symbols) Get(e Entry) string { return string(s[e.O : e.O+e.L]) }
+
+// Set is a list of entries.
+type Set struct {
+	IsBitfield bool
+	Entries    []Entry
+}
+
+// Entry is a single value-symbol entry.
+type Entry struct {
+	V uint64 // The value
+	O int    // The symbol table offset
+	L int    // The symbol length
+}

--- a/gapil/semantic/type.go
+++ b/gapil/semantic/type.go
@@ -53,6 +53,16 @@ func (*Class) isType() {}
 
 func (t *Class) ASTNode() ast.Node { return t.AST }
 
+// FieldByName returns the field of t with the name n, or nil.
+func (t *Class) FieldByName(n string) *Field {
+	for _, f := range t.Fields {
+		if f.Name() == n {
+			return f
+		}
+	}
+	return nil
+}
+
 // Field represents a field entry in a class.
 type Field struct {
 	owned

--- a/gapil/template/constant_sets.go
+++ b/gapil/template/constant_sets.go
@@ -1,0 +1,194 @@
+// Copyright (C) 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package template
+
+import (
+	"bytes"
+	"fmt"
+	"sort"
+
+	"github.com/google/gapid/gapil/analysis"
+	"github.com/google/gapid/gapil/constset"
+	"github.com/google/gapid/gapil/resolver"
+	"github.com/google/gapid/gapil/semantic"
+)
+
+type constsetBuilder struct {
+	sets    []constset.Set // Deterministic ordered.
+	setIdx  map[string]int // Used for removing duplicates.
+	symOff  map[string]int // Symbol offsets.
+	symbols bytes.Buffer   // Full packed symbols.
+}
+
+func (b *constsetBuilder) build() constset.Pack {
+	return constset.Pack{
+		Symbols: constset.Symbols(b.symbols.String()),
+		Sets:    b.sets,
+	}
+}
+
+func (b *constsetBuilder) addSym(sym string) (int, int) {
+	offset, ok := b.symOff[sym]
+	if !ok {
+		offset = b.symbols.Len()
+		b.symOff[sym] = offset
+		b.symbols.WriteString(sym)
+	}
+	return offset, len(sym)
+}
+
+func (b *constsetBuilder) addLabels(labels analysis.Labels, isBitfield bool) int {
+	keys := make(u64s, 0, len(labels))
+	for k := range labels {
+		keys = append(keys, k)
+	}
+	sort.Sort(keys)
+
+	set := constset.Set{
+		IsBitfield: isBitfield,
+		Entries:    make([]constset.Entry, len(keys)),
+	}
+	for i, k := range keys {
+		set.Entries[i].V = k
+		set.Entries[i].O, set.Entries[i].L = b.addSym(labels[k])
+	}
+
+	id := fmt.Sprintf("%+v", set)
+	idx, ok := b.setIdx[id]
+	if !ok {
+		idx = len(b.sets)
+		b.setIdx[id] = idx
+		b.sets = append(b.sets, set)
+	}
+	return idx
+}
+
+type u64s []uint64
+
+func (p u64s) Len() int           { return len(p) }
+func (p u64s) Less(i, j int) bool { return p[i] < p[j] }
+func (p u64s) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }
+
+// ConstantSets consatins the constset.Pack, and each semantic mapping to a
+// constset.Set index.
+type ConstantSets struct {
+	Pack constset.Pack
+	Sets map[semantic.Node]int
+}
+
+type nodeLabeler struct {
+	nodes map[semantic.Node]analysis.Labels
+	seen  map[analysis.Value]bool
+}
+
+func (nl *nodeLabeler) addLabels(n semantic.Node, v analysis.Value) {
+	ev, ok := v.(*analysis.EnumValue)
+	if !ok || len(ev.Labels) == 0 {
+		return // Parameter wasn't an enum, or had no labels.
+	}
+	l, ok := nl.nodes[n]
+	if !ok {
+		l = analysis.Labels{}
+		nl.nodes[n] = l
+	}
+	l.Merge(ev.Labels)
+}
+
+func (nl *nodeLabeler) traverse(n semantic.Node, v analysis.Value) {
+	if nl.seen[v] {
+		return
+	}
+	nl.seen[v] = true
+	nl.addLabels(n, v)
+	switch v := v.(type) {
+	case *analysis.ClassValue:
+		for n, fv := range v.Fields {
+			nl.traverse(v.Class.FieldByName(n), fv)
+		}
+	case *analysis.MapValue:
+		for k, v := range v.KeyToValue {
+			nl.traverse(nil, k)
+			nl.traverse(nil, v)
+		}
+	}
+}
+
+func buildConstantSets(api *semantic.API, mappings *resolver.Mappings) *ConstantSets {
+	b := &constsetBuilder{
+		setIdx: map[string]int{},
+		symOff: map[string]int{},
+	}
+
+	a := analysis.Analyze(api, mappings)
+
+	constsets := map[semantic.Node]int{}
+
+	for _, f := range api.Functions {
+		for _, p := range f.FullParameters {
+			v, ok := a.Parameters[p]
+			if !ok {
+				continue // No analysis for this parameter.
+			}
+			ev, ok := v.(*analysis.EnumValue)
+			if !ok || len(ev.Labels) == 0 {
+				continue // Parameter wasn't an enum, or had no labels.
+			}
+			constsets[p] = b.addLabels(ev.Labels, ev.Ty.IsBitfield)
+		}
+	}
+
+	nl := nodeLabeler{
+		nodes: map[semantic.Node]analysis.Labels{},
+		seen:  map[analysis.Value]bool{},
+	}
+	// Gather all the labeled nodes.
+	for n, v := range a.Globals {
+		nl.traverse(n, v)
+	}
+	for n, v := range a.Instances {
+		nl.traverse(n, v)
+	}
+	// Create constant sets for all the nodes.
+	for n, l := range nl.nodes {
+		isBitfield := false // TODO
+		constsets[n] = b.addLabels(l, isBitfield)
+	}
+
+	return &ConstantSets{
+		Pack: b.build(),
+		Sets: constsets,
+	}
+}
+
+func (f *Functions) constantSets() *ConstantSets {
+	if f.cs != nil {
+		return f.cs
+	}
+	f.cs = buildConstantSets(f.api, f.mappings)
+	return f.cs
+}
+
+// ConstantSets returns the full constants set pack for the API.
+func (f *Functions) ConstantSets() constset.Pack {
+	return f.constantSets().Pack
+}
+
+// ConstantSetIndex returns the constant set for the given parameter.
+func (f *Functions) ConstantSetIndex(n semantic.Node) int {
+	if i, ok := f.constantSets().Sets[n]; ok {
+		return i
+	}
+	return -1
+}

--- a/gapil/template/functions.go
+++ b/gapil/template/functions.go
@@ -50,6 +50,7 @@ type Functions struct {
 	basePath  string
 	apiFile   string
 	api       *semantic.API
+	cs        *ConstantSets
 	loader    func(filename string) ([]byte, error)
 }
 

--- a/gapil/template/types.go
+++ b/gapil/template/types.go
@@ -217,6 +217,25 @@ func (*Functions) IsNumericType(t interface{}) bool {
 	}
 }
 
+// UniqueEnumKeys returns the enum's list of EnumEntry with duplicate values
+// removed. To remove duplicates the entry with the shortest name is picked.
+func (*Functions) UniqueEnumKeys(e *semantic.Enum) ([]*semantic.EnumEntry, error) {
+	keys := map[uint32]*semantic.EnumEntry{}
+	for _, e := range e.Entries {
+		if got, found := keys[e.Value]; !found || len(got.Name()) > len(e.Name()) {
+			keys[e.Value] = e
+		}
+	}
+	out := make([]*semantic.EnumEntry, 0, len(keys))
+	for _, e := range e.Entries {
+		if got := keys[e.Value]; got == e {
+			out = append(out, e)
+			delete(keys, e.Value)
+		}
+	}
+	return out, nil
+}
+
 // Returns the base name of the type of v
 func baseType(v interface{}) reflect.Type {
 	ty := reflect.TypeOf(v)


### PR DESCRIPTION
This PR adds support for generating constant set data used to describe enums and bitfields.
These changes have no effect on the runtime (except better analysis for the gfxapi VSCode plugin).