### PR TITLE
Vulkan:vkGetEventStatus on replay side

### DIFF
--- a/gapir/cc/context.cpp
+++ b/gapir/cc/context.cpp
@@ -385,6 +385,18 @@ void Context::registerCallbacks(Interpreter* interpreter) {
             return false;
         }
     });
+
+    interpreter->registerBuiltin(Builtins::ReplayGetEventStatus,
+                                 [this, interpreter](Stack* stack, bool push_return) {
+        GAPID_INFO("ReplayGetEventStatus()");
+        if (mBoundVulkanRenderer != nullptr) {
+            auto* api = mBoundVulkanRenderer->getApi<Vulkan>();
+            return api->replayGetEventStatus(stack, push_return);
+        } else {
+            GAPID_WARNING("ReplayGetEventStatus called without a bound Vulkan renderer");
+            return false;
+        }
+    });
 }
 
 bool Context::loadResource(Stack* stack) {

--- a/gapir/cc/vulkan_gfx_api.inl
+++ b/gapir/cc/vulkan_gfx_api.inl
@@ -75,8 +75,21 @@ bool replayRegisterVkCommandBuffers(Stack* stack);
 // - number of command buffers.
 bool replayUnregisterVkCommandBuffers(Stack* stack);
 
+// Builtin function for setting the virtual swapchain to
+// always returns the requsted swapchain imge.
 bool toggleVirtualSwapchainReturnAcquiredImage(Stack* stack);
 
+// Builtin function for replaying vkGetFenceStatus. If the return of
+// vkGetFenceStatus is VK_SUCCESS, this function makes sure the replay will not
+// proceed until VK_SUCCESS is returned from vkGetFenceStatus in the replay
+// side.
 bool replayGetFenceStatus(Stack* stack, bool pushReturn);
 
+// Builtin function for replaying vkGetEventStatus. This function makes sure
+// the replay will not proceed until the expected return code is returned from
+// vkGetEventStatus on replay end.
+bool replayGetEventStatus(Stack* stack, bool pushReturn);
+
+// Builtin function for getting image memory requirement and allocating
+// corresponding memory for a image on the replay side.
 bool replayAllocateImageMemory(Stack* stack, bool pushReturn);

--- a/gapir/cc/vulkan_gfx_api.inl
+++ b/gapir/cc/vulkan_gfx_api.inl
@@ -85,9 +85,15 @@ bool toggleVirtualSwapchainReturnAcquiredImage(Stack* stack);
 // side.
 bool replayGetFenceStatus(Stack* stack, bool pushReturn);
 
-// Builtin function for replaying vkGetEventStatus. This function makes sure
-// the replay will not proceed until the expected return code is returned from
-// vkGetEventStatus on replay end.
+// Builtin function for replaying vkGetEventStatus.  The traced return of
+// vkGetEventStatus can be used to block this function if and only if the
+// traced return matches with the global state mutation result.  For example:
+// Call vkQueueSubmit a queue with vkCmdSetEvent in the command buffer first,
+// then call vkGetEventStatus. In the trace, the return of vkGetEventStatus
+// might be 'unsignaled', but after the mutation of the state, the record in
+// the global state should be 'signaled'. In such a case, waiting for the
+// vkGetEventStatus returns 'unsignaled' on the replay may cause an infinite
+// long waiting.
 bool replayGetEventStatus(Stack* stack, bool pushReturn);
 
 // Builtin function for getting image memory requirement and allocating

--- a/gapis/gfxapi/templates/vulkan_gfx_api_extras.tmpl
+++ b/gapis/gfxapi/templates/vulkan_gfx_api_extras.tmpl
@@ -377,6 +377,32 @@ bool Vulkan::replayGetFenceStatus(Stack* stack, bool pushReturn) {
     }
 }
 ¶
+bool Vulkan::replayGetEventStatus(Stack* stack, bool pushReturn) {
+    auto expected = gapir::Vulkan::VkResult(stack->pop<uint32_t>());
+    auto event = stack->pop<uint64_t>();
+    auto device = static_cast<size_val>(stack->pop<size_val>());
+    if (stack->isValid()) {
+        GAPID_INFO("vkGetEventStatus(%" PRIsize ", %" PRIu64 ")", device, event);
+        if (mVkDeviceFunctionStubs.find(device) != mVkDeviceFunctionStubs.end() &&
+        mVkDeviceFunctionStubs[device].vkGetEventStatus) {
+            VkResult return_value;
+            do {
+                return_value = mVkDeviceFunctionStubs[device].vkGetEventStatus(device, event);
+            } while (return_value != expected);
+            GAPID_INFO("Returned: %u", return_value);
+            if (pushReturn) {
+                stack->push<VkResult>(return_value);
+            }
+        } else {
+            GAPID_WARNING("Attempted to call unsupported function vkGetEventStatus");
+        }
+        return true;
+    } else {
+        GAPID_WARNING("Error during calling function vkGetEventStatus");
+        return false;
+    }
+}
+¶
   »}  // namespace gapir
 ¶
 {{end}}

