### PR TITLE
Change strings in cmd types from std::string to char*.

### DIFF
--- a/gapis/gfxapi/templates/api_types.h.tmpl
+++ b/gapis/gfxapi/templates/api_types.h.tmpl
@@ -282,7 +282,10 @@
       ::google::protobuf::Message* toProto() const;
       ¶
       {{range $p := $.FullParameters}}
-        {{Template "C++.Type" $p}} {{$p.Name}};
+        {{$ty := TypeOf $p | Underlying}}
+        {{if IsString $ty}}const char* {{$p.Name}};
+        {{else           }}{{Template "C++.Type" $p}} {{$p.Name}};
+        {{end            }}
       {{end}}
     };
   {{end}}


### PR DESCRIPTION
5edbc9bf broke tracing any app that used command with a string parameter. This CL removed the inline proto construction with helper structs now in xxx_types.{h,cpp}.

These structs used std::string for string types, but the constructors did not consider nullptrs. This CL changes the string field type to char*, as these are already correctly handled by the toProto() functions.
