### PR TITLE
gapic: Ensure selection contains correct capture ID.

### DIFF
--- a/gapic/src/main/com/google/gapid/models/AtomStream.java
+++ b/gapic/src/main/com/google/gapid/models/AtomStream.java
@@ -36,6 +36,7 @@ import com.google.gapid.rpclib.rpccore.Rpc.Result;
 import com.google.gapid.rpclib.rpccore.RpcException;
 import com.google.gapid.server.Client;
 import com.google.gapid.util.Events;
+import com.google.gapid.util.Loadable;
 import com.google.gapid.util.Messages;
 import com.google.gapid.util.Paths;
 import com.google.gapid.util.Ranges;
@@ -75,6 +76,14 @@ public class AtomStream extends ModelBase.ForPath<AtomStream.Node, Void, AtomStr
   public void onCaptureLoadingStart(boolean maintainState) {
     if (!maintainState) {
       selection = null;
+    }
+  }
+
+  @Override
+  public void onCaptureLoaded(Loadable.Message error) {
+    if (error == null && selection != null) {
+      selection = selection.withCapture(capture.getData());
+      resolve(selection.getCommand(), node -> selectAtoms(selection.withNode(node), true));
     }
   }
 
@@ -380,6 +389,10 @@ public class AtomStream extends ModelBase.ForPath<AtomStream.Node, Void, AtomStr
 
     public AtomIndex withNode(Path.CommandTreeNode newNode) {
       return new AtomIndex(command, newNode, group);
+    }
+
+    public AtomIndex withCapture(Path.Capture capture) {
+      return new AtomIndex(command.toBuilder().setCapture(capture).build(), null, group);
     }
 
     public Path.Command getCommand() {

--- a/gapic/src/main/com/google/gapid/views/AtomTree.java
+++ b/gapic/src/main/com/google/gapid/views/AtomTree.java
@@ -458,11 +458,9 @@ public class AtomTree extends Composite implements Tab, Capture.Listener, AtomSt
     viewer.getTree().setSelection(viewer.getTree().getItem(0));
     viewer.getTree().showSelection();
 
-    /*
     if (models.atoms.getSelectedAtoms() != null) {
       onAtomsSelected(models.atoms.getSelectedAtoms());
     }
-    */
   }
 
   private ListenableFuture<TreePath> getTreePath(AtomIndex index) {


### PR DESCRIPTION
When a capture is edited, the model maintains the selection state. The state, however, needs to be updated to reflect the path with the new capture ID.

Fixes #454