### PR TITLE
Switch off some of the OS checks for the more generic check.

### DIFF
--- a/core/memory_tracker/cc/memory_tracker_test.cpp
+++ b/core/memory_tracker/cc/memory_tracker_test.cpp
@@ -15,7 +15,7 @@
  */
 
 #include "memory_tracker.h"
-#if (TARGET_OS == GAPID_OS_LINUX) || (TARGET_OS == GAPID_OS_ANDROID)
+#ifdef COHERENT_TRACKING_ENABLED
 
 #include <gmock/gmock.h>
 

--- a/gapii/cc/spy_base.cpp
+++ b/gapii/cc/spy_base.cpp
@@ -33,7 +33,7 @@ SpyBase::SpyBase()
     , mCommandStartEndCounter(0)
     , mExpectedNextCommandStartCounterValue(0)
     , mNullEncoder(PackEncoder::noop())
-#if (TARGET_OS == GAPID_OS_LINUX) || (TARGET_OS == GAPID_OS_ANDROID)
+#ifdef COHERENT_TRACKING_ENABLED
     , mMemoryTracker()
 #endif // TARGET_OS
 {

--- a/gapii/cc/spy_base.h
+++ b/gapii/cc/spy_base.h
@@ -194,7 +194,7 @@ protected:
     // return for this call. The actual return value comes from the driver.
     template <typename T> void setExpectedReturn(const T& t);
 
-#if (TARGET_OS == GAPID_OS_LINUX) || (TARGET_OS == GAPID_OS_ANDROID)
+#ifdef COHERENT_TRACKING_ENABLED
     TrackMemory::MemoryTracker mMemoryTracker;
 #endif // TARGET_OS
 private:


### PR DESCRIPTION
This lets us turn on/off Coherent memory tracking more easily.