### PR TITLE
Don't pass an empty string as the adb flag.

### DIFF
--- a/gapic/src/main/com/google/gapid/server/GapisProcess.java
+++ b/gapic/src/main/com/google/gapid/server/GapisProcess.java
@@ -99,8 +99,10 @@ public class GapisProcess extends ChildProcess<Integer> {
     args.add("--idle-timeout");
     args.add(IDLE_TIMEOUT_MS + "ms");
 
-    args.add("--adb");
-    args.add(GapiPaths.adb());
+    if (!GapiPaths.adb().isEmpty()) {
+      args.add("--adb");
+      args.add(GapiPaths.adb());
+    }
 
     pb.command(args);
     return null;

--- a/gapic/src/main/com/google/gapid/server/GapitPkgInfoProcess.java
+++ b/gapic/src/main/com/google/gapid/server/GapitPkgInfoProcess.java
@@ -76,8 +76,10 @@ public class GapitPkgInfoProcess extends ChildProcess<PkgInfo.PackageList> {
       args.add(deviceSerial);
     }
 
-    args.add("--adb");
-    args.add(GapiPaths.adb());
+    if (!GapiPaths.adb().isEmpty()) {
+      args.add("--adb");
+      args.add(GapiPaths.adb());
+    }
 
     pb.command(args);
     return null;

--- a/gapic/src/main/com/google/gapid/server/GapitTraceProcess.java
+++ b/gapic/src/main/com/google/gapid/server/GapitTraceProcess.java
@@ -61,6 +61,12 @@ public class GapitTraceProcess extends ChildProcess<Boolean> {
     args.add(logLevel.get().gapisLevel);
 
     args.add("trace");
+
+    if (!GapiPaths.adb().isEmpty()) {
+      args.add("--adb");
+      args.add(GapiPaths.adb());
+    }
+
     request.appendCommandLine(args);
 
     pb.command(args);


### PR DESCRIPTION
A certain platform doesn't like it. Also, pass the adb path to gapit trace, while we're at it.

Fixes #540