### PR TITLE
Don't attempt to use ccache for LLVM on Windows.

### DIFF
--- a/gapii/interceptor-lib/cc/CMakeBuild.cmake
+++ b/gapii/interceptor-lib/cc/CMakeBuild.cmake
@@ -12,10 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set(LLVM_CCACHE_BUILD "OFF")
-find_program(CCACHE_FOUND ccache)
-if(CCACHE_FOUND)
-    set(LLVM_CCACHE_BUILD "ON")
+set(LLVM_CCACHE_BUILD OFF)
+if(NOT CMAKE_HOST_WIN32)
+    find_program(CCACHE_FOUND ccache)
+    if(CCACHE_FOUND)
+        set(LLVM_CCACHE_BUILD ON)
+    endif()
 endif()
 
 if(ANDROID_ABI)


### PR DESCRIPTION
LLVM assumes that if ccache is enabled, it's on a UNIX style system and attempts to set env variables as part of the ccache command, which fails horribly on Windows.