### PR TITLE
Optimize protobuf code for size.

### DIFF
--- a/gapis/gfxapi/templates/api.proto.tmpl
+++ b/gapis/gfxapi/templates/api.proto.tmpl
@@ -21,6 +21,8 @@
 {{define "api.proto"}}
   {{template "Proto.GeneratedHeader" (Global "OutputDir")}}
 
+  option optimize_for = CODE_SIZE;
+
   {{range $c := AllCommands $}}
     {{Template "CommandEntry" $c}}
   {{end}}


### PR DESCRIPTION
Decreases the build time by 20%.

They do not take that much user time, but their size puts
them on critical path.