### PR TITLE
Fix panic in CommandTreeNode builder.

### DIFF
--- a/gapis/atom/group.go
+++ b/gapis/atom/group.go
@@ -269,6 +269,15 @@ func (g Group) IterateBackwards(index uint64, cb func(childIdx uint64, item Grou
 // Attemping to call this function after atoms have been added may result in
 // panics!
 func (g *Group) AddGroup(start, end ID, name string) error {
+	if start > end {
+		return fmt.Errorf("sub-group start (%d) is greater than end (%v)", start, end)
+	}
+	if start < g.Range.Start {
+		return fmt.Errorf("sub-group start (%d) is earlier than group start (%v)", start, g.Range.Start)
+	}
+	if end > g.Range.End {
+		return fmt.Errorf("sub-group end (%d) is later than group end (%v)", end, g.Range.End)
+	}
 	r := Range{Start: start, End: end}
 	s, c := interval.Intersect(&g.Spans, r.Span())
 	if c == 0 {

--- a/gapis/resolve/command_tree.go
+++ b/gapis/resolve/command_tree.go
@@ -192,7 +192,7 @@ func (g *markerGrouper) process(ctx context.Context, id atom.ID, a atom.Atom, s 
 
 func (g *markerGrouper) flush(count uint64) {
 	for len(g.stack) > 0 {
-		g.pop(atom.ID(count))
+		g.pop(atom.ID(count) - 1)
 	}
 }
 
@@ -226,9 +226,9 @@ func (r *CommandTreeResolvable) Resolve(ctx context.Context) (interface{}, error
 	}
 
 	if p.GroupByContext {
-		var noContextId interface{} = nil
+		var noContextID interface{}
 		if p.IncludeNoContextGroups {
-			noContextId = gfxapi.ContextID{}
+			noContextID = gfxapi.ContextID{}
 		}
 		groupers = append(groupers, &runGrouper{f: func(a atom.Atom, s *gfxapi.State) (interface{}, string) {
 			if api := a.API(); api != nil {
@@ -236,7 +236,7 @@ func (r *CommandTreeResolvable) Resolve(ctx context.Context) (interface{}, error
 					return context.ID(), context.Name()
 				}
 			}
-			return noContextId, "No context"
+			return noContextID, "No context"
 		}})
 	}
 


### PR DESCRIPTION
The marker grouper would terminate incomplete marker groups with 1 greater than the number of atoms in the capture.

Fixes #445