### PR TITLE
api.go.tmpl: Make static arrays arrays, not structs.

### DIFF
--- a/gapis/gfxapi/gles/string.go
+++ b/gapis/gfxapi/gles/string.go
@@ -21,48 +21,39 @@ func (c Color) String() string {
 }
 
 func (v Vec2f) String() string {
-	return fmt.Sprintf("(% 6f, % 6f)",
-		v.Elements[0], v.Elements[1])
+	return fmt.Sprintf("(% 6f, % 6f)", v[0], v[1])
 }
 
 func (v Vec3f) String() string {
-	return fmt.Sprintf("(% 6f, % 6f, % 6f)",
-		v.Elements[0], v.Elements[1], v.Elements[2])
+	return fmt.Sprintf("(% 6f, % 6f, % 6f)", v[0], v[1], v[2])
 }
 
 func (v Vec4f) String() string {
-	return fmt.Sprintf("(% 6f, % 6f, % 6f, % 6f)",
-		v.Elements[0], v.Elements[1], v.Elements[2], v.Elements[3])
+	return fmt.Sprintf("(% 6f, % 6f, % 6f, % 6f)", v[0], v[1], v[2], v[3])
 }
 
 func (v Vec2i) String() string {
-	return fmt.Sprintf("(% 6d, % 6d)",
-		v.Elements[0], v.Elements[1])
+	return fmt.Sprintf("(% 6d, % 6d)", v[0], v[1])
 }
 
 func (v Vec3i) String() string {
-	return fmt.Sprintf("(% 6d, % 6d, % 6d)",
-		v.Elements[0], v.Elements[1], v.Elements[2])
+	return fmt.Sprintf("(% 6d, % 6d, % 6d)", v[0], v[1], v[2])
 }
 
 func (v Vec4i) String() string {
-	return fmt.Sprintf("(% 6d, % 6d, % 6d, % 6d)",
-		v.Elements[0], v.Elements[1], v.Elements[2], v.Elements[3])
+	return fmt.Sprintf("(% 6d, % 6d, % 6d, % 6d)", v[0], v[1], v[2], v[3])
 }
 
 func (m Mat2f) String() string {
-	return fmt.Sprintf("[%v, %v]",
-		m.Elements[0], m.Elements[1])
+	return fmt.Sprintf("[%v, %v]", m[0], m[1])
 }
 
 func (m Mat3f) String() string {
-	return fmt.Sprintf("[%v, %v, %v]",
-		m.Elements[0], m.Elements[1], m.Elements[2])
+	return fmt.Sprintf("[%v, %v, %v]", m[0], m[1], m[2])
 }
 
 func (m Mat4f) String() string {
-	return fmt.Sprintf("[%v, %v, %v, %v]",
-		m.Elements[0], m.Elements[1], m.Elements[2], m.Elements[3])
+	return fmt.Sprintf("[%v, %v, %v, %v]", m[0], m[1], m[2], m[3])
 }
 
 func (a VertexAttributeArray) String() string {

--- a/gapis/gfxapi/templates/api.go.tmpl
+++ b/gapis/gfxapi/templates/api.go.tmpl
@@ -151,25 +151,23 @@
   {{AssertType $ "StaticArray"}}
 
   {{$ty := Macro "Go.Type" $}}
-  type {{$ty}} struct {
-    Elements [{{$.Size}}]{{Template "Go.Type" $.ValueType}}
-  }
+  type {{$ty}} [{{$.Size}}]{{Template "Go.Type" $.ValueType}}
 
   func (a *{{$ty}}) Encode(ϟl *device.MemoryLayout, e binary.Writer) {
-    for _, v := range a.Elements {
+    for _, v := range (*a) {
       {{Template "Go.Encode" "Name" "v" "Type" $.ValueType "ErrHandler" "panic(e.Error())"}}
     }
   }
 
   func (a *{{$ty}}) Decode(ϟl *device.MemoryLayout, d binary.Reader) {
-    for i := range a.Elements {
-      {{Template "Go.Decode" "Name" "a.Elements[i]" "Type" $.ValueType "ErrHandler" "panic(d.Error())"}}
+    for i := range (*a) {
+      {{Template "Go.Decode" "Name" "(*a)[i]" "Type" $.ValueType "ErrHandler" "panic(d.Error())"}}
     }
   }
 
   {{if IsNumericType $.ValueType}}
     func (a {{$ty}}) value(ϟb *builder.Builder, ϟa atom.Atom, ϟs *gfxapi.State) value.Pointer {
-      for _, v := range a.Elements {
+      for _, v := range a {
         ϟb.Push({{Template "Go.Replay.Value" "Type" $.ValueType "Name" "v"}})
       }
       return ϟb.Buffer({{$.Size}})
@@ -731,19 +729,6 @@
     }
     return nil, nil
   }
-{{end}}
-
-
-{{/*
--------------------------------------------------------------------------------
-  Emits a type declaration and implementation for the specified static array.
--------------------------------------------------------------------------------
-*/}}
-{{define "StaticArray"}}
-  {{AssertType $ "StaticArray"}}
-  type {{$.Name}} [{{$.Size}}]{{Template "Go.Type" $.ValueType}}
-  func (s {{$.Name}}) Len() int { return {{$.Size}} }
-  func (s {{$.Name}}) Range() [{{$.Size}}]{{Template "Go.Type" $.ValueType}} { return s}
 {{end}}
 
 

--- a/gapis/gfxapi/templates/convert.go.tmpl
+++ b/gapis/gfxapi/templates/convert.go.tmpl
@@ -149,7 +149,7 @@
   {{if IsStaticArray $truetype}}
     to.{{$proto}} = make([]{{Macro "Convert.StorageType" $truetype.ValueType}}, {{$truetype.Size}})¶
     for ϟi := 0; ϟi < {{$type.Size}}; ϟi++ {»¶
-      ϟv := ϟa.{{$name}}.Elements[ϟi]¶
+      ϟv := ϟa.{{$name}}[ϟi]¶
       to.{{$proto}}[ϟi] = {{Template "Convert.ToProto" "Type" $truetype.ValueType "Value" "ϟv"}}¶
     «}¶
   {{else if IsMap $truetype}}
@@ -180,7 +180,7 @@
   {{if IsStaticArray $truetype}}
     for ϟi := 0; ϟi < {{$truetype.Size}}; ϟi++ {»¶
       ϟv := from.{{$proto}}[ϟi]¶
-      ϟa.{{$name}}.Elements[ϟi] = {{Template "Convert.FromProto" "Type" $truetype.ValueType "Value" "ϟv"}}¶
+      ϟa.{{$name}}[ϟi] = {{Template "Convert.FromProto" "Type" $truetype.ValueType "Value" "ϟv"}}¶
     «}¶
   {{else if IsMap $truetype}}
     ϟa.{{$name}} = make({{$.Field.Type.Name}}, len(from.{{$proto}}))¶

--- a/gapis/gfxapi/templates/go_common.tmpl
+++ b/gapis/gfxapi/templates/go_common.tmpl
@@ -593,7 +593,7 @@
   {{else if IsMember           $}}{{Template "Go.Member" $}}
   {{else if IsGlobal           $}}{{Template "Go.Global" $}}
   {{else if IsParameter        $}}{{Template "Go.Parameter" $}}
-  {{else if IsArrayIndex       $}}{{Template "Go.Read" $.Array}}.Elements[{{Template "Go.Read" $.Index}}]
+  {{else if IsArrayIndex       $}}{{Template "Go.Read" $.Array}}[{{Template "Go.Read" $.Index}}]
   {{else if IsMapIndex         $}}{{Template "Go.Read" $.Map}}.Get({{Template "Go.Read" $.Index}})
   {{else if IsMapContains      $}}{{Template "Go.Read" $.Map}}.Contains({{Template "Go.Read" $.Key}})
   {{else if IsLength           $}}{{Template "Go.Type" $.Type}}({{Template "Go.ReadLength" "Type" (TypeOf $.Object) "Value" $.Object}})
@@ -722,7 +722,7 @@
   {{AssertType $ "ArrayInitializer"}}
 
   {{$a := $.Array | Underlying | Unpack}}
-  {{Template "Go.Type" $}}{ Elements: [{{$a.Size}}]{{Template "Go.Type" $a.ValueType}}{ {{ForEach $.Values "Go.Read" | JoinWith ", "}} } }
+  {{Template "Go.Type" $}}{ {{ForEach $.Values "Go.Read" | JoinWith ", "}} }
 {{end}}
 
 

--- a/gapis/gfxapi/templates/mutate.go.tmpl
+++ b/gapis/gfxapi/templates/mutate.go.tmpl
@@ -527,7 +527,7 @@
 {{define "ArrayAssign"}}
   {{AssertType $ "ArrayAssign"}}
 
-  {{Template "Go.Read" $.To.Array}}.Elements[{{Template "Go.Read" $.To.Index}}] {{$.Operator}} {{Template "Go.Read" $.Value}}
+  {{Template "Go.Read" $.To.Array}}[{{Template "Go.Read" $.To.Index}}] {{$.Operator}} {{Template "Go.Read" $.Value}}
 {{end}}
 
 

--- a/gapis/gfxapi/vulkan/read_framebuffer.go
+++ b/gapis/gfxapi/vulkan/read_framebuffer.go
@@ -205,7 +205,7 @@ func postImageData(ctx context.Context,
 	physicalDeviceMemoryPropertiesData := MustAllocData(ctx, s, physicalDevice.MemoryProperties)
 	bufferMemoryTypeIndex := uint32(0)
 	for i := uint32(0); i < physicalDevice.MemoryProperties.MemoryTypeCount; i++ {
-		t := physicalDevice.MemoryProperties.MemoryTypes.Elements[i]
+		t := physicalDevice.MemoryProperties.MemoryTypes[i]
 		if 0 != (t.PropertyFlags & VkMemoryPropertyFlags(VkMemoryPropertyFlagBits_VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT|
 			VkMemoryPropertyFlagBits_VK_MEMORY_PROPERTY_HOST_COHERENT_BIT)) {
 			bufferMemoryTypeIndex = i
@@ -538,17 +538,15 @@ func postImageData(ctx context.Context,
 			LayerCount:     1,
 		},
 		SrcOffsets: VkOffset3Dː2ᵃ{
-			Elements: [2]VkOffset3D{
-				{
-					X: 0,
-					Y: 0,
-					Z: 0,
-				},
-				{
-					X: int32(imgWidth),
-					Y: int32(imgHeight),
-					Z: 1,
-				},
+			{
+				X: 0,
+				Y: 0,
+				Z: 0,
+			},
+			{
+				X: int32(imgWidth),
+				Y: int32(imgHeight),
+				Z: 1,
 			},
 		},
 		DstSubresource: VkImageSubresourceLayers{
@@ -558,17 +556,15 @@ func postImageData(ctx context.Context,
 			LayerCount:     1,
 		},
 		DstOffsets: VkOffset3Dː2ᵃ{
-			Elements: [2]VkOffset3D{
-				{
-					X: int32(0),
-					Y: int32(0),
-					Z: 0,
-				},
-				{
-					X: int32(reqWidth),
-					Y: int32(reqHeight),
-					Z: 1,
-				},
+			{
+				X: int32(0),
+				Y: int32(0),
+				Z: 0,
+			},
+			{
+				X: int32(reqWidth),
+				Y: int32(reqHeight),
+				Z: 1,
 			},
 		},
 	}


### PR DESCRIPTION
Kill the pointless struct with a single Elements field.
This was a wart left over from codergen.

Fixes: #356