### PR TITLE
GAPIS: Log messages to stdout when there's no GetLogStream().

### DIFF
--- a/core/log/broadcast.go
+++ b/core/log/broadcast.go
@@ -19,7 +19,7 @@ import "sync"
 // Broadcaster forwards all messages to all supplied handlers.
 // Broadcaster implements the Handler interface.
 type Broadcaster struct {
-	m sync.Mutex
+	m sync.RWMutex
 	l []Handler
 }
 
@@ -44,11 +44,18 @@ func (b *Broadcaster) Listen(h Handler) (unlisten func()) {
 
 // Handle broadcasts the page to all the listening handlers.
 func (b *Broadcaster) Handle(m *Message) {
-	b.m.Lock()
-	defer b.m.Unlock()
+	b.m.RLock()
+	defer b.m.RUnlock()
 	for _, h := range b.l {
 		h.Handle(m)
 	}
+}
+
+// Count returns the number of registered handlers.
+func (b *Broadcaster) Count() int {
+	b.m.RLock()
+	defer b.m.RUnlock()
+	return len(b.l)
 }
 
 // Close calls Close on all the listening handlers and removes them from the

--- a/core/log/log_pb/CMakeFiles.cmake
+++ b/core/log/log_pb/CMakeFiles.cmake
@@ -18,10 +18,10 @@
 # build and the file will be recreated, check in the new version.
 
 set(files
+    log.go
     log.pb.go
     log.proto
-    pb.go
 )
 set(dirs
-    
+
 )

--- a/core/log/log_pb/log.go
+++ b/core/log/log_pb/log.go
@@ -16,7 +16,6 @@ package log_pb
 
 import (
 	"fmt"
-
 	"time"
 
 	"github.com/golang/protobuf/ptypes/timestamp"

--- a/core/log/testing.go
+++ b/core/log/testing.go
@@ -19,7 +19,7 @@ import "context"
 // Testing returns a default context with a TestHandler installed.
 func Testing(t delegate) context.Context {
 	ctx := context.Background()
-	return PutHandler(ctx, TestHandler(t, Normal))
+	return PutHandler(ctx, TestHandler(t, Detailed))
 }
 
 // TestHandler is a Writer that uses the style to write records to t's using the

--- a/core/os/process/client.go
+++ b/core/os/process/client.go
@@ -74,6 +74,9 @@ type StartOptions struct {
 
 	// Standard error pipe for the new process.
 	Stderr io.Writer
+
+	// Should all stderr and and stdout also be logged to the logger?
+	Verbose bool
 }
 
 // Start runs the application with the given path and options, waits for
@@ -89,11 +92,14 @@ func Start(ctx context.Context, name string, opts StartOptions) (int, error) {
 	}
 
 	go func() {
-		errChan <- shell.
+		cmd := shell.
 			Command(name, opts.Args...).
 			Env(opts.Env).
-			Capture(stdout, opts.Stderr).
-			Run(ctx)
+			Capture(stdout, opts.Stderr)
+		if opts.Verbose {
+			cmd = cmd.Verbose()
+		}
+		errChan <- cmd.Run(ctx)
 	}()
 
 	select {

--- a/gapis/client/process.go
+++ b/gapis/client/process.go
@@ -84,12 +84,16 @@ func Connect(ctx context.Context, cfg Config) (Client, *schema.Message, error) {
 
 	var err error
 	if cfg.Port == 0 || len(cfg.Args) > 0 {
-		cfg.Args = append(cfg.Args, "--log-level", logLevel(ctx).String())
+		cfg.Args = append(cfg.Args,
+			"--log-level", logLevel(ctx).String(),
+			"--log-style", log.Brief.String(),
+		)
 		if cfg.Token != auth.NoAuth {
 			cfg.Args = append(cfg.Args, "--gapis-auth-token", string(cfg.Token))
 		}
 		cfg.Port, err = process.Start(ctx, cfg.Path.System(), process.StartOptions{
-			Args: cfg.Args,
+			Args:    cfg.Args,
+			Verbose: true,
 		})
 		if err != nil {
 			return nil, nil, err


### PR DESCRIPTION
GAPIT: Watch for GAPIS messages on stdout / stderr.

Fixes issues where crashes and early messages can go unreported.
