### PR TITLE
gapir: Add --wait-for-debugger flag.

### DIFF
--- a/cmd/gapir/cc/main.cpp
+++ b/cmd/gapir/cc/main.cpp
@@ -23,6 +23,7 @@
 #include "gapir/cc/server_listener.h"
 
 #include "core/cc/connection.h"
+#include "core/cc/debugger.h"
 #include "core/cc/log.h"
 #include "core/cc/socket_connection.h"
 #include "core/cc/supported_abis.h"
@@ -146,6 +147,7 @@ int main(int argc, const char* argv[]) {
     int logLevel = LOG_LEVEL;
     const char* logPath = "logs/gapir.log";
 
+    bool wait_for_debugger = false;
     const char* cachePath = nullptr;
     const char* portStr = "0";
     const char* authToken = nullptr;
@@ -191,12 +193,19 @@ int main(int argc, const char* argv[]) {
                 GAPID_FATAL("Usage: --idle-timeout-ms <timeout in milliseconds>");
             }
             idleTimeoutMs = atoi(argv[++i]);
+        } else if (strcmp(argv[i], "--wait-for-debugger") == 0) {
+            wait_for_debugger = true;
         } else {
             GAPID_FATAL("Unknown argument: %s", argv[i]);
         }
     }
 
     GAPID_LOGGER_INIT(logLevel, "gapir", logPath);
+
+    if (wait_for_debugger) {
+        GAPID_INFO("Waiting for debugger to attach");
+        core::Debugger::waitForAttach();
+    }
 
     MemoryManager memoryManager(memorySizes);
     auto conn = SocketConnection::createSocket("127.0.0.1", portStr);

