### PR TITLE
Marker fixes

### DIFF
--- a/gapis/gfxapi/gles/compat.go
+++ b/gapis/gfxapi/gles/compat.go
@@ -858,8 +858,12 @@ func compat(ctx context.Context, device *device.Instance) (transform.Transformer
 
 		case *GlInsertEventMarkerEXT,
 			*GlPushGroupMarkerEXT,
-			*GlPopGroupMarkerEXT:
-			// GL_EXT_debug_marker may not be supported on the replay device.
+			*GlPopGroupMarkerEXT,
+			*GlPushDebugGroup,
+			*GlPopDebugGroup,
+			*GlPushDebugGroupKHR,
+			*GlPopDebugGroupKHR:
+			// Debug markers may not be supported on the replay device.
 			// As they do not affect rendering output, just drop them.
 			return
 

--- a/gapis/resolve/command_tree.go
+++ b/gapis/resolve/command_tree.go
@@ -166,8 +166,12 @@ type markerGrouper struct {
 }
 
 func (g *markerGrouper) push(ctx context.Context, id atom.ID, a atom.Atom, s *gfxapi.State) {
+	var name string
 	if l, ok := a.(atom.Labeled); ok {
-		g.stack = append(g.stack, group{start: id, name: l.Label(ctx, s)})
+		name = l.Label(ctx, s)
+	}
+	if len(name) > 0 {
+		g.stack = append(g.stack, group{start: id, name: name})
 	} else {
 		g.stack = append(g.stack, group{start: id, name: fmt.Sprintf("Marker %d", g.count)})
 		g.count++


### PR DESCRIPTION
Still got to figure out what to do about [Unity's 0 length, null-terminated `glPushDebugGroupKHR`](https://github.com/google/gapid/issues/459#issuecomment-305113685).