### PR TITLE
Make SizeTy interface to group all size_t types

### DIFF
--- a/gapis/gfxapi/templates/api.go.tmpl
+++ b/gapis/gfxapi/templates/api.go.tmpl
@@ -125,11 +125,25 @@
   {{else if IsVoid     $u}}
   {{else}}
     {{$to := Macro "Go.Type" $.To}}
-
     type {{$.Name}} {{$to}}
-    {{if (GetAnnotation $ "dispatchHandle")}}
-      // Dummy function to make dispatchable handle implement SizeTy interface
+    {{if IsSize $u}}
+      // Dummy function to make {{$.Name}} implement SizeTy interface
       func ({{$.Name}}) IsMemorySize() {}
+
+    {{end}}
+    {{if IsChar $u}}
+      // Dummy function to make {{$.Name}} implement CharTy interface
+      func ({{$.Name}}) IsChar() {}
+
+    {{end}}
+    {{if IsInt $u}}
+      // Dummy function to make {{$.Name}} implement IntTy interface
+      func ({{$.Name}}) IsInt() {}
+
+    {{end}}
+    {{if IsUint $u}}
+      // Dummy function to make {{$.Name}} implement UintTy interface
+      func ({{$.Name}}) IsUint() {}
 
     {{end}}
   {{end}}

--- a/gapis/gfxapi/templates/api.go.tmpl
+++ b/gapis/gfxapi/templates/api.go.tmpl
@@ -127,6 +127,11 @@
     {{$to := Macro "Go.Type" $.To}}
 
     type {{$.Name}} {{$to}}
+    {{if (GetAnnotation $ "dispatchHandle")}}
+      // Dummy function to make dispatchable handle implement SizeTy interface
+      func ({{$.Name}}) IsMemorySize() {}
+
+    {{end}}
   {{end}}
 
   {{template "LabelsForLabeledType" $}}

