### PR TITLE
Capture/Replay the actual presentation images.

### DIFF
--- a/gapis/gfxapi/templates/api_spy.cpp.tmpl
+++ b/gapis/gfxapi/templates/api_spy.cpp.tmpl
@@ -195,6 +195,9 @@
       bool called = false;
       auto call = [{{Macro "CallCapture" $}}] {
         called = true;
+        {{if GetAnnotation $ "EndOfFrame"}}
+          onPreEndOfFrame({{Global "ApiIndex"}});
+        {{end}}
 
         observer->invoke();
 
@@ -217,8 +220,6 @@
         {{end}}
         onPostFence(observer);
       };
-¶
-      {{if GetAnnotation $ "EndOfFrame"}}onPreEndOfFrame({{Global "ApiIndex"}});{{end}}
 ¶
       uint64_t counter_at_begin = mCommandStartEndCounter++;
 ¶

--- a/gapis/gfxapi/vulkan/vulkan.api
+++ b/gapis/gfxapi/vulkan/vulkan.api
@@ -2777,6 +2777,7 @@ cmd VkResult vkQueueSubmit(
     u32                 submitCount,
     const VkSubmitInfo* pSubmits,
     VkFence             fence) {
+  LastSubmission = SUBMIT
   submitInfo := pSubmits[0:submitCount]
   LastBoundQueue = Queues[queue]
 
@@ -7940,7 +7941,14 @@ cmd VkResult vkAcquireNextImageKHR(
 cmd VkResult vkQueuePresentKHR(
     VkQueue                 queue,
     const VkPresentInfoKHR* pPresentInfo) {
+  LastSubmission = PRESENT
   LastBoundQueue = Queues[queue]
+  for i in (0 .. LastPresentInfo.PresentImageCount) {
+    delete(LastPresentInfo.PresentImages, i)
+  }
+  LastPresentInfo.PresentImageCount = 0
+
+
   info := pPresentInfo[0]
   // TODO: handle pNext
 
@@ -7955,6 +7963,9 @@ cmd VkResult vkQueuePresentKHR(
   for i in (0 .. info.swapchainCount) {
     swapchain := Swapchains[swapchains[i]]
     image := swapchain.SwapchainImages[imageIndices[i]]
+    LastPresentInfo.PresentImages[LastPresentInfo.PresentImageCount] =
+      image
+    LastPresentInfo.PresentImageCount = LastPresentInfo.PresentImageCount + 1
     image.LastBoundQueue = Queues[queue]
   }
   fence
@@ -8495,6 +8506,22 @@ ref!ComputePipelineObject  CurrentComputePipeline
 }
 // Records the draw information of the last draw.
 DrawInfo LastDrawInfo
+
+@internal class PresentInfo {
+  // The number of images presented last present
+  u32                                 PresentImageCount
+  // The images presented in the last present
+  map!(u32, ref!ImageObject)          PresentImages
+}
+
+PresentInfo LastPresentInfo
+
+enum LastSubmissionType {
+  SUBMIT = 0
+  PRESENT = 1
+}
+
+LastSubmissionType LastSubmission
 
 // Clear the recorded descriptor sets in the last draw
 sub void clearLastDrawInfoDescriptorSets() {


### PR DESCRIPTION
We had been getting the framebuffer attachments for the most recent draw
call rather than the presented image. This switches that logic.