### PR TITLE
Windows build fixes for the ASTC 3rd party library.

### DIFF
--- a/third_party/astc-encoder.cmake
+++ b/third_party/astc-encoder.cmake
@@ -29,6 +29,13 @@ set(sources
 if(NOT DISABLED_CXX)
     add_library(astc-encoder ${sources})
 
-    target_compile_options(astc-encoder PRIVATE "-Wno-c++11-narrowing")
+    if(WIN32)
+        target_compile_options(astc-encoder PRIVATE "-Wno-narrowing"
+            "-D__NO_INLINE__"                     # Avoids a lvalue compile error
+            "-D_GLIBCXX_INCLUDE_NEXT_C_HEADERS"   # Avoids redefinition compile error
+        )
+    else()
+        target_compile_options(astc-encoder PRIVATE "-Wno-c++11-narrowing")
+    endif()
     target_include_directories(astc-encoder PUBLIC "${astc-encoder_gen}")
 endif()


### PR DESCRIPTION
This seems pretty hacky, but it makes the build work. I tested that the resulting gapis doesn't crash, but I couldn't test that ASTC stuff still works.