### PR TITLE
Fix random crash in gRPC library when calling GetLogStream().

### DIFF
--- a/gapis/server/server.go
+++ b/gapis/server/server.go
@@ -319,8 +319,12 @@ func (s *server) GetProfile(ctx context.Context, name string, debug int32) ([]by
 }
 
 func (s *server) GetLogStream(ctx context.Context, handler log.Handler) error {
+	handler = log.Channel(handler, 64)
 	unregister := s.logBroadcaster.Listen(handler)
-	defer unregister()
+	defer func() {
+		unregister()
+		handler.Close()
+	}()
 	<-task.ShouldStop(ctx)
 	return task.StopReason(ctx)
 }


### PR DESCRIPTION
We weren't synchronizing the log messages, resulting in
random race conditions inside the gRPC library.

Use the log.Channel to keep everything concurrent-safe.