### PR TITLE
path.Proto: Add Result() to complement Parameter()

### DIFF
--- a/gapis/messages/en-us.stb.md
+++ b/gapis/messages/en-us.stb.md
@@ -51,6 +51,10 @@ Value of type {{ty}} does not have field {{field}}.
 
 Command of type {{ty}} does not have parameter {{field}}.
 
+# ERR_RESULT_DOES_NOT_EXIST
+
+Command of type {{ty}} does not have a result value.
+
 # ERR_MAP_KEY_DOES_NOT_EXIST
 
 Map does not contain entry with key {{key}}.

--- a/gapis/resolve/atoms.go
+++ b/gapis/resolve/atoms.go
@@ -80,3 +80,24 @@ func Parameter(ctx context.Context, p *path.Parameter) (interface{}, error) {
 		return nil, err
 	}
 }
+
+// Result resolves and returns the command's result from the path p.
+func Result(ctx context.Context, p *path.Result) (interface{}, error) {
+	obj, err := ResolveInternal(ctx, p.Parent())
+	if err != nil {
+		return nil, err
+	}
+	a := obj.(atom.Atom)
+	param, err := atom.Result(ctx, a)
+	switch err {
+	case nil:
+		return param, nil
+	case atom.ErrResultNotFound:
+		return nil, &service.ErrInvalidPath{
+			Reason: messages.ErrResultDoesNotExist(a.AtomName()),
+			Path:   p.Path(),
+		}
+	default:
+		return nil, err
+	}
+}

--- a/gapis/resolve/resolve.go
+++ b/gapis/resolve/resolve.go
@@ -258,6 +258,8 @@ func ResolveInternal(ctx context.Context, p path.Node) (interface{}, error) {
 		return ResourceData(ctx, p)
 	case *path.Resources:
 		return Resources(ctx, p.Capture)
+	case *path.Result:
+		return Result(ctx, p)
 	case *path.Slice:
 		return Slice(ctx, p)
 	case *path.State:

--- a/gapis/service/path/path.go
+++ b/gapis/service/path/path.go
@@ -78,6 +78,7 @@ func (n *Parameter) Path() *Any                 { return &Any{&Any_Parameter{n}}
 func (n *Report) Path() *Any                    { return &Any{&Any_Report{n}} }
 func (n *ResourceData) Path() *Any              { return &Any{&Any_ResourceData{n}} }
 func (n *Resources) Path() *Any                 { return &Any{&Any_Resources{n}} }
+func (n *Result) Path() *Any                    { return &Any{&Any_Result{n}} }
 func (n *Slice) Path() *Any                     { return &Any{&Any_Slice{n}} }
 func (n *State) Path() *Any                     { return &Any{&Any_State{n}} }
 func (n *StateTree) Path() *Any                 { return &Any{&Any_StateTree{n}} }
@@ -108,6 +109,7 @@ func (n Parameter) Parent() Node                 { return n.Command }
 func (n Report) Parent() Node                    { return n.Capture }
 func (n ResourceData) Parent() Node              { return n.After }
 func (n Resources) Parent() Node                 { return n.Capture }
+func (n Result) Parent() Node                    { return n.Command }
 func (n Slice) Parent() Node                     { return oneOfNode(n.Array) }
 func (n State) Parent() Node                     { return n.After }
 func (n StateTree) Parent() Node                 { return n.After }
@@ -150,6 +152,7 @@ func (n ResourceData) Text() string {
 	return fmt.Sprintf("%v.resource-data<%x>", n.Parent().Text(), n.Id)
 }
 func (n Resources) Text() string { return fmt.Sprintf("%v.resources", n.Parent().Text()) }
+func (n Result) Text() string    { return fmt.Sprintf("%v.result", n.Parent().Text()) }
 func (n Slice) Text() string     { return fmt.Sprintf("%v[%v:%v]", n.Parent().Text(), n.Start, n.End) }
 func (n State) Text() string     { return fmt.Sprintf("%v.state-after", n.Parent().Text()) }
 func (n StateTree) Text() string { return fmt.Sprintf("%v.state-tree") }
@@ -439,6 +442,11 @@ func (n *StateTreeNode) Child(i uint64) *StateTreeNode {
 // Parameter returns the path node to the parameter with the given name.
 func (n *Command) Parameter(name string) *Parameter {
 	return &Parameter{Name: name, Command: n}
+}
+
+// Result returns the path node to the command's result.
+func (n *Command) Result() *Result {
+	return &Result{Command: n}
 }
 
 func (n *State) Field(name string) *Field             { return NewField(name, n) }

--- a/gapis/service/path/path.proto
+++ b/gapis/service/path/path.proto
@@ -49,11 +49,12 @@ message Any {
     Report report = 22;
     ResourceData resource_data = 23;
     Resources resources = 24;
-    Slice slice = 25;
-    State state = 26;
-    StateTree state_tree = 27;
-    StateTreeNode state_tree_node = 28;
-    Thumbnail thumbnail = 29;
+    Result result = 25;
+    Slice slice = 26;
+    State state = 27;
+    StateTree state_tree = 28;
+    StateTreeNode state_tree_node = 29;
+    Thumbnail thumbnail = 30;
   }
 }
 
@@ -156,6 +157,11 @@ message Events {
 message Parameter {
     string name = 1;
     Command command = 2;
+}
+
+// Result is the path to the result value of a command.
+message Result {
+    Command command = 1;
 }
 
 // Threads is path to a list of threads in a capture.

--- a/gapis/service/path/validate.go
+++ b/gapis/service/path/validate.go
@@ -225,6 +225,11 @@ func (n *Resources) Validate() error {
 }
 
 // Validate checks the path is valid.
+func (n *Result) Validate() error {
+	return checkNotNilAndValidate(n, n.Command, "command")
+}
+
+// Validate checks the path is valid.
 func (n *Slice) Validate() error {
 	return checkNotNilAndValidate(n, protoutil.OneOf(n.Array), "array")
 }


### PR DESCRIPTION
Let the client get / set / follow command results.

Fixes: #368
