### PR TITLE
Fixes for broken shader-editing in Vulkan.

### DIFF
--- a/gapis/shadertools/cc/libmanager.cpp
+++ b/gapis/shadertools/cc/libmanager.cpp
@@ -308,7 +308,7 @@ spirv_binary_t* assembleToBinary(const char* text) {
   std::vector<uint32_t> words;
   spvtools::SpirvTools tools(SPV_ENV_VULKAN_1_0);
   const auto result = tools.Assemble(disassembly, &words);
-  if (result != SPV_SUCCESS) {
+  if (!result) {
     return nullptr;
   }
   binary->words_num = words.size();


### PR DESCRIPTION
This fixes shader editing in Vulkan. There were 3 issues fixed.
1) libmanager.cpp was checking result (bool) != SPV_SUCCESS (0), which
always returned the wrong thing.
2) The memory layout was not set when re-encoding the new
VkCreateShaderModule paramters, so this only worked on ARM32.
3) We missed RecreateShaderModule in mid-execution capture. Now we can
modify shaders in RecreateShaderModule.