### PR TITLE
Track bound GL objects by reference rather than by ID

### DIFF
--- a/gapii/cc/gles_extras.cpp
+++ b/gapii/cc/gles_extras.cpp
@@ -132,13 +132,13 @@ bool GlesSpy::getFramebufferAttachmentSize(uint32_t* width, uint32_t* height) {
       return false;
     }
 
-    auto framebuffer = ctx->mObjects.mFramebuffers.find(ctx->mBoundReadFramebuffer);
-    if (framebuffer == ctx->mObjects.mFramebuffers.end()) {
+    auto framebuffer = ctx->mBound.mReadFramebuffer;
+    if (framebuffer == nullptr) {
         return false;
     }
 
-    auto attachment = framebuffer->second->mColorAttachments.find(0);
-    if (attachment == framebuffer->second->mColorAttachments.end()) {
+    auto attachment = framebuffer->mColorAttachments.find(0);
+    if (attachment == framebuffer->mColorAttachments.end()) {
         return false;
     }
 

--- a/gapis/gfxapi/gles/api/asynchronous_queries.api
+++ b/gapis/gfxapi/gles/api/asynchronous_queries.api
@@ -14,6 +14,8 @@
 
 @internal
 class Query {
+  QueryId ID
+
   // Table 21.31: Query Object State
   // GLuint QueryResult = 0 // TODO: or GL_FALSE?
   // GLboolean QueryResultAvailable = GL_FALSE
@@ -89,7 +91,7 @@ cmd void glGenQueries(GLsizei count, QueryId* queries) {
   for i in (0 .. count) {
     id := as!QueryId(?)
     // TODO: This should only reserve the name, but not create the object.
-    ctx.Objects.Queries[id] = new!Query()
+    ctx.Objects.Queries[id] = new!Query(ID: id)
     q[i] = id
   }
 }

--- a/gapis/gfxapi/gles/api/buffer_objects.api
+++ b/gapis/gfxapi/gles/api/buffer_objects.api
@@ -14,6 +14,8 @@
 
 @internal
 class Buffer {
+  BufferId ID
+
   @internal u8[] Data
 
   // Table 21.5: Buffer Object State
@@ -27,80 +29,76 @@ class Buffer {
   @unused string Label
 }
 
-@internal
-class BufferBinding {
-  // Table 21.32: Atomic Counter Buffer Binding State
-  // Table 21.34: Shader Storage Buffer Binding State
-  // Table 21.35: Transform Feedback State
-  // Table 21.36: Uniform Buffer Binding State
-  BufferId   Binding
-  GLintptr   Start
-  GLsizeiptr Size
-}
-
 sub ref!Buffer GetBoundBufferOrError(GLenum target) {
   ctx := GetContext()
   // TODO: The error conditions are not spelled out for all commands in the spec.
-  // TODO: Add back version checks.
-  id := switch (target) {
+  b := switch (target) {
     @if(Version.GLES20)
     case GL_ARRAY_BUFFER: {
-      ctx.BoundBuffers.ArrayBuffer
+      ctx.Bound.ArrayBuffer
     }
     @if(Version.GLES20)
     case GL_ELEMENT_ARRAY_BUFFER: {
-      ctx.Objects.VertexArrays[ctx.BoundVertexArray].ElementArrayBuffer
+      ctx.Bound.VertexArray.ElementArrayBuffer
     }
     @if(Version.GLES30)
     case GL_COPY_READ_BUFFER: {
-      ctx.BoundBuffers.CopyReadBuffer
+      ctx.Bound.CopyReadBuffer
     }
     @if(Version.GLES30)
     case GL_COPY_WRITE_BUFFER: {
-      ctx.BoundBuffers.CopyWriteBuffer
+      ctx.Bound.CopyWriteBuffer
     }
     @if(Version.GLES30)
     case GL_PIXEL_PACK_BUFFER: {
-      ctx.BoundBuffers.PixelPackBuffer
+      ctx.Bound.PixelPackBuffer
     }
     @if(Version.GLES30)
     case GL_PIXEL_UNPACK_BUFFER: {
-      ctx.BoundBuffers.PixelUnpackBuffer
+      ctx.Bound.PixelUnpackBuffer
     }
     @if(Version.GLES30)
     case GL_TRANSFORM_FEEDBACK_BUFFER: {
-      ctx.BoundBuffers.TransformFeedbackBuffer
+      ctx.Bound.TransformFeedbackBuffer
     }
     @if(Version.GLES30)
     case GL_UNIFORM_BUFFER: {
-      ctx.BoundBuffers.UniformBuffer
+      ctx.Bound.UniformBuffer
     }
     @if(Version.GLES31)
     case GL_ATOMIC_COUNTER_BUFFER: {
-      ctx.BoundBuffers.AtomicCounterBuffer
+      ctx.Bound.AtomicCounterBuffer
     }
     @if(Version.GLES31)
     case GL_DISPATCH_INDIRECT_BUFFER: {
-      ctx.BoundBuffers.DispatchIndirectBuffer
+      ctx.Bound.DispatchIndirectBuffer
     }
     @if(Version.GLES31)
     case GL_DRAW_INDIRECT_BUFFER: {
-      ctx.BoundBuffers.DrawIndirectBuffer
+      ctx.Bound.DrawIndirectBuffer
     }
     @if(Version.GLES31)
     case GL_SHADER_STORAGE_BUFFER: {
-      ctx.BoundBuffers.ShaderStorageBuffer
+      ctx.Bound.ShaderStorageBuffer
     }
     @if(Version.GLES32)
     case GL_TEXTURE_BUFFER: {
-      ctx.BoundBuffers.TextureBuffer
+      ctx.Bound.TextureBuffer
     }
     default: {
-      // glErrorInvalidEnum(target)
-      as!BufferId(0)
+      // TODO: glErrorInvalidEnum(target)
+      as!ref!Buffer(null)
     }
   }
-  if id == 0 { glErrorInvalidOperation() }
+  if b == null { glErrorInvalidOperation() }
+  return b
+}
+
+sub ref!Buffer GetOrCreateBuffer(BufferId id) {
+  ctx := GetContext()
+  if (id != 0) && (ctx.Objects.Shared.Buffers[id] == null) {
+    ctx.Objects.Shared.Buffers[id] = new!Buffer(ID: id)
+  }
   return ctx.Objects.Shared.Buffers[id]
 }
 
@@ -113,64 +111,57 @@ cmd void glBindBuffer(GLenum target, BufferId buffer) {
   ctx := GetContext()
   switch (target) {
     case GL_ARRAY_BUFFER: {
-      ctx.BoundBuffers.ArrayBuffer = buffer
+      ctx.Bound.ArrayBuffer = GetOrCreateBuffer(buffer)
     }
     case GL_ELEMENT_ARRAY_BUFFER: {
-      ctx.Objects.VertexArrays[ctx.BoundVertexArray].ElementArrayBuffer = buffer
+      ctx.Bound.VertexArray.ElementArrayBuffer = GetOrCreateBuffer(buffer)
     }
     @if(Version.GLES30)
     case GL_COPY_READ_BUFFER: {
-      ctx.BoundBuffers.CopyReadBuffer = buffer
+      ctx.Bound.CopyReadBuffer = GetOrCreateBuffer(buffer)
     }
     @if(Version.GLES30)
     case GL_COPY_WRITE_BUFFER: {
-      ctx.BoundBuffers.CopyWriteBuffer = buffer
+      ctx.Bound.CopyWriteBuffer = GetOrCreateBuffer(buffer)
     }
     @if(Version.GLES30)
     case GL_PIXEL_PACK_BUFFER: {
-      ctx.BoundBuffers.PixelPackBuffer = buffer
+      ctx.Bound.PixelPackBuffer = GetOrCreateBuffer(buffer)
     }
     @if(Version.GLES30)
     case GL_PIXEL_UNPACK_BUFFER: {
-      ctx.BoundBuffers.PixelUnpackBuffer = buffer
+      ctx.Bound.PixelUnpackBuffer = GetOrCreateBuffer(buffer)
     }
     @if(Version.GLES30)
     case GL_TRANSFORM_FEEDBACK_BUFFER: {
-      ctx.BoundBuffers.TransformFeedbackBuffer = buffer
+      ctx.Bound.TransformFeedbackBuffer = GetOrCreateBuffer(buffer)
     }
     @if(Version.GLES30)
     case GL_UNIFORM_BUFFER: {
-      ctx.BoundBuffers.UniformBuffer = buffer
+      ctx.Bound.UniformBuffer = GetOrCreateBuffer(buffer)
     }
     @if(Version.GLES31)
     case GL_ATOMIC_COUNTER_BUFFER: {
-      ctx.BoundBuffers.AtomicCounterBuffer = buffer
+      ctx.Bound.AtomicCounterBuffer = GetOrCreateBuffer(buffer)
     }
     @if(Version.GLES31)
     case GL_DISPATCH_INDIRECT_BUFFER: {
-      ctx.BoundBuffers.DispatchIndirectBuffer = buffer
+      ctx.Bound.DispatchIndirectBuffer = GetOrCreateBuffer(buffer)
     }
     @if(Version.GLES31)
     case GL_DRAW_INDIRECT_BUFFER: {
-      ctx.BoundBuffers.DrawIndirectBuffer = buffer
+      ctx.Bound.DrawIndirectBuffer = GetOrCreateBuffer(buffer)
     }
     @if(Version.GLES31)
     case GL_SHADER_STORAGE_BUFFER: {
-      ctx.BoundBuffers.ShaderStorageBuffer = buffer
+      ctx.Bound.ShaderStorageBuffer = GetOrCreateBuffer(buffer)
     }
     @if(Version.GLES32)
     case GL_TEXTURE_BUFFER: {
-      ctx.BoundBuffers.TextureBuffer = buffer
+      ctx.Bound.TextureBuffer = GetOrCreateBuffer(buffer)
     }
     default: {
       glErrorInvalidEnum(target)
-    }
-  }
-
-  // Create the buffer if need (after checking whether the enum is valid)
-  if buffer != 0 {
-    if !(buffer in ctx.Objects.Shared.Buffers) {
-      ctx.Objects.Shared.Buffers[buffer] = new!Buffer()
     }
   }
 }
@@ -206,41 +197,33 @@ sub void BindBufferRange(GLenum     target,
                          GLintptr   offset,
                          GLsizeiptr size) {
   ctx := GetContext()
-  bufferBinding := BufferBinding(
-    Binding: buffer,
-    Start:   offset,
-    Size:    size
-  )
   switch (target) {
     @if(Version.GLES30)
     case GL_TRANSFORM_FEEDBACK_BUFFER: {
-      ctx.BoundBuffers.TransformFeedbackBuffer = buffer
-      GetBoundTransformFeedback().Buffers[index] = bufferBinding
+      b := GetOrCreateBuffer(buffer)
+      ctx.Bound.TransformFeedbackBuffer = b
+      ctx.Bound.TransformFeedback.Buffers[index] = BufferBinding(b, offset, size)
     }
     @if(Version.GLES30)
     case GL_UNIFORM_BUFFER: {
-      ctx.BoundBuffers.UniformBuffer = buffer
-      ctx.BoundBuffers.UniformBuffers[index] = bufferBinding
+      b := GetOrCreateBuffer(buffer)
+      ctx.Bound.UniformBuffer = b
+      ctx.Bound.UniformBuffers[index] = BufferBinding(b, offset, size)
     }
     @if(Version.GLES31)
     case GL_ATOMIC_COUNTER_BUFFER: {
-      ctx.BoundBuffers.AtomicCounterBuffer = buffer
-      ctx.BoundBuffers.AtomicCounterBuffers[index] = bufferBinding
+      b := GetOrCreateBuffer(buffer)
+      ctx.Bound.AtomicCounterBuffer = b
+      ctx.Bound.AtomicCounterBuffers[index] = BufferBinding(b, offset, size)
     }
     @if(Version.GLES31)
     case GL_SHADER_STORAGE_BUFFER: {
-      ctx.BoundBuffers.ShaderStorageBuffer = buffer
-      ctx.BoundBuffers.ShaderStorageBuffers[index] = bufferBinding
+      b := GetOrCreateBuffer(buffer)
+      ctx.Bound.ShaderStorageBuffer = b
+      ctx.Bound.ShaderStorageBuffers[index] = BufferBinding(b, offset, size)
     }
     default: {
       glErrorInvalidEnum(target)
-    }
-  }
-
-  // Create the buffer if need (after checking whether the enum is valid)
-  if buffer != 0 {
-    if !(buffer in ctx.Objects.Shared.Buffers) {
-      ctx.Objects.Shared.Buffers[buffer] = new!Buffer()
     }
   }
 }
@@ -337,7 +320,7 @@ cmd void glGenBuffers(GLsizei count, BufferId* buffers) {
   for i in (0 .. count) {
     id := as!BufferId(?)
     assert(id != 0)
-    ctx.Objects.Shared.Buffers[id] = new!Buffer()
+    ctx.Objects.Shared.Buffers[id] = new!Buffer(ID: id)
     b[i] = id
   }
 }

--- a/gapis/gfxapi/gles/api/draw_commands.api
+++ b/gapis/gfxapi/gles/api/draw_commands.api
@@ -65,8 +65,8 @@ cmd void glDrawArrays(GLenum draw_mode, GLint first_index, GLsizei indices_count
 cmd void glDrawArraysIndirect(GLenum draw_mode, const void* indirect) {
   checkPrimitiveType(draw_mode)
   ctx := GetContext()
-  if ctx.BoundVertexArray == 0 { glErrorInvalidOperation() } // SPEC: missing in html
-  if ctx.BoundBuffers.DrawIndirectBuffer == 0 { glErrorInvalidOperation() } // SPEC: missing in html
+  if IsDefaultVertexArrayBound() { glErrorInvalidOperation() }
+  if ctx.Bound.DrawIndirectBuffer == null { glErrorInvalidOperation() }
   // TODO: INVALID_OPERATION error if the command would source data beyond the end of the buffer object.
   // TODO: if as!u64(indirect) % 4 != 0 { glErrorInvalidValue() }
 }
@@ -102,10 +102,10 @@ sub void DrawElements(ref!Context    ctx,
   if instance_count < 0 { glErrorInvalidValue() } // SPEC: missing in pdf
   if indices_count > 0 {
     count := as!u32(indices_count)
-    id := ctx.Objects.VertexArrays[ctx.BoundVertexArray].ElementArrayBuffer
-    if (id != 0) {
+    index_buffer := ctx.Bound.VertexArray.ElementArrayBuffer
+    if (index_buffer != null) {
       // Element array buffer bound - indices is an offset on the buffer.
-      index_data := ctx.Objects.Shared.Buffers[id].Data
+      index_data := index_buffer.Data
       offset := as!s32(as!u64(indices))
 
       // Read the vertices
@@ -170,9 +170,9 @@ cmd void glDrawElementsIndirect(GLenum draw_mode, GLenum indices_type, const voi
   checkIndicesType(indices_type)
 
   ctx := GetContext()
-  if ctx.BoundVertexArray == 0 { glErrorInvalidOperation() } // SPEC: missing in html
+  if IsDefaultVertexArrayBound() { glErrorInvalidOperation() }
   // TODO: Error if enabled array is not bound or is mapped.
-  if ctx.BoundBuffers.DrawIndirectBuffer == 0 { glErrorInvalidOperation() } // SPEC: missing in html
+  if ctx.Bound.DrawIndirectBuffer == null { glErrorInvalidOperation() }
   // TODO: INVALID_OPERATION error if the command would source data beyond the end of the buffer object.
   // TODO: if as!u64(indirect) % 4 != 0 { glErrorInvalidValue() }
 }

--- a/gapis/gfxapi/gles/api/extensions.api
+++ b/gapis/gfxapi/gles/api/extensions.api
@@ -924,7 +924,7 @@ cmd void glGenQueriesEXT(GLsizei count, QueryId* queries) {
   ctx := GetContext()
   for i in (0 .. count) {
     id := as!QueryId(?)
-    ctx.Objects.Queries[id] = new!Query()
+    ctx.Objects.Queries[id] = new!Query(ID: id)
     q[i] = id
   }
 }

--- a/gapis/gfxapi/gles/api/framebuffer.api
+++ b/gapis/gfxapi/gles/api/framebuffer.api
@@ -29,6 +29,8 @@ class FramebufferState {
 
 @internal
 class Framebuffer {
+  FramebufferId ID
+
   map!(GLint, FramebufferAttachment) ColorAttachments
   FramebufferAttachment DepthAttachment
   FramebufferAttachment StencilAttachment
@@ -109,25 +111,13 @@ class FramebufferDependentValues {
 */
 
 sub ref!Framebuffer GetBoundFramebufferOrErrorInvalidEnum(GLenum framebuffer_target) {
-  // TODO: Merge this switch with the one below.
-  switch (framebuffer_target) {
-    @if(Version.GLES20)
-    case GL_FRAMEBUFFER: {
-    }
-    @if(Version.GLES30)
-    case GL_DRAW_FRAMEBUFFER, GL_READ_FRAMEBUFFER: {
-    }
-    default: {
-      glErrorInvalidEnum(framebuffer_target)
-    }
-  }
   ctx := GetContext()
-  framebufferId := switch (framebuffer_target) {
-    case GL_FRAMEBUFFER:      ctx.BoundDrawFramebuffer
-    case GL_DRAW_FRAMEBUFFER: ctx.BoundDrawFramebuffer
-    case GL_READ_FRAMEBUFFER: ctx.BoundReadFramebuffer
+  return switch (framebuffer_target) {
+    @if(Version.GLES20) case GL_FRAMEBUFFER: ctx.Bound.DrawFramebuffer
+    @if(Version.GLES30) case GL_DRAW_FRAMEBUFFER: ctx.Bound.DrawFramebuffer
+    @if(Version.GLES30) case GL_READ_FRAMEBUFFER: ctx.Bound.ReadFramebuffer
+    default: ctx.Bound.DrawFramebuffer // TODO: glErrorInvalidEnum(framebuffer_target)
   }
-  return ctx.Objects.Framebuffers[framebufferId]
 }
 
 sub bool IsDefaultFramebuffer(ref!Framebuffer framebuffer) {
@@ -178,24 +168,30 @@ cmd void glBindFramebuffer(GLenum target, FramebufferId framebuffer) {
   switch (target) {
     case GL_FRAMEBUFFER: {
       // version 2.0
-      ctx.BoundReadFramebuffer = framebuffer
-      ctx.BoundDrawFramebuffer = framebuffer
+      fb := GetOrCreateFramebuffer(framebuffer)
+      ctx.Bound.ReadFramebuffer = fb
+      ctx.Bound.DrawFramebuffer = fb
     }
     @if(Version.GLES30)
     case GL_READ_FRAMEBUFFER: {
-      ctx.BoundReadFramebuffer = framebuffer
+      ctx.Bound.ReadFramebuffer = GetOrCreateFramebuffer(framebuffer)
     }
     @if(Version.GLES30)
     case GL_DRAW_FRAMEBUFFER: {
-      ctx.BoundDrawFramebuffer = framebuffer
+      ctx.Bound.DrawFramebuffer = GetOrCreateFramebuffer(framebuffer)
     }
     default: {
       glErrorInvalidEnum(target)
     }
   }
-  if !(framebuffer in ctx.Objects.Framebuffers) {
-    ctx.Objects.Framebuffers[framebuffer] = new!Framebuffer()
+}
+
+sub ref!Framebuffer GetOrCreateFramebuffer(FramebufferId id) {
+  ctx := GetContext()
+  if (id != 0) && (ctx.Objects.Framebuffers[id] == null) {
+    ctx.Objects.Framebuffers[id] = new!Framebuffer(ID: id)
   }
+  return ctx.Objects.Framebuffers[id]
 }
 
 @if(Version.GLES20)
@@ -207,16 +203,20 @@ cmd void glBindRenderbuffer(GLenum target, RenderbufferId renderbuffer) {
   ctx := GetContext()
   switch (target) {
     case GL_RENDERBUFFER: {
-      // version 2.0
-      ctx.BoundRenderbuffer = renderbuffer
+      ctx.Bound.Renderbuffer = GetOrCreateRenderbuffer(renderbuffer)
     }
     default: {
       glErrorInvalidEnum(target)
     }
   }
-  if !(renderbuffer in ctx.Objects.Shared.Renderbuffers) {
-    ctx.Objects.Shared.Renderbuffers[renderbuffer] = new!Renderbuffer(ID: renderbuffer)
+}
+
+sub ref!Renderbuffer GetOrCreateRenderbuffer(RenderbufferId id) {
+  ctx := GetContext()
+  if (id != 0) && (ctx.Objects.Shared.Renderbuffers[id] == null) {
+    ctx.Objects.Shared.Renderbuffers[id] = new!Renderbuffer(ID: id)
   }
+  return ctx.Objects.Shared.Renderbuffers[id]
 }
 
 @if(Version.GLES30)
@@ -449,11 +449,11 @@ cmd void glDeleteFramebuffers(GLsizei count, const FramebufferId* framebuffers) 
     id := f[i]
     if id != 0 {
       delete(ctx.Objects.Framebuffers, id)
-      if id == ctx.BoundReadFramebuffer {
-        ctx.BoundReadFramebuffer = 0
+      if id == ctx.Bound.ReadFramebuffer.ID {
+        ctx.Bound.ReadFramebuffer = ctx.Objects.Framebuffers[0]
       }
-      if id == ctx.BoundDrawFramebuffer {
-        ctx.BoundDrawFramebuffer = 0
+      if id == ctx.Bound.DrawFramebuffer.ID {
+        ctx.Bound.DrawFramebuffer = ctx.Objects.Framebuffers[0]
       }
     }
   }
@@ -671,7 +671,7 @@ cmd void glGenFramebuffers(GLsizei count, FramebufferId* framebuffers) {
   ctx := GetContext()
   for i in (0 .. count) {
     id := as!FramebufferId(?)
-    ctx.Objects.Framebuffers[id] = new!Framebuffer()
+    ctx.Objects.Framebuffers[id] = new!Framebuffer(ID: id)
     f[i] = id
   }
 }
@@ -825,9 +825,8 @@ cmd void glGetRenderbufferParameteriv(GLenum target, GLenum parameter, GLint* va
   }
 
   ctx := GetContext()
-  id := ctx.BoundRenderbuffer
-  if id == 0 { glErrorInvalidOperation() } // PDF spec
-  rb := ctx.Objects.Shared.Renderbuffers[id]
+  rb := ctx.Bound.Renderbuffer
+  if rb == null { glErrorInvalidOperation() }
   values[0] = switch (parameter) {
     case GL_RENDERBUFFER_WIDTH:           as!GLint(rb.Width)
     case GL_RENDERBUFFER_HEIGHT:          as!GLint(rb.Height)
@@ -999,7 +998,7 @@ cmd void glReadPixels(GLint   x,
   checkReadPixels(width, height, format, type)
 
   ctx := GetContext()
-  if (ctx.BoundBuffers.PixelPackBuffer == 0) && (data != null) {
+  if (ctx.Bound.PixelPackBuffer == null) && (data != null) {
     requiredSize := uncompressedImageSize(width, height, format, type)
     write(data[0:requiredSize])
   }
@@ -1021,7 +1020,7 @@ cmd void glReadnPixels(GLint   x,
 sub void ReadnPixels(GLint x, GLint y, GLsizei width, GLsizei height, GLenum format, GLenum type, GLsizei bufSize, void* data) {
   checkReadPixels(width, height, format, type)
   ctx := GetContext()
-  if (ctx.BoundBuffers.PixelPackBuffer == 0) && (data != null) {
+  if (ctx.Bound.PixelPackBuffer == null) && (data != null) {
     requiredSize := uncompressedImageSize(width, height, format, type)
     if as!GLsizei(requiredSize) > bufSize { glErrorInvalidOperation() }
     write(data[0:requiredSize])
@@ -1076,9 +1075,8 @@ sub void RenderbufferStorageMultisample(GLenum target, GLsizei samples, GLenum i
     glErrorInvalidValue()
   }
 
-  id := ctx.BoundRenderbuffer
-  if id == 0 { glErrorInvalidOperation() }
-  rb := ctx.Objects.Shared.Renderbuffers[id]
+  rb := ctx.Bound.Renderbuffer
+  if rb == null { glErrorInvalidOperation() }
   rb.InternalFormat = internalformat
   rb.Width = width
   rb.Height = height

--- a/gapis/gfxapi/gles/api/programs_and_shaders.api
+++ b/gapis/gfxapi/gles/api/programs_and_shaders.api
@@ -242,49 +242,54 @@ sub void writeString(GLsizei  buffer_size,
   }
 }
 
-sub void checkShader(ref!Context ctx, ShaderId shader) {
-  if (!shader in ctx.Objects.Shared.Shaders) {
+sub ref!Shader GetShaderOrError(ShaderId shader) {
+  ctx := GetContext()
+  s := ctx.Objects.Shared.Shaders[shader]
+  if s == null {
     if (!as!ProgramId(shader) in ctx.Objects.Shared.Programs) {
       glErrorInvalidValue()
     } else {
       glErrorInvalidOperation()
     }
   }
+  return s
 }
 
-sub void checkProgram(ref!Context ctx, ProgramId program) {
-  if (!program in ctx.Objects.Shared.Programs) {
+sub ref!Program GetProgramOrError(ProgramId program) {
+  ctx := GetContext()
+  p := ctx.Objects.Shared.Programs[program]
+  if p == null {
     if (!as!ShaderId(program) in ctx.Objects.Shared.Shaders) {
       glErrorInvalidValue()
     } else {
       glErrorInvalidOperation()
     }
   }
+  return p
 }
 
-sub void reapShader(ref!Context ctx, ref!Shader shader) {
+sub void reapShader(ref!Shader shader) {
+  ctx := GetContext()
   if (shader.DeleteStatus && shader.RefCount == 0) {
     delete(ctx.Objects.Shared.Shaders, shader.ID)
   }
 }
 
-sub void reapProgram(ref!Context ctx, ProgramId program) {
-  if (program != 0) {
-    p := ctx.Objects.Shared.Programs[program]
+sub void reapProgram(ref!Program p) {
+  ctx := GetContext()
+  if (p != null) {
     if (p.DeleteStatus) {
       for _ , _ , s in p.Shaders {
         s.RefCount -= 1
-        reapShader(ctx, s)
+        reapShader(s)
       }
-      delete(ctx.Objects.Shared.Programs, program)
+      delete(ctx.Objects.Shared.Programs, p.ID)
     }
   }
 }
 
-sub void SetProgramUniform(ProgramId program, UniformLocation location, u8[] value, GLenum type) {
-  ctx := GetContext()
-  checkProgram(ctx, program)
-  p := ctx.Objects.Shared.Programs[program]
+sub void SetProgramUniform(ref!Program p, UniformLocation location, u8[] value, GLenum type) {
+  if p == null { glErrorInvalidOperation() }
   if location != -1 { // -1 is silently ignored.
     if !(location in p.Uniforms) { glErrorInvalidOperation() }
     // TODO: Remove the temporary.
@@ -316,8 +321,8 @@ cmd void glActiveShaderProgram(PipelineId pipeline, ProgramId program) {
 cmd void glAttachShader(ProgramId program, ShaderId shader) {
 
   ctx := GetContext()
-  checkShader(ctx, shader)
-  checkProgram(ctx, program)
+  _ = GetShaderOrError(shader)
+  _ = GetProgramOrError(program)
 
   p := ctx.Objects.Shared.Programs[program]
   s := ctx.Objects.Shared.Shaders[shader]
@@ -335,7 +340,7 @@ cmd void glBindAttribLocation(ProgramId program, AttributeLocation location, str
   n := as!char[](name)
   if (len(n) > 2) && (as!string(n[0:3]) == "gl_") { glErrorInvalidOperation() }
   ctx := GetContext()
-  checkProgram(ctx, program)
+  _ = GetProgramOrError(program)
   if location >= as!AttributeLocation(ctx.Constants.MaxVertexAttribs) { glErrorInvalidValue() }
   p := ctx.Objects.Shared.Programs[program]
   p.AttributeBindings[name] = location
@@ -355,8 +360,7 @@ cmd void glBindProgramPipeline(PipelineId pipeline) {
 @doc("https://www.khronos.org/opengles/sdk/docs/man32/html/glCompileShader.xhtml", Version.GLES32)
 cmd void glCompileShader(ShaderId shader) {
 
-  ctx := GetContext()
-  checkShader(ctx, shader)
+  _ = GetShaderOrError(shader)
 
   // TODO: shader.Binary < ?
 }
@@ -397,7 +401,7 @@ cmd ShaderId glCreateShader(GLenum type) {
 
   ctx := GetContext()
   id := ?
-  ctx.Objects.Shared.Shaders[id] = new!Shader(ID: id,ShaderType:  type)
+  ctx.Objects.Shared.Shaders[id] = new!Shader(ID: id, ShaderType:  type)
   s := ctx.Objects.Shared.Shaders[id]
   s.Type = type
   return id
@@ -435,11 +439,12 @@ cmd void glDeleteProgram(ProgramId program) {
 
   if program != 0 {
     ctx := GetContext()
-    checkProgram(ctx, program)
-    ctx.Objects.Shared.Programs[program].DeleteStatus = true
+    p := GetProgramOrError(program)
+    p.DeleteStatus = true
     // Do not reap while the program is in use.
-    if ctx.BoundProgram != program {
-      reapProgram(ctx, program)
+    // TODO: Programs can be shared between contexts so this does not quite work
+    if ctx.Bound.Program != p {
+      reapProgram(p)
     }
   }
 }
@@ -460,13 +465,9 @@ cmd void glDeleteProgramPipelines(GLsizei n, const PipelineId* pipelines) {
 cmd void glDeleteShader(ShaderId shader) {
 
   if shader != 0 {
-    ctx := GetContext()
-    checkShader(ctx, shader)
-    if shader in ctx.Objects.Shared.Shaders { // TODO: Remove once we have go aborts.
-      s := ctx.Objects.Shared.Shaders[shader]
-      s.DeleteStatus = true
-      reapShader(ctx, s)
-    }
+    s := GetShaderOrError(shader)
+    s.DeleteStatus = true
+    reapShader(s)
   }
 }
 
@@ -477,17 +478,13 @@ cmd void glDeleteShader(ShaderId shader) {
 @doc("https://www.khronos.org/opengles/sdk/docs/man32/html/glDetachShader.xhtml", Version.GLES32)
 cmd void glDetachShader(ProgramId program, ShaderId shader) {
 
-  ctx := GetContext()
+  s := GetShaderOrError(shader)
+  p := GetProgramOrError(program)
 
-  checkShader(ctx, shader)
-  checkProgram(ctx, program)
-
-  s := ctx.Objects.Shared.Shaders[shader]
-  p := ctx.Objects.Shared.Programs[program]
   if (!(s.Type in p.Shaders)) || (p.Shaders[s.Type] != s) { glErrorInvalidOperation() }
   delete(p.Shaders, s.Type)
   s.RefCount -= 1
-  reapShader(ctx, s)
+  reapShader(s)
 }
 
 @if(Version.GLES31)
@@ -528,7 +525,7 @@ cmd void glGetActiveAttrib(ProgramId      program,
   if buffer_size < 0 { glErrorInvalidValue() }
 
   ctx := GetContext()
-  checkProgram(ctx, program)
+  _ = GetProgramOrError(program)
   p := ctx.Objects.Shared.Programs[program]
   if !(index in p.ActiveAttributes) { glErrorInvalidValue() }
 
@@ -552,7 +549,7 @@ cmd void glGetActiveUniform(ProgramId    program,
                             GLchar*      name) {
 
   ctx := GetContext()
-  checkProgram(ctx, program)
+  _ = GetProgramOrError(program)
   if buffer_size < 0 { glErrorInvalidValue() }
   p := ctx.Objects.Shared.Programs[program]
   if !(index in p.ActiveUniforms) { glErrorInvalidValue() }
@@ -634,7 +631,7 @@ cmd void glGetAttachedShaders(ProgramId program,
                               ShaderId* shaders) {
 
   ctx := GetContext()
-  checkProgram(ctx, program)
+  _ = GetProgramOrError(program)
   if buffer_length < 0 { glErrorInvalidValue() }
   p := ctx.Objects.Shared.Programs[program]
   l := min(as!s32(buffer_length), len(p.Shaders))
@@ -656,9 +653,8 @@ cmd void glGetAttachedShaders(ProgramId program,
 @doc("https://www.khronos.org/opengles/sdk/docs/man31/html/glGetAttribLocation.xhtml", Version.GLES31)
 @doc("https://www.khronos.org/opengles/sdk/docs/man32/html/glGetAttribLocation.xhtml", Version.GLES32)
 cmd GLint glGetAttribLocation(ProgramId program, string name) {
-  ctx := GetContext()
   // The HTML and PDF give different error codes. This matches the PDF.
-  checkProgram(ctx, program)
+  _ = GetProgramOrError(program)
   return ?
 }
 
@@ -667,8 +663,7 @@ cmd GLint glGetAttribLocation(ProgramId program, string name) {
 @doc("https://www.khronos.org/opengles/sdk/docs/man31/html/glGetFragDataLocation.xhtml", Version.GLES31)
 @doc("https://www.khronos.org/opengles/sdk/docs/man32/html/glGetFragDataLocation.xhtml", Version.GLES32)
 cmd GLint glGetFragDataLocation(ProgramId program, string name) {
-  ctx := GetContext()
-  checkProgram(ctx, program)
+  _ = GetProgramOrError(program)
   return ?
 }
 
@@ -705,8 +700,7 @@ cmd void glGetProgramInfoLog(ProgramId program,
                              GLsizei   buffer_length,
                              GLsizei*  string_length_written,
                              GLchar*   info) {
-  ctx := GetContext()
-  checkProgram(ctx, program)
+  _ = GetProgramOrError(program)
   if buffer_length < 0 { glErrorInvalidValue() }
   writeString(buffer_length, string_length_written, info)
 }
@@ -894,8 +888,7 @@ cmd void glGetProgramiv(ProgramId program, GLenum parameter, GLint* value) {
       glErrorInvalidEnum(parameter)
     }
   }
-  ctx := GetContext()
-  checkProgram(ctx, program)
+  _ = GetProgramOrError(program)
 
   value[0] = ?
 }
@@ -909,8 +902,7 @@ cmd void glGetShaderInfoLog(ShaderId shader,
                             GLsizei  buffer_length,
                             GLsizei* string_length_written,
                             GLchar*  info) {
-  ctx := GetContext()
-  checkShader(ctx, shader)
+  _ = GetShaderOrError(shader)
   if buffer_length < 0 { glErrorInvalidValue() }
   writeString(buffer_length, string_length_written, info)
 }
@@ -954,8 +946,7 @@ cmd void glGetShaderSource(ShaderId shader,
                            GLsizei  buffer_length,
                            GLsizei* string_length_written,
                            GLchar*  source) {
-  ctx := GetContext()
-  checkShader(ctx, shader)
+  _ = GetShaderOrError(shader)
   if buffer_length < 0 { glErrorInvalidValue() }
   // TODO: Handle properly. Mind the null-terminator.
   writeString(buffer_length, string_length_written, source)
@@ -978,7 +969,7 @@ cmd void glGetShaderiv(ShaderId shader, GLenum parameter, GLint* value) {
   }
 
   ctx := GetContext()
-  checkShader(ctx, shader)
+  _ = GetShaderOrError(shader)
   s := ctx.Objects.Shared.Shaders[shader]
   value[0] = switch (parameter) {
     case GL_SHADER_TYPE:          as!GLint(s.Type)
@@ -1020,14 +1011,12 @@ cmd void glGetUniformIndices(ProgramId            program,
 @doc("https://www.khronos.org/opengles/sdk/docs/man31/html/glGetUniformLocation.xhtml", Version.GLES31)
 @doc("https://www.khronos.org/opengles/sdk/docs/man32/html/glGetUniformLocation.xhtml", Version.GLES32)
 cmd UniformLocation glGetUniformLocation(ProgramId program, string name) {
-  ctx := GetContext()
-  checkProgram(ctx, program)
+  _ = GetProgramOrError(program)
   return ?
 }
 
 sub void GetUniformv!T(ProgramId program, UniformLocation location, T values) {
-  ctx := GetContext()
-  checkProgram(ctx, program)
+  _ = GetProgramOrError(program)
   // TODO: Determine size based on uniform type.
   _ = program // TODO
   _ = location // TODO
@@ -1141,8 +1130,7 @@ cmd GLboolean glIsShader(ShaderId shader) {
 @doc("https://www.khronos.org/opengles/sdk/docs/man31/html/glLinkProgram.xhtml", Version.GLES31)
 @doc("https://www.khronos.org/opengles/sdk/docs/man32/html/glLinkProgram.xhtml", Version.GLES32)
 cmd void glLinkProgram(ProgramId program) {
-  ctx := GetContext()
-  checkProgram(ctx, program)
+  _ = GetProgramOrError(program)
 
   ApplyProgramInfoExtra(program, GetProgramInfoExtra(program))
 }
@@ -1233,7 +1221,7 @@ cmd void glProgramBinary(ProgramId   program,
 
 sub void ProgramBinary(ProgramId program, GLenum binaryFormat, const void* binary, GLsizei length) {
   ctx := GetContext()
-  checkProgram(ctx, program)
+  _ = GetProgramOrError(program)
   p := ctx.Objects.Shared.Programs[program]
   switch (binaryFormat) {
     case GL_Z400_BINARY_AMD: {
@@ -1276,7 +1264,7 @@ sub void ProgramUniformv!T(ProgramId       program,
                            UniformLocation location,
                            T               values,
                            GLenum          type) {
-  SetProgramUniform(program, location, as!u8[](values), type)
+  SetProgramUniform(GetProgramOrError(program), location, as!u8[](values), type)
 }
 
 @if(Version.GLES31)
@@ -1648,7 +1636,7 @@ sub void ProgramUniformMatrixv!T(ProgramId       program,
                                  T               values,
                                  GLenum          type) {
   _ = transpose // TODO: transpose values if the flag is set
-  SetProgramUniform(program, location, as!u8[](values), type)
+  SetProgramUniform(GetProgramOrError(program), location, as!u8[](values), type)
 }
 
 @if(Version.GLES31)
@@ -1840,7 +1828,7 @@ cmd void glShaderSource(ShaderId             shader,
 
   sources := source[0:count]
   ctx := GetContext()
-  checkShader(ctx, shader)
+  _ = GetShaderOrError(shader)
 
   s := ctx.Objects.Shared.Shaders[shader]
   s.Source = as!string(null)
@@ -1862,7 +1850,7 @@ cmd void glShaderSource(ShaderId             shader,
 
 sub void Uniformv!T(UniformLocation location, T values, GLenum type) {
   ctx := GetContext()
-  SetProgramUniform(ctx.BoundProgram, location, as!u8[](values), type)
+  SetProgramUniform(ctx.Bound.Program, location, as!u8[](values), type)
 }
 
 @if(Version.GLES20)
@@ -2134,7 +2122,7 @@ sub void UniformMatrixv!T(UniformLocation location,
                           GLenum          type) {
   _ = transpose // TODO: Transpose if the flag is set.
   ctx := GetContext()
-  SetProgramUniform(ctx.BoundProgram, location, as!u8[](values), type)
+  SetProgramUniform(ctx.Bound.Program, location, as!u8[](values), type)
 }
 
 @if(Version.GLES20)
@@ -2281,19 +2269,16 @@ cmd void glUseProgram(ProgramId program) {
 
   ctx := GetContext()
   if program != 0 {
-    checkProgram(ctx, program)
+    _ = GetProgramOrError(program)
+  }
+  p := ctx.Objects.Shared.Programs[program]
+
+  // Lazy delete. See glDeleteProgram.
+  if ctx.Bound.Program != p {
+    reapProgram(ctx.Bound.Program)
   }
 
-  // TODO: Remove the check once we have go aborts.
-  if (program == 0) || (program in ctx.Objects.Shared.Programs) {
-
-    // Lazy delete. See glDeleteProgram.
-    if (ctx.BoundProgram != program) {
-      reapProgram(ctx, ctx.BoundProgram)
-    }
-
-    ctx.BoundProgram = program
-  }
+  ctx.Bound.Program = p
 }
 
 @if(Version.GLES31)
@@ -2318,8 +2303,7 @@ cmd void glUseProgramStages(PipelineId pipeline, GLbitfield stages, ProgramId pr
 @doc("https://www.khronos.org/opengles/sdk/docs/man31/html/glValidateProgram.xhtml", Version.GLES31)
 @doc("https://www.khronos.org/opengles/sdk/docs/man32/html/glValidateProgram.xhtml", Version.GLES32)
 cmd void glValidateProgram(ProgramId program) {
-  ctx := GetContext()
-  checkProgram(ctx, program)
+  _ = GetProgramOrError(program)
 }
 
 @if(Version.GLES31)

--- a/gapis/gfxapi/gles/api/state_queries.api
+++ b/gapis/gfxapi/gles/api/state_queries.api
@@ -18,6 +18,13 @@ sub bool VersionGreaterOrEqual(ref!Context ctx, GLint major, GLint minor) {
   return (ctx.Constants.MajorVersion > major) || ((ctx.Constants.MajorVersion == major) && (ctx.Constants.MinorVersion >= minor))
 }
 
+sub ID GetID!(ID,OBJ)(ref!OBJ o) {
+  return switch o != null {
+    case true: as!ID(o.ID)
+    case false: as!ID(0)
+  }
+}
+
 @if(Version.GLES31)
 @doc("https://www.khronos.org/opengles/sdk/docs/man31/html/glGet.xhtml", Version.GLES31)
 @doc("https://www.khronos.org/opengles/sdk/docs/man32/html/glGet.xhtml", Version.GLES32)
@@ -215,20 +222,20 @@ sub void GetStateVariable!T(GLenum name, bool isIndexed, GLuint index, T* v) {
     }
     @if(Version.GLES20)
     case GL_ARRAY_BUFFER_BINDING: {
-      v[0] = as!T(ctx.BoundBuffers.ArrayBuffer)
+      v[0] = GetID!(T,Buffer)(ctx.Bound.ArrayBuffer)
     }
     @if(Version.GLES31)
     case GL_ATOMIC_COUNTER_BUFFER_BINDING: {
       if isIndexed {
-        v[0] = as!T(ctx.BoundBuffers.AtomicCounterBuffers[index].Binding)
+        v[0] = GetID!(T,Buffer)(ctx.Bound.AtomicCounterBuffers[index].Binding)
       } else {
-        v[0] = as!T(ctx.BoundBuffers.AtomicCounterBuffer)
+        v[0] = GetID!(T,Buffer)(ctx.Bound.AtomicCounterBuffer)
       }
     }
     @if(Version.GLES31)
     case GL_ATOMIC_COUNTER_BUFFER_SIZE: {
       if isIndexed {
-        v[0] = as!T(ctx.BoundBuffers.AtomicCounterBuffers[index].Size)
+        v[0] = as!T(ctx.Bound.AtomicCounterBuffers[index].Size)
       } else {
         glErrorInvalidEnum(name)
       }
@@ -236,7 +243,7 @@ sub void GetStateVariable!T(GLenum name, bool isIndexed, GLuint index, T* v) {
     @if(Version.GLES31)
     case GL_ATOMIC_COUNTER_BUFFER_START: {
       if isIndexed {
-        v[0] = as!T(ctx.BoundBuffers.AtomicCounterBuffers[index].Start)
+        v[0] = as!T(ctx.Bound.AtomicCounterBuffers[index].Start)
       } else {
         glErrorInvalidEnum(name)
       }
@@ -322,11 +329,11 @@ sub void GetStateVariable!T(GLenum name, bool isIndexed, GLuint index, T* v) {
     }
     @if(Version.GLES30)
     case GL_COPY_READ_BUFFER_BINDING: {
-      v[0] = as!T(ctx.BoundBuffers.CopyReadBuffer)
+      v[0] = GetID!(T,Buffer)(ctx.Bound.CopyReadBuffer)
     }
     @if(Version.GLES30)
     case GL_COPY_WRITE_BUFFER_BINDING: {
-      v[0] = as!T(ctx.BoundBuffers.CopyWriteBuffer)
+      v[0] = GetID!(T,Buffer)(ctx.Bound.CopyWriteBuffer)
     }
     @if(Version.GLES20)
     case GL_CULL_FACE: {
@@ -338,7 +345,7 @@ sub void GetStateVariable!T(GLenum name, bool isIndexed, GLuint index, T* v) {
     }
     @if(Version.GLES20)
     case GL_CURRENT_PROGRAM: {
-      v[0] = as!T(ctx.BoundProgram)
+      v[0] = GetID!(T,Program)(ctx.Bound.Program)
     }
     @if(Version.GLES32)
     case GL_DEBUG_GROUP_STACK_DEPTH: {
@@ -380,7 +387,7 @@ sub void GetStateVariable!T(GLenum name, bool isIndexed, GLuint index, T* v) {
     }
     @if(Version.GLES31)
     case GL_DISPATCH_INDIRECT_BUFFER_BINDING: {
-      v[0] = as!T(ctx.BoundBuffers.DispatchIndirectBuffer)
+      v[0] = GetID!(T,Buffer)(ctx.Bound.DispatchIndirectBuffer)
     }
     @if(Version.GLES20)
     case GL_DITHER: {
@@ -400,11 +407,11 @@ sub void GetStateVariable!T(GLenum name, bool isIndexed, GLuint index, T* v) {
     }
     @if(Version.GLES20)
     case GL_DRAW_FRAMEBUFFER_BINDING: {
-      v[0] = as!T(ctx.BoundDrawFramebuffer)
+      v[0] = GetID!(T,Framebuffer)(ctx.Bound.DrawFramebuffer)
     }
     @if(Version.GLES20)
     case GL_ELEMENT_ARRAY_BUFFER_BINDING: {
-      v[0] = as!T(ctx.Objects.VertexArrays[ctx.BoundVertexArray].ElementArrayBuffer)
+      v[0] = GetID!(T,Buffer)(ctx.Bound.VertexArray.ElementArrayBuffer)
     }
     @if(Version.GLES32)
     case GL_FRAGMENT_INTERPOLATION_OFFSET_BITS: {
@@ -1076,11 +1083,11 @@ sub void GetStateVariable!T(GLenum name, bool isIndexed, GLuint index, T* v) {
     }
     @if(Version.GLES30)
     case GL_PIXEL_PACK_BUFFER_BINDING: {
-      v[0] = as!T(ctx.BoundBuffers.PixelPackBuffer)
+      v[0] = GetID!(T,Buffer)(ctx.Bound.PixelPackBuffer)
     }
     @if(Version.GLES30)
     case GL_PIXEL_UNPACK_BUFFER_BINDING: {
-      v[0] = as!T(ctx.BoundBuffers.PixelUnpackBuffer)
+      v[0] = GetID!(T,Buffer)(ctx.Bound.PixelUnpackBuffer)
     }
     @if(Version.GLES20)
     case GL_POLYGON_OFFSET_FACTOR: {
@@ -1123,7 +1130,7 @@ sub void GetStateVariable!T(GLenum name, bool isIndexed, GLuint index, T* v) {
     }
     @if(Version.GLES30)
     case GL_READ_FRAMEBUFFER_BINDING: {
-      v[0] = as!T(ctx.BoundReadFramebuffer)
+      v[0] = GetID!(T,Framebuffer)(ctx.Bound.ReadFramebuffer)
     }
     @if(Version.GLES20)
     case GL_RED_BITS: {
@@ -1131,7 +1138,7 @@ sub void GetStateVariable!T(GLenum name, bool isIndexed, GLuint index, T* v) {
     }
     @if(Version.GLES20)
     case GL_RENDERBUFFER_BINDING: {
-      v[0] = as!T(ctx.BoundRenderbuffer)
+      v[0] = GetID!(T,Renderbuffer)(ctx.Bound.Renderbuffer)
     }
     @if(Version.GLES32 || Extension.GL_EXT_robustness)
     case GL_RESET_NOTIFICATION_STRATEGY: {
@@ -1195,9 +1202,9 @@ sub void GetStateVariable!T(GLenum name, bool isIndexed, GLuint index, T* v) {
     @if(Version.GLES31)
     case GL_SHADER_STORAGE_BUFFER_BINDING: {
       if isIndexed {
-        v[0] = as!T(ctx.BoundBuffers.ShaderStorageBuffers[index].Binding)
+        v[0] = GetID!(T,Buffer)(ctx.Bound.ShaderStorageBuffers[index].Binding)
       } else {
-        v[0] = as!T(ctx.BoundBuffers.ShaderStorageBuffer)
+        v[0] = GetID!(T,Buffer)(ctx.Bound.ShaderStorageBuffer)
       }
     }
     @if(Version.GLES31)
@@ -1207,7 +1214,7 @@ sub void GetStateVariable!T(GLenum name, bool isIndexed, GLuint index, T* v) {
     @if(Version.GLES31)
     case GL_SHADER_STORAGE_BUFFER_SIZE: {
       if isIndexed {
-        v[0] = as!T(ctx.BoundBuffers.ShaderStorageBuffers[index].Size)
+        v[0] = as!T(ctx.Bound.ShaderStorageBuffers[index].Size)
       } else {
         glErrorInvalidEnum(name)
       }
@@ -1215,7 +1222,7 @@ sub void GetStateVariable!T(GLenum name, bool isIndexed, GLuint index, T* v) {
     @if(Version.GLES31)
     case GL_SHADER_STORAGE_BUFFER_START: {
       if isIndexed {
-        v[0] = as!T(ctx.BoundBuffers.ShaderStorageBuffers[index].Start)
+        v[0] = as!T(ctx.Bound.ShaderStorageBuffers[index].Start)
       } else {
         glErrorInvalidEnum(name)
       }
@@ -1294,39 +1301,39 @@ sub void GetStateVariable!T(GLenum name, bool isIndexed, GLuint index, T* v) {
     }
     @if(Version.GLES20)
     case GL_TEXTURE_BINDING_2D: {
-      v[0] = as!T(ctx.TextureUnits[ctx.ActiveTextureUnit].Binding2d)
+      v[0] = GetID!(T,Texture)(ctx.TextureUnits[ctx.ActiveTextureUnit].Binding2d)
     }
     @if(Version.GLES20)
     case GL_TEXTURE_BINDING_EXTERNAL_OES: {
-      v[0] = as!T(ctx.TextureUnits[ctx.ActiveTextureUnit].BindingExternalOes)
+      v[0] = GetID!(T,Texture)(ctx.TextureUnits[ctx.ActiveTextureUnit].BindingExternalOes)
     }
     @if(Version.GLES30)
     case GL_TEXTURE_BINDING_2D_ARRAY: {
-      v[0] = as!T(ctx.TextureUnits[ctx.ActiveTextureUnit].Binding2dArray)
+      v[0] = GetID!(T,Texture)(ctx.TextureUnits[ctx.ActiveTextureUnit].Binding2dArray)
     }
     @if(Version.GLES31)
     case GL_TEXTURE_BINDING_2D_MULTISAMPLE: {
-      v[0] = as!T(ctx.TextureUnits[ctx.ActiveTextureUnit].Binding2dMultisample)
+      v[0] = GetID!(T,Texture)(ctx.TextureUnits[ctx.ActiveTextureUnit].Binding2dMultisample)
     }
     @if(Version.GLES32)
     case GL_TEXTURE_BINDING_2D_MULTISAMPLE_ARRAY: {
-      v[0] = as!T(ctx.TextureUnits[ctx.ActiveTextureUnit].Binding2dMultisampleArray)
+      v[0] = GetID!(T,Texture)(ctx.TextureUnits[ctx.ActiveTextureUnit].Binding2dMultisampleArray)
     }
     @if(Version.GLES30)
     case GL_TEXTURE_BINDING_3D: {
-      v[0] = as!T(ctx.TextureUnits[ctx.ActiveTextureUnit].Binding3d)
+      v[0] = GetID!(T,Texture)(ctx.TextureUnits[ctx.ActiveTextureUnit].Binding3d)
     }
     @if(Version.GLES32)
     case GL_TEXTURE_BINDING_BUFFER: {
-      v[0] = as!T(ctx.TextureUnits[ctx.ActiveTextureUnit].BindingBuffer)
+      v[0] = GetID!(T,Texture)(ctx.TextureUnits[ctx.ActiveTextureUnit].BindingBuffer)
     }
     @if(Version.GLES20)
     case GL_TEXTURE_BINDING_CUBE_MAP: {
-      v[0] = as!T(ctx.TextureUnits[ctx.ActiveTextureUnit].BindingCubeMap)
+      v[0] = GetID!(T,Texture)(ctx.TextureUnits[ctx.ActiveTextureUnit].BindingCubeMap)
     }
     @if(Version.GLES32)
     case GL_TEXTURE_BINDING_CUBE_MAP_ARRAY: {
-      v[0] = as!T(ctx.TextureUnits[ctx.ActiveTextureUnit].BindingCubeMapArray)
+      v[0] = GetID!(T,Texture)(ctx.TextureUnits[ctx.ActiveTextureUnit].BindingCubeMapArray)
     }
     @if(Version.GLES32)
     case GL_TEXTURE_BUFFER_BINDING: {
@@ -1338,24 +1345,24 @@ sub void GetStateVariable!T(GLenum name, bool isIndexed, GLuint index, T* v) {
     }
     @if(Version.GLES30)
     case GL_TRANSFORM_FEEDBACK_ACTIVE: {
-      v[0] = as!T(GetBoundTransformFeedback().Active)
+      v[0] = as!T(ctx.Bound.TransformFeedback.Active)
     }
     @if(Version.GLES30)
     case GL_TRANSFORM_FEEDBACK_BINDING: {
-      v[0] = as!T(ctx.BoundTransformFeedback)
+      v[0] = GetID!(T,TransformFeedback)(ctx.Bound.TransformFeedback)
     }
     @if(Version.GLES30)
     case GL_TRANSFORM_FEEDBACK_BUFFER_BINDING: {
       if isIndexed {
-        v[0] = as!T(GetBoundTransformFeedback().Buffers[index].Binding)
+        v[0] = GetID!(T,Buffer)(ctx.Bound.TransformFeedback.Buffers[index].Binding)
       } else {
-        v[0] = as!T(ctx.BoundBuffers.TransformFeedbackBuffer)
+        v[0] = GetID!(T,Buffer)(ctx.Bound.TransformFeedbackBuffer)
       }
     }
     @if(Version.GLES30)
     case GL_TRANSFORM_FEEDBACK_BUFFER_SIZE: {
       if isIndexed {
-        v[0] = as!T(GetBoundTransformFeedback().Buffers[index].Size)
+        v[0] = as!T(ctx.Bound.TransformFeedback.Buffers[index].Size)
       } else {
         glErrorInvalidEnum(name)
       }
@@ -1363,21 +1370,21 @@ sub void GetStateVariable!T(GLenum name, bool isIndexed, GLuint index, T* v) {
     @if(Version.GLES30)
     case GL_TRANSFORM_FEEDBACK_BUFFER_START: {
       if isIndexed {
-        v[0] = as!T(GetBoundTransformFeedback().Buffers[index].Start)
+        v[0] = as!T(ctx.Bound.TransformFeedback.Buffers[index].Start)
       } else {
         glErrorInvalidEnum(name)
       }
     }
     @if(Version.GLES30)
     case GL_TRANSFORM_FEEDBACK_PAUSED: {
-      v[0] = as!T(GetBoundTransformFeedback().Paused)
+      v[0] = as!T(ctx.Bound.TransformFeedback.Paused)
     }
     @if(Version.GLES30)
     case GL_UNIFORM_BUFFER_BINDING: {
       if isIndexed {
-        v[0] = as!T(ctx.BoundBuffers.UniformBuffers[index].Binding)
+        v[0] = GetID!(T,Buffer)(ctx.Bound.UniformBuffers[index].Binding)
       } else {
-        v[0] = as!T(ctx.BoundBuffers.UniformBuffer)
+        v[0] = GetID!(T,Buffer)(ctx.Bound.UniformBuffer)
       }
     }
     @if(Version.GLES30)
@@ -1387,7 +1394,7 @@ sub void GetStateVariable!T(GLenum name, bool isIndexed, GLuint index, T* v) {
     @if(Version.GLES30)
     case GL_UNIFORM_BUFFER_SIZE: {
       if isIndexed {
-        v[0] = as!T(ctx.BoundBuffers.UniformBuffers[index].Size)
+        v[0] = as!T(ctx.Bound.UniformBuffers[index].Size)
       } else {
         glErrorInvalidEnum(name)
       }
@@ -1395,7 +1402,7 @@ sub void GetStateVariable!T(GLenum name, bool isIndexed, GLuint index, T* v) {
     @if(Version.GLES30)
     case GL_UNIFORM_BUFFER_START: {
       if isIndexed {
-        v[0] = as!T(ctx.BoundBuffers.UniformBuffers[index].Start)
+        v[0] = as!T(ctx.Bound.UniformBuffers[index].Start)
       } else {
         glErrorInvalidEnum(name)
       }
@@ -1426,13 +1433,13 @@ sub void GetStateVariable!T(GLenum name, bool isIndexed, GLuint index, T* v) {
     }
     @if(Version.GLES30)
     case GL_VERTEX_ARRAY_BINDING: {
-      v[0] = as!T(ctx.BoundVertexArray)
+      v[0] = GetID!(T,VertexArray)(ctx.Bound.VertexArray)
     }
     @if(Version.GLES31)
     case GL_VERTEX_BINDING_DIVISOR: {
       if isIndexed {
         i := as!VertexBufferBindingIndex(index)
-        v[0] = as!T(ctx.Objects.VertexArrays[ctx.BoundVertexArray].VertexBufferBindings[i].Divisor)
+        v[0] = as!T(ctx.Bound.VertexArray.VertexBufferBindings[i].Divisor)
       } else {
         glErrorInvalidEnum(name)
       }
@@ -1441,7 +1448,7 @@ sub void GetStateVariable!T(GLenum name, bool isIndexed, GLuint index, T* v) {
     case GL_VERTEX_BINDING_OFFSET: {
       if isIndexed {
         i := as!VertexBufferBindingIndex(index)
-        v[0] = as!T(ctx.Objects.VertexArrays[ctx.BoundVertexArray].VertexBufferBindings[i].Offset)
+        v[0] = as!T(ctx.Bound.VertexArray.VertexBufferBindings[i].Offset)
       } else {
         glErrorInvalidEnum(name)
       }
@@ -1450,7 +1457,7 @@ sub void GetStateVariable!T(GLenum name, bool isIndexed, GLuint index, T* v) {
     case GL_VERTEX_BINDING_STRIDE: {
       if isIndexed {
         i := as!VertexBufferBindingIndex(index)
-        v[0] = as!T(ctx.Objects.VertexArrays[ctx.BoundVertexArray].VertexBufferBindings[i].Stride)
+        v[0] = as!T(ctx.Bound.VertexArray.VertexBufferBindings[i].Stride)
       } else {
         glErrorInvalidEnum(name)
       }

--- a/gapis/gfxapi/gles/api/textures_and_samplers.api
+++ b/gapis/gfxapi/gles/api/textures_and_samplers.api
@@ -14,23 +14,42 @@
 
 @internal
 class TextureUnit {
+  TextureUnitId ID
+
   // Table 21.9: Textures (selector; state per texture unit)
-  TextureId         Binding2d                 = 0
-  TextureId         Binding3d                 = 0
-  TextureId         Binding2dArray            = 0
-  TextureId         BindingBuffer             = 0
-  TextureId         BindingCubeMap            = 0
-  TextureId         BindingCubeMapArray       = 0
-  TextureId         Binding2dMultisample      = 0
-  TextureId         Binding2dMultisampleArray = 0
-  TextureId         BindingExternalOes        = 0 // OES_EGL_image_external
+  ref!Texture       Binding2d                 = null
+  ref!Texture       Binding3d                 = null
+  ref!Texture       Binding2dArray            = null
+  ref!Texture       BindingBuffer             = null
+  ref!Texture       BindingCubeMap            = null
+  ref!Texture       BindingCubeMapArray       = null
+  ref!Texture       Binding2dMultisample      = null
+  ref!Texture       Binding2dMultisampleArray = null
+  ref!Texture       BindingExternalOes        = null // OES_EGL_image_external
   @unused SamplerId SamplerBinding            = 0
+}
+
+sub ref!TextureUnit NewTextureUnit(TextureUnitId id) {
+  ctx := GetContext()
+  return new!TextureUnit(
+    ID:                         id,
+    Binding2d:                  ctx.Objects.Default.Texture2d,
+    Binding3d:                  ctx.Objects.Default.Texture2dArray,
+    Binding2dArray:             ctx.Objects.Default.Texture2dMultisample,
+    BindingBuffer:              ctx.Objects.Default.Texture2dMultisampleArray,
+    BindingCubeMap:             ctx.Objects.Default.Texture3d,
+    BindingCubeMapArray:        ctx.Objects.Default.TextureBuffer,
+    Binding2dMultisample:       ctx.Objects.Default.TextureCubeMap,
+    Binding2dMultisampleArray:  ctx.Objects.Default.TextureCubeMapArray,
+    BindingExternalOes:         ctx.Objects.Default.TextureExternalOes,
+  )
 }
 
 @internal
 @resource
 class Texture {
   TextureId                 ID
+
   GLenum                    Kind
   map!(GLint, Level)        Levels
 
@@ -93,6 +112,8 @@ class Image {
 
 @internal
 class Sampler {
+  SamplerId ID
+
   // Table 21.12: Textures (state per sampler object)
   @unused Vec4f  BorderColor = Vec4f(0.0, 0.0, 0.0, 0.0)
   GLenum         MinFilter   = GL_NEAREST_MIPMAP_LINEAR
@@ -157,75 +178,47 @@ sub ref!Texture GetBoundTextureOrErrorInvalidEnum(GLenum target) {
 }
 
 sub ref!Texture GetBoundTextureForUnit(ref!Context ctx, GLenum unit, GLenum target) {
-  // TODO: Add back version checks.
   tu := ctx.TextureUnits[unit]
   return switch (target) {
     @if(Version.GLES20)
     case GL_TEXTURE_2D: {
-      switch (tu.Binding2d != 0) {
-        case true:  ctx.Objects.Shared.Textures[tu.Binding2d]
-        case false: ctx.Objects.DefaultTextures.Texture2d
-      }
+      tu.Binding2d
     }
     @if(Version.GLES20)
     case GL_TEXTURE_EXTERNAL_OES: {
-      switch (tu.BindingExternalOes != 0) {
-        case true:  ctx.Objects.Shared.Textures[tu.BindingExternalOes]
-        case false: ctx.Objects.DefaultTextures.TextureExternalOes
-      }
+      tu.BindingExternalOes
     }
     @if(Version.GLES30)
     case GL_TEXTURE_2D_ARRAY: {
-      switch (tu.Binding2dArray != 0) {
-        case true:  ctx.Objects.Shared.Textures[tu.Binding2dArray]
-        case false: ctx.Objects.DefaultTextures.Texture2dArray
-      }
+      tu.Binding2dArray
     }
     @if(Version.GLES31)
     case GL_TEXTURE_2D_MULTISAMPLE: {
-      switch (tu.Binding2dMultisample != 0) {
-        case true:  ctx.Objects.Shared.Textures[tu.Binding2dMultisample]
-        case false: ctx.Objects.DefaultTextures.Texture2dMultisample
-      }
+      tu.Binding2dMultisample
     }
     @if(Version.GLES32)
     case GL_TEXTURE_2D_MULTISAMPLE_ARRAY: {
-      switch (tu.Binding2dMultisampleArray != 0) {
-        case true:  ctx.Objects.Shared.Textures[tu.Binding2dMultisampleArray]
-        case false: ctx.Objects.DefaultTextures.Texture2dMultisampleArray
-      }
+      tu.Binding2dMultisampleArray
     }
     @if(Version.GLES30)
     case GL_TEXTURE_3D: {
-      switch (tu.Binding3d != 0) {
-        case true:  ctx.Objects.Shared.Textures[tu.Binding3d]
-        case false: ctx.Objects.DefaultTextures.Texture3d
-      }
+      tu.Binding3d
     }
     @if(Version.GLES32)
     case GL_TEXTURE_BUFFER: {
-      switch (tu.BindingBuffer != 0) {
-        case true:  ctx.Objects.Shared.Textures[tu.BindingBuffer]
-        case false: ctx.Objects.DefaultTextures.TextureBuffer
-      }
+      tu.BindingBuffer
     }
     @if(Version.GLES20)
     case GL_TEXTURE_CUBE_MAP, GL_TEXTURE_CUBE_MAP_POSITIVE_X, GL_TEXTURE_CUBE_MAP_POSITIVE_Y, GL_TEXTURE_CUBE_MAP_POSITIVE_Z, GL_TEXTURE_CUBE_MAP_NEGATIVE_X, GL_TEXTURE_CUBE_MAP_NEGATIVE_Y, GL_TEXTURE_CUBE_MAP_NEGATIVE_Z: {
-      switch (tu.BindingCubeMap != 0) {
-        case true:  ctx.Objects.Shared.Textures[tu.BindingCubeMap]
-        case false: ctx.Objects.DefaultTextures.TextureCubeMap
-      }
+      tu.BindingCubeMap
     }
     @if(Version.GLES32)
     case GL_TEXTURE_CUBE_MAP_ARRAY: {
-      switch (tu.BindingCubeMapArray != 0) {
-        case true:  ctx.Objects.Shared.Textures[tu.BindingCubeMapArray]
-        case false: ctx.Objects.DefaultTextures.TextureCubeMapArray
-      }
+      tu.BindingCubeMapArray
     }
     default: {
-      // glErrorInvalidEnum(target)
-      ctx.Objects.DefaultTextures.Texture2d
+      // TODO: glErrorInvalidEnum(target)
+      tu.Binding2d
     }
   }
 }
@@ -233,8 +226,9 @@ sub ref!Texture GetBoundTextureForUnit(ref!Context ctx, GLenum unit, GLenum targ
 @ignore_unreachables
 sub GLenum GetTextureTargetFromSamplerType(GLenum samplerType) {
 	return switch (samplerType) {
-	case GL_INT_SAMPLER_2D, GL_SAMPLER_2D, GL_UNSIGNED_INT_SAMPLER_2D, GL_SAMPLER_2D_SHADOW:
+	case GL_INT_SAMPLER_2D, GL_SAMPLER_2D, GL_UNSIGNED_INT_SAMPLER_2D, GL_SAMPLER_2D_SHADOW: {
 		GL_TEXTURE_2D
+  }
 	case GL_INT_SAMPLER_2D_ARRAY, GL_SAMPLER_2D_ARRAY, GL_UNSIGNED_INT_SAMPLER_2D_ARRAY, GL_SAMPLER_2D_ARRAY_SHADOW:
 		GL_TEXTURE_2D_ARRAY
 	case GL_INT_SAMPLER_2D_MULTISAMPLE, GL_SAMPLER_2D_MULTISAMPLE, GL_UNSIGNED_INT_SAMPLER_2D_MULTISAMPLE:
@@ -434,7 +428,7 @@ sub void TexImage(TexImageFlags  flags,
         UpdateImageData(img, xoffset, yoffset, width, height,
                         src_skip_images, data_format, data_type, data)
       } else if isCompressedTexImageCmd {
-        if (ctx.BoundBuffers.PixelUnpackBuffer == 0) && (data != null) {
+        if (ctx.Bound.PixelUnpackBuffer == null) && (data != null) {
           // TODO: Implement sub-range updates
           img.Data = clone(as!u8*(data)[0:data_size])
         }
@@ -477,7 +471,7 @@ sub void UpdateImageData(ref!Image      dst_image,
   dst_image.DataFormat = format
   dst_image.DataType = type
 
-  pbo := ctx.Objects.Shared.Buffers[ctx.BoundBuffers.PixelUnpackBuffer]
+  pbo := ctx.Bound.PixelUnpackBuffer
   copy_size := as!GLint(width) * pixel_size
   for y in (0 .. as!GLint(height)) {
     dst := dst_offset + (dst_row_size * y)
@@ -567,17 +561,11 @@ cmd void glBindSampler(GLuint index, SamplerId sampler) {
   ctx.TextureUnits[unit].SamplerBinding = sampler
 }
 
-@if(Version.GLES10)
-@doc("https://www.khronos.org/opengles/sdk/docs/man/xhtml/glBindTexture.xml", Version.GLES20)
-@doc("https://www.khronos.org/opengles/sdk/docs/man3/html/glBindTexture.xhtml", Version.GLES30)
-@doc("https://www.khronos.org/opengles/sdk/docs/man31/html/glBindTexture.xhtml", Version.GLES31)
-@doc("https://www.khronos.org/opengles/sdk/docs/man32/html/glBindTexture.xhtml", Version.GLES32)
-cmd void glBindTexture(GLenum target, TextureId texture) {
+sub ref!Texture GetOrCreateTexture(GLenum target, TextureId texture, ref!Texture defaultTexture) {
   ctx := GetContext()
-
-  // TODO: Do not initialize if the enum is not valid.
   if (texture != 0) {
-    if !(texture in ctx.Objects.Shared.Textures) {
+    // Create the texture if it does not exist already
+    if (ctx.Objects.Shared.Textures[texture] == null) {
       if target == GL_TEXTURE_EXTERNAL_OES {
         ctx.Objects.Shared.Textures[texture] = new!Texture(
           ID:         texture,
@@ -585,12 +573,11 @@ cmd void glBindTexture(GLenum target, TextureId texture) {
           WrapT:      GL_CLAMP_TO_EDGE,
           MinFilter:  GL_LINEAR)
       } else {
-        ctx.Objects.Shared.Textures[texture] = new!Texture(
-          ID: texture,
-        )
+        ctx.Objects.Shared.Textures[texture] = new!Texture(ID: texture)
       }
     }
 
+    // Set or check the kind of the texture
     t := ctx.Objects.Shared.Textures[texture]
     if t.Kind == as!GLenum(0) {
       t.Kind = target
@@ -598,44 +585,53 @@ cmd void glBindTexture(GLenum target, TextureId texture) {
       if t.Kind != target { glErrorInvalidOperation() }
     }
   }
+  return Select!ref!Texture(texture != 0, ctx.Objects.Shared.Textures[texture], defaultTexture)
+}
 
+@if(Version.GLES10)
+@doc("https://www.khronos.org/opengles/sdk/docs/man/xhtml/glBindTexture.xml", Version.GLES20)
+@doc("https://www.khronos.org/opengles/sdk/docs/man3/html/glBindTexture.xhtml", Version.GLES30)
+@doc("https://www.khronos.org/opengles/sdk/docs/man31/html/glBindTexture.xhtml", Version.GLES31)
+@doc("https://www.khronos.org/opengles/sdk/docs/man32/html/glBindTexture.xhtml", Version.GLES32)
+cmd void glBindTexture(GLenum target, TextureId texture) {
+  ctx := GetContext()
   tu := ctx.TextureUnits[ctx.ActiveTextureUnit]
   switch (target) {
     @if(Version.GLES20)
     case GL_TEXTURE_2D: {
-      tu.Binding2d = texture
+      tu.Binding2d = GetOrCreateTexture(target, texture, ctx.Objects.Default.Texture2d)
     }
     @if(Version.GLES20)
     case GL_TEXTURE_EXTERNAL_OES: {
-      tu.BindingExternalOes = texture
+      tu.BindingExternalOes = GetOrCreateTexture(target, texture, ctx.Objects.Default.TextureExternalOes)
     }
     @if(Version.GLES30)
     case GL_TEXTURE_2D_ARRAY: {
-      tu.Binding2dArray = texture
+      tu.Binding2dArray = GetOrCreateTexture(target, texture, ctx.Objects.Default.Texture2dArray)
     }
     @if(Version.GLES31)
     case GL_TEXTURE_2D_MULTISAMPLE: {
-      tu.Binding2dMultisample = texture
+      tu.Binding2dMultisample = GetOrCreateTexture(target, texture, ctx.Objects.Default.Texture2dMultisample)
     }
     @if(Version.GLES32)
     case GL_TEXTURE_2D_MULTISAMPLE_ARRAY: {
-      tu.Binding2dMultisampleArray = texture
+      tu.Binding2dMultisampleArray = GetOrCreateTexture(target, texture, ctx.Objects.Default.Texture2dMultisampleArray)
     }
     @if(Version.GLES30)
     case GL_TEXTURE_3D: {
-      tu.Binding3d = texture
+      tu.Binding3d = GetOrCreateTexture(target, texture, ctx.Objects.Default.Texture3d)
     }
     @if(Version.GLES32)
     case GL_TEXTURE_BUFFER: {
-      tu.BindingBuffer = texture
+      tu.BindingBuffer = GetOrCreateTexture(target, texture, ctx.Objects.Default.TextureBuffer)
     }
     @if(Version.GLES20)
     case GL_TEXTURE_CUBE_MAP: {
-      tu.BindingCubeMap = texture
+      tu.BindingCubeMap = GetOrCreateTexture(target, texture, ctx.Objects.Default.TextureCubeMap)
     }
     @if(Version.GLES32)
     case GL_TEXTURE_CUBE_MAP_ARRAY: {
-      tu.BindingCubeMapArray = texture
+      tu.BindingCubeMapArray = GetOrCreateTexture(target, texture, ctx.Objects.Default.TextureCubeMapArray)
     }
     default: {
       glErrorInvalidEnum(target)
@@ -895,7 +891,7 @@ cmd void glGenSamplers(GLsizei count, SamplerId* samplers) {
   ctx := GetContext()
   for i in (0 .. count) {
     id := as!SamplerId(?)
-    ctx.Objects.Shared.Samplers[id] = new!Sampler()
+    ctx.Objects.Shared.Samplers[id] = new!Sampler(ID: id)
     s[i] = id
   }
 }

--- a/gapis/gfxapi/gles/api/transform_feedback.api
+++ b/gapis/gfxapi/gles/api/transform_feedback.api
@@ -14,16 +14,13 @@
 
 @internal
 class TransformFeedback {
+  TransformFeedbackId ID
+
   // Table 21.35: Transform Feedback State
   map!(GLuint, BufferBinding) Buffers
   GLboolean                   Paused  = GL_FALSE
   GLboolean                   Active  = GL_FALSE
   @unused string              Label
-}
-
-sub ref!TransformFeedback GetBoundTransformFeedback() {
-  ctx := GetContext()
-  return ctx.Objects.TransformFeedbacks[ctx.BoundTransformFeedback]
 }
 
 @if(Version.GLES30)
@@ -39,7 +36,8 @@ cmd void glBeginTransformFeedback(GLenum primitiveMode) {
       glErrorInvalidEnum(primitiveMode)
     }
   }
-  GetBoundTransformFeedback().Active = 1
+  ctx := GetContext()
+  ctx.Bound.TransformFeedback.Active = 1
 }
 
 @if(Version.GLES30)
@@ -47,19 +45,24 @@ cmd void glBeginTransformFeedback(GLenum primitiveMode) {
 @doc("https://www.khronos.org/opengles/sdk/docs/man31/html/glBindTransformFeedback.xhtml", Version.GLES31)
 @doc("https://www.khronos.org/opengles/sdk/docs/man32/html/glBindTransformFeedback.xhtml", Version.GLES32)
 cmd void glBindTransformFeedback(GLenum target, TransformFeedbackId id) {
+  ctx := GetContext()
   switch (target) {
     case GL_TRANSFORM_FEEDBACK: {
       // version 3.0
+      ctx.Bound.TransformFeedback = GetOrCreateTransformFeedback(id)
     }
     default: {
       glErrorInvalidEnum(target)
     }
   }
+}
+
+sub ref!TransformFeedback GetOrCreateTransformFeedback(TransformFeedbackId id) {
   ctx := GetContext()
-  if !(id in ctx.Objects.TransformFeedbacks) {
-    ctx.Objects.TransformFeedbacks[id] = new!TransformFeedback()
+  if (id != 0) && (ctx.Objects.TransformFeedbacks[id] == null) {
+    ctx.Objects.TransformFeedbacks[id] = new!TransformFeedback(ID: id)
   }
-  ctx.BoundTransformFeedback = id
+  return ctx.Objects.TransformFeedbacks[id]
 }
 
 @if(Version.GLES30)
@@ -82,8 +85,9 @@ cmd void glDeleteTransformFeedbacks(GLsizei n, const TransformFeedbackId* ids) {
 @doc("https://www.khronos.org/opengles/sdk/docs/man31/html/glBeginTransformFeedback.xhtml", Version.GLES31)
 @doc("https://www.khronos.org/opengles/sdk/docs/man32/html/glBeginTransformFeedback.xhtml", Version.GLES32)
 cmd void glEndTransformFeedback() {
-  GetBoundTransformFeedback().Paused = 0
-  GetBoundTransformFeedback().Active = 0
+  ctx := GetContext()
+  ctx.Bound.TransformFeedback.Paused = 0
+  ctx.Bound.TransformFeedback.Active = 0
 }
 
 @if(Version.GLES30)
@@ -95,7 +99,7 @@ cmd void glGenTransformFeedbacks(GLsizei n, TransformFeedbackId* ids) {
   ctx := GetContext()
   for i in (0 .. n) {
     id := as!TransformFeedbackId(?)
-    ctx.Objects.TransformFeedbacks[id] = new!TransformFeedback()
+    ctx.Objects.TransformFeedbacks[id] = new!TransformFeedback(ID: id)
     tfs[i] = id
   }
 }
@@ -131,7 +135,8 @@ cmd GLboolean glIsTransformFeedback(TransformFeedbackId id) {
 @doc("https://www.khronos.org/opengles/sdk/docs/man31/html/glPauseTransformFeedback.xhtml", Version.GLES31)
 @doc("https://www.khronos.org/opengles/sdk/docs/man32/html/glPauseTransformFeedback.xhtml", Version.GLES32)
 cmd void glPauseTransformFeedback() {
-  GetBoundTransformFeedback().Paused = 1
+  ctx := GetContext()
+  ctx.Bound.TransformFeedback.Paused = 1
 }
 
 @if(Version.GLES30)
@@ -139,7 +144,8 @@ cmd void glPauseTransformFeedback() {
 @doc("https://www.khronos.org/opengles/sdk/docs/man31/html/glResumeTransformFeedback.xhtml", Version.GLES31)
 @doc("https://www.khronos.org/opengles/sdk/docs/man32/html/glResumeTransformFeedback.xhtml", Version.GLES32)
 cmd void glResumeTransformFeedback() {
-  GetBoundTransformFeedback().Paused = 0
+  ctx := GetContext()
+  ctx.Bound.TransformFeedback.Paused = 0
 }
 
 @if(Version.GLES30)

--- a/gapis/gfxapi/gles/api/vertex_arrays.api
+++ b/gapis/gfxapi/gles/api/vertex_arrays.api
@@ -17,11 +17,13 @@ type GLuint VertexBufferBindingIndex
 // Vertex Array Object (VAO)
 @internal
 class VertexArray {
+  VertexArrayId ID
+
   map!(VertexBufferBindingIndex, ref!VertexBufferBinding) VertexBufferBindings
   map!(AttributeLocation, ref!VertexAttributeArray)       VertexAttributeArrays
 
   // Table 21.3: Vertex Array Object State
-  BufferId       ElementArrayBuffer = 0
+  ref!Buffer     ElementArrayBuffer
   @unused string Label
 }
 
@@ -58,8 +60,22 @@ class VertexAttributeValue {
   @unused u8[] Value // Used if VertexAttributeArray is disabled.
 }
 
-sub ref!VertexArray NewVertexArray(ref!Context ctx) {
-  array := new!VertexArray()
+sub bool IsDefaultVertexArrayBound() {
+  ctx := GetContext()
+  return ctx.Bound.VertexArray.ID == 0
+}
+
+sub ref!VertexArray GetOrCreateVertexArray(VertexArrayId id) {
+  ctx := GetContext()
+  if (id != 0) && (ctx.Objects.VertexArrays[id] == null) {
+    ctx.Objects.VertexArrays[id] = NewVertexArray(id)
+  }
+  return ctx.Objects.VertexArrays[id]
+}
+
+sub ref!VertexArray NewVertexArray(VertexArrayId id) {
+  ctx := GetContext()
+  array := new!VertexArray(ID: id)
   if VersionGreaterOrEqual(ctx, 3, 1) {
     for i in 0 .. as!VertexBufferBindingIndex(ctx.Constants.MaxVertexAttribBindings) {
       array.VertexBufferBindings[i] = new!VertexBufferBinding()
@@ -77,7 +93,7 @@ sub ref!VertexArray NewVertexArray(ref!Context ctx) {
 
 // Logic shared by glGetVertexAttrib* commands.
 sub u64 GetVertexAttrib(ref!Context ctx, AttributeLocation index, GLenum pname) {
-  vao := ctx.Objects.VertexArrays[ctx.BoundVertexArray]
+  vao := ctx.Bound.VertexArray
   array := vao.VertexAttributeArrays[index]
   // TODO: Uncomment all the version checks
   return switch (pname) {
@@ -124,13 +140,13 @@ sub GLint VertexAttribTypeSize(GLenum type) {
 sub void ReadVertexArrays(ref!Context ctx, u32 first_index, u32 index_count, u32 instance_count) {
   if (index_count > 0) && (instance_count > 0) {
     // Only the default vertex array can contain client data pointer.
-    if ctx.BoundVertexArray == 0 {
+    if IsDefaultVertexArrayBound() {
       vao := ctx.Objects.VertexArrays[0]
       for i in (0 .. as!AttributeLocation(ctx.Constants.MaxVertexAttribs)) {
         arr := vao.VertexAttributeArrays[i]
         if arr.Enabled == GL_TRUE {
           binding := vao.VertexBufferBindings[arr.Binding]
-          if (binding.Buffer == 0) && (arr.Pointer != null) {
+          if (binding.Buffer == null) && (arr.Pointer != null) {
             stride := binding.Stride
             size := VertexAttribTypeSize(arr.Type) * arr.Size
             divisor := as!u32(binding.Divisor)
@@ -165,11 +181,7 @@ cmd void glBindVertexArray(VertexArrayId array) {
 
 sub void BindVertexArray(VertexArrayId array) {
   ctx := GetContext()
-  // TODO: if !((array == 0) || (array in ctx.UsedNames.VertexArrays)) { glErrorInvalidOperation() }
-  if !(array in ctx.Objects.VertexArrays) {
-    ctx.Objects.VertexArrays[array] = NewVertexArray(ctx)
-  }
-  ctx.BoundVertexArray = array
+  ctx.Bound.VertexArray = GetOrCreateVertexArray(array)
 }
 
 sub void BindVertexBuffer(ref!Context ctx, VertexBufferBindingIndex binding_index, BufferId buffer, GLintptr offset, GLsizei stride) {
@@ -186,13 +198,8 @@ sub void BindVertexBuffer(ref!Context ctx, VertexBufferBindingIndex binding_inde
           as!s64(stride), as!s64(ctx.Constants.MaxVertexAttribStride)))
     }
   }
-  // TODO: if !((buffer == 0) || (buffer in ctx.UsedNames.Buffers)) { glErrorInvalidOperation() } // SPEC: html is different
-  if buffer != 0 {
-    if !(buffer in ctx.Objects.Shared.Buffers) {
-      ctx.Objects.Shared.Buffers[buffer] = new!Buffer()
-    }
-  }
-  vao := ctx.Objects.VertexArrays[ctx.BoundVertexArray]
+  _ = GetOrCreateBuffer(buffer)
+  vao := ctx.Bound.VertexArray
   binding := vao.VertexBufferBindings[binding_index]
   binding.Buffer = buffer
   binding.Offset = offset
@@ -204,7 +211,7 @@ sub void BindVertexBuffer(ref!Context ctx, VertexBufferBindingIndex binding_inde
 @doc("https://www.khronos.org/opengles/sdk/docs/man32/html/glBindVertexBuffer.xhtml", Version.GLES32)
 cmd void glBindVertexBuffer(VertexBufferBindingIndex binding_index, BufferId buffer, GLintptr offset, GLsizei stride) {
   ctx := GetContext()
-  if ctx.BoundVertexArray == 0 { glErrorInvalidOperation() }
+  if IsDefaultVertexArrayBound() { glErrorInvalidOperation() }
   BindVertexBuffer(ctx, binding_index, buffer, offset, stride)
 }
 
@@ -224,11 +231,10 @@ sub void DeleteVertexArrays(GLsizei count, const VertexArrayId* arrays) {
     id := a[i]
     // Silently ignore invalid ids
     if id != 0 {
-      // TODO: ctx.UsedNames.VertexArrays[id] = false
       if id in ctx.Objects.VertexArrays {
         delete(ctx.Objects.VertexArrays, id)
-        if ctx.BoundVertexArray == id {
-          ctx.BoundVertexArray = 0
+        if ctx.Bound.VertexArray.ID == id {
+          ctx.Bound.VertexArray = ctx.Objects.Default.VertexArray
         }
       }
     }
@@ -243,7 +249,7 @@ sub void DeleteVertexArrays(GLsizei count, const VertexArrayId* arrays) {
 cmd void glDisableVertexAttribArray(AttributeLocation location) {
   ctx := GetContext()
   if location >= as!AttributeLocation(ctx.Constants.MaxVertexAttribs) { glErrorInvalidValue() }
-  vao := ctx.Objects.VertexArrays[ctx.BoundVertexArray]
+  vao := ctx.Bound.VertexArray
   vao.VertexAttributeArrays[location].Enabled = GL_FALSE
 }
 
@@ -255,7 +261,7 @@ cmd void glDisableVertexAttribArray(AttributeLocation location) {
 cmd void glEnableVertexAttribArray(AttributeLocation location) {
   ctx := GetContext()
   if location >= as!AttributeLocation(ctx.Constants.MaxVertexAttribs) { glErrorInvalidValue() }
-  vao := ctx.Objects.VertexArrays[ctx.BoundVertexArray]
+  vao := ctx.Bound.VertexArray
   vao.VertexAttributeArrays[location].Enabled = GL_TRUE
 }
 
@@ -319,7 +325,7 @@ cmd void glGetVertexAttribPointerv(AttributeLocation index, GLenum pname, void**
   ctx := GetContext()
   if index >= as!AttributeLocation(ctx.Constants.MaxVertexAttribs) { glErrorInvalidValue() }
   if pname != GL_VERTEX_ATTRIB_ARRAY_POINTER { glErrorInvalidEnum(pname) }
-  vao := ctx.Objects.VertexArrays[ctx.BoundVertexArray]
+  vao := ctx.Bound.VertexArray
   pointer[0] = as!void*(vao.VertexAttributeArrays[index].Pointer)
 }
 
@@ -480,7 +486,7 @@ sub void VertexAttribBinding(ref!Context ctx, AttributeLocation index, VertexBuf
   }
   // NB: Some callers may use the default VertexArray and some may not.
   //     Therefore the caller should do the check if it is needed.
-  vao := ctx.Objects.VertexArrays[ctx.BoundVertexArray]
+  vao := ctx.Bound.VertexArray
   vao.VertexAttributeArrays[index].Binding = binding_index
 }
 
@@ -489,7 +495,7 @@ sub void VertexAttribBinding(ref!Context ctx, AttributeLocation index, VertexBuf
 @doc("https://www.khronos.org/opengles/sdk/docs/man32/html/glVertexAttribBinding.xhtml", Version.GLES32)
 cmd void glVertexAttribBinding(AttributeLocation index, VertexBufferBindingIndex binding_index) {
   ctx := GetContext()
-  if ctx.BoundVertexArray == 0 { glErrorInvalidOperation() }
+  if IsDefaultVertexArrayBound() { glErrorInvalidOperation() }
   VertexAttribBinding(ctx, index, binding_index)
 }
 
@@ -505,7 +511,7 @@ sub void VertexAttribDivisor(AttributeLocation index, GLuint divisor) {
   ctx := GetContext()
   binding_index := as!VertexBufferBindingIndex(index)
   VertexAttribBinding(ctx, index, binding_index)
-  vao := ctx.Objects.VertexArrays[ctx.BoundVertexArray]
+  vao := ctx.Bound.VertexArray
   vao.VertexBufferBindings[binding_index].Divisor = divisor
 }
 
@@ -556,7 +562,7 @@ sub void VertexAttribFormat(ref!Context       ctx,
   if VersionGreaterOrEqual(ctx, 3, 1) {
     if relativeOffset > as!GLuint(ctx.Constants.MaxVertexAttribRelativeOffset) { glErrorInvalidValue() }
   }
-  vao := ctx.Objects.VertexArrays[ctx.BoundVertexArray]
+  vao := ctx.Bound.VertexArray
   format := vao.VertexAttributeArrays[index]
   format.Size = size
   format.Type = type
@@ -576,7 +582,7 @@ cmd void glVertexAttribFormat(AttributeLocation index,
                               GLboolean         normalized,
                               GLuint            relativeoffset) {
   ctx := GetContext()
-  if ctx.BoundVertexArray == 0 { glErrorInvalidOperation() }
+  if IsDefaultVertexArrayBound() { glErrorInvalidOperation() }
   VertexAttribFormat(ctx, index, size, type, normalized, relativeoffset, false)
 }
 
@@ -629,7 +635,7 @@ cmd void glVertexAttribI4uiv(AttributeLocation index, const GLuint* values) {
 @doc("https://www.khronos.org/opengles/sdk/docs/man32/html/glVertexAttribFormat.xhtml", Version.GLES32)
 cmd void glVertexAttribIFormat(AttributeLocation index, GLint size, GLenum type, GLuint relativeoffset) {
   ctx := GetContext()
-  if ctx.BoundVertexArray == 0 { glErrorInvalidOperation() }
+  if IsDefaultVertexArrayBound() { glErrorInvalidOperation() }
   VertexAttribFormat(ctx, index, size, type, as!GLboolean(0), relativeoffset, true)
 }
 
@@ -641,9 +647,9 @@ sub void VertexAttribPointer(ref!Context       ctx,
                              GLsizei           stride,
                              VertexPointer     pointer,
                              bool              integer) {
-  boundArrayBuffer := ctx.BoundBuffers.ArrayBuffer
+  boundArrayBuffer := ctx.Bound.ArrayBuffer
   // Do not allow use of client's memory for non-default vertex array.
-  if (ctx.BoundVertexArray != 0) && (boundArrayBuffer == 0) && (pointer != null) { glErrorInvalidOperation() }
+  if !IsDefaultVertexArrayBound() && (boundArrayBuffer == null) && (pointer != null) { glErrorInvalidOperation() }
   VertexAttribFormat(ctx, index, size, type, normalized, 0, integer)
   binding_index := as!VertexBufferBindingIndex(index)
   VertexAttribBinding(ctx, index, binding_index)
@@ -652,10 +658,10 @@ sub void VertexAttribPointer(ref!Context       ctx,
     case true:  stride
     case false: as!GLsizei(vertexTypeSize * size)
   }
-  vao := ctx.Objects.VertexArrays[ctx.BoundVertexArray]
+  vao := ctx.Bound.VertexArray
   vao.VertexAttributeArrays[index].Stride = stride
   vao.VertexAttributeArrays[index].Pointer = pointer
-  if (ctx.BoundVertexArray == 0) && (boundArrayBuffer == 0) {
+  if IsDefaultVertexArrayBound() && (boundArrayBuffer == null) {
     // Use client's memory as data buffer - this is the only way to set it.
     BindVertexBuffer(ctx, binding_index, 0, 0, effectiveStride)
   } else {
@@ -663,7 +669,8 @@ sub void VertexAttribPointer(ref!Context       ctx,
     // although it is possible to clear the buffer later while keeping pointer set.
     // I wonder how drivers handle it.  We just ignore non-default vertex arrays.
     offset := as!GLintptr(as!u64(pointer))
-    BindVertexBuffer(ctx, binding_index, boundArrayBuffer, offset, effectiveStride)
+    boundArrayBufferId := GetID!(BufferId,Buffer)(boundArrayBuffer)
+    BindVertexBuffer(ctx, binding_index, boundArrayBufferId, offset, effectiveStride)
   }
 }
 
@@ -701,7 +708,7 @@ cmd void glVertexAttribPointer(AttributeLocation location,
 cmd void glVertexBindingDivisor(VertexBufferBindingIndex binding_index, GLuint divisor) {
   ctx := GetContext()
   if binding_index >= as!VertexBufferBindingIndex(ctx.Constants.MaxVertexAttribBindings) { glErrorInvalidValue() }
-  if ctx.BoundVertexArray == 0 { glErrorInvalidOperation() }
-  vao := ctx.Objects.VertexArrays[ctx.BoundVertexArray]
+  if IsDefaultVertexArrayBound() { glErrorInvalidOperation() }
+  vao := ctx.Bound.VertexArray
   vao.VertexBufferBindings[binding_index].Divisor = divisor
 }

--- a/gapis/gfxapi/gles/compat_test.go
+++ b/gapis/gfxapi/gles/compat_test.go
@@ -195,7 +195,7 @@ func TestGlVertexAttribPointerCompatTest(t *testing.T) {
 		}
 		if _, ok := a.(*gles.GlDrawElements); ok {
 			ctx := gles.GetContext(s)
-			vao := ctx.Objects.VertexArrays[ctx.BoundVertexArray]
+			vao := ctx.Bound.VertexArray
 			array := vao.VertexAttributeArrays[0]
 			binding := vao.VertexBufferBindings[array.Binding]
 			if binding.Buffer != 0 && array.Pointer.Address() == 0 {

--- a/gapis/gfxapi/gles/custom_replay.go
+++ b/gapis/gfxapi/gles/custom_replay.go
@@ -84,7 +84,7 @@ func (i TextureId) remap(a atom.Atom, s *gfxapi.State) (key interface{}, remap b
 
 func (i UniformBlockId) remap(a atom.Atom, s *gfxapi.State) (key interface{}, remap bool) {
 	ctx := GetContext(s)
-	program := ctx.BoundProgram
+	program := ctx.Bound.Program.GetID()
 	switch a := a.(type) {
 	case *GlGetActiveUniformBlockName:
 		program = a.Program
@@ -155,7 +155,7 @@ func (i TransformFeedbackId) remap(a atom.Atom, s *gfxapi.State) (key interface{
 
 func (i UniformLocation) remap(a atom.Atom, s *gfxapi.State) (key interface{}, remap bool) {
 	ctx := GetContext(s)
-	program := ctx.BoundProgram
+	program := ctx.Bound.Program.GetID()
 	switch a := a.(type) {
 	case *GlGetActiveUniform:
 		program = a.Program
@@ -210,7 +210,7 @@ func remapImageId(name GLuint, target GLenum, s *gfxapi.State) (key interface{},
 
 func (i IndicesPointer) value(b *builder.Builder, a atom.Atom, s *gfxapi.State) value.Value {
 	c := GetContext(s)
-	if c.Objects.VertexArrays[c.BoundVertexArray].ElementArrayBuffer != 0 {
+	if c.Bound.VertexArray.ElementArrayBuffer != nil {
 		return value.AbsolutePointer(i.addr)
 	} else {
 		return value.ObservedPointer(i.addr)
@@ -218,7 +218,8 @@ func (i IndicesPointer) value(b *builder.Builder, a atom.Atom, s *gfxapi.State) 
 }
 
 func (i VertexPointer) value(b *builder.Builder, a atom.Atom, s *gfxapi.State) value.Value {
-	if GetContext(s).BoundBuffers.ArrayBuffer != 0 {
+	c := GetContext(s)
+	if c.Bound.ArrayBuffer != nil {
 		return value.AbsolutePointer(i.addr)
 	} else {
 		return value.ObservedPointer(i.addr)
@@ -226,7 +227,7 @@ func (i VertexPointer) value(b *builder.Builder, a atom.Atom, s *gfxapi.State) v
 }
 
 func (i TexturePointer) value(b *builder.Builder, a atom.Atom, s *gfxapi.State) value.Value {
-	if i.addr == 0 || GetContext(s).BoundBuffers.PixelUnpackBuffer != 0 {
+	if i.addr == 0 || GetContext(s).Bound.PixelUnpackBuffer != nil {
 		return value.AbsolutePointer(i.addr)
 	} else {
 		return value.ObservedPointer(i.addr)

--- a/gapis/gfxapi/gles/draw_call.go
+++ b/gapis/gfxapi/gles/draw_call.go
@@ -54,19 +54,15 @@ func (a *GlDrawElements) getIndices(
 		GLenum_GL_UNSIGNED_SHORT: 2,
 		GLenum_GL_UNSIGNED_INT:   4,
 	}[a.IndicesType]
-	indexBufferID := c.Objects.VertexArrays[c.BoundVertexArray].ElementArrayBuffer
+	indexBuffer := c.Bound.VertexArray.ElementArrayBuffer
 	size := uint64(a.IndicesCount) * indexSize
 
 	var reader binary.Reader
-	if indexBufferID == 0 {
+	if indexBuffer == nil {
 		// Get the index buffer data from pointer
 		reader = a.Indices.Slice(0, size, s.MemoryLayout).Reader(ctx, s)
 	} else {
 		// Get the index buffer data from buffer, offset by the 'indices' pointer.
-		indexBuffer := c.Objects.Shared.Buffers[indexBufferID]
-		if indexBuffer == nil {
-			return nil, 0, fmt.Errorf("Can not find buffer %v", indexBufferID)
-		}
 		offset := a.Indices.addr
 		reader = indexBuffer.Data.Slice(offset, offset+size, s.MemoryLayout).Reader(ctx, s)
 	}

--- a/gapis/gfxapi/gles/draw_call_mesh.go
+++ b/gapis/gfxapi/gles/draw_call_mesh.go
@@ -72,13 +72,13 @@ func drawCallMesh(ctx context.Context, dc drawCall, p *path.Mesh) (*gfxapi.Mesh,
 		return nil, &service.ErrDataUnavailable{Reason: messages.ErrMeshHasNoVertices()}
 	}
 
-	program, found := c.Objects.Shared.Programs[c.BoundProgram]
-	if !found {
+	program := c.Bound.Program
+	if program == nil {
 		return nil, &service.ErrDataUnavailable{Reason: messages.ErrNoProgramBound()}
 	}
 
 	vb := &vertex.Buffer{}
-	va := c.Objects.VertexArrays[c.BoundVertexArray]
+	va := c.Bound.VertexArray
 	for _, attr := range program.ActiveAttributes {
 		vaa := va.VertexAttributeArrays[attr.Location]
 		if vaa == nil || vaa.Enabled == GLboolean_GL_FALSE {

--- a/gapis/gfxapi/gles/gles.api
+++ b/gapis/gfxapi/gles/gles.api
@@ -60,6 +60,14 @@ sub void glErrorInvalidEnum(GLenum param) {
   abort
 }
 
+sub T glErrorInvalidEnumWithReturn!T(GLenum param, T v) {
+  onGlError(GL_INVALID_ENUM)
+  // TODO: be more specific in callers
+  _ = newMsg(SEVERITY_ERROR, new!ERR_INVALID_ENUM_VALUE(value: 0,variable:  "variable"))
+  abort
+  return v
+}
+
 sub void glErrorInvalidValue() {
   onGlError(GL_INVALID_VALUE)
   _ = newMsg(SEVERITY_ERROR, new!ERR_INVALID_VALUE(value: "value",variable:  "variable"))
@@ -300,6 +308,7 @@ class Rect {
 type GLuint               UniformIndex
 type GLuint               AttributeLocation
 type GLuint               AttributeIndex
+type GLuint               TextureUnitId
 @replay_remap type GLuint SamplerId
 @replay_remap type GLuint PipelineId
 @replay_remap type GLuint UniformBlockId
@@ -313,22 +322,25 @@ type GLuint               AttributeIndex
 @replay_custom_value type const void* BufferDataPointer
 
 @internal
-class DefaultTextureObjects {
-  ref!Texture Texture2d
-  ref!Texture Texture2dArray
-  ref!Texture Texture2dMultisample
-  ref!Texture Texture2dMultisampleArray
-  ref!Texture Texture3d
-  ref!Texture TextureBuffer
-  ref!Texture TextureCubeMap
-  ref!Texture TextureCubeMapArray
-  ref!Texture TextureExternalOes
+class DefaultObjects {
+  ref!Framebuffer       Framebuffer
+  ref!VertexArray       VertexArray
+  ref!TransformFeedback TransformFeedback
+  ref!Texture           Texture2d
+  ref!Texture           Texture2dArray
+  ref!Texture           Texture2dMultisample
+  ref!Texture           Texture2dMultisampleArray
+  ref!Texture           Texture3d
+  ref!Texture           TextureBuffer
+  ref!Texture           TextureCubeMap
+  ref!Texture           TextureCubeMapArray
+  ref!Texture           TextureExternalOes
 }
 
 // Objects which are never shared between contexts.
 @internal
 class Objects {
-  DefaultTextureObjects                            DefaultTextures
+  DefaultObjects                                   Default
   ref!SharedObjects                                Shared
   map!(FramebufferId, ref!Framebuffer)             Framebuffers
   @unused map!(PipelineId, ref!Pipeline)           Pipelines
@@ -341,13 +353,13 @@ class Objects {
 // See: Chapter 5 - "Shared Objects and Multiple Contexts"
 @internal
 class SharedObjects {
-  map!(RenderbufferId, ref!Renderbuffer)           Renderbuffers
-  map!(TextureId, ref!Texture)                     Textures
-  map!(BufferId, ref!Buffer)                       Buffers
-  map!(SamplerId, ref!Sampler)                     Samplers
-  map!(ShaderId, ref!Shader)                       Shaders
-  map!(ProgramId, ref!Program)                     Programs
-  map!(GLsync, ref!SyncObject)                     SyncObjects
+  map!(RenderbufferId, ref!Renderbuffer) Renderbuffers
+  map!(TextureId, ref!Texture)           Textures
+  map!(BufferId, ref!Buffer)             Buffers
+  map!(SamplerId, ref!Sampler)           Samplers
+  map!(ShaderId, ref!Shader)             Shaders
+  map!(ProgramId, ref!Program)           Programs
+  map!(GLsync, ref!SyncObject)           SyncObjects
 }
 
 @internal type s32 ContextID
@@ -360,43 +372,50 @@ class ContextCreationInfo {
 }
 
 @internal
-class BufferBindings {
-  BufferId                    ArrayBuffer
-  BufferId                    AtomicCounterBuffer
+class Bindings {
+  ref!Buffer                  ArrayBuffer
+  ref!Buffer                  AtomicCounterBuffer
   map!(GLuint, BufferBinding) AtomicCounterBuffers
-  BufferId                    CopyReadBuffer
-  BufferId                    CopyWriteBuffer
-  BufferId                    DispatchIndirectBuffer
-  BufferId                    DrawIndirectBuffer
-  BufferId                    PixelPackBuffer
-  BufferId                    PixelUnpackBuffer
-  BufferId                    ShaderStorageBuffer
+  ref!Buffer                  CopyReadBuffer
+  ref!Buffer                  CopyWriteBuffer
+  ref!Buffer                  DispatchIndirectBuffer
+  ref!Framebuffer             DrawFramebuffer
+  ref!Buffer                  DrawIndirectBuffer
+  ref!Buffer                  PixelPackBuffer
+  ref!Buffer                  PixelUnpackBuffer
+  ref!Program                 Program
+  ref!Framebuffer             ReadFramebuffer
+  ref!Renderbuffer            Renderbuffer
+  ref!Buffer                  ShaderStorageBuffer
   map!(GLuint, BufferBinding) ShaderStorageBuffers
-  BufferId                    TextureBuffer
-  BufferId                    TransformFeedbackBuffer
-  BufferId                    UniformBuffer
+  ref!Buffer                  TextureBuffer
+  ref!TransformFeedback       TransformFeedback
+  ref!Buffer                  TransformFeedbackBuffer
+  ref!Buffer                  UniformBuffer
   map!(GLuint, BufferBinding) UniformBuffers
+  ref!VertexArray             VertexArray
+}
+
+@internal
+class BufferBinding {
+  ref!Buffer Binding
+  GLintptr   Start
+  GLsizeiptr Size
 }
 
 @internal
 class Context {
   ContextID                                             Identifier
   ContextCreationInfo                                   Info
+  Bindings                                              Bound
   DebugState                                            Debug
   RasterizationState                                    Rasterization
   FragmentOperationsState                               FragmentOperations
   FramebufferState                                      Framebuffer
-  FramebufferId                                         BoundReadFramebuffer
-  FramebufferId                                         BoundDrawFramebuffer
-  RenderbufferId                                        BoundRenderbuffer
-  BufferBindings                                        BoundBuffers
-  ProgramId                                             BoundProgram
-  TransformFeedbackId                                   BoundTransformFeedback
-  VertexArrayId                                         BoundVertexArray
   @unused map!(AttributeLocation, VertexAttributeValue) VertexAttributes
   map!(GLenum, ref!TextureUnit)                         TextureUnits
   map!(GLuint, ImageUnit)                               ImageUnits
-  GLenum                                                ActiveTextureUnit      = GL_TEXTURE0
+  GLenum                                                ActiveTextureUnit  = GL_TEXTURE0
   PixelStorageState                                     PixelStorage
   MiscellaneousState                                    Miscellaneous
   map!(GLenum, QueryId)                                 ActiveQueries
@@ -428,8 +447,7 @@ sub ref!Context CreateContext(ref!Context sharedContext) {
   identifier := NextContextID
   NextContextID = NextContextID + 1
 
-  ctx := new!Context()
-  ctx.Identifier = identifier
+  ctx := new!Context(Identifier: identifier)
 
   if sharedContext != null {
     ctx.Info.SharedContext = sharedContext.Identifier
@@ -452,21 +470,30 @@ sub void ApplyStaticContextState(ref!Context ctx, ref!StaticContextState staticS
     // First initialization for the context.
     ctx.Constants = staticState.Constants
 
-    ctx.Objects.Framebuffers[0] = new!Framebuffer(ReadBuffer: GL_BACK)
-    ctx.Objects.Shared.Renderbuffers[0] = new!Renderbuffer(ID:0)
-    ctx.Objects.TransformFeedbacks[0] = new!TransformFeedback()
-    ctx.Objects.VertexArrays[0] = NewVertexArray(ctx)
-    ctx.TextureUnits[GL_TEXTURE0] = new!TextureUnit()
+    ctx.Objects.Default.Framebuffer = new!Framebuffer(ID: 0, ReadBuffer: GL_BACK)
+    ctx.Objects.Framebuffers[0] = ctx.Objects.Default.Framebuffer
+    ctx.Bound.DrawFramebuffer = ctx.Objects.Default.Framebuffer
+    ctx.Bound.ReadFramebuffer = ctx.Objects.Default.Framebuffer
 
-    ctx.Objects.DefaultTextures.Texture2d = new!Texture(Kind: GL_TEXTURE_2D)
-    ctx.Objects.DefaultTextures.Texture2dArray = new!Texture(Kind: GL_TEXTURE_2D_ARRAY)
-    ctx.Objects.DefaultTextures.Texture2dMultisample = new!Texture(Kind: GL_TEXTURE_2D_MULTISAMPLE)
-    ctx.Objects.DefaultTextures.Texture2dMultisampleArray = new!Texture(Kind: GL_TEXTURE_2D_MULTISAMPLE_ARRAY)
-    ctx.Objects.DefaultTextures.Texture3d = new!Texture(Kind: GL_TEXTURE_3D)
-    ctx.Objects.DefaultTextures.TextureBuffer = new!Texture(Kind: GL_TEXTURE_BUFFER)
-    ctx.Objects.DefaultTextures.TextureCubeMap = new!Texture(Kind: GL_TEXTURE_CUBE_MAP)
-    ctx.Objects.DefaultTextures.TextureCubeMapArray = new!Texture(Kind: GL_TEXTURE_CUBE_MAP_ARRAY)
-    ctx.Objects.DefaultTextures.TextureExternalOes = new!Texture(Kind: GL_TEXTURE_EXTERNAL_OES)
+    ctx.Objects.Default.TransformFeedback = new!TransformFeedback(ID: 0)
+    ctx.Objects.TransformFeedbacks[0] = ctx.Objects.Default.TransformFeedback
+    ctx.Bound.TransformFeedback = ctx.Objects.Default.TransformFeedback
+
+    ctx.Objects.Default.VertexArray = NewVertexArray(0)
+    ctx.Objects.VertexArrays[0] = ctx.Objects.Default.VertexArray
+    ctx.Bound.VertexArray = ctx.Objects.Default.VertexArray
+
+    ctx.TextureUnits[GL_TEXTURE0] = NewTextureUnit(0)
+
+    ctx.Objects.Default.Texture2d = new!Texture(ID: 0, Kind: GL_TEXTURE_2D)
+    ctx.Objects.Default.Texture2dArray = new!Texture(ID: 0, Kind: GL_TEXTURE_2D_ARRAY)
+    ctx.Objects.Default.Texture2dMultisample = new!Texture(ID: 0, Kind: GL_TEXTURE_2D_MULTISAMPLE)
+    ctx.Objects.Default.Texture2dMultisampleArray = new!Texture(ID: 0, Kind: GL_TEXTURE_2D_MULTISAMPLE_ARRAY)
+    ctx.Objects.Default.Texture3d = new!Texture(ID: 0, Kind: GL_TEXTURE_3D)
+    ctx.Objects.Default.TextureBuffer = new!Texture(ID: 0, Kind: GL_TEXTURE_BUFFER)
+    ctx.Objects.Default.TextureCubeMap = new!Texture(ID: 0, Kind: GL_TEXTURE_CUBE_MAP)
+    ctx.Objects.Default.TextureCubeMapArray = new!Texture(ID: 0, Kind: GL_TEXTURE_CUBE_MAP_ARRAY)
+    ctx.Objects.Default.TextureExternalOes = new!Texture(ID: 0, Kind: GL_TEXTURE_EXTERNAL_OES)
 
     ctx.Objects.Shared.Renderbuffers[color_id] = new!Renderbuffer(ID: color_id)
     ctx.Objects.Shared.Renderbuffers[depth_id] = new!Renderbuffer(ID: depth_id)
@@ -488,9 +515,6 @@ sub void ApplyStaticContextState(ref!Context ctx, ref!StaticContextState staticS
       Renderbuffer:        ctx.Objects.Shared.Renderbuffers[stencil_id],
     )
 
-    ctx.BoundDrawFramebuffer = 0
-    ctx.BoundReadFramebuffer = 0
-
     for i in 0 .. as!AttributeLocation(staticState.Constants.MaxVertexAttribs) {
       v := make!Vec4f(1)
       v[0] = Vec4f(0.0, 0.0, 0.0, 1.0)
@@ -499,7 +523,7 @@ sub void ApplyStaticContextState(ref!Context ctx, ref!StaticContextState staticS
 
     for i in 0 .. staticState.Constants.MaxCombinedTextureImageUnits {
       name := GL_TEXTURE0 + as!GLenum(i)
-      ctx.TextureUnits[name] = new!TextureUnit()
+      ctx.TextureUnits[name] = NewTextureUnit(as!TextureUnitId(i))
     }
 
     for i in 0 .. as!GLuint(staticState.Constants.MaxImageUnits) {

--- a/gapis/gfxapi/gles/gles.go
+++ b/gapis/gfxapi/gles/gles.go
@@ -27,6 +27,54 @@ func GetContext(s *gfxapi.State) *Context {
 	return GetState(s).getContext()
 }
 
+func (b *Buffer) GetID() BufferId {
+	if b != nil {
+		return b.ID
+	} else {
+		return 0
+	}
+}
+
+func (b *Framebuffer) GetID() FramebufferId {
+	if b != nil {
+		return b.ID
+	} else {
+		return 0
+	}
+}
+
+func (b *Renderbuffer) GetID() RenderbufferId {
+	if b != nil {
+		return b.ID
+	} else {
+		return 0
+	}
+}
+
+func (b *Program) GetID() ProgramId {
+	if b != nil {
+		return b.ID
+	} else {
+		return 0
+	}
+}
+
+func (b *VertexArray) GetID() VertexArrayId {
+	if b != nil {
+		return b.ID
+	} else {
+		return 0
+	}
+}
+
+func (b *Texture) GetID() TextureId {
+	if b != nil {
+		return b.ID
+	} else {
+		return 0
+	}
+}
+
 // GetFramebufferAttachmentInfo returns the width, height and format of the specified framebuffer attachment.
 func (api) GetFramebufferAttachmentInfo(state *gfxapi.State, attachment gfxapi.FramebufferAttachment) (width, height uint32, format *image.Format, err error) {
 	w, h, sizedFormat, err := GetState(state).getFramebufferAttachmentInfo(attachment)

--- a/gapis/gfxapi/gles/links.go
+++ b/gapis/gfxapi/gles/links.go
@@ -71,13 +71,12 @@ func (o AttributeLocation) Link(ctx context.Context, p path.Node) (path.Node, er
 	if i == nil {
 		return nil, err
 	}
-	va, ok := c.Objects.VertexArrays[c.BoundVertexArray]
-	if !ok || !va.VertexAttributeArrays.Contains(o) {
+	if !c.Bound.VertexArray.VertexAttributeArrays.Contains(o) {
 		return nil, nil
 	}
 	return i.
 		Field("VertexArrays").
-		MapIndex(c.BoundVertexArray).
+		MapIndex(c.Bound.VertexArray.GetID()).
 		Field("VertexAttributeArrays").
 		MapIndex(o), nil
 }
@@ -172,7 +171,7 @@ func (o UniformLocation) Link(ctx context.Context, p path.Node) (path.Node, erro
 	case *GlGetUniformLocation:
 		program = atom.Program
 	default:
-		program = c.BoundProgram
+		program = c.Bound.Program.GetID()
 	}
 
 	prog, ok := c.Objects.Shared.Programs[program]

--- a/gapis/gfxapi/gles/read_framebuffer.go
+++ b/gapis/gfxapi/gles/read_framebuffer.go
@@ -95,12 +95,12 @@ func (t *readFramebuffer) Color(id atom.ID, width, height, bufferIdx uint32, res
 		dID := id.Derived()
 		t := newTweaker(ctx, out, dID)
 
-		t.glBindFramebuffer_Read(c.BoundDrawFramebuffer)
+		t.glBindFramebuffer_Read(c.Bound.DrawFramebuffer.GetID())
 
 		// TODO: These glReadBuffer calls need to be changed for on-device
 		//       replay. Note that glReadBuffer was only introduced in
 		//       OpenGL ES 3.0, and that GL_FRONT is not a legal enum value.
-		if c.BoundDrawFramebuffer == 0 {
+		if c.Bound.DrawFramebuffer == c.Objects.Default.Framebuffer {
 			out.MutateAndWrite(ctx, dID, replay.Custom(func(ctx context.Context, s *gfxapi.State, b *builder.Builder) error {
 				// TODO: We assume here that the default framebuffer is
 				//       single-buffered. Once we support double-buffering we

--- a/gapis/gfxapi/gles/state.go
+++ b/gapis/gfxapi/gles/state.go
@@ -35,10 +35,7 @@ func (s *State) getFramebufferAttachmentInfo(att gfxapi.FramebufferAttachment) (
 		return 0, 0, 0, fmt.Errorf("Context not initialized")
 	}
 
-	framebuffer, ok := c.Objects.Framebuffers[c.BoundDrawFramebuffer]
-	if !ok {
-		return 0, 0, 0, fmt.Errorf("No GL_FRAMEBUFFER bound")
-	}
+	framebuffer := c.Bound.DrawFramebuffer
 
 	var a FramebufferAttachment
 	switch att {

--- a/gapis/gfxapi/gles/texture_compat.go
+++ b/gapis/gfxapi/gles/texture_compat.go
@@ -212,11 +212,11 @@ func decompressTexImage2D(ctx context.Context, i atom.ID, a *GlCompressedTexImag
 	c := GetContext(s)
 
 	data := a.Data
-	if pb := c.BoundBuffers.PixelUnpackBuffer; pb != 0 {
+	if pb := c.Bound.PixelUnpackBuffer; pb != nil {
 		base := a.Data.addr
-		data = NewTexturePointer(c.Objects.Shared.Buffers[pb].Data.Index(base, s.MemoryLayout))
+		data = NewTexturePointer(pb.Data.Index(base, s.MemoryLayout))
 		out.MutateAndWrite(ctx, dID, NewGlBindBuffer(GLenum_GL_PIXEL_UNPACK_BUFFER, 0))
-		defer out.MutateAndWrite(ctx, dID, NewGlBindBuffer(GLenum_GL_PIXEL_UNPACK_BUFFER, pb))
+		defer out.MutateAndWrite(ctx, dID, NewGlBindBuffer(GLenum_GL_PIXEL_UNPACK_BUFFER, pb.ID))
 	} else {
 		a.Extras().Observations().ApplyReads(s.Memory[memory.ApplicationPool])
 	}
@@ -259,11 +259,11 @@ func decompressTexSubImage2D(ctx context.Context, i atom.ID, a *GlCompressedTexS
 	c := GetContext(s)
 
 	data := a.Data
-	if pb := c.BoundBuffers.PixelUnpackBuffer; pb != 0 {
+	if pb := c.Bound.PixelUnpackBuffer; pb != nil {
 		base := a.Data.addr
-		data = TexturePointer(c.Objects.Shared.Buffers[pb].Data.Index(base, s.MemoryLayout))
+		data = TexturePointer(pb.Data.Index(base, s.MemoryLayout))
 		out.MutateAndWrite(ctx, dID, NewGlBindBuffer(GLenum_GL_PIXEL_UNPACK_BUFFER, 0))
-		defer out.MutateAndWrite(ctx, dID, NewGlBindBuffer(GLenum_GL_PIXEL_UNPACK_BUFFER, pb))
+		defer out.MutateAndWrite(ctx, dID, NewGlBindBuffer(GLenum_GL_PIXEL_UNPACK_BUFFER, pb.ID))
 	} else {
 		a.Extras().Observations().ApplyReads(s.Memory[memory.ApplicationPool])
 	}

--- a/gapis/gfxapi/gles/tweaker.go
+++ b/gapis/gfxapi/gles/tweaker.go
@@ -164,7 +164,7 @@ func (t *tweaker) makeVertexArray(enabledLocations ...AttributeLocation) {
 		}
 	} else {
 		// GLES 2.0 does not have Vertex Array Objects, but the state is fairly simple.
-		vao := t.c.Objects.VertexArrays[t.c.BoundVertexArray]
+		vao := t.c.Bound.VertexArray
 		// Disable all vertex attribute arrays
 		for location, origVertexAttrib := range vao.VertexAttributeArrays {
 			if origVertexAttrib.Enabled == GLboolean_GL_TRUE {
@@ -174,7 +174,7 @@ func (t *tweaker) makeVertexArray(enabledLocations ...AttributeLocation) {
 			}
 		}
 		// Enable and save state for the attribute arrays that we will use
-		origArrayBufferID := t.c.BoundBuffers.ArrayBuffer
+		origArrayBufferID := t.c.Bound.ArrayBuffer.GetID()
 		for _, location := range enabledLocations {
 			location := location
 			t.doAndUndo(
@@ -291,7 +291,7 @@ func (t *tweaker) glScissor(x, y GLint, w, h GLsizei) {
 }
 
 func (t *tweaker) GlBindBuffer_ArrayBuffer(id BufferId) {
-	if o := t.c.BoundBuffers.ArrayBuffer; o != id {
+	if o := t.c.Bound.ArrayBuffer.GetID(); o != id {
 		t.doAndUndo(
 			NewGlBindBuffer(GLenum_GL_ARRAY_BUFFER, id),
 			NewGlBindBuffer(GLenum_GL_ARRAY_BUFFER, o))
@@ -299,8 +299,8 @@ func (t *tweaker) GlBindBuffer_ArrayBuffer(id BufferId) {
 }
 
 func (t *tweaker) GlBindBuffer_ElementArrayBuffer(id BufferId) {
-	vao := t.c.Objects.VertexArrays[t.c.BoundVertexArray]
-	if o := vao.ElementArrayBuffer; o != id {
+	vao := t.c.Bound.VertexArray
+	if o := vao.ElementArrayBuffer.GetID(); o != id {
 		t.doAndUndo(
 			NewGlBindBuffer(GLenum_GL_ELEMENT_ARRAY_BUFFER, id),
 			NewGlBindBuffer(GLenum_GL_ELEMENT_ARRAY_BUFFER, o))
@@ -308,7 +308,7 @@ func (t *tweaker) GlBindBuffer_ElementArrayBuffer(id BufferId) {
 }
 
 func (t *tweaker) glBindFramebuffer_Draw(id FramebufferId) {
-	if o := t.c.BoundDrawFramebuffer; o != id {
+	if o := t.c.Bound.DrawFramebuffer.GetID(); o != id {
 		t.doAndUndo(
 			NewGlBindFramebuffer(GLenum_GL_DRAW_FRAMEBUFFER, id),
 			NewGlBindFramebuffer(GLenum_GL_DRAW_FRAMEBUFFER, o))
@@ -316,7 +316,7 @@ func (t *tweaker) glBindFramebuffer_Draw(id FramebufferId) {
 }
 
 func (t *tweaker) glBindFramebuffer_Read(id FramebufferId) {
-	if o := t.c.BoundReadFramebuffer; o != id {
+	if o := t.c.Bound.ReadFramebuffer.GetID(); o != id {
 		t.doAndUndo(
 			NewGlBindFramebuffer(GLenum_GL_READ_FRAMEBUFFER, id),
 			NewGlBindFramebuffer(GLenum_GL_READ_FRAMEBUFFER, o))
@@ -324,7 +324,7 @@ func (t *tweaker) glBindFramebuffer_Read(id FramebufferId) {
 }
 
 func (t *tweaker) glReadBuffer(id GLenum) {
-	fb := t.c.Objects.Framebuffers[t.c.BoundReadFramebuffer]
+	fb := t.c.Bound.ReadFramebuffer
 	if o := fb.ReadBuffer; o != id {
 		t.doAndUndo(
 			NewGlReadBuffer(id),
@@ -333,7 +333,7 @@ func (t *tweaker) glReadBuffer(id GLenum) {
 }
 
 func (t *tweaker) glBindRenderbuffer(id RenderbufferId) {
-	if o := t.c.BoundRenderbuffer; o != id {
+	if o := t.c.Bound.Renderbuffer.GetID(); o != id {
 		t.doAndUndo(
 			NewGlBindRenderbuffer(GLenum_GL_RENDERBUFFER, id),
 			NewGlBindRenderbuffer(GLenum_GL_RENDERBUFFER, o))
@@ -341,7 +341,7 @@ func (t *tweaker) glBindRenderbuffer(id RenderbufferId) {
 }
 
 func (t *tweaker) glBindTexture_2D(id TextureId) {
-	if o := t.c.TextureUnits[t.c.ActiveTextureUnit].Binding2d; o != id {
+	if o := t.c.TextureUnits[t.c.ActiveTextureUnit].Binding2d.GetID(); o != id {
 		t.doAndUndo(
 			NewGlBindTexture(GLenum_GL_TEXTURE_2D, id),
 			NewGlBindTexture(GLenum_GL_TEXTURE_2D, o))
@@ -349,7 +349,7 @@ func (t *tweaker) glBindTexture_2D(id TextureId) {
 }
 
 func (t *tweaker) glBindVertexArray(id VertexArrayId) {
-	if o := t.c.BoundVertexArray; o != id {
+	if o := t.c.Bound.VertexArray.GetID(); o != id {
 		t.doAndUndo(
 			NewGlBindVertexArray(id),
 			NewGlBindVertexArray(o))
@@ -357,7 +357,7 @@ func (t *tweaker) glBindVertexArray(id VertexArrayId) {
 }
 
 func (t *tweaker) glUseProgram(id ProgramId) {
-	if o := t.c.BoundProgram; o != id {
+	if o := t.c.Bound.Program.GetID(); o != id {
 		t.doAndUndo(
 			NewGlUseProgram(id),
 			NewGlUseProgram(o))
@@ -382,12 +382,12 @@ func (t *tweaker) setPixelStorage(state PixelStorageState, packBufferId, unpackB
 				NewGlPixelStorei(name, o))
 		}
 	})
-	if o := t.c.BoundBuffers.PixelPackBuffer; o != packBufferId {
+	if o := t.c.Bound.PixelPackBuffer.GetID(); o != packBufferId {
 		t.doAndUndo(
 			NewGlBindBuffer(GLenum_GL_PIXEL_PACK_BUFFER, packBufferId),
 			NewGlBindBuffer(GLenum_GL_PIXEL_PACK_BUFFER, o))
 	}
-	if o := t.c.BoundBuffers.PixelUnpackBuffer; o != unpackBufferId {
+	if o := t.c.Bound.PixelUnpackBuffer.GetID(); o != unpackBufferId {
 		t.doAndUndo(
 			NewGlBindBuffer(GLenum_GL_PIXEL_UNPACK_BUFFER, unpackBufferId),
 			NewGlBindBuffer(GLenum_GL_PIXEL_UNPACK_BUFFER, o))

--- a/gapis/gfxapi/gles/wireframe.go
+++ b/gapis/gfxapi/gles/wireframe.go
@@ -107,7 +107,7 @@ func drawWireframe(ctx context.Context, i atom.ID, dc drawCall, s *gfxapi.State,
 
 	// Unbind the index buffer
 	tmp := atom.Must(atom.Alloc(ctx, s, uint64(len(wireframeData))))
-	oldIndexBufferID := c.Objects.VertexArrays[c.BoundVertexArray].ElementArrayBuffer
+	oldIndexBuffer := c.Bound.VertexArray.ElementArrayBuffer
 	out.MutateAndWrite(ctx, dID,
 		NewGlBindBuffer(GLenum_GL_ELEMENT_ARRAY_BUFFER, 0).
 			AddRead(tmp.Range(), resID))
@@ -118,7 +118,7 @@ func drawWireframe(ctx context.Context, i atom.ID, dc drawCall, s *gfxapi.State,
 
 	// Rebind the old index buffer
 	out.MutateAndWrite(ctx, dID, NewGlBindBuffer(
-		GLenum_GL_ELEMENT_ARRAY_BUFFER, oldIndexBufferID))
+		GLenum_GL_ELEMENT_ARRAY_BUFFER, oldIndexBuffer.GetID()))
 
 	return nil
 }


### PR DESCRIPTION
This simplifies the code and will help us track lifetime of objects correctly.