--- a/gapis/memory/alignof_sizeof.go
+++ b/gapis/memory/alignof_sizeof.go
@@ -29,7 +29,7 @@ func AlignOf(t reflect.Type, m *device.MemoryLayout) uint64 {
 		return uint64(m.GetPointer().GetAlignment())
 	case t == tyInt, t == tyUint:
 		return uint64(m.GetInteger().GetAlignment())
-	case t == tySize:
+	case t.Implements(reflect.TypeOf((*SizeTy)(nil)).Elem()):
 		return uint64(m.GetSize().GetAlignment())
 	default:
 

--- a/gapis/memory/alignof_sizeof.go
+++ b/gapis/memory/alignof_sizeof.go
@@ -27,9 +27,11 @@ func AlignOf(t reflect.Type, m *device.MemoryLayout) uint64 {
 	switch {
 	case t.Implements(tyPointer):
 		return uint64(m.GetPointer().GetAlignment())
-	case t == tyInt, t == tyUint:
+	case t.Implements(tyChar):
+		return uint64(m.GetChar().GetAlignment())
+	case t.Implements(tyInt), t.Implements(tyUint):
 		return uint64(m.GetInteger().GetAlignment())
-	case t.Implements(reflect.TypeOf((*SizeTy)(nil)).Elem()):
+	case t.Implements(tySize):
 		return uint64(m.GetSize().GetAlignment())
 	default:
 
@@ -71,9 +73,11 @@ func SizeOf(t reflect.Type, m *device.MemoryLayout) uint64 {
 	switch {
 	case t.Implements(tyPointer):
 		return uint64(m.GetPointer().GetSize())
-	case t == tyInt, t == tyUint:
+	case t.Implements(tyChar):
+		return uint64(m.GetChar().GetSize())
+	case t.Implements(tyInt), t.Implements(tyUint):
 		return uint64(m.GetInteger().GetSize())
-	case t == tySize:
+	case t.Implements(tySize):
 		return uint64(m.GetSize().GetSize())
 	default:
 

--- a/gapis/memory/alignof_sizeof.go
+++ b/gapis/memory/alignof_sizeof.go
@@ -27,11 +27,11 @@ func AlignOf(t reflect.Type, m *device.MemoryLayout) uint64 {
 	switch {
 	case t.Implements(tyPointer):
 		return uint64(m.GetPointer().GetAlignment())
-	case t.Implements(tyChar):
+	case t.Implements(tyCharTy):
 		return uint64(m.GetChar().GetAlignment())
-	case t.Implements(tyInt), t.Implements(tyUint):
+	case t.Implements(tyIntTy), t.Implements(tyUintTy):
 		return uint64(m.GetInteger().GetAlignment())
-	case t.Implements(tySize):
+	case t.Implements(tySizeTy):
 		return uint64(m.GetSize().GetAlignment())
 	default:
 
@@ -73,11 +73,11 @@ func SizeOf(t reflect.Type, m *device.MemoryLayout) uint64 {
 	switch {
 	case t.Implements(tyPointer):
 		return uint64(m.GetPointer().GetSize())
-	case t.Implements(tyChar):
+	case t.Implements(tyCharTy):
 		return uint64(m.GetChar().GetSize())
-	case t.Implements(tyInt), t.Implements(tyUint):
+	case t.Implements(tyIntTy), t.Implements(tyUintTy):
 		return uint64(m.GetInteger().GetSize())
-	case t.Implements(tySize):
+	case t.Implements(tySizeTy):
 		return uint64(m.GetSize().GetSize())
 	default:
 

--- a/gapis/memory/read.go
+++ b/gapis/memory/read.go
@@ -39,13 +39,13 @@ func decode(d *Decoder, v reflect.Value) {
 	case t.Implements(tyPointer):
 		p := v.Interface().(Pointer).Set(d.Pointer(), ApplicationPool)
 		v.Set(reflect.ValueOf(p))
-	case t.Implements(tyChar):
+	case t.Implements(tyCharTy):
 		v.SetUint(uint64(d.Char()))
-	case t.Implements(tyInt):
+	case t.Implements(tyIntTy):
 		v.SetInt(int64(d.Int()))
-	case t.Implements(tyUint):
+	case t.Implements(tyUintTy):
 		v.SetUint(uint64(d.Uint()))
-	case t.Implements(tySize):
+	case t.Implements(tySizeTy):
 		v.SetUint(uint64(d.Size()))
 	default:
 

--- a/gapis/memory/read.go
+++ b/gapis/memory/read.go
@@ -45,7 +45,7 @@ func decode(d *Decoder, v reflect.Value) {
 		v.SetInt(int64(d.Int()))
 	case t == tyUint:
 		v.SetUint(uint64(d.Uint()))
-	case t == tySize:
+	case t.Implements(reflect.TypeOf((*SizeTy)(nil)).Elem()):
 		v.SetUint(uint64(d.Size()))
 	default:
 

--- a/gapis/memory/read.go
+++ b/gapis/memory/read.go
@@ -39,13 +39,13 @@ func decode(d *Decoder, v reflect.Value) {
 	case t.Implements(tyPointer):
 		p := v.Interface().(Pointer).Set(d.Pointer(), ApplicationPool)
 		v.Set(reflect.ValueOf(p))
-	case t == tyChar:
+	case t.Implements(tyChar):
 		v.SetUint(uint64(d.Char()))
-	case t == tyInt:
+	case t.Implements(tyInt):
 		v.SetInt(int64(d.Int()))
-	case t == tyUint:
+	case t.Implements(tyUint):
 		v.SetUint(uint64(d.Uint()))
-	case t.Implements(reflect.TypeOf((*SizeTy)(nil)).Elem()):
+	case t.Implements(tySize):
 		v.SetUint(uint64(d.Size()))
 	default:
 

--- a/gapis/memory/types.go
+++ b/gapis/memory/types.go
@@ -18,10 +18,10 @@ import "reflect"
 
 var (
 	tyPointer = reflect.TypeOf((*Pointer)(nil)).Elem()
-	tyChar    = reflect.TypeOf((*CharTy)(nil)).Elem()
-	tyInt     = reflect.TypeOf((*IntTy)(nil)).Elem()
-	tyUint    = reflect.TypeOf((*UintTy)(nil)).Elem()
-	tySize    = reflect.TypeOf((*SizeTy)(nil)).Elem()
+	tyCharTy  = reflect.TypeOf((*CharTy)(nil)).Elem()
+	tyIntTy   = reflect.TypeOf((*IntTy)(nil)).Elem()
+	tyUintTy  = reflect.TypeOf((*UintTy)(nil)).Elem()
+	tySizeTy  = reflect.TypeOf((*SizeTy)(nil)).Elem()
 )
 
 // Int is a signed integer type.
@@ -49,12 +49,12 @@ func (Uint) IsUint() {}
 // Char is the possibly signed but maybe unsigned C/C++ char.
 type Char uint8
 
-// UintTy is the interface implemented by types that should be treated as char type.
+// CharTy is the interface implemented by types that should be treated as char type.
 type CharTy interface {
 	IsChar()
 }
 
-// Dummy function to make Uint implement CharTy interface
+// Dummy function to make Char implement CharTy interface
 func (Char) IsChar() {}
 
 // CharToBytes changes the Char values to their byte[] representation.

--- a/gapis/memory/types.go
+++ b/gapis/memory/types.go
@@ -18,20 +18,44 @@ import "reflect"
 
 var (
 	tyPointer = reflect.TypeOf((*Pointer)(nil)).Elem()
-	tyChar    = reflect.TypeOf(Char(0))
-	tyInt     = reflect.TypeOf(Int(0))
-	tyUint    = reflect.TypeOf(Uint(0))
-	tySize    = reflect.TypeOf(Size(0))
+	tyChar    = reflect.TypeOf((*CharTy)(nil)).Elem()
+	tyInt     = reflect.TypeOf((*IntTy)(nil)).Elem()
+	tyUint    = reflect.TypeOf((*UintTy)(nil)).Elem()
+	tySize    = reflect.TypeOf((*SizeTy)(nil)).Elem()
 )
 
 // Int is a signed integer type.
 type Int int64
 
+// IntTy is the interface implemented by types that should be treated as int type.
+type IntTy interface {
+	IsInt()
+}
+
+// Dummy function to make Int implement IntTy interface
+func (Int) IsInt() {}
+
 // Uint is an unsigned integer type.
 type Uint uint64
 
+// UintTy is the interface implemented by types that should be treated as uint type.
+type UintTy interface {
+	IsUint()
+}
+
+// Dummy function to make Uint implement UintTy interface
+func (Uint) IsUint() {}
+
 // Char is the possibly signed but maybe unsigned C/C++ char.
 type Char uint8
+
+// UintTy is the interface implemented by types that should be treated as char type.
+type CharTy interface {
+	IsChar()
+}
+
+// Dummy function to make Uint implement CharTy interface
+func (Char) IsChar() {}
 
 // CharToBytes changes the Char values to their byte[] representation.
 func CharToBytes(ϟchars []Char) []byte {
@@ -45,7 +69,7 @@ func CharToBytes(ϟchars []Char) []byte {
 // Size is a size_t type.
 type Size uint64
 
-// SizeTy is the interface implemented by types that should be treated as a size_t type.
+// SizeTy is the interface implemented by types that should be treated as size_t type.
 type SizeTy interface {
 	IsMemorySize()
 }

--- a/gapis/memory/types.go
+++ b/gapis/memory/types.go
@@ -30,9 +30,6 @@ type Int int64
 // Uint is an unsigned integer type.
 type Uint uint64
 
-// Size is a size_t type.
-type Size uint64
-
 // Char is the possibly signed but maybe unsigned C/C++ char.
 type Char uint8
 
@@ -43,4 +40,21 @@ func CharToBytes(ϟchars []Char) []byte {
 		bytes[i] = byte(ϟchars[i])
 	}
 	return bytes
+}
+
+// Size is a size_t type.
+type Size uint64
+
+// SizeTy is the interface implemented by types that should be treated as a size_t type.
+type SizeTy interface {
+	IsMemorySize()
+}
+
+// Dummy function to make Size implement SizeTy interface
+func (Size) IsMemorySize() {}
+
+// IsSize returns true if v is a Size or alias to a Size.
+func IsSize(v interface{}) bool {
+	_, ok := v.(SizeTy)
+	return ok
 }

--- a/gapis/memory/write.go
+++ b/gapis/memory/write.go
@@ -34,13 +34,13 @@ func encode(e *Encoder, v reflect.Value) {
 	switch {
 	case t.Implements(tyPointer):
 		e.Pointer(v.Interface().(Pointer).Address())
-	case t == tyChar:
+	case t.Implements(tyChar):
 		e.Char(Char(v.Uint()))
-	case t == tyInt:
+	case t.Implements(tyInt):
 		e.Int(Int(v.Int()))
-	case t == tyUint:
+	case t.Implements(tyUint):
 		e.Uint(Uint(v.Uint()))
-	case t.Implements(reflect.TypeOf((*SizeTy)(nil)).Elem()):
+	case t.Implements(tySize):
 		e.Size(Size(v.Uint()))
 	default:
 		switch t.Kind() {

--- a/gapis/memory/write.go
+++ b/gapis/memory/write.go
@@ -34,13 +34,13 @@ func encode(e *Encoder, v reflect.Value) {
 	switch {
 	case t.Implements(tyPointer):
 		e.Pointer(v.Interface().(Pointer).Address())
-	case t.Implements(tyChar):
+	case t.Implements(tyCharTy):
 		e.Char(Char(v.Uint()))
-	case t.Implements(tyInt):
+	case t.Implements(tyIntTy):
 		e.Int(Int(v.Int()))
-	case t.Implements(tyUint):
+	case t.Implements(tyUintTy):
 		e.Uint(Uint(v.Uint()))
-	case t.Implements(tySize):
+	case t.Implements(tySizeTy):
 		e.Size(Size(v.Uint()))
 	default:
 		switch t.Kind() {

--- a/gapis/memory/write.go
+++ b/gapis/memory/write.go
@@ -40,7 +40,7 @@ func encode(e *Encoder, v reflect.Value) {
 		e.Int(Int(v.Int()))
 	case t == tyUint:
 		e.Uint(Uint(v.Uint()))
-	case t == tySize:
+	case t.Implements(reflect.TypeOf((*SizeTy)(nil)).Elem()):
 		e.Size(Size(v.Uint()))
 	default:
 		switch t.Kind() {


### PR DESCRIPTION
This fixes the incorrect parsing of Vulkan dispatchable handles, which
is caused by not considering those dispatchable handles as size_t type
values.

Fix issue #439 .