### PR TITLE
Cleanup core/app.Verb

### DIFF
--- a/cmd/apic/format.go
+++ b/cmd/apic/format.go
@@ -32,15 +32,16 @@ import (
 )
 
 func init() {
-	verb := &app.Verb{
+	app.AddVerb(&app.Verb{
 		Name:      "format",
 		ShortHelp: "Formats an api file",
-		Run:       doFormat,
-	}
-	app.AddVerb(verb)
+		Auto:      &formatVerb{},
+	})
 }
 
-func doFormat(ctx context.Context, flags flag.FlagSet) error {
+type formatVerb struct{}
+
+func (v *formatVerb) Run(ctx context.Context, flags flag.FlagSet) error {
 	args := flags.Args()
 	if len(args) < 1 {
 		app.Usage(ctx, "Missing api file")

--- a/cmd/apic/format.go
+++ b/cmd/apic/format.go
@@ -35,7 +35,7 @@ func init() {
 	app.AddVerb(&app.Verb{
 		Name:      "format",
 		ShortHelp: "Formats an api file",
-		Auto:      &formatVerb{},
+		Action:    &formatVerb{},
 	})
 }
 

--- a/cmd/apic/template.go
+++ b/cmd/apic/template.go
@@ -35,7 +35,7 @@ func init() {
 	app.AddVerb(&app.Verb{
 		Name:      "template",
 		ShortHelp: "Passes the ast to a template for code generation",
-		Auto: &templateVerb{
+		Action: &templateVerb{
 			Dir: cwd(),
 		},
 	})

--- a/cmd/apic/validate.go
+++ b/cmd/apic/validate.go
@@ -31,15 +31,16 @@ import (
 )
 
 func init() {
-	verb := &app.Verb{
+	app.AddVerb(&app.Verb{
 		Name:      "validate",
 		ShortHelp: "Validates an api file for correctness",
-		Run:       doValidate,
-	}
-	app.AddVerb(verb)
+		Auto:      &validateVerb{},
+	})
 }
 
-func doValidate(ctx context.Context, flags flag.FlagSet) error {
+type validateVerb struct{}
+
+func (v *validateVerb) Run(ctx context.Context, flags flag.FlagSet) error {
 	args := flags.Args()
 	if len(args) < 1 {
 		app.Usage(ctx, "Missing api file")

--- a/cmd/apic/validate.go
+++ b/cmd/apic/validate.go
@@ -34,7 +34,7 @@ func init() {
 	app.AddVerb(&app.Verb{
 		Name:      "validate",
 		ShortHelp: "Validates an api file for correctness",
-		Auto:      &validateVerb{},
+		Action:    &validateVerb{},
 	})
 }
 

--- a/cmd/do/do.go
+++ b/cmd/do/do.go
@@ -144,52 +144,52 @@ func init() {
 	app.AddVerb(&app.Verb{
 		Name:      "init",
 		ShortHelp: "initialise all pre-requisites to build gapid",
-		Auto:      &initVerb{InitOptions: InitOptions{Force: true}},
+		Action:    &initVerb{InitOptions: InitOptions{Force: true}},
 	})
 	app.AddVerb(&app.Verb{
 		Name:      "config",
 		ShortHelp: "set configuration parameters",
-		Auto:      &configVerb{ConfigOptions: ConfigOptions{Interactive: true}},
+		Action:    &configVerb{ConfigOptions: ConfigOptions{Interactive: true}},
 	})
 	app.AddVerb(&app.Verb{
 		Name:      "build",
 		ShortHelp: "start a build of the optional target",
-		Auto:      &buildVerb{},
+		Action:    &buildVerb{},
 	})
 	app.AddVerb(&app.Verb{
 		Name:      "glob",
 		ShortHelp: "update CMakeFiles.cmake",
-		Auto:      &globVerb{},
+		Action:    &globVerb{},
 	})
 	app.AddVerb(&app.Verb{
 		Name:      "clean",
 		ShortHelp: "delete the output directory",
-		Auto:      &cleanVerb{},
+		Action:    &cleanVerb{},
 	})
 	app.AddVerb(&app.Verb{
 		Name:      "run",
 		ShortHelp: "build and run a target",
-		Auto:      &runVerb{},
+		Action:    &runVerb{},
 	})
 	app.AddVerb(&app.Verb{
 		Name:      "gapit",
 		ShortHelp: "build and run gapit",
-		Auto:      &gapitVerb{},
+		Action:    &gapitVerb{},
 	})
 	app.AddVerb(&app.Verb{
 		Name:      "robot",
 		ShortHelp: "build and run robot",
-		Auto:      &robotVerb{},
+		Action:    &robotVerb{},
 	})
 	app.AddVerb(&app.Verb{
 		Name:      "upload",
 		ShortHelp: "build gapid package and upload to robot",
-		Auto:      &uploadVerb{},
+		Action:    &uploadVerb{},
 	})
 	app.AddVerb(&app.Verb{
 		Name:      "go",
 		ShortHelp: "run the go tool with the correct environment",
-		Auto:      &goVerb{},
+		Action:    &goVerb{},
 	})
 }
 

--- a/cmd/gapit/commands.go
+++ b/cmd/gapit/commands.go
@@ -37,7 +37,7 @@ func init() {
 	app.AddVerb(&app.Verb{
 		Name:      "commands",
 		ShortHelp: "Prints the command tree for a .gfxtrace file",
-		Auto:      verb,
+		Action:    verb,
 	})
 }
 

--- a/cmd/gapit/devices.go
+++ b/cmd/gapit/devices.go
@@ -33,7 +33,7 @@ func init() {
 	app.AddVerb(&app.Verb{
 		Name:      "devices",
 		ShortHelp: "Lists the devices available",
-		Auto:      verb,
+		Action:    verb,
 	})
 }
 

--- a/cmd/gapit/dump.go
+++ b/cmd/gapit/dump.go
@@ -33,7 +33,7 @@ func init() {
 	app.AddVerb(&app.Verb{
 		Name:      "dump",
 		ShortHelp: "Dump a textual representation of a .gfxtrace file",
-		Auto:      verb,
+		Action:    verb,
 	})
 }
 

--- a/cmd/gapit/dump_shaders.go
+++ b/cmd/gapit/dump_shaders.go
@@ -37,7 +37,7 @@ func init() {
 	app.AddVerb(&app.Verb{
 		Name:      "dump_resources",
 		ShortHelp: "Dump all shaders at a particular atom from a .gfxtrace",
-		Auto:      verb,
+		Action:    verb,
 	})
 }
 

--- a/cmd/gapit/info.go
+++ b/cmd/gapit/info.go
@@ -33,7 +33,7 @@ func init() {
 	app.AddVerb(&app.Verb{
 		Name:      "info",
 		ShortHelp: "Prints information about a gfx trace capture file",
-		Auto:      verb,
+		Action:    verb,
 	})
 }
 

--- a/cmd/gapit/packages.go
+++ b/cmd/gapit/packages.go
@@ -33,7 +33,7 @@ func init() {
 	app.AddVerb(&app.Verb{
 		Name:      "packages",
 		ShortHelp: "Prints information about packages installed on a device",
-		Auto: &packagesVerb{
+		Action: &packagesVerb{
 			PackagesFlags{
 				Icons:       false,
 				IconDensity: 1.0,

--- a/cmd/gapit/packages.go
+++ b/cmd/gapit/packages.go
@@ -30,16 +30,15 @@ import (
 type packagesVerb struct{ PackagesFlags }
 
 func init() {
-	verb := &packagesVerb{
-		PackagesFlags{
-			Icons:       false,
-			IconDensity: 1.0,
-		},
-	}
 	app.AddVerb(&app.Verb{
 		Name:      "packages",
 		ShortHelp: "Prints information about packages installed on a device",
-		Auto:      verb,
+		Auto: &packagesVerb{
+			PackagesFlags{
+				Icons:       false,
+				IconDensity: 1.0,
+			},
+		},
 	})
 }
 

--- a/cmd/gapit/report.go
+++ b/cmd/gapit/report.go
@@ -35,7 +35,7 @@ func init() {
 	app.AddVerb(&app.Verb{
 		Name:      "report",
 		ShortHelp: "Check a capture replays without issues",
-		Auto:      verb,
+		Action:    verb,
 	})
 }
 

--- a/cmd/gapit/state.go
+++ b/cmd/gapit/state.go
@@ -41,7 +41,7 @@ func init() {
 	app.AddVerb(&app.Verb{
 		Name:      "state",
 		ShortHelp: "Prints the state tree for a point in a .gfxtrace file",
-		Auto:      verb,
+		Action:    verb,
 	})
 }
 

--- a/cmd/gapit/stresstest.go
+++ b/cmd/gapit/stresstest.go
@@ -34,7 +34,7 @@ func init() {
 	app.AddVerb(&app.Verb{
 		Name:      "stress-test",
 		ShortHelp: "Performs evil things on GAPIS to try to break it",
-		Auto:      &stresstestVerb{},
+		Action:    &stresstestVerb{},
 	})
 }
 

--- a/cmd/gapit/trace.go
+++ b/cmd/gapit/trace.go
@@ -45,7 +45,7 @@ func init() {
 	app.AddVerb(&app.Verb{
 		Name:      "trace",
 		ShortHelp: "Captures a gfx trace from an application",
-		Auto:      verb,
+		Action:    verb,
 	})
 }
 

--- a/cmd/gapit/video.go
+++ b/cmd/gapit/video.go
@@ -61,7 +61,7 @@ func init() {
 	app.AddVerb(&app.Verb{
 		Name:      "video",
 		ShortHelp: "Produce a video or sequence of frames from a .gfxtrace file",
-		Auto:      verb,
+		Action:    verb,
 	})
 }
 

--- a/cmd/perf/bench.go
+++ b/cmd/perf/bench.go
@@ -171,14 +171,14 @@ func singleRun(ctx context.Context, bench *Benchmark, runIdx int, tracefile stri
 }
 
 func (s *session) maybeBeginProfile() error {
-	if s.bench.Input.EnableCpuProfile {
+	if s.bench.Input.EnableCPUProfile {
 		return s.client.BeginCPUProfile(s.ctx)
 	}
 	return nil
 }
 
 func (s *session) maybeSaveProfileData() error {
-	if s.bench.Input.EnableCpuProfile {
+	if s.bench.Input.EnableCPUProfile {
 		data, err := s.client.EndCPUProfile(s.ctx)
 		if err != nil {
 			return err

--- a/cmd/perf/cat.go
+++ b/cmd/perf/cat.go
@@ -28,7 +28,7 @@ func init() {
 		Name:       "cat",
 		ShortHelp:  "Prints data out of a .perfz file",
 		ShortUsage: "<perfz> [[benchmark]:[link]]",
-		Auto:       &catVerb{},
+		Action:     &catVerb{},
 	})
 }
 

--- a/cmd/perf/cat.go
+++ b/cmd/perf/cat.go
@@ -24,16 +24,17 @@ import (
 )
 
 func init() {
-	verb := &app.Verb{
+	app.AddVerb(&app.Verb{
 		Name:       "cat",
 		ShortHelp:  "Prints data out of a .perfz file",
-		Run:        catVerb,
 		ShortUsage: "<perfz> [[benchmark]:[link]]",
-	}
-	app.AddVerb(verb)
+		Auto:       &catVerb{},
+	})
 }
 
-func catVerb(ctx context.Context, flags flag.FlagSet) error {
+type catVerb struct{}
+
+func (v *catVerb) Run(ctx context.Context, flags flag.FlagSet) error {
 	if flags.NArg() < 1 {
 		app.Usage(ctx, "At least one argument expected, got %d", flags.NArg())
 		return nil
@@ -48,11 +49,10 @@ func catVerb(ctx context.Context, flags flag.FlagSet) error {
 	if flags.NArg() == 1 {
 		fmt.Println(perfz.String())
 		return nil
-	} else {
-		_, link, err := selectLink(perfz, flags.Arg(1), nil)
-		if err != nil {
-			return err
-		}
-		return link.Get().WriteTo(os.Stdout)
 	}
+	_, link, err := selectLink(perfz, flags.Arg(1), nil)
+	if err != nil {
+		return err
+	}
+	return link.Get().WriteTo(os.Stdout)
 }

--- a/cmd/perf/list.go
+++ b/cmd/perf/list.go
@@ -27,7 +27,7 @@ func init() {
 		Name:       "list",
 		ShortHelp:  "Lists benchmarks and associated data in .perfz",
 		ShortUsage: "<perfz>",
-		Auto:       &listVerb{},
+		Action:     &listVerb{},
 	})
 }
 

--- a/cmd/perf/list.go
+++ b/cmd/perf/list.go
@@ -23,16 +23,17 @@ import (
 )
 
 func init() {
-	verb := &app.Verb{
+	app.AddVerb(&app.Verb{
 		Name:       "list",
 		ShortHelp:  "Lists benchmarks and associated data in .perfz",
-		Run:        listVerb,
 		ShortUsage: "<perfz>",
-	}
-	app.AddVerb(verb)
+		Auto:       &listVerb{},
+	})
 }
 
-func listVerb(ctx context.Context, flags flag.FlagSet) error {
+type listVerb struct{}
+
+func (v *listVerb) Run(ctx context.Context, flags flag.FlagSet) error {
 	if flags.NArg() != 1 {
 		app.Usage(ctx, "One argument expected, got %d", flags.NArg())
 		return nil

--- a/cmd/perf/perfz.go
+++ b/cmd/perf/perfz.go
@@ -74,7 +74,7 @@ type BenchmarkInput struct {
 	Seed              int64
 	BenchmarkType     string
 	SampleOrder       string
-	EnableCpuProfile  bool
+	EnableCPUProfile  bool
 	EnableHeapProfile bool
 	MaxFrameWidth     int
 	MaxFrameHeight    int

--- a/cmd/perf/plot.go
+++ b/cmd/perf/plot.go
@@ -59,7 +59,7 @@ func init() {
 		Name:       "plot",
 		ShortHelp:  "Plots samples from a benchmark out of one or two perfz files",
 		ShortUsage: "<perfz> [perfz]",
-		Auto: &plotVerb{
+		Action: &plotVerb{
 			ShowMinMax:  true,
 			ShowAverage: true,
 			RunGnuplot:  true,

--- a/cmd/perf/pprof.go
+++ b/cmd/perf/pprof.go
@@ -28,13 +28,15 @@ func init() {
 	verb := &app.Verb{
 		Name:       "pprof",
 		ShortHelp:  "Runs pprof",
-		Run:        pprofVerb,
 		ShortUsage: "<perfz> [[benchmark]:[link]]",
+		Auto:       &pprofVerb{},
 	}
 	app.AddVerb(verb)
 }
 
-func pprofVerb(ctx context.Context, flags flag.FlagSet) error {
+type pprofVerb struct{}
+
+func (v *pprofVerb) Run(ctx context.Context, flags flag.FlagSet) error {
 	if flags.NArg() < 1 {
 		app.Usage(ctx, "At least one argument expected, got %d", flags.NArg())
 		return nil

--- a/cmd/perf/pprof.go
+++ b/cmd/perf/pprof.go
@@ -29,7 +29,7 @@ func init() {
 		Name:       "pprof",
 		ShortHelp:  "Runs pprof",
 		ShortUsage: "<perfz> [[benchmark]:[link]]",
-		Auto:       &pprofVerb{},
+		Action:     &pprofVerb{},
 	}
 	app.AddVerb(verb)
 }

--- a/cmd/perf/redo.go
+++ b/cmd/perf/redo.go
@@ -30,7 +30,7 @@ func init() {
 		Name:       "redo",
 		ShortHelp:  "Runs all benchmarks in the source .perfz and saves the output to a new file",
 		ShortUsage: "<source> <destination>",
-		Auto: &redoVerb{
+		Action: &redoVerb{
 			Output: "-",
 		},
 	}

--- a/cmd/perf/redo.go
+++ b/cmd/perf/redo.go
@@ -29,10 +29,11 @@ func init() {
 	verb := &app.Verb{
 		Name:       "redo",
 		ShortHelp:  "Runs all benchmarks in the source .perfz and saves the output to a new file",
-		Run:        redoVerb,
 		ShortUsage: "<source> <destination>",
+		Auto: &redoVerb{
+			Output: "-",
+		},
 	}
-	verb.Flags.Raw.StringVar(&flagTextualOutput, "json", "-", "output results in JSON format")
 	app.AddVerb(verb)
 }
 
@@ -57,7 +58,11 @@ func clonePerfzInputs(p *Perfz) (*Perfz, error) {
 	return result, nil
 }
 
-func redoVerb(ctx context.Context, flags flag.FlagSet) error {
+type redoVerb struct {
+	Output string `help:"output results in JSON format"`
+}
+
+func (v *redoVerb) Run(ctx context.Context, flags flag.FlagSet) error {
 	if flags.NArg() != 2 {
 		app.Usage(ctx, "Two arguments expected, got %d", flags.NArg())
 		return nil
@@ -85,7 +90,7 @@ func redoVerb(ctx context.Context, flags flag.FlagSet) error {
 		return log.Err(ctx, err, "outputPerfz.WriteTo")
 	}
 
-	return writeAllFn(flagTextualOutput, func(w io.Writer) error {
+	return writeAllFn(v.Output, func(w io.Writer) error {
 		_, err := w.Write([]byte(outputPerfz.String()))
 		return err
 	})

--- a/cmd/perf/rm.go
+++ b/cmd/perf/rm.go
@@ -27,14 +27,17 @@ func init() {
 	verb := &app.Verb{
 		Name:       "rm",
 		ShortHelp:  "Removes a benchmark from a .perfz file",
-		Run:        rmVerb,
 		ShortUsage: "<perfz> <benchmark>",
+		Auto:       &rmVerb{},
 	}
-	verb.Flags.Raw.StringVar(&flagPerfzOutput, "o", "", "output .perfz file, same as input if empty")
 	app.AddVerb(verb)
 }
 
-func rmVerb(ctx context.Context, flags flag.FlagSet) error {
+type rmVerb struct {
+	Output string `help:"output .perfz file, same as input if empty"`
+}
+
+func (v *rmVerb) Run(ctx context.Context, flags flag.FlagSet) error {
 	if flags.NArg() != 2 {
 		app.Usage(ctx, "Two arguments expected, got %d", flags.NArg())
 		return nil
@@ -54,11 +57,11 @@ func rmVerb(ctx context.Context, flags flag.FlagSet) error {
 
 	delete(perfz.Benchmarks, benchmarkName)
 
-	if flagPerfzOutput == "" {
-		flagPerfzOutput = perfzFile
+	if v.Output == "" {
+		v.Output = perfzFile
 	}
 
-	err = perfz.WriteTo(ctx, flagPerfzOutput)
+	err = perfz.WriteTo(ctx, v.Output)
 	if err != nil {
 		return log.Err(ctx, err, "perfz.WriteTo")
 	}

--- a/cmd/perf/rm.go
+++ b/cmd/perf/rm.go
@@ -28,7 +28,7 @@ func init() {
 		Name:       "rm",
 		ShortHelp:  "Removes a benchmark from a .perfz file",
 		ShortUsage: "<perfz> <benchmark>",
-		Auto:       &rmVerb{},
+		Action:     &rmVerb{},
 	}
 	app.AddVerb(verb)
 }

--- a/cmd/perf/run.go
+++ b/cmd/perf/run.go
@@ -31,7 +31,7 @@ func init() {
 		Name:       "run",
 		ShortHelp:  "Runs a single benchmark and adds the results to the passed perfz file",
 		ShortUsage: "<perfz> <trace>",
-		Auto: &runVerb{
+		Action: &runVerb{
 			Timeout:       -1,
 			BenchmarkName: "default",
 			SampleLimit:   50,

--- a/cmd/perf/summary.go
+++ b/cmd/perf/summary.go
@@ -37,7 +37,7 @@ func init() {
 		Name:       "summary",
 		ShortHelp:  "Summarizes metrics from a perfz file or compares two perfz files",
 		ShortUsage: "<perfz> [perfz]",
-		Auto: &summaryVerb{
+		Action: &summaryVerb{
 			Level: 1,
 		},
 	}

--- a/cmd/robot/actions.go
+++ b/cmd/robot/actions.go
@@ -52,12 +52,12 @@ func init() {
 	app.AddVerb(&app.Verb{
 		Name:      "stop",
 		ShortHelp: "Stop a server",
-		Auto:      &stopVerb{},
+		Action:    &stopVerb{},
 	})
 	app.AddVerb(&app.Verb{
 		Name:      "restart",
 		ShortHelp: "Restart a server",
-		Auto:      &restartVerb{},
+		Action:    &restartVerb{},
 	})
 }
 

--- a/cmd/robot/build.go
+++ b/cmd/robot/build.go
@@ -37,31 +37,31 @@ func init() {
 		Name:       "build",
 		ShortHelp:  "Upload a build to the server",
 		ShortUsage: "<filenames>",
-		Auto:       &buildUploadVerb{},
+		Action:     &buildUploadVerb{},
 	})
 	searchVerb.Add(&app.Verb{
 		Name:       "artifact",
 		ShortHelp:  "List build artifacts in the server",
 		ShortUsage: "<query>",
-		Auto:       &artifactSearchVerb{},
+		Action:     &artifactSearchVerb{},
 	})
 	searchVerb.Add(&app.Verb{
 		Name:       "package",
 		ShortHelp:  "List build packages in the server",
 		ShortUsage: "<query>",
-		Auto:       &packageSearchVerb{},
+		Action:     &packageSearchVerb{},
 	})
 	searchVerb.Add(&app.Verb{
 		Name:       "track",
 		ShortHelp:  "List build tracks in the server",
 		ShortUsage: "<query>",
-		Auto:       &trackSearchVerb{},
+		Action:     &trackSearchVerb{},
 	})
 	setVerb.Add(&app.Verb{
 		Name:       "track",
 		ShortHelp:  "Sets values on a track",
 		ShortUsage: "<id or name>",
-		Auto:       &trackUpdateVerb{},
+		Action:     &trackUpdateVerb{},
 	})
 }
 

--- a/cmd/robot/job.go
+++ b/cmd/robot/job.go
@@ -42,18 +42,18 @@ func init() {
 		Name:       "device",
 		ShortHelp:  "List the devices",
 		ShortUsage: "<query>",
-		Auto:       &deviceSearchFlags{},
+		Action:     &deviceSearchFlags{},
 	})
 	searchVerb.Add(&app.Verb{
 		Name:       "worker",
 		ShortHelp:  "List the workers",
 		ShortUsage: "<query>",
-		Auto:       &workerSearchFlags{},
+		Action:     &workerSearchFlags{},
 	})
 	startVerb.Add(&app.Verb{
 		Name:      "worker",
 		ShortHelp: "Starts a robot worker",
-		Auto:      &workerStartFlags{},
+		Action:    &workerStartFlags{},
 	})
 }
 

--- a/cmd/robot/job.go
+++ b/cmd/robot/job.go
@@ -38,29 +38,28 @@ import (
 )
 
 func init() {
-	deviceSearch := &app.Verb{
+	searchVerb.Add(&app.Verb{
 		Name:       "device",
 		ShortHelp:  "List the devices",
 		ShortUsage: "<query>",
-		Run:        doDeviceSearch,
-	}
-	searchVerb.Add(deviceSearch)
-	workerSearch := &app.Verb{
+		Auto:       &deviceSearchFlags{},
+	})
+	searchVerb.Add(&app.Verb{
 		Name:       "worker",
 		ShortHelp:  "List the workers",
 		ShortUsage: "<query>",
-		Run:        doWorkerSearch,
-	}
-	searchVerb.Add(workerSearch)
-	workerStart := &app.Verb{
+		Auto:       &workerSearchFlags{},
+	})
+	startVerb.Add(&app.Verb{
 		Name:      "worker",
 		ShortHelp: "Starts a robot worker",
-		Run:       doWorkerStart,
-	}
-	startVerb.Add(workerStart)
+		Auto:      &workerStartFlags{},
+	})
 }
 
-func doDeviceSearch(ctx context.Context, flags flag.FlagSet) error {
+type deviceSearchFlags struct{}
+
+func (v *deviceSearchFlags) Run(ctx context.Context, flags flag.FlagSet) error {
 	return grpcutil.Client(ctx, serverAddress, func(ctx context.Context, conn *grpc.ClientConn) error {
 		w := job.NewRemote(ctx, conn)
 		expression := strings.Join(flags.Args(), " ")
@@ -76,7 +75,9 @@ func doDeviceSearch(ctx context.Context, flags flag.FlagSet) error {
 	}, grpc.WithInsecure())
 }
 
-func doWorkerSearch(ctx context.Context, flags flag.FlagSet) error {
+type workerSearchFlags struct{}
+
+func (v *workerSearchFlags) Run(ctx context.Context, flags flag.FlagSet) error {
 	return grpcutil.Client(ctx, serverAddress, func(ctx context.Context, conn *grpc.ClientConn) error {
 		w := job.NewRemote(ctx, conn)
 		expression := strings.Join(flags.Args(), " ")
@@ -92,7 +93,9 @@ func doWorkerSearch(ctx context.Context, flags flag.FlagSet) error {
 	}, grpc.WithInsecure())
 }
 
-func doWorkerStart(ctx context.Context, flags flag.FlagSet) error {
+type workerStartFlags struct{}
+
+func (v *workerStartFlags) Run(ctx context.Context, flags flag.FlagSet) error {
 	tempName, err := ioutil.TempDir("", "robot")
 	if err != nil {
 		return err

--- a/cmd/robot/main.go
+++ b/cmd/robot/main.go
@@ -15,18 +15,10 @@
 package main
 
 import (
-	"flag"
-
 	"github.com/google/gapid/core/app"
 	_ "github.com/google/gapid/test/robot/stash/grpc"
 	_ "github.com/google/gapid/test/robot/stash/local"
 )
-
-var serverAddress = "localhost:8081"
-
-func init() {
-	flag.StringVar(&serverAddress, "server", serverAddress, "The address of the server")
-}
 
 func main() {
 	app.ShortHelp = "Robot is a command line tool for interacting with gapid automatic test servers."

--- a/cmd/robot/master.go
+++ b/cmd/robot/master.go
@@ -58,7 +58,7 @@ func init() {
 	startVerb.Add(&app.Verb{
 		Name:      "master",
 		ShortHelp: "Starts a robot master server",
-		Auto: &masterVerb{
+		Action: &masterVerb{
 			BaseAddr:     file.Abs("."),
 			StashAddr:    "",
 			ShelfAddr:    "",
@@ -71,7 +71,7 @@ func init() {
 		Name:       "master",
 		ShortHelp:  "List satellites registered with the master",
 		ShortUsage: "<query>",
-		Auto:       &masterSearchVerb{},
+		Action:     &masterSearchVerb{},
 	})
 }
 

--- a/cmd/robot/replay.go
+++ b/cmd/robot/replay.go
@@ -30,16 +30,17 @@ import (
 )
 
 func init() {
-	replaySearch := &app.Verb{
+	searchVerb.Add(&app.Verb{
 		Name:       "replay",
 		ShortHelp:  "List build replays in the server",
 		ShortUsage: "<query>",
-		Run:        doReplaySearch,
-	}
-	searchVerb.Add(replaySearch)
+		Auto:       &replaySearchFlags{},
+	})
 }
 
-func doReplaySearch(ctx context.Context, flags flag.FlagSet) error {
+type replaySearchFlags struct{}
+
+func (v *replaySearchFlags) Run(ctx context.Context, flags flag.FlagSet) error {
 	return grpcutil.Client(ctx, serverAddress, func(ctx context.Context, conn *grpc.ClientConn) error {
 		replays := replay.NewRemote(ctx, conn)
 		expression := strings.Join(flags.Args(), " ")

--- a/cmd/robot/replay.go
+++ b/cmd/robot/replay.go
@@ -34,7 +34,7 @@ func init() {
 		Name:       "replay",
 		ShortHelp:  "List build replays in the server",
 		ShortUsage: "<query>",
-		Auto:       &replaySearchFlags{},
+		Action:     &replaySearchFlags{},
 	})
 }
 

--- a/cmd/robot/replay.go
+++ b/cmd/robot/replay.go
@@ -34,14 +34,16 @@ func init() {
 		Name:       "replay",
 		ShortHelp:  "List build replays in the server",
 		ShortUsage: "<query>",
-		Action:     &replaySearchFlags{},
+		Action:     &replaySearchFlags{ServerAddress: defaultMasterAddress},
 	})
 }
 
-type replaySearchFlags struct{}
+type replaySearchFlags struct {
+	ServerAddress string `help:"The master server address"`
+}
 
 func (v *replaySearchFlags) Run(ctx context.Context, flags flag.FlagSet) error {
-	return grpcutil.Client(ctx, serverAddress, func(ctx context.Context, conn *grpc.ClientConn) error {
+	return grpcutil.Client(ctx, v.ServerAddress, func(ctx context.Context, conn *grpc.ClientConn) error {
 		replays := replay.NewRemote(ctx, conn)
 		expression := strings.Join(flags.Args(), " ")
 		out := os.Stdout

--- a/cmd/robot/report.go
+++ b/cmd/robot/report.go
@@ -34,14 +34,16 @@ func init() {
 		Name:       "report",
 		ShortHelp:  "List build reports in the server",
 		ShortUsage: "<query>",
-		Action:     &reportSearchFlags{},
+		Action:     &reportSearchFlags{ServerAddress: defaultMasterAddress},
 	})
 }
 
-type reportSearchFlags struct{}
+type reportSearchFlags struct {
+	ServerAddress string `help:"The master server address"`
+}
 
 func (v *reportSearchFlags) Run(ctx context.Context, flags flag.FlagSet) error {
-	return grpcutil.Client(ctx, serverAddress, func(ctx context.Context, conn *grpc.ClientConn) error {
+	return grpcutil.Client(ctx, v.ServerAddress, func(ctx context.Context, conn *grpc.ClientConn) error {
 		reports := report.NewRemote(ctx, conn)
 		expression := strings.Join(flags.Args(), " ")
 		out := os.Stdout

--- a/cmd/robot/report.go
+++ b/cmd/robot/report.go
@@ -34,7 +34,7 @@ func init() {
 		Name:       "report",
 		ShortHelp:  "List build reports in the server",
 		ShortUsage: "<query>",
-		Auto:       &reportSearchFlags{},
+		Action:     &reportSearchFlags{},
 	})
 }
 

--- a/cmd/robot/report.go
+++ b/cmd/robot/report.go
@@ -30,16 +30,17 @@ import (
 )
 
 func init() {
-	reportSearch := &app.Verb{
+	searchVerb.Add(&app.Verb{
 		Name:       "report",
 		ShortHelp:  "List build reports in the server",
 		ShortUsage: "<query>",
-		Run:        doReportSearch,
-	}
-	searchVerb.Add(reportSearch)
+		Auto:       &reportSearchFlags{},
+	})
 }
 
-func doReportSearch(ctx context.Context, flags flag.FlagSet) error {
+type reportSearchFlags struct{}
+
+func (v *reportSearchFlags) Run(ctx context.Context, flags flag.FlagSet) error {
 	return grpcutil.Client(ctx, serverAddress, func(ctx context.Context, conn *grpc.ClientConn) error {
 		reports := report.NewRemote(ctx, conn)
 		expression := strings.Join(flags.Args(), " ")

--- a/cmd/robot/stash.go
+++ b/cmd/robot/stash.go
@@ -35,28 +35,32 @@ func init() {
 		Name:       "stash",
 		ShortHelp:  "Upload a file to the stash",
 		ShortUsage: "<filenames>",
-		Action:     &stashUploadVerb{},
+		Action:     &stashUploadVerb{ServerAddress: defaultMasterAddress},
 	})
 	searchVerb.Add(&app.Verb{
 		Name:       "stash",
 		ShortHelp:  "List entries in the stash",
 		ShortUsage: "<query>",
-		Action:     &stashSearchVerb{},
+		Action:     &stashSearchVerb{ServerAddress: defaultMasterAddress},
 	})
 }
 
-type stashUploadVerb struct{}
+type stashUploadVerb struct {
+	ServerAddress string `help:"The master server address"`
+}
 
 func (v *stashUploadVerb) Run(ctx context.Context, flags flag.FlagSet) error {
-	return upload(ctx, flags, v)
+	return upload(ctx, flags, v.ServerAddress, v)
 }
 func (stashUploadVerb) prepare(context.Context, *grpc.ClientConn) error { return nil }
 func (stashUploadVerb) process(context.Context, string) error           { return nil }
 
-type stashSearchVerb struct{}
+type stashSearchVerb struct {
+	ServerAddress string `help:"The master server address"`
+}
 
 func (v *stashSearchVerb) Run(ctx context.Context, flags flag.FlagSet) error {
-	return grpcutil.Client(ctx, serverAddress, func(ctx context.Context, conn *grpc.ClientConn) error {
+	return grpcutil.Client(ctx, v.ServerAddress, func(ctx context.Context, conn *grpc.ClientConn) error {
 		store, err := stashgrpc.Connect(ctx, conn)
 		if err != nil {
 			return err

--- a/cmd/robot/stash.go
+++ b/cmd/robot/stash.go
@@ -31,28 +31,31 @@ import (
 )
 
 func init() {
-	stashUpload := &app.Verb{
+	uploadVerb.Add(&app.Verb{
 		Name:       "stash",
 		ShortHelp:  "Upload a file to the stash",
 		ShortUsage: "<filenames>",
-		Run:        doUpload(stashUploader{}),
-	}
-	uploadVerb.Add(stashUpload)
-	stashSearch := &app.Verb{
+		Auto:       &stashUploadVerb{},
+	})
+	searchVerb.Add(&app.Verb{
 		Name:       "stash",
 		ShortHelp:  "List entries in the stash",
 		ShortUsage: "<query>",
-		Run:        doStashSearch,
-	}
-	searchVerb.Add(stashSearch)
+		Auto:       &stashSearchVerb{},
+	})
 }
 
-type stashUploader struct{}
+type stashUploadVerb struct{}
 
-func (stashUploader) prepare(context.Context, *grpc.ClientConn) error { return nil }
-func (stashUploader) process(context.Context, string) error           { return nil }
+func (v *stashUploadVerb) Run(ctx context.Context, flags flag.FlagSet) error {
+	return upload(ctx, flags, v)
+}
+func (stashUploadVerb) prepare(context.Context, *grpc.ClientConn) error { return nil }
+func (stashUploadVerb) process(context.Context, string) error           { return nil }
 
-func doStashSearch(ctx context.Context, flags flag.FlagSet) error {
+type stashSearchVerb struct{}
+
+func (v *stashSearchVerb) Run(ctx context.Context, flags flag.FlagSet) error {
 	return grpcutil.Client(ctx, serverAddress, func(ctx context.Context, conn *grpc.ClientConn) error {
 		store, err := stashgrpc.Connect(ctx, conn)
 		if err != nil {

--- a/cmd/robot/stash.go
+++ b/cmd/robot/stash.go
@@ -35,13 +35,13 @@ func init() {
 		Name:       "stash",
 		ShortHelp:  "Upload a file to the stash",
 		ShortUsage: "<filenames>",
-		Auto:       &stashUploadVerb{},
+		Action:     &stashUploadVerb{},
 	})
 	searchVerb.Add(&app.Verb{
 		Name:       "stash",
 		ShortHelp:  "List entries in the stash",
 		ShortUsage: "<query>",
-		Auto:       &stashSearchVerb{},
+		Action:     &stashSearchVerb{},
 	})
 }
 

--- a/cmd/robot/subject.go
+++ b/cmd/robot/subject.go
@@ -36,13 +36,13 @@ func init() {
 		Name:       "subject",
 		ShortHelp:  "Upload a traceable application to the server",
 		ShortUsage: "<filenames>",
-		Auto:       &subjectUploadVerb{},
+		Action:     &subjectUploadVerb{},
 	})
 	searchVerb.Add(&app.Verb{
 		Name:       "subject",
 		ShortHelp:  "List traceable applications in the server",
 		ShortUsage: "<query>",
-		Auto:       &subjectSearchVerb{},
+		Action:     &subjectSearchVerb{},
 	})
 }
 

--- a/cmd/robot/trace.go
+++ b/cmd/robot/trace.go
@@ -35,13 +35,13 @@ func init() {
 		Name:       "trace",
 		ShortHelp:  "Upload a gfx trace to the server",
 		ShortUsage: "<filenames>",
-		Auto:       &traceUploadVerb{},
+		Action:     &traceUploadVerb{},
 	})
 	searchVerb.Add(&app.Verb{
 		Name:       "trace",
 		ShortHelp:  "List build traces in the server",
 		ShortUsage: "<query>",
-		Auto:       &traceSearchVerb{},
+		Action:     &traceSearchVerb{},
 	})
 }
 

--- a/cmd/robot/upload.go
+++ b/cmd/robot/upload.go
@@ -31,7 +31,7 @@ type uploader interface {
 	process(context.Context, string) error
 }
 
-func upload(ctx context.Context, flags flag.FlagSet, u uploader) error {
+func upload(ctx context.Context, flags flag.FlagSet, serverAddress string, u uploader) error {
 	if flags.NArg() == 0 {
 		app.Usage(ctx, "No files given")
 		return nil

--- a/cmd/robot/web.go
+++ b/cmd/robot/web.go
@@ -44,7 +44,7 @@ func init() {
 	startVerb.Add(&app.Verb{
 		Name:      "web",
 		ShortHelp: "Starts a robot web server",
-		Auto: &webVerb{
+		Action: &webVerb{
 			Port: 8080,
 		},
 	})

--- a/cmd/robot/web.go
+++ b/cmd/robot/web.go
@@ -35,23 +35,25 @@ import (
 	"google.golang.org/grpc"
 )
 
-type webVerb struct {
-	Port int       `help:"The port to serve the website on"`
-	Root file.Path `help:"The directory to use as the root of static content"`
-}
-
 func init() {
 	startVerb.Add(&app.Verb{
 		Name:      "web",
 		ShortHelp: "Starts a robot web server",
 		Action: &webVerb{
-			Port: 8080,
+			Port:          8080,
+			ServerAddress: defaultMasterAddress,
 		},
 	})
 }
 
+type webVerb struct {
+	Port          int       `help:"The port to serve the website on"`
+	Root          file.Path `help:"The directory to use as the root of static content"`
+	ServerAddress string    `help:"The master server address"`
+}
+
 func (v *webVerb) Run(ctx context.Context, flags flag.FlagSet) error {
-	return grpcutil.Client(ctx, serverAddress, func(ctx context.Context, conn *grpc.ClientConn) error {
+	return grpcutil.Client(ctx, v.ServerAddress, func(ctx context.Context, conn *grpc.ClientConn) error {
 		config := web.Config{
 			Port:       v.Port,
 			StaticRoot: v.Root,

--- a/cmd/stash/search.go
+++ b/cmd/stash/search.go
@@ -30,7 +30,7 @@ func init() {
 	verb := &app.Verb{
 		Name:      "search",
 		ShortHelp: "Prints information about stash entries",
-		Auto:      &infoVerb{},
+		Action:    &infoVerb{},
 	}
 	app.AddVerb(verb)
 }

--- a/cmd/stash/search.go
+++ b/cmd/stash/search.go
@@ -26,25 +26,26 @@ import (
 	"github.com/google/gapid/test/robot/stash"
 )
 
-var monitor = false
-
 func init() {
 	verb := &app.Verb{
 		Name:      "search",
 		ShortHelp: "Prints information about stash entries",
-		Run:       doInfo,
+		Auto:      &infoVerb{},
 	}
-	verb.Flags.Raw.BoolVar(&monitor, "monitor", monitor, "Monitor for changes")
 	app.AddVerb(verb)
 }
 
-func doInfo(ctx context.Context, flags flag.FlagSet) error {
+type infoVerb struct {
+	Monitor bool `help:"Monitor for changes"`
+}
+
+func (v *infoVerb) Run(ctx context.Context, flags flag.FlagSet) error {
 	return withStore(ctx, false, func(ctx context.Context, client *stash.Client) error {
-		return getInfo(ctx, client, strings.Join(flags.Args(), " "))
+		return getInfo(ctx, client, strings.Join(flags.Args(), " "), v.Monitor)
 	})
 }
 
-func getInfo(ctx context.Context, client *stash.Client, expression string) error {
+func getInfo(ctx context.Context, client *stash.Client, expression string, monitor bool) error {
 	expr, err := script.Parse(ctx, expression)
 	if err != nil {
 		return log.Err(ctx, err, "Malformed search query")

--- a/cmd/stash/server.go
+++ b/cmd/stash/server.go
@@ -31,12 +31,14 @@ func init() {
 	verb := &app.Verb{
 		Name:      "server",
 		ShortHelp: "Starts a stash server",
-		Run:       doServer,
+		Auto:      &serverVerb{},
 	}
 	app.AddVerb(verb)
 }
 
-func doServer(ctx context.Context, flags flag.FlagSet) error {
+type serverVerb struct{}
+
+func (v *serverVerb) Run(ctx context.Context, flags flag.FlagSet) error {
 	serveAt := ""
 	switch flags.NArg() {
 	case 0:

--- a/cmd/stash/server.go
+++ b/cmd/stash/server.go
@@ -31,7 +31,7 @@ func init() {
 	verb := &app.Verb{
 		Name:      "server",
 		ShortHelp: "Starts a stash server",
-		Auto:      &serverVerb{},
+		Action:    &serverVerb{},
 	}
 	app.AddVerb(verb)
 }

--- a/cmd/stash/upload.go
+++ b/cmd/stash/upload.go
@@ -28,12 +28,14 @@ func init() {
 	verb := &app.Verb{
 		Name:      "upload",
 		ShortHelp: "Upload a file to the stash",
-		Run:       doUpload,
+		Auto:      &uploadVerb{},
 	}
 	app.AddVerb(verb)
 }
 
-func doUpload(ctx context.Context, flags flag.FlagSet) error {
+type uploadVerb struct{}
+
+func (v *uploadVerb) Run(ctx context.Context, flags flag.FlagSet) error {
 	if flags.NArg() == 0 {
 		app.Usage(ctx, "No files to upload given")
 		return nil

--- a/cmd/stash/upload.go
+++ b/cmd/stash/upload.go
@@ -28,7 +28,7 @@ func init() {
 	verb := &app.Verb{
 		Name:      "upload",
 		ShortHelp: "Upload a file to the stash",
-		Auto:      &uploadVerb{},
+		Action:    &uploadVerb{},
 	}
 	app.AddVerb(verb)
 }

--- a/core/app/flags/choices_test.go
+++ b/core/app/flags/choices_test.go
@@ -19,7 +19,6 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/google/gapid/core/app"
 	"github.com/google/gapid/core/app/flags"
 	"github.com/google/gapid/core/assert"
 )
@@ -100,11 +99,11 @@ func TestChoiceParsing(t *testing.T) {
 		{[]string{"-villain", "Harley Quinn"}, true, 0, HarleyQuinn, ""},
 	} {
 		verb := &struct{ MyVerbFlags }{}
-		appVerb := &app.Verb{}
-		appVerb.Flags.Raw.Usage = func() {}
-		appVerb.Flags.Raw.SetOutput(ioutil.Discard)
-		appVerb.Flags.Bind("", verb, "")
-		err := appVerb.Flags.Raw.Parse(cs.args)
+		flags := flags.Set{}
+		flags.Raw.Usage = func() {}
+		flags.Raw.SetOutput(ioutil.Discard)
+		flags.Bind("", verb, "")
+		err := flags.Raw.Parse(cs.args)
 		if cs.ok {
 			assert.With(ctx).ThatError(err).Succeeded()
 			assert.With(ctx).ThatString(verb.Str).Equals(cs.s)

--- a/core/app/flags/flags.go
+++ b/core/app/flags/flags.go
@@ -94,6 +94,9 @@ func (s *Set) Bind(name string, value interface{}, help string) {
 	t := e.Type()
 	for i := 0; i < e.NumField(); i++ {
 		tf := t.Field(i)
+		if tf.PkgPath != "" {
+			continue // Unexported.
+		}
 		field := e.Field(i)
 		if !field.CanSet() {
 			panic(fmt.Sprintf("Unsettable field %q : %v", tf.Name, field.Type()))

--- a/core/app/help.go
+++ b/core/app/help.go
@@ -72,7 +72,7 @@ func verbShorthelp(raw io.Writer, v *Verb, verbose bool) {
 
 func verbUsage(raw io.Writer, v *Verb, verbose bool) {
 	fmt.Fprintf(raw, " %s", v.Name)
-	if v.Flags.HasVisibleFlags(verbose) {
+	if v.flags.HasVisibleFlags(verbose) {
 		fmt.Fprintf(raw, " [%s-flags]", v.Name)
 	}
 	if v.selected != nil {
@@ -90,10 +90,10 @@ func verbUsage(raw io.Writer, v *Verb, verbose bool) {
 }
 
 func verbHelp(raw io.Writer, v *Verb, verbose bool) {
-	if v.Flags.HasVisibleFlags(verbose) {
+	if v.flags.HasVisibleFlags(verbose) {
 		fmt.Fprintf(raw, "%s-flags:", v.Name)
 		fmt.Fprintln(raw)
-		fmt.Fprint(raw, v.Flags.Usage(verbose))
+		fmt.Fprint(raw, v.flags.Usage(verbose))
 		fmt.Fprintln(raw)
 	}
 	if v.selected != nil {

--- a/core/app/run.go
+++ b/core/app/run.go
@@ -98,11 +98,11 @@ func Run(main task.Task) {
 	// parse the command line
 	flag.CommandLine.Usage = func() { Usage(ctx, "") }
 	verbMainPrepare(flags)
-	globalVerbs.Flags.Parse(os.Args[1:]...)
+	globalVerbs.flags.Parse(os.Args[1:]...)
 	// Force the global verb's flags back into the default location for
 	// main programs that still look in flag.Args()
 	//TODO: We need to stop doing this
-	globalVerbs.Flags.ForceCommandLine()
+	globalVerbs.flags.ForceCommandLine()
 	// apply the flags
 	if flags.Version {
 		fmt.Fprint(os.Stdout, Name, " version ", Version, "\n")

--- a/core/app/verbs.go
+++ b/core/app/verbs.go
@@ -103,8 +103,10 @@ func (v *Verb) Invoke(ctx context.Context, args []string) error {
 
 // AddVerb adds a new verb to the supported set, it will panic if a
 // duplicate name is encountered.
-func AddVerb(v *Verb) {
+// v is returned so the function can be used in a fluent-style.
+func AddVerb(v *Verb) *Verb {
 	globalVerbs.Add(v)
+	return v
 }
 
 // FilterVerbs returns the filtered list of verbs who's names match the specified


### PR DESCRIPTION
The command line verb system had multiple ways of declaring flags.

The old 'Run' system involved explicit binding to variables (usually globals), which often lead to bugs and gross littering of globals.

The newer 'Auto' system uses reflection to expose and bind flags to struct fields. No more globals.

This PR moves everything to 'Auto' (now called 'Action'), and standardizes the usage.

As part of this - the default port between `robot start master` and `robot start web` are now different.

It's likely that I've screwed up defaults / names somewhere. Fresh eyes would be helpful in double checking the more critical apps (template, gapit, etc).