### PR TITLE
Vulkan:Fix crash caused by accessing NULL handle in Vulkan DCE

### DIFF
--- a/gapis/gfxapi/vulkan/dependency_graph.go
+++ b/gapis/gfxapi/vulkan/dependency_graph.go
@@ -336,6 +336,7 @@ func (g *DependencyGraph) getBehaviour(ctx context.Context, s *gfxapi.State, id 
 	getOverlappedBindingsForImage := func(image VkImage) []*vulkanDeviceMemoryBinding {
 		if !GetState(s).Images.Contains(image) {
 			log.E(ctx, "Error Image: %v: does not exist in state", image)
+			return []*vulkanDeviceMemoryBinding{}
 		}
 		imageObj := GetState(s).Images.Get(image)
 		if imageObj.IsSwapchainImage {
@@ -355,6 +356,7 @@ func (g *DependencyGraph) getBehaviour(ctx context.Context, s *gfxapi.State, id 
 	getOverlappedBindingsForBuffer := func(buffer VkBuffer) []*vulkanDeviceMemoryBinding {
 		if !GetState(s).Buffers.Contains(buffer) {
 			log.E(ctx, "Error Buffer: %v: does not exist in state", buffer)
+			return []*vulkanDeviceMemoryBinding{}
 		}
 		bufferObj := GetState(s).Buffers.Get(buffer)
 		if bufferObj.Memory != nil {


### PR DESCRIPTION
Check if the given Vulkan Handle exist in the state before getting the object of the handle. Sometime using VK_NULL_HANDLE (value 0) is valid, but no object should be obtained from that null handle.