### PR TITLE
Handle attached null Image

### DIFF
--- a/gapis/gfxapi/gles/state.go
+++ b/gapis/gfxapi/gles/state.go
@@ -63,6 +63,10 @@ func (s *State) getFramebufferAttachmentInfo(att gfxapi.FramebufferAttachment) (
 		switch t.Kind {
 		case GLenum_GL_TEXTURE_2D, GLenum_GL_TEXTURE_CUBE_MAP:
 			l := t.Levels[a.TextureLevel].Layers[a.TextureLayer]
+			if l == nil {
+				return 0, 0, 0, fmt.Errorf("Texture %v does not have Level[%v].Layer[%v]",
+					t.ID, a.TextureLevel, a.TextureLayer)
+			}
 			return uint32(l.Width), uint32(l.Height), l.SizedFormat, nil
 		default:
 			return 0, 0, 0, fmt.Errorf("Unknown texture kind %v", t.Kind)


### PR DESCRIPTION
It seems that the spec allows attaching mip level
before creating it in the first place.