### PR TITLE
Convert the format of EGLImage

### DIFF
--- a/gapis/gfxapi/gles/api/extensions.api
+++ b/gapis/gfxapi/gles/api/extensions.api
@@ -12,6 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+sub GLenum EGLSizedFormat2GLSizedFormat(AndroidGraphicsBufferFormat eglSizedFormat) {
+  return switch eglSizedFormat {
+    case HAL_PIXEL_FORMAT_RGBA_8888:    GL_RGBA8
+    case HAL_PIXEL_FORMAT_RGBX_8888:    GL_RGB8 // Does not have a precise match
+    case HAL_PIXEL_FORMAT_RGB_888:      GL_RGB8
+    case HAL_PIXEL_FORMAT_RGB_565:      GL_RGB565
+    case HAL_PIXEL_FORMAT_BGRA_8888:    GL_BGRA8_EXT
+    case HAL_PIXEL_FORMAT_RGBA_5551:    GL_RGB5_A1
+    case HAL_PIXEL_FORMAT_RGBA_4444:    GL_RGB4
+    case HAL_PIXEL_FORMAT_YCrCb_420_SP: GL_RGB8 // Does not have a precise match
+    default: GL_RGBA8 // TODO: Report warning
+  }
+}
+
 @Doc("https://www.khronos.org/registry/gles/extensions/EXT/EXT_separate_shader_objects.txt", "GL_EXT_separate_shader_objects")
 cmd void glActiveShaderProgramEXT(PipelineId pipeline, ProgramId program) {
   requiresExtension(GL_EXT_separate_shader_objects)
@@ -630,16 +644,16 @@ cmd void glEGLImageTargetTexture2DOES(GLenum target, GLeglImageOES image) {
   if as!EGLImageKHR(image) in EGLImages {
     info := EGLImages[as!EGLImageKHR(image)]
     t := GetBoundTextureOrErrorInvalidEnum(target)
-    // TODO: Convert the format from EGLImage
+    sf := EGLSizedFormat2GLSizedFormat(info.Format)
+    sfInfo := GetSizedFormatInfo(sf)
     i := Image(
-      Width:        as!GLsizei(info.Width),
-      Height:       as!GLsizei(info.Height),
-      SizedFormat:  GL_RGB8,
-      DataFormat:   GL_RGB,
-      DataType:     GL_UNSIGNED_BYTE,
+      Width:       as!GLsizei(info.Width),
+      Height:      as!GLsizei(info.Height),
+      SizedFormat: sf,
+      DataFormat:  sfInfo.UnsizedFormat,
+      DataType:    sfInfo.DataType,
     )
-    i.Data = make!u8(uncompressedImageSize(i.Width, i.Height, i.DataFormat, i.DataType))
-    tmpLevel := t.Levels[0] // TODO: Update directly
+    tmpLevel := t.Levels[0]
     tmpLevel.Layers[0] = i
     t.Levels[0] = tmpLevel
     t.EGLImage = image

--- a/gapis/gfxapi/gles/compat.go
+++ b/gapis/gfxapi/gles/compat.go
@@ -201,8 +201,10 @@ func compat(ctx context.Context, device *device.Instance) (transform.Transformer
 				img := boundTexture.Levels[0].Layers[0]
 				data := eglImageData[boundTexture.EGLImage]
 				out.MutateAndWrite(ctx, i, NewGlPixelStorei(GLenum_GL_UNPACK_ALIGNMENT, 1))
+				sizedFormat := img.SizedFormat
+				textureCompat.convertFormat(GLenum_GL_TEXTURE_2D, &sizedFormat, nil, nil, out, i)
 				out.MutateAndWrite(ctx, i, replay.Custom(func(ctx context.Context, s *gfxapi.State, b *builder.Builder) error {
-					NewGlTexImage2D(GLenum_GL_TEXTURE_2D, 0, GLint(img.DataFormat), img.Width, img.Height, 0, img.DataFormat, img.DataType, data).Call(ctx, s, b)
+					NewGlTexImage2D(GLenum_GL_TEXTURE_2D, 0, GLint(sizedFormat), img.Width, img.Height, 0, img.DataFormat, img.DataType, data).Call(ctx, s, b)
 					return nil
 				}))
 				out.MutateAndWrite(ctx, i, NewGlPixelStorei(GLenum_GL_UNPACK_ALIGNMENT, origUnpackAlignment))


### PR DESCRIPTION
The format is used create replacement texture in compat,
which needs to have correct format for glCopyImageSubData.