### PR TITLE
gapis/database: Add stacktrace information to panics in Resolve().

### DIFF
--- a/gapis/database/CMakeFiles.cmake
+++ b/gapis/database/CMakeFiles.cmake
@@ -19,10 +19,11 @@
 
 set(files
     database.go
+    debug.go
     hash.go
     memory.go
     resolvable.go
 )
 set(dirs
-    
+
 )

--- a/gapis/database/debug.go
+++ b/gapis/database/debug.go
@@ -1,0 +1,109 @@
+// Copyright (C) 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"runtime"
+	"strings"
+
+	"github.com/google/gapid/core/context/keys"
+)
+
+// resolveChain is a value that is stored in the context of a Resolve().
+// It holds a pointer to the record that is currently being resolved, and a
+// pointer to the parent resolve (if any exists). This forms a chain of resolves
+// that can be walked for displaying resolve stack traces.
+type resolveChain struct {
+	record *record
+	parent *resolveChain
+}
+
+type resolveChainKeyTy string
+
+var resolveChainKey resolveChainKeyTy = "<database.resolveChain>"
+
+func getResolveChain(ctx context.Context) *resolveChain {
+	if v := ctx.Value(resolveChainKey); v != nil {
+		return v.(*resolveChain)
+	}
+	return nil
+}
+
+func (c *resolveChain) bind(ctx context.Context) context.Context {
+	return keys.WithValue(ctx, resolveChainKey, c)
+}
+
+// callstack is a stack of program counters.
+type callstack []uintptr
+
+func (c callstack) String() string {
+	lines := []string{}
+	frames := runtime.CallersFrames(([]uintptr)(c))
+	for frame, more := frames.Next(); more; frame, more = frames.Next() {
+		lines = append(lines, fmt.Sprintf("%v:%v  %v", frame.File, frame.Line, frame.Function))
+	}
+	return strings.Join(lines, "\n")
+}
+
+func getCallstack(skip int) callstack {
+	const stackLimit = 10
+	callers := make([]uintptr, stackLimit)
+	count := runtime.Callers(skip, callers)
+	return callstack(callers[:count])
+}
+
+type rethrownPanic string
+
+func (p rethrownPanic) Error() string { return string(p) }
+
+// resolvePanicHandler catches and rethrows panics to add resolve chain
+// information to the error message.
+func (d *memory) resolvePanicHandler(ctx context.Context) {
+	err := recover()
+	switch err.(type) {
+	case nil:
+		return
+	case rethrownPanic:
+		panic(err)
+	default:
+		d.mutex.Lock()
+		defer d.mutex.Unlock()
+
+		buf := &bytes.Buffer{}
+		for c := getResolveChain(ctx); c != nil; c = c.parent {
+			r := c.record
+			fmt.Fprintln(buf)
+			fmt.Fprintf(buf, "--- %T ---\n", r.object)
+			fmt.Fprintln(buf, indent(fmt.Sprintf("%+v", r.object), 1))
+			fmt.Fprintf(buf, " Store():\n")
+			fmt.Fprintln(buf, indent(r.created.String(), 2))
+			fmt.Fprintln(buf)
+			for i, c := range r.resolveState.callstacks {
+				fmt.Fprintf(buf, " Build() #%d:\n", i)
+				fmt.Fprintln(buf, indent(c.String(), 2))
+			}
+		}
+
+		panic(rethrownPanic(buf.String()))
+	}
+}
+
+func indent(s string, depth int) string {
+	i := strings.Repeat(" ", depth)
+	return i + strings.Replace(s, "\n", "\n"+i, -1)
+}

--- a/gapis/database/memory.go
+++ b/gapis/database/memory.go
@@ -39,14 +39,16 @@ type record struct {
 	proto        proto.Message
 	object       interface{}
 	resolveState *resolveState
+	created      callstack
 }
 
 type resolveState struct {
-	ctx      context.Context // Context for the resolve
-	err      error           // Error raised when resolving
-	finished chan struct{}   // Signal that resolve has finished. Set to nil when done.
-	waiting  uint32          // Number of go-routines waiting for the resolve
-	cancel   func()          // Cancels ctx
+	ctx        context.Context // Context for the resolve
+	err        error           // Error raised when resolving
+	finished   chan struct{}   // Signal that resolve has finished. Set to nil when done.
+	waiting    uint32          // Number of go-routines waiting for the resolve
+	cancel     func()          // Cancels ctx
+	callstacks []callstack
 }
 
 func (r *record) resolve(ctx context.Context) error {
@@ -97,7 +99,7 @@ func (d *memory) storeLocked(ctx context.Context, id id.ID, v interface{}, m pro
 	}
 	r, got := d.records[id]
 	if !got {
-		d.records[id] = &record{object: v, proto: m}
+		d.records[id] = &record{object: v, proto: m, created: getCallstack(4)}
 	} else if config.DebugDatabaseVerify {
 		if !reflect.DeepEqual(m, r.proto) {
 			return fmt.Errorf("Duplicate object id %v", id)
@@ -123,39 +125,43 @@ func (d *memory) resolveLocked(ctx context.Context, id id.ID) (interface{}, erro
 		return nil, fmt.Errorf("Resource '%v' not found", id)
 	}
 
-	// TODO: Don't kick a go-routine if the record doesn't need resolving.
-
 	rs := r.resolveState
 	if rs == nil {
 		// First request for this resolvable.
 
-		// Build a cancellable context for the resolve.
+		// Grab the resolve chain from the caller's context.
+		rc := &resolveChain{r, getResolveChain(ctx)}
+
+		// Build a cancellable context for the resolve from database's resolve
+		// context. We use this as we don't to cancel the resolve if a single
+		// caller cancel's their context.
 		resolveCtx, cancel := task.WithCancel(d.resolveCtx)
 
 		rs = &resolveState{
-			ctx:      resolveCtx,
+			ctx:      rc.bind(resolveCtx),
 			finished: make(chan struct{}),
 			cancel:   cancel,
 		}
 		r.resolveState = rs
 
 		// Build the resolvable on a separate go-routine.
-		go func() {
-			err := r.resolve(rs.ctx)
+		go func(ctx context.Context) {
+			defer d.resolvePanicHandler(ctx)
+			err := r.resolve(ctx)
 
 			// Signal that the resolvable has finished.
 			d.mutex.Lock()
 			close(rs.finished)
 			rs.err, rs.finished = err, nil
 			d.mutex.Unlock()
-		}()
+		}(rs.ctx)
 	}
 
 	if finished := rs.finished; finished != nil {
 		// Buildable has not yet finished.
 		// Increment the waiting go-routine counter.
 		rs.waiting++
-
+		rs.callstacks = append(rs.callstacks, getCallstack(4))
 		// Wait for either the resolve to finish or ctx to be cancelled.
 		d.mutex.Unlock()
 		select {


### PR DESCRIPTION
As Resolves() are executed on a separate go-routine, we only get the
panic callstack up to the point the worker go-routine is created.

With this CL, a panic will now display:
* The stack trace of the call to database.Store() for the resolvable.
* The resolvable's data.
* The stack trace of the call(s) to database.Resolve().
* All of the above for other resolvables that kicks sub-resolvables.

Greatly helps diagnose issues.