--- a/gapis/gfxapi/templates/vulkan_gfx_api_extras.tmpl
+++ b/gapis/gfxapi/templates/vulkan_gfx_api_extras.tmpl
@@ -378,6 +378,7 @@ bool Vulkan::replayGetFenceStatus(Stack* stack, bool pushReturn) {
 }
 ¶
 bool Vulkan::replayGetEventStatus(Stack* stack, bool pushReturn) {
+    auto wait = stack->pop<bool>();
     auto expected = gapir::Vulkan::VkResult(stack->pop<uint32_t>());
     auto event = stack->pop<uint64_t>();
     auto device = static_cast<size_val>(stack->pop<size_val>());
@@ -388,7 +389,7 @@ bool Vulkan::replayGetEventStatus(Stack* stack, bool pushReturn) {
             VkResult return_value;
             do {
                 return_value = mVkDeviceFunctionStubs[device].vkGetEventStatus(device, event);
-            } while (return_value != expected);
+            } while (wait && (return_value != expected));
             GAPID_INFO("Returned: %u", return_value);
             if (pushReturn) {
                 stack->push<VkResult>(return_value);

--- a/gapis/gfxapi/vulkan/custom_replay.go
+++ b/gapis/gfxapi/vulkan/custom_replay.go
@@ -1034,6 +1034,14 @@ func (a *VkGetFenceStatus) Mutate(ctx context.Context, s *gfxapi.State, b *build
 	return NewReplayGetFenceStatus(a.Device, a.Fence, a.Result, a.Result).Mutate(ctx, s, b)
 }
 
+func (a *VkGetEventStatus) Mutate(ctx context.Context, s *gfxapi.State, b *builder.Builder) error {
+	err := a.mutate(ctx, s, b)
+	if b == nil || err != nil {
+		return err
+	}
+	return NewReplayGetEventStatus(a.Device, a.Event, a.Result, a.Result).Mutate(ctx, s, b)
+}
+
 func (a *ReplayAllocateImageMemory) Mutate(ctx context.Context, s *gfxapi.State, b *builder.Builder) error {
 	if err := a.mutate(ctx, s, b); err != nil {
 		return err

--- a/gapis/gfxapi/vulkan/custom_replay.go
+++ b/gapis/gfxapi/vulkan/custom_replay.go
@@ -1039,7 +1039,17 @@ func (a *VkGetEventStatus) Mutate(ctx context.Context, s *gfxapi.State, b *build
 	if b == nil || err != nil {
 		return err
 	}
-	return NewReplayGetEventStatus(a.Device, a.Event, a.Result, a.Result).Mutate(ctx, s, b)
+	var wait bool
+	switch a.Result {
+	case VkResult_VK_EVENT_SET:
+		wait = GetState(s).Events.Get(a.Event).Signaled == true
+	case VkResult_VK_EVENT_RESET:
+		wait = GetState(s).Events.Get(a.Event).Signaled == false
+	default:
+		wait = false
+	}
+
+	return NewReplayGetEventStatus(a.Device, a.Event, a.Result, wait, a.Result).Mutate(ctx, s, b)
 }
 
 func (a *ReplayAllocateImageMemory) Mutate(ctx context.Context, s *gfxapi.State, b *builder.Builder) error {

--- a/gapis/gfxapi/vulkan/synthetic.api
+++ b/gapis/gfxapi/vulkan/synthetic.api
@@ -103,7 +103,8 @@ cmd VkResult replayGetFenceStatus(
 cmd VkResult replayGetEventStatus(
     VkDevice device,
     VkEvent  event,
-    VkResult expected) {
+    VkResult expected,
+    bool     wait) {
   return ?
 }
 

--- a/gapis/gfxapi/vulkan/synthetic.api
+++ b/gapis/gfxapi/vulkan/synthetic.api
@@ -100,6 +100,14 @@ cmd VkResult replayGetFenceStatus(
 }
 
 @synthetic
+cmd VkResult replayGetEventStatus(
+    VkDevice device,
+    VkEvent  event,
+    VkResult expected) {
+  return ?
+}
+
+@synthetic
 @custom
 cmd VkResult replayAllocateImageMemory(VkDevice device, VkPhysicalDeviceMemoryProperties* pPhysicalDeviceMemoryProperties, VkImage image, VkDeviceMemory* pMemory) {
   _ = pPhysicalDeviceMemoryProperties[0]

--- a/gapis/gfxapi/vulkan/vulkan.api
+++ b/gapis/gfxapi/vulkan/vulkan.api
@@ -3356,6 +3356,7 @@ cmd void vkDestroyEvent(
 
 @threadSafety("system")
 @indirect("VkDevice")
+@custom
 cmd VkResult vkGetEventStatus(
     VkDevice device,
     VkEvent  event) {


### PR DESCRIPTION
On replay side, the vkGetEventStatus can proceed only when the return
code matches with the return code in trace