### PR TITLE
Vulkan:Missing pieces of VkEvent Support

### DIFF
--- a/gapii/cc/vulkan_mid_execution.cpp
+++ b/gapii/cc/vulkan_mid_execution.cpp
@@ -992,6 +992,17 @@ void VulkanSpy::EnumerateVulkanResources(CallObserver* observer) {
         }
     }
     {
+      VkEventCreateInfo create_info {
+        VkStructureType::VK_STRUCTURE_TYPE_EVENT_CREATE_INFO,
+          nullptr,
+          0
+      };
+      for (auto& event : Events) {
+        RecreateEvent(observer, event.second->mDevice, &create_info,
+                      event.second->mSignaled, &event.second->mVulkanHandle);
+      }
+    }
+    {
         VkCommandPoolCreateInfo create_info = {
             VkStructureType::VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO,
             nullptr,

--- a/gapis/gfxapi/vulkan/dependency_graph.go
+++ b/gapis/gfxapi/vulkan/dependency_graph.go
@@ -1435,6 +1435,26 @@ func (g *DependencyGraph) getBehaviour(ctx context.Context, s *gfxapi.State, id 
 	case *RecreateCmdSetBlendConstants:
 		recordCommand(&b, a.CommandBuffer, func(b *AtomBehaviour) {})
 
+	case *VkCmdSetEvent:
+		recordCommand(&b, a.CommandBuffer, func(b *AtomBehaviour) {})
+
+	case *RecreateCmdSetEvent:
+		recordCommand(&b, a.CommandBuffer, func(b *AtomBehaviour) {})
+
+	case *VkCmdResetEvent:
+		recordCommand(&b, a.CommandBuffer, func(b *AtomBehaviour) {})
+
+	case *RecreateCmdResetEvent:
+		recordCommand(&b, a.CommandBuffer, func(b *AtomBehaviour) {})
+
+	case *VkCmdWaitEvents:
+		recordCommand(&b, a.CommandBuffer, func(b *AtomBehaviour) {})
+		//TODO: handle the image and buffer memory barriers?
+
+	case *RecreateCmdWaitEvents:
+		recordCommand(&b, a.CommandBuffer, func(b *AtomBehaviour) {})
+		//TODO: handle the image and buffer memory barriers?
+
 	case *VkCmdExecuteCommands:
 		secondaryCmdBufs := a.PCommandBuffers.Slice(0, uint64(a.CommandBufferCount), l)
 		for i := uint32(0); i < a.CommandBufferCount; i++ {

--- a/gapis/gfxapi/vulkan/vulkan.api
+++ b/gapis/gfxapi/vulkan/vulkan.api
@@ -3322,6 +3322,8 @@ cmd void RecreateEvent(
     const VkEventCreateInfo*     pCreateInfo,
     VkBool32                     signaled,
     VkEvent*                     pEvent) {
+  read(pCreateInfo[0:1])
+  write(pEvent[0:1])
 }
 
 @threadSafety("system")
@@ -5644,6 +5646,12 @@ cmd void vkCmdBindDescriptorSets(
           bind_buffer_and_descriptor_sets.BoundBuffers[len(bind_buffer_and_descriptor_sets.BoundBuffers)] = BoundBuffer(
               Buffers[bufferBinding.Buffer], binding_offset, bufferBinding.Range)
         }
+        for k in (0 .. len(binding.BufferViewBindings)) {
+          buffer_view := binding.BufferViewBindings[as!u32(k)]
+          buffer_view_object := BufferViews[buffer_view]
+          bind_buffer_and_descriptor_sets.BoundBuffers[len(bind_buffer_and_descriptor_sets.BoundBuffers)] = BoundBuffer(
+            buffer_view_object.Buffer, buffer_view_object.Offset, buffer_view_object.Range)
+        }
       }
     }
   }
@@ -5787,7 +5795,11 @@ sub void readCoherentMemory(ref!DeviceMemoryObject memory, VkDeviceSize readOffs
 sub void readCoherentMemoryInBuffer(ref!BufferObject buffer, VkDeviceSize readOffset, VkDeviceSize readSize) {
   mem := buffer.Memory
   if mem != null {
-    readCoherentMemory(mem, buffer.MemoryOffset + readOffset, readSize)
+    if as!u64(readSize) == 0xFFFFFFFFFFFFFFFF {
+      readCoherentMemory(mem, buffer.MemoryOffset + readOffset, buffer.Info.Size - readOffset)
+    } else {
+      readCoherentMemory(mem, buffer.MemoryOffset + readOffset, readSize)
+    }
   }
 }
 


### PR DESCRIPTION
* MEC support of VkEvent
* Add read observation for buffers used in descriptors via buffer view
* Add vkCmdSet/ResetEvent and vkCmdWaitEvents in dependency graph

based on #442 