### PR TITLE
Replace glob .gitignore for *.pb.go with explicit ignores.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,6 @@
 
 # General patterns
 *.gfxtrace
-*.pb.go
 *ycm_extra_conf.py*
 *_binary.go
 *_binary_test.go

--- a/core/data/pack/.gitignore
+++ b/core/data/pack/.gitignore
@@ -1,0 +1,1 @@
+pack.pb.go

--- a/core/data/pod/.gitignore
+++ b/core/data/pod/.gitignore
@@ -1,0 +1,1 @@
+pod.pb.go

--- a/core/data/record/.gitignore
+++ b/core/data/record/.gitignore
@@ -1,0 +1,1 @@
+record.pb.go

--- a/core/data/search/.gitignore
+++ b/core/data/search/.gitignore
@@ -1,0 +1,1 @@
+search.pb.go

--- a/core/data/stash/.gitignore
+++ b/core/data/stash/.gitignore
@@ -1,0 +1,1 @@
+stash.pb.go

--- a/core/image/.gitignore
+++ b/core/image/.gitignore
@@ -1,0 +1,1 @@
+image.pb.go

--- a/core/log/.gitignore
+++ b/core/log/.gitignore
@@ -1,0 +1,1 @@
+log.pb.go

--- a/core/log/log_pb/.gitignore
+++ b/core/log/log_pb/.gitignore
@@ -1,0 +1,1 @@
+log.pb.go

--- a/core/os/android/.gitignore
+++ b/core/os/android/.gitignore
@@ -1,0 +1,1 @@
+keycodes.pb.go

--- a/core/os/android/apk/.gitignore
+++ b/core/os/android/apk/.gitignore
@@ -1,0 +1,1 @@
+apk.pb.go

--- a/core/os/device/.gitignore
+++ b/core/os/device/.gitignore
@@ -1,0 +1,1 @@
+device.pb.go

--- a/core/os/device/bind/.gitignore
+++ b/core/os/device/bind/.gitignore
@@ -1,0 +1,1 @@
+bind.pb.go

--- a/core/stream/.gitignore
+++ b/core/stream/.gitignore
@@ -1,0 +1,1 @@
+stream.pb.go

--- a/gapidapk/pkginfo/.gitignore
+++ b/gapidapk/pkginfo/.gitignore
@@ -1,0 +1,1 @@
+pkginfo.pb.go

--- a/gapis/atom/atom_pb/.gitignore
+++ b/gapis/atom/atom_pb/.gitignore
@@ -1,0 +1,1 @@
+atom.pb.go

--- a/gapis/capture/.gitignore
+++ b/gapis/capture/.gitignore
@@ -1,0 +1,1 @@
+capture.pb.go

--- a/gapis/gfxapi/.gitignore
+++ b/gapis/gfxapi/.gitignore
@@ -1,3 +1,5 @@
+gfxapi.pb.go
+
 /*/api.go
 /*/enum.go
 /*/mutate.go

--- a/gapis/gfxapi/gles/.gitignore
+++ b/gapis/gfxapi/gles/.gitignore
@@ -1,0 +1,1 @@
+resolvables.pb.go

--- a/gapis/gfxapi/gles/gles_pb/.gitignore
+++ b/gapis/gfxapi/gles/gles_pb/.gitignore
@@ -1,2 +1,3 @@
-/api.pb.go
-/api.proto
+api.pb.go
+api.proto
+extras.pb.go

--- a/gapis/memory/.gitignore
+++ b/gapis/memory/.gitignore
@@ -1,0 +1,1 @@
+memory.pb.go

--- a/gapis/replay/.gitignore
+++ b/gapis/replay/.gitignore
@@ -1,0 +1,1 @@
+replay.pb.go

--- a/gapis/replay/protocol/.gitignore
+++ b/gapis/replay/protocol/.gitignore
@@ -1,0 +1,1 @@
+replay_protocol.pb.go

--- a/gapis/resolve/.gitignore
+++ b/gapis/resolve/.gitignore
@@ -1,0 +1,1 @@
+resolvables.pb.go

--- a/gapis/resolve/testatom_pb/.gitignore
+++ b/gapis/resolve/testatom_pb/.gitignore
@@ -1,0 +1,1 @@
+testatom.pb.go

--- a/gapis/service/.gitignore
+++ b/gapis/service/.gitignore
@@ -1,0 +1,1 @@
+service.pb.go

--- a/gapis/service/box/.gitignore
+++ b/gapis/service/box/.gitignore
@@ -1,0 +1,1 @@
+box.pb.go

--- a/gapis/service/path/.gitignore
+++ b/gapis/service/path/.gitignore
@@ -1,0 +1,1 @@
+path.pb.go

--- a/gapis/stringtable/.gitignore
+++ b/gapis/stringtable/.gitignore
@@ -1,0 +1,1 @@
+stringtable.pb.go

--- a/gapis/vertex/.gitignore
+++ b/gapis/vertex/.gitignore
@@ -1,0 +1,1 @@
+vertex.pb.go

--- a/test/robot/build/.gitignore
+++ b/test/robot/build/.gitignore
@@ -1,0 +1,1 @@
+build.pb.go

--- a/test/robot/job/.gitignore
+++ b/test/robot/job/.gitignore
@@ -1,0 +1,1 @@
+job.pb.go

--- a/test/robot/job/worker/.gitignore
+++ b/test/robot/job/worker/.gitignore
@@ -1,0 +1,1 @@
+worker.pb.go

--- a/test/robot/master/.gitignore
+++ b/test/robot/master/.gitignore
@@ -1,0 +1,1 @@
+master.pb.go

--- a/test/robot/replay/.gitignore
+++ b/test/robot/replay/.gitignore
@@ -1,0 +1,1 @@
+replay.pb.go

--- a/test/robot/report/.gitignore
+++ b/test/robot/report/.gitignore
@@ -1,0 +1,1 @@
+report.pb.go

--- a/test/robot/subject/.gitignore
+++ b/test/robot/subject/.gitignore
@@ -1,0 +1,1 @@
+subject.pb.go

--- a/test/robot/trace/.gitignore
+++ b/test/robot/trace/.gitignore
@@ -1,0 +1,1 @@
+trace.pb.go


### PR DESCRIPTION
While the old glob may be convenient, it causes horrible and confusing
issues when packages are moved or deleted.