--- a/core/cc/CMakeFiles.cmake
+++ b/core/cc/CMakeFiles.cmake
@@ -25,6 +25,8 @@ set(files
     connection.h
     connection_test.cpp
     core_ptr_types.h
+    debugger.cpp
+    debugger.h
     dl_loader.cpp
     dl_loader.h
     encoder.cpp

--- a/core/cc/android/CMakeFiles.cmake
+++ b/core/cc/android/CMakeFiles.cmake
@@ -19,10 +19,11 @@
 
 set(files
     compatibility.cpp
+    debugger.cpp
     get_gles_proc_address.cpp
     get_vulkan_proc_address.cpp
     thread.cpp
 )
 set(dirs
-    
+
 )

--- a/core/cc/android/debugger.cpp
+++ b/core/cc/android/debugger.cpp
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "../debugger.h"
+
+static volatile bool gIsDebuggerAttached = false;
+
+namespace core {
+
+bool Debugger::isAttached() {
+    return gIsDebuggerAttached;
+}
+
+}  // namespace core
+

--- a/core/cc/debugger.cpp
+++ b/core/cc/debugger.cpp
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "debugger.h"
+
+namespace core {
+
+void Debugger::waitForAttach() {
+    while (!isAttached()) {}
+}
+
+}  // namespace core
+

--- a/core/cc/debugger.h
+++ b/core/cc/debugger.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef CORE_DEBUGGER_H
+#define CORE_DEBUGGER_H
+
+namespace core {
+
+// Utility class for detecting debugger attachment.
+class Debugger {
+public:
+    static bool isAttached();
+    static void waitForAttach();
+};
+
+}  // namespace core
+
+#endif  // CORE_DEBUGGER_H

--- a/core/cc/linux/CMakeFiles.cmake
+++ b/core/cc/linux/CMakeFiles.cmake
@@ -18,10 +18,11 @@
 # build and the file will be recreated, check in the new version.
 
 set(files
+    debugger.cpp
     get_gles_proc_address.cpp
     get_vulkan_proc_address.cpp
     thread.cpp
 )
 set(dirs
-    
+
 )

--- a/core/cc/linux/debugger.cpp
+++ b/core/cc/linux/debugger.cpp
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "../debugger.h"
+
+static volatile bool gIsDebuggerAttached = false;
+
+namespace core {
+
+bool Debugger::isAttached() {
+    return gIsDebuggerAttached;
+}
+
+}  // namespace core
+

--- a/core/cc/osx/CMakeFiles.cmake
+++ b/core/cc/osx/CMakeFiles.cmake
@@ -18,10 +18,11 @@
 # build and the file will be recreated, check in the new version.
 
 set(files
+    debugger.cpp
     get_gles_proc_address.cpp
     get_vulkan_proc_address.cpp
     thread.cpp
 )
 set(dirs
-    
+
 )

--- a/core/cc/osx/debugger.cpp
+++ b/core/cc/osx/debugger.cpp
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "../debugger.h"
+
+#include <assert.h>
+#include <stdbool.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <sys/sysctl.h>
+
+namespace {
+
+// https://developer.apple.com/library/content/qa/qa1361/_index.html
+static bool AmIBeingDebugged(void)
+    // Returns true if the current process is being debugged (either
+    // running under the debugger or has a debugger attached post facto).
+{
+    int                 junk;
+    int                 mib[4];
+    struct kinfo_proc   info;
+    size_t              size;
+
+    // Initialize the flags so that, if sysctl fails for some bizarre
+    // reason, we get a predictable result.
+
+    info.kp_proc.p_flag = 0;
+
+    // Initialize mib, which tells sysctl the info we want, in this case
+    // we're looking for information about a specific process ID.
+
+    mib[0] = CTL_KERN;
+    mib[1] = KERN_PROC;
+    mib[2] = KERN_PROC_PID;
+    mib[3] = getpid();
+
+    // Call sysctl.
+
+    size = sizeof(info);
+    junk = sysctl(mib, sizeof(mib) / sizeof(*mib), &info, &size, NULL, 0);
+    assert(junk == 0);
+
+    // We're being debugged if the P_TRACED flag is set.
+
+    return ( (info.kp_proc.p_flag & P_TRACED) != 0 );
+}
+
+}  // anonymous namespace
+
+namespace core {
+
+bool Debugger::isAttached() {
+    return AmIBeingDebugged();
+}
+
+}  // namespace core
+

--- a/core/cc/posix/CMakeFiles.cmake
+++ b/core/cc/posix/CMakeFiles.cmake
@@ -18,6 +18,7 @@
 # build and the file will be recreated, check in the new version.
 
 set(files
+    debugger.cpp
     mutex.cpp
     thread_local.cpp
     thread.cpp

--- a/core/cc/posix/debugger.cpp
+++ b/core/cc/posix/debugger.cpp
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "../debugger.h"
+
+static volatile bool gIsDebuggerAttached = false;
+
+namespace core {
+
+bool Debugger::isAttached() {
+    return gIsDebuggerAttached;
+}
+
+}  // namespace core
+

--- a/core/cc/windows/CMakeFiles.cmake
+++ b/core/cc/windows/CMakeFiles.cmake
@@ -18,6 +18,7 @@
 # build and the file will be recreated, check in the new version.
 
 set(files
+    debugger.cpp
     get_gles_proc_address.cpp
     get_vulkan_proc_address.cpp
     mutex.cpp
@@ -25,5 +26,5 @@ set(files
     thread_local.cpp
 )
 set(dirs
-    
+
 )

--- a/core/cc/windows/debugger.cpp
+++ b/core/cc/windows/debugger.cpp
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "../debugger.h"
+
+#include <windows.h>
+
+namespace core {
+
+bool Debugger::isAttached() {
+    return IsDebuggerPresent();
+}
+
+}  // namespace core
+

--- a/gapir/cc/linux/CMakeFiles.cmake
+++ b/gapir/cc/linux/CMakeFiles.cmake
@@ -22,5 +22,5 @@ set(files
     vulkan_renderer.cpp
 )
 set(dirs
-    
+
 )

--- a/gapir/cc/osx/CMakeFiles.cmake
+++ b/gapir/cc/osx/CMakeFiles.cmake
@@ -22,5 +22,5 @@ set(files
     vulkan_renderer.mm
 )
 set(dirs
-    
+
 )

--- a/gapir/cc/posix/CMakeFiles.cmake
+++ b/gapir/cc/posix/CMakeFiles.cmake
@@ -18,8 +18,7 @@
 # build and the file will be recreated, check in the new version.
 
 set(files
-    
 )
 set(dirs
-    
+
 )


### PR DESCRIPTION
If you have a crashing replay, this enables you to:

```bash
./do run gapit report --gapir-args="--wait-for-debugger" <trace>
```

Then in another console:
```bash
lldb -n gapir
```

For posix / linux I haven't found a reliable way to detect debugger attachment, so you need to set `gIsDebuggerAttached` to true to continue.