### PR TITLE
Temporarily fix Robot on OS X and add some cleanup.

### DIFF
--- a/core/vulkan/loader/loader.go
+++ b/core/vulkan/loader/loader.go
@@ -64,11 +64,14 @@ func SetupReplay(ctx context.Context, env *shell.Env) (func(), error) {
 func findLibraryAndJSON(ctx context.Context, libType layout.LibraryType) (file.Path, file.Path, error) {
 	lib, err := layout.Library(ctx, libType)
 	if err != nil {
-		return lib, lib, err
+		return file.Path{}, file.Path{}, err
 	}
 
 	json, err := layout.Json(ctx, libType)
-	return lib, json, err
+	if err != nil {
+		return file.Path{}, file.Path{}, err
+	}
+	return lib, json, nil
 }
 
 func setupJSON(library, json file.Path, env *shell.Env) (func(), error) {

--- a/test/robot/build/artifact.go
+++ b/test/robot/build/artifact.go
@@ -104,6 +104,9 @@ var toolPatterns = []*ToolSet{{
 	Gapir: "osx/x86_64/gapir",
 	Gapis: "osx/x86_64/gapis",
 	Gapit: "osx/x86_64/gapit",
+	// TODO(baldwinn): These should not be required, https://github.com/google/gapid/issues/570
+	VirtualSwapChainLib:  "osx/x86_64/libVkLayer_VirtualSwapchain.so",
+	VirtualSwapChainJson: "osx/x86_64/VirtualSwapchainLayer.json",
 }, {
 	Abi:                  device.WindowsX86_64,
 	Gapir:                "windows/x86_64/gapir",

--- a/test/robot/trace/client.go
+++ b/test/robot/trace/client.go
@@ -172,21 +172,24 @@ func doTrace(ctx context.Context, action string, in *Input, store *stash.Client,
 		"-gapii-device", d.Instance().Serial,
 	}
 	cmd := shell.Command(gapit.System(), params...)
-	output, callErr := cmd.Call(ctx)
+	output, err := cmd.Call(ctx)
 	output = fmt.Sprintf("%s\n\n%s", cmd, output)
+	if err != nil {
+		return nil, log.Errf(ctx, err, "gapit call failed %v", output);
+	}
 
 	outputObj := &Output{}
 	logID, err := store.UploadString(ctx, stash.Upload{Name: []string{"trace.log"}}, output)
 	if err != nil {
-		return outputObj, err
+		return nil, err
 	}
 	outputObj.Log = logID
 	traceID, err := store.UploadFile(ctx, tracefile)
 	if err != nil {
-		return outputObj, err
+		return nil, err
 	}
 	outputObj.Trace = traceID
-	return outputObj, callErr
+	return outputObj, nil
 }
 
 type offlineDevice struct {


### PR DESCRIPTION
Some error case returns in robot were still returning "valid" data which goes against the style, changed these to return nil or empty structs instead. A temporary fix to get Robot running GAPIR on OS X by adding Vulkan library and Json just to make a failure case not get hit ([bug](https://github.com/google/gapid/issues/570)).