### PR TITLE
Reduce {api}_spy.cpp parallelism to 2.

### DIFF
--- a/gapii/cc/CMakeFiles.cmake
+++ b/gapii/cc/CMakeFiles.cmake
@@ -32,10 +32,6 @@ set(files
     core_spy_1.cpp
     core_spy_2.cpp
     core_spy_3.cpp
-    core_spy_4.cpp
-    core_spy_5.cpp
-    core_spy_6.cpp
-    core_spy_7.cpp
     core_spy_subroutines_0.cpp
     core_spy_subroutines_1.cpp
     core_types.cpp
@@ -51,10 +47,6 @@ set(files
     gles_spy_1.cpp
     gles_spy_2.cpp
     gles_spy_3.cpp
-    gles_spy_4.cpp
-    gles_spy_5.cpp
-    gles_spy_6.cpp
-    gles_spy_7.cpp
     gles_spy_externs.cpp
     gles_spy_subroutines_0.cpp
     gles_spy_subroutines_1.cpp
@@ -89,10 +81,6 @@ set(files
     vulkan_spy_1.cpp
     vulkan_spy_2.cpp
     vulkan_spy_3.cpp
-    vulkan_spy_4.cpp
-    vulkan_spy_5.cpp
-    vulkan_spy_6.cpp
-    vulkan_spy_7.cpp
     vulkan_spy_helpers.cpp
     vulkan_spy_subroutines_0.cpp
     vulkan_spy_subroutines_1.cpp

--- a/gapis/gfxapi/templates/api_spy.cpp.tmpl
+++ b/gapis/gfxapi/templates/api_spy.cpp.tmpl
@@ -31,7 +31,7 @@
 
 {{define "SpyCpp"}}
   {{AssertType $ "API"}}
-  {{range $i, $part := (Partition (AllCommands $) "CommandKey" 8)}}
+  {{range $i, $part := (Partition (AllCommands $) "CommandKey" 4)}}
      {{$filename := print (Global "API") "_spy_" $i ".cpp"}}
      {{$part | Macro "SpyCppPart" | Reflow 4 | Write $filename}}
   {{end}}


### PR DESCRIPTION
This reduces build time by about 5%.

We seem to have decent amount of parallelism already.
Having the value too high just adds per-file overhead.
More importantly, too many parallel compilers can
trash the memory of the operating system.