### PR TITLE
gles/compat: Drop debug message for replay

### DIFF
--- a/gapis/gfxapi/gles/compat.go
+++ b/gapis/gfxapi/gles/compat.go
@@ -913,7 +913,8 @@ func compat(ctx context.Context, device *device.Instance) (transform.Transformer
 			*GlPushDebugGroup,
 			*GlPopDebugGroup,
 			*GlPushDebugGroupKHR,
-			*GlPopDebugGroupKHR:
+			*GlPopDebugGroupKHR,
+			*GlDebugMessageInsertKHR:
 			// Debug markers may not be supported on the replay device.
 			// As they do not affect rendering output, just drop them.
 			return


### PR DESCRIPTION
Silent the errors in Log tab.
But we may still need to parse the message in command tree tab. Currently it is not parsed.