### PR TITLE
GAPIR/GAPII: Use the same GL context search order for linux.

### DIFF
--- a/core/cc/gl/CMakeFiles.cmake
+++ b/core/cc/gl/CMakeFiles.cmake
@@ -20,7 +20,8 @@
 set(files
     formats.cpp
     formats.h
+    versions.h
 )
 set(dirs
-    
+
 )

--- a/core/cc/gl/versions.h
+++ b/core/cc/gl/versions.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef CORE_GL_VERSIONS_H
+#define CORE_GL_VERSIONS_H
+
+namespace core {
+namespace gl {
+
+// Version represents a single major.minor version of an OpenGL context.
+struct Version {
+    int major;
+    int minor;
+};
+
+
+// sVersionSearchOrder is an preference-ordered list of OpenGL context versions
+// that should be searched in order to pick the most recent version of OpenGL.
+// The driver is always free to return a newer version, however some
+// implementations will return the precise version requested, so if we request
+// 3.2, we would get 3.2 even if a new version is available.
+static const Version sVersionSearchOrder[] = {
+    {4, 5}, // Compatible with OpenGL ES 3.1
+    {4, 4},
+    {4, 3}, // Compatible with OpenGL ES 3.0
+    {4, 2},
+    {4, 1}, // Compatible with OpenGL ES 2.0
+    {4, 0},
+    {3, 3},
+    {3, 2}, // Introduces core profile
+};
+
+}  // namespace gl
+}  // namespace core
+
+#endif  // CORE_GL_VERSIONS_H

--- a/gapir/cc/linux/gles_renderer.cpp
+++ b/gapir/cc/linux/gles_renderer.cpp
@@ -18,6 +18,7 @@
 #include "gapir/cc/gles_renderer.h"
 
 #include "core/cc/gl/formats.h"
+#include "core/cc/gl/versions.h"
 #include "core/cc/log.h"
 
 #include <cstring>
@@ -249,23 +250,9 @@ void GlesRendererImpl::setBackbuffer(Backbuffer backbuffer) {
     if (glXCreateContextAttribsARB == nullptr) {
         GAPID_FATAL("Unable to get address of glXCreateContextAttribsARB");
     }
-    // Try to get the most recent version of OpenGL available.
-    // The implementation is always free to return a newer version.
-    // However some implementations will return the precise version,
-    // so if we request 3.2, we would get 3.2 even if new is available.
-    struct { int major; int minor; } gl_versions[] = {
-        {4, 5}, // Compatible with OpenGL ES 3.1
-        {4, 4},
-        {4, 3}, // Compatible with OpenGL ES 3.0
-        {4, 2},
-        {4, 1}, // Compatible with OpenGL ES 2.0
-        {4, 0},
-        {3, 3},
-        {3, 2}, // Introduces core profile
-    };
     // Prevent X from taking down the process if the GL version is not supported.
     auto oldHandler = XSetErrorHandler([](Display*, XErrorEvent*)->int{ return 0; });
-    for (auto gl_version : gl_versions) {
+    for (auto gl_version : core::gl::sVersionSearchOrder) {
         // List of name-value pairs.
         const int contextAttribs[] = {
             GLX_RENDER_TYPE, GLX_RGBA_TYPE,


### PR DESCRIPTION
Fixes: #208