### PR TITLE
Handle blocking synchronization events in replay.

### DIFF
--- a/cmd/gapit/flags.go
+++ b/cmd/gapit/flags.go
@@ -110,11 +110,12 @@ type (
 			Width  int `help:"maximum video width"`
 			Height int `help:"maximum video height"`
 		}
-		Type   VideoType `help:"type of output to produce"`
-		Text   string    `help:"summary prefix (use '║' for aligned columns, '¶' for new line)"`
-		Frames struct {
+		Type     VideoType `help:"type of output to produce"`
+		Text     string    `help:"summary prefix (use '║' for aligned columns, '¶' for new line)"`
+		Commands bool      `help:"Treat every command as its own frame"`
+		Frames   struct {
 			Start int `help:"frame to start capture from"`
-			End   int `help:"frame to end capture on: -1 for last frame"`
+			Count int `help:"number of frames after Start to capture: -1 for all frames"`
 		}
 	}
 	DumpShadersFlags struct {

--- a/gapis/atom/test/atoms.go
+++ b/gapis/atom/test/atoms.go
@@ -30,6 +30,7 @@ import (
 	"github.com/google/gapid/gapis/memory"
 	"github.com/google/gapid/gapis/replay/builder"
 	"github.com/google/gapid/gapis/service/box"
+	"github.com/google/gapid/gapis/service/path"
 )
 
 type AtomA struct {
@@ -135,6 +136,9 @@ func (API) Index() uint8                 { return 15 }
 func (API) ConstantSets() *constset.Pack { return nil }
 func (API) GetFramebufferAttachmentInfo(state *gfxapi.State, attachment gfxapi.FramebufferAttachment) (uint32, uint32, *image.Format, error) {
 	return 0, 0, nil, nil
+}
+func (API) ResolveSynchronization(ctx context.Context, d *gfxapi.SynchronizationData, c *path.Capture) error {
+	return nil
 }
 func (API) Context(*gfxapi.State) gfxapi.Context { return nil }
 

--- a/gapis/gfxapi/CMakeFiles.cmake
+++ b/gapis/gfxapi/CMakeFiles.cmake
@@ -26,6 +26,7 @@ set(files
     mesh.go
     resource.go
     state.go
+    synchronization_data.go
     texture.go
 )
 set(dirs

--- a/gapis/gfxapi/api.go
+++ b/gapis/gfxapi/api.go
@@ -15,11 +15,13 @@
 package gfxapi
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/google/gapid/core/data/id"
 	"github.com/google/gapid/core/image"
 	"github.com/google/gapid/gapil/constset"
+	"github.com/google/gapid/gapis/service/path"
 )
 
 // API is the common interface to a graphics programming api.
@@ -41,6 +43,10 @@ type API interface {
 
 	// Context returns the active context for the given state.
 	Context(*State) Context
+
+	// ResolveSynchroniation fills the given SynchronizationData with the
+	// set of blocking operations between commands in the given capture for this API.
+	ResolveSynchronization(ctx context.Context, d *SynchronizationData, c *path.Capture) error
 }
 
 // ID is an API identifier

--- a/gapis/gfxapi/core/core.go
+++ b/gapis/gfxapi/core/core.go
@@ -15,9 +15,14 @@
 package core
 
 import (
+	"context"
+
 	"github.com/google/gapid/core/image"
 	"github.com/google/gapid/gapis/gfxapi"
+	"github.com/google/gapid/gapis/service/path"
 )
+
+type CustomState struct{}
 
 // GetFramebufferAttachmentInfo returns the width, height and format of the specified framebuffer attachment.
 func (api) GetFramebufferAttachmentInfo(state *gfxapi.State, attachment gfxapi.FramebufferAttachment) (width, height uint32, format *image.Format, err error) {
@@ -26,5 +31,9 @@ func (api) GetFramebufferAttachmentInfo(state *gfxapi.State, attachment gfxapi.F
 
 // Context returns the active context for the given state.
 func (api) Context(*gfxapi.State) gfxapi.Context {
+	return nil
+}
+
+func (api) ResolveSynchronization(ctx context.Context, d *gfxapi.SynchronizationData, c *path.Capture) error {
 	return nil
 }

--- a/gapis/gfxapi/gles/gles.go
+++ b/gapis/gfxapi/gles/gles.go
@@ -23,6 +23,8 @@ import (
 	"github.com/google/gapid/gapis/service/path"
 )
 
+type CustomState struct{}
+
 func GetContext(s *gfxapi.State) *Context {
 	return GetState(s).getContext()
 }
@@ -103,4 +105,8 @@ func (api) Mesh(ctx context.Context, o interface{}, p *path.Mesh) (*gfxapi.Mesh,
 		return drawCallMesh(ctx, dc, p)
 	}
 	return nil, nil
+}
+
+func (api) ResolveSynchronization(ctx context.Context, d *gfxapi.SynchronizationData, c *path.Capture) error {
+	return nil
 }

--- a/gapis/gfxapi/synchronization_data.go
+++ b/gapis/gfxapi/synchronization_data.go
@@ -1,0 +1,117 @@
+// Copyright (C) 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gfxapi
+
+import "sort"
+
+// An index, typically an atom ID that defines the location of one side
+// synchronization dependency.
+type SynchronizationIndex uint64
+type SynchronizationIndices []SynchronizationIndex
+
+// The index of a subcommand within a command
+type SubcommandIndex []uint64
+
+// ExecutionRanges contains the information about a blocked command.
+// LastIndex is the final subcommand that exists within this command.
+// Ranges defines which future command will unblock the command in question, and
+// which subcommandis the last that will be run at that point.
+type ExecutionRanges struct {
+	LastIndex SubcommandIndex
+	Ranges    map[SynchronizationIndex]SubcommandIndex
+}
+
+// SynchronizationData contains a map of synchronization pairs.
+// The SynchronizationIndex is the command that will be blocked from
+// completion, and what subcommands will be made available by future commands.
+type SynchronizationData struct {
+	CommandRanges map[SynchronizationIndex]ExecutionRanges
+}
+
+// NewSynchronizationData creates a new clean SynchronizationData object
+func NewSynchronizationData() *SynchronizationData {
+	s := new(SynchronizationData)
+	s.CommandRanges = make(map[SynchronizationIndex]ExecutionRanges)
+	return s
+}
+
+// LessThan returns true if s comes before s2.
+func (s SubcommandIndex) LessThan(s2 SubcommandIndex) bool {
+	for i := range s {
+		if i > len(s2)-1 {
+			// This case is a bit weird, but
+			// {0} > {0, 1}, since {0} represents
+			// the ALL commands under 0.
+			return true
+		}
+		if s[i] < s2[i] {
+			return true
+		}
+		if s[i] > s2[i] {
+			return false
+		}
+	}
+	return false
+}
+
+// Decrement returns the subcommand that preceded this subcommand.
+// Decrement will decrement its way UP subcommand chains.
+// Eg: {0, 1}.Decrement() == {0, 0}
+//     {1, 0}.Decrement() == {0}
+//     {0}.Decrement() == {}
+func (s *SubcommandIndex) Decrement() {
+	for len(*s) > 0 {
+		if (*s)[len(*s)-1] > 0 {
+			(*s)[len(*s)-1]--
+			return
+		}
+		*s = (*s)[:len(*s)-1]
+	}
+}
+
+// Len returns the length of subcommand indices
+func (s SynchronizationIndices) Len() int {
+	return len(s)
+}
+
+// Swap swaps the 2 subcommands in the given slice
+func (s SynchronizationIndices) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}
+
+// Less returns true if s[i] < s[j]
+func (s SynchronizationIndices) Less(i, j int) bool {
+	return s[i] < s[j]
+}
+
+// SortedKeys returns the keys of 's' in sorted order
+func (s SynchronizationData) SortedKeys() SynchronizationIndices {
+	v := make(SynchronizationIndices, 0, len(s.CommandRanges))
+	for k, _ := range s.CommandRanges {
+		v = append(v, k)
+	}
+	sort.Sort(v)
+	return v
+}
+
+// SortedKeys returns the keys of 'e' in sorted order
+func (e ExecutionRanges) SortedKeys() SynchronizationIndices {
+	v := make(SynchronizationIndices, 0, len(e.Ranges))
+	for k, _ := range e.Ranges {
+		v = append(v, k)
+	}
+	sort.Sort(v)
+	return v
+}

--- a/gapis/gfxapi/templates/api.go.tmpl
+++ b/gapis/gfxapi/templates/api.go.tmpl
@@ -1081,6 +1081,7 @@
     {{range $g := $.Globals}}
       {{Title $g.Name}} {{Template "Go.Type" $g}}
     {{end}}
+    CustomState `nobox:"true"`
   }
 
   func (g *State) Init() {

--- a/gapis/gfxapi/test/CMakeFiles.cmake
+++ b/gapis/gfxapi/test/CMakeFiles.cmake
@@ -26,6 +26,7 @@ set(files
     mutate.go
     mutate_test.go
     subroutines_test.go
+    synchronization_data_test.go
     test.go
 )
 set(dirs

--- a/gapis/gfxapi/test/synchronization_data_test.go
+++ b/gapis/gfxapi/test/synchronization_data_test.go
@@ -1,0 +1,53 @@
+// Copyright (C) 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package test
+
+import (
+	"testing"
+
+	"github.com/google/gapid/core/assert"
+	"github.com/google/gapid/core/log"
+
+	"github.com/google/gapid/gapis/gfxapi"
+)
+
+func TestSubcommandLessThan(t *testing.T) {
+	ctx := log.Testing(t)
+	assert.With(ctx).That(gfxapi.SubcommandIndex{0}.LessThan(gfxapi.SubcommandIndex{1})).Equals(true)
+	assert.With(ctx).That(gfxapi.SubcommandIndex{1}.LessThan(gfxapi.SubcommandIndex{0})).Equals(false)
+	assert.With(ctx).That(gfxapi.SubcommandIndex{0}.LessThan(gfxapi.SubcommandIndex{0})).Equals(false)
+	assert.With(ctx).That(gfxapi.SubcommandIndex{0, 0}.LessThan(gfxapi.SubcommandIndex{0, 1})).Equals(true)
+	assert.With(ctx).That(gfxapi.SubcommandIndex{1, 0}.LessThan(gfxapi.SubcommandIndex{0, 1})).Equals(false)
+	assert.With(ctx).That(gfxapi.SubcommandIndex{1, 0}.LessThan(gfxapi.SubcommandIndex{0, 1})).Equals(false)
+
+	assert.With(ctx).That(gfxapi.SubcommandIndex{1, 0}.LessThan(gfxapi.SubcommandIndex{1})).Equals(true)
+	assert.With(ctx).That(gfxapi.SubcommandIndex{1}.LessThan(gfxapi.SubcommandIndex{1, 0})).Equals(false)
+}
+
+func deceq(s gfxapi.SubcommandIndex, s2 gfxapi.SubcommandIndex) bool {
+	r := s
+	r.Decrement()
+	return !((r.LessThan(s2)) || s2.LessThan(r))
+}
+
+func TestDecrement(t *testing.T) {
+	ctx := log.Testing(t)
+	assert.With(ctx).That(deceq(gfxapi.SubcommandIndex{1}, gfxapi.SubcommandIndex{0})).Equals(true)
+	assert.With(ctx).That(deceq(gfxapi.SubcommandIndex{1, 1}, gfxapi.SubcommandIndex{1, 0})).Equals(true)
+	assert.With(ctx).That(deceq(gfxapi.SubcommandIndex{1, 0}, gfxapi.SubcommandIndex{0})).Equals(true)
+	assert.With(ctx).That(deceq(gfxapi.SubcommandIndex{2, 3, 4}, gfxapi.SubcommandIndex{2, 3, 3})).Equals(true)
+	assert.With(ctx).That(deceq(gfxapi.SubcommandIndex{0}, gfxapi.SubcommandIndex{})).Equals(true)
+	assert.With(ctx).That(deceq(gfxapi.SubcommandIndex{2, 3, 0}, gfxapi.SubcommandIndex{2, 2})).Equals(true)
+}

--- a/gapis/gfxapi/vulkan/CMakeFiles.cmake
+++ b/gapis/gfxapi/vulkan/CMakeFiles.cmake
@@ -20,6 +20,7 @@
 set(files
     api.go
     buffer_command.go
+    command_buffer_rebuilder.go
     convert.go
     custom_replay.go
     dead_code_elimination.go
@@ -38,6 +39,7 @@ set(files
     resources.go
     state.go
     vulkan.go
+    vulkan_terminator.go
 )
 set(dirs
     android

--- a/gapis/gfxapi/vulkan/README.md
+++ b/gapis/gfxapi/vulkan/README.md
@@ -9,175 +9,181 @@ Mid-Execution capture is currently in progress. Currently there is no way
 exposed to start a capture at any frame other than 0, but this will
 be exposed once the functionality is at parity with non mid-execution capture.
 
+## Subcommands
+When replaying to a specific command within a command buffer, we have to
+re-write the command-buffer. The Subcommands list shows all commands in
+command-buffers that support re-writing.
+
+
 ## Current Support
 The current status of support for the Vulkan API on a method by method basis
 are as follows.
 
-| Command Name                                          | Capture | Mid-Execution |
-|-------------------------------------------------------|:-------:|:-------------:|
-| vkAllocateCommandBuffers                              |   :white_check_mark:      |      :white_check_mark:         |
-| vkCreateDevice                                        |   :white_check_mark:      |      :white_check_mark:         |
-| vkCreateInstance                                      |   :white_check_mark:      |      :white_check_mark:         |
-| vkDestroyDevice                                       |   :white_check_mark:      |      :white_check_mark:         |
-| vkDestroyInstance                                     |   :white_check_mark:      |      :white_check_mark:         |
-| vkEnumerateDeviceExtensionProperties                  |   :white_check_mark:      |      :heavy_minus_sign:         |
-| vkEnumerateDeviceLayerProperties                      |   :white_check_mark:      |      :heavy_minus_sign:         |
-| vkEnumerateInstanceExtensionProperties                |   :white_check_mark:      |      :heavy_minus_sign:         |
-| vkEnumerateInstanceLayerProperties                    |   :white_check_mark:      |      :heavy_minus_sign:         |
-| vkEnumeratePhysicalDevices                            |   :white_check_mark:      |      :heavy_minus_sign:         |
-| vkFreeCommandBuffers                                  |   :white_check_mark:      |      :white_check_mark:         |
-| vkGetDeviceProcAddr                                   |   :white_check_mark:      |      :heavy_minus_sign:         |
-| vkGetDeviceQueue                                      |   :white_check_mark:      |      :white_check_mark:         |
-| vkGetInstanceProcAddr                                 |   :white_check_mark:      |      :heavy_minus_sign:         |
-| vkGetPhysicalDeviceSparseImageFormatProperties        |   :white_check_mark:      |      :heavy_minus_sign:         |
-| vkGetPhysicalDeviceFeatures                           |   :white_check_mark:      |      :heavy_minus_sign:         |
-| vkGetPhysicalDeviceFormatProperties                   |   :white_check_mark:      |      :heavy_minus_sign:         |
-| vkGetPhysicalDeviceImageFormatProperties              |   :white_check_mark:      |      :heavy_minus_sign:         |
-| vkGetPhysicalDeviceMemoryProperties                   |   :white_check_mark:      |      :heavy_minus_sign:         |
-| vkGetPhysicalDeviceProperties                         |   :white_check_mark:      |      :heavy_minus_sign:         |
-| vkGetPhysicalDeviceQueueFamilyProperties              |   :white_check_mark:      |      :heavy_minus_sign:         |
-| vkAcquireNextImageKHR                                 |   :white_check_mark:      |      :heavy_minus_sign:         |
-| vkAllocateDescriptorSets                              |   :white_check_mark:      |      :white_check_mark:         |
-| vkAllocateMemory                                      |   :white_check_mark:      |      :white_check_mark:         |
-| vkBeginCommandBuffer                                  |   :white_check_mark:      |      :white_check_mark:         |
-| vkBindBufferMemory                                    |   :white_check_mark:      |      :white_check_mark:         |
-| vkBindImageMemory                                     |   :white_check_mark:      |      :white_check_mark:         |
-| vkCmdBeginQuery                                       |   :white_check_mark:      |      :white_check_mark:         |
-| vkCmdBeginRenderPass                                  |   :white_check_mark:      |      :white_check_mark:         |
-| vkCmdBindDescriptorSets                               |   :white_check_mark:      |      :white_check_mark:         |
-| vkCmdBindIndexBuffer                                  |   :white_check_mark:      |      :white_check_mark:         |
-| vkCmdBindPipeline                                     |   :white_check_mark:      |      :white_check_mark:         |
-| vkCmdBindVertexBuffers                                |   :white_check_mark:      |      :white_check_mark:         |
-| vkCmdBlitImage                                        |   :white_check_mark:      |      :white_check_mark:         |
-| vkCmdClearAttachments                                 |   :white_check_mark:      |      :white_check_mark:         |
-| vkCmdClearColorImage                                  |   :white_check_mark:      |      :white_check_mark:         |
-| vkCmdClearDepthStencilImage                           |   :white_check_mark:      |      :white_check_mark:         |
-| vkCmdCopyBuffer                                       |   :white_check_mark:      |      :white_check_mark:         |
-| vkCmdCopyBufferToImage                                |   :white_check_mark:      |      :white_check_mark:         |
-| vkCmdCopyImage                                        |   :white_check_mark:      |      :white_check_mark:         |
-| vkCmdCopyImageToBuffer                                |   :white_check_mark:      |      :white_check_mark:         |
-| vkCmdCopyQueryPoolResults                             |   :white_check_mark:      |      :white_check_mark:         |
-| vkCmdDispatch                                         |   :white_check_mark:      |      :white_check_mark:         |
-| vkCmdDispatchIndirect                                 |   :white_check_mark:      |      :white_check_mark:         |
-| vkCmdDraw                                             |   :white_check_mark:      |      :white_check_mark:         |
-| vkCmdDrawIndexed                                      |   :white_check_mark:      |      :white_check_mark:         |
-| vkCmdDrawIndexedIndirect                              |   :white_check_mark:      |      :white_check_mark:         |
-| vkCmdDrawIndirect                                     |   :white_check_mark:      |      :white_check_mark:         |
-| vkCmdEndQuery                                         |   :white_check_mark:      |      :white_check_mark:         |
-| vkCmdEndRenderPass                                    |   :white_check_mark:      |      :white_check_mark:         |
-| vkCmdExecuteCommands                                  |   :white_check_mark:      |      :white_check_mark:         |
-| vkCmdFillBuffer                                       |   :white_check_mark:      |      :white_check_mark:         |
-| vkCmdNextSubpass                                      |   :white_medium_square:   |      :white_medium_square:      |
-| vkCmdPipelineBarrier                                  |   :white_check_mark:      |      :white_check_mark:         |
-| vkCmdPushConstants                                    |   :white_check_mark:      |      :white_check_mark:         |
-| vkCmdResetEvent                                       |   :white_medium_square:   |      :white_medium_square:      |
-| vkCmdResetQueryPool                                   |   :white_check_mark:      |      :white_check_mark:         |
-| vkCmdResolveImage                                     |   :white_check_mark:      |      :white_check_mark:         |
-| vkCmdSetBlendConstants                                |   :white_check_mark:      |      :white_check_mark:         |
-| vkCmdSetDepthBias                                     |   :white_check_mark:      |      :white_check_mark:         |
-| vkCmdSetDepthBounds                                   |   :white_medium_square:   |      :white_medium_square:      |
-| vkCmdSetEvent                                         |   :white_medium_square:   |      :white_medium_square:      |
-| vkCmdSetLineWidth                                     |   :white_check_mark:      |      :white_check_mark:         |
-| vkCmdSetScissor                                       |   :white_check_mark:      |      :white_check_mark:         |
-| vkCmdSetStencilCompareMask                            |   :white_medium_square:   |      :white_medium_square:      |
-| vkCmdSetStencilReference                              |   :white_medium_square:   |      :white_medium_square:      |
-| vkCmdSetStencilWriteMask                              |   :white_medium_square:   |      :white_medium_square:      |
-| vkCmdSetViewport                                      |   :white_check_mark:      |      :white_check_mark:         |
-| vkCmdUpdateBuffer                                     |   :white_check_mark:      |      :white_check_mark:         |
-| vkCmdWaitEvents                                       |   :white_medium_square:   |      :white_medium_square:      |
-| vkCmdWriteTimestamp                                   |   :white_medium_square:   |      :white_medium_square:      |
-| vkCreateAndroidSurfaceKHR                             |   :white_check_mark:      |      :white_check_mark:         |
-| vkCreateBuffer                                        |   :white_check_mark:      |      :white_check_mark:         |
-| vkCreateBufferView                                    |   :white_check_mark:      |      :white_check_mark:         |
-| vkCreateCommandPool                                   |   :white_check_mark:      |      :white_check_mark:         |
-| vkCreateComputePipelines                              |   :white_check_mark:      |      :white_check_mark:         |
-| vkCreateDescriptorPool                                |   :white_check_mark:      |      :white_check_mark:         |
-| vkCreateDescriptorSetLayout                           |   :white_check_mark:      |      :white_check_mark:         |
-| vkCreateDisplayModeKHR                                |   :white_medium_square:   |      :white_medium_square:      |
-| vkCreateDisplayPlaneSurfaceKHR                        |   :white_medium_square:   |      :white_medium_square:      |
-| vkCreateEvent                                         |   :white_medium_square:   |      :white_medium_square:      |
-| vkCreateFramebuffer                                   |   :white_check_mark:      |      :white_check_mark:         |
-| vkCreateGraphicsPipelines                             |   :white_check_mark:      |      :white_check_mark:         |
-| vkCreateImage                                         |   :white_check_mark:      |      :white_check_mark:         |
-| vkCreateImageView                                     |   :white_check_mark:      |      :white_check_mark:         |
-| vkCreateMirSurfaceKHR                                 |   :white_medium_square:   |      :white_medium_square:      |
-| vkCreatePipelineCache                                 |   :white_check_mark:      |      :white_check_mark:         |
-| vkCreatePipelineLayout                                |   :white_check_mark:      |      :white_check_mark:         |
-| vkCreateQueryPool                                     |   :white_check_mark:      |      :white_check_mark:         |
-| vkCreateRenderPass                                    |   :white_check_mark:      |      :white_check_mark:         |
-| vkCreateSampler                                       |   :white_check_mark:      |      :white_check_mark:         |
-| vkCreateSemaphore                                     |   :white_check_mark:      |      :white_check_mark:         |
-| vkCreateShaderModule                                  |   :white_check_mark:      |      :white_check_mark:         |
-| vkCreateSharedSwapchainsKHR                           |   :white_medium_square:   |      :white_medium_square:      |
-| vkCreateSwapchainKHR                                  |   :white_check_mark:      |      :white_check_mark:         |
-| vkCreateWaylandSurfaceKHR                             |   :white_medium_square:   |      :white_medium_square:      |
-| vkCreateWin32SurfaceKHR                               |   :white_check_mark:      |      :white_medium_square:      |
-| vkCreateXcbSurfaceKHR                                 |   :white_check_mark:      |      :white_check_mark:         |
-| vkCreateXlibSurfaceKHR                                |   :white_medium_square:   |      :white_medium_square:      |
-| vkDestroyBuffer                                       |   :white_check_mark:      |      :white_check_mark:         |
-| vkDestroyBufferView                                   |   :white_check_mark:      |      :white_check_mark:         |
-| vkDestroyCommandPool                                  |   :white_check_mark:      |      :white_check_mark:         |
-| vkDestroyDescriptorPool                               |   :white_check_mark:      |      :white_check_mark:         |
-| vkDestroyDescriptorSetLayout                          |   :white_check_mark:      |      :white_check_mark:         |
-| vkDestroyEvent                                        |   :white_medium_square:   |      :white_medium_square:      |
-| vkDestroyFramebuffer                                  |   :white_check_mark:      |      :white_check_mark:         |
-| vkDestroyImage                                        |   :white_check_mark:      |      :white_check_mark:         |
-| vkDestroyImageView                                    |   :white_check_mark:      |      :white_check_mark:         |
-| vkDestroyPipeline                                     |   :white_check_mark:      |      :white_check_mark:         |
-| vkDestroyPipelineCache                                |   :white_check_mark:      |      :white_check_mark:         |
-| vkDestroyPipelineLayout                               |   :white_check_mark:      |      :white_check_mark:         |
-| vkDestroyQueryPool                                    |   :white_check_mark:      |      :white_check_mark:         |
-| vkDestroyRenderPass                                   |   :white_check_mark:      |      :white_check_mark:         |
-| vkDestroySampler                                      |   :white_check_mark:      |      :white_check_mark:         |
-| vkDestroySemaphore                                    |   :white_check_mark:      |      :white_check_mark:         |
-| vkDestroyShaderModule                                 |   :white_check_mark:      |      :white_check_mark:         |
-| vkDestroySwapchainKHR                                 |   :white_check_mark:      |      :white_check_mark:         |
-| vkDeviceWaitIdle                                      |   :white_check_mark:      |      :white_check_mark:         |
-| vkEndCommandBuffer                                    |   :white_check_mark:      |      :white_check_mark:         |
-| vkFlushMappedMemoryRanges                             |   :white_check_mark:      |      :heavy_minus_sign:         |
-| vkFreeDescriptorSets                                  |   :white_check_mark:      |      :white_check_mark:         |
-| vkFreeMemory                                          |   :white_check_mark:      |      :white_check_mark:         |
-| vkGetBufferMemoryRequirements                         |   :white_check_mark:      |      :heavy_minus_sign:         |
-| vkGetDeviceMemoryCommitment                           |   :white_medium_square:   |      :heavy_minus_sign:         |
-| vkGetDisplayModePropertiesKHR                         |   :white_medium_square:   |      :heavy_minus_sign:         |
-| vkGetDisplayPlaneCapabilitiesKHR                      |   :white_medium_square:   |      :heavy_minus_sign:         |
-| vkGetDisplayPlaneSupportedDisplaysKHR                 |   :white_medium_square:   |      :heavy_minus_sign:         |
-| vkGetEventStatus                                      |   :white_medium_square:   |      :heavy_minus_sign:         |
-| vkGetFenceStatus                                      |   :white_check_mark:      |      :heavy_minus_sign:         |
-| vkGetImageMemoryRequirements                          |   :white_check_mark:      |      :heavy_minus_sign:         |
-| vkGetImageSparseMemoryRequirements                    |   :white_medium_square:   |      :heavy_minus_sign:         |
-| vkGetImageSubresourceLayout                           |   :white_medium_square:   |      :heavy_minus_sign:         |
-| vkGetPhysicalDeviceDisplayPlanePropertiesKHR          |   :white_medium_square:   |      :heavy_minus_sign:         |
-| vkGetPhysicalDeviceDisplayPropertiesKHR               |   :white_medium_square:   |      :heavy_minus_sign:         |
-| vkGetPhysicalDeviceMirPresentationSupportKHR          |   :white_medium_square:   |      :heavy_minus_sign:         |
-| vkGetPhysicalDeviceSurfaceCapabilitiesKHR             |   :white_check_mark:      |      :heavy_minus_sign:         |
-| vkGetPhysicalDeviceSurfaceFormatsKHR                  |   :white_check_mark:      |      :heavy_minus_sign:         |
-| vkGetPhysicalDeviceSurfacePresentModesKHR             |   :white_check_mark:      |      :heavy_minus_sign:         |
-| vkGetPhysicalDeviceSurfaceSupportKHR                  |   :white_check_mark:      |      :heavy_minus_sign:         |
-| vkGetPhysicalDeviceWaylandPresentationSupportKHR      |   :white_medium_square:   |      :heavy_minus_sign:         |
-| vkGetPhysicalDeviceWin32PresentationSupportKHR        |   :white_medium_square:   |      :heavy_minus_sign:         |
-| vkGetPhysicalDeviceXcbPresentationSupportKHR          |   :white_medium_square:   |      :heavy_minus_sign:         |
-| vkGetPhysicalDeviceXlibPresentationSupportKHR         |   :white_medium_square:   |      :heavy_minus_sign:         |
-| vkGetPipelineCacheData                                |   :white_check_mark:      |      :heavy_minus_sign:         |
-| vkGetQueryPoolResults                                 |   :white_check_mark:      |      :heavy_minus_sign:         |
-| vkGetRenderAreaGranularity                            |   :white_medium_square:   |      :heavy_minus_sign:         |
-| vkGetSwapchainImagesKHR                               |   :white_check_mark:      |      :heavy_minus_sign:         |
-| vkInvalidateMappedMemoryRanges                        |   :white_check_mark:      |      :heavy_minus_sign:         |
-| vkMapMemory                                           |   :white_check_mark:      |      :white_check_mark:         |
-| vkMergePipelineCaches                                 |   :white_medium_square:   |      :heavy_minus_sign:         |
-| vkQueueBindSparse                                     |   :white_medium_square:   |      :white_medium_square:      |
-| vkQueuePresentKHR                                     |   :white_check_mark:      |      :heavy_minus_sign:         |
-| vkQueueSubmit                                         |   :white_check_mark:      |      :white_check_mark:         |
-| vkQueueWaitIdle                                       |   :white_check_mark:      |      :heavy_minus_sign:         |
-| vkResetCommandBuffer                                  |   :white_check_mark:      |      :white_check_mark:         |
-| vkResetCommandPool                                    |   :white_medium_square:   |      :white_medium_square:      |
-| vkResetDescriptorPool                                 |   :white_check_mark:      |      :white_medium_square:      |
-| vkResetEvent                                          |   :white_medium_square:   |      :white_medium_square:      |
-| vkResetFences                                         |   :white_check_mark:      |      :white_check_mark:         |
-| vkSetEvent                                            |   :white_medium_square:   |      :heavy_minus_sign:         |
-| vkUnmapMemory                                         |   :white_check_mark:      |      :white_check_mark:         |
-| vkUpdateDescriptorSets                                |   :white_check_mark:      |      :white_check_mark:         |
-| vkWaitForFences                                       |   :white_check_mark:      |      :heavy_minus_sign:         |
-| vkCreateFence                                         |   :white_check_mark:      |      :white_check_mark:         |
-| vkDestroyFence                                        |   :white_check_mark:      |      :white_check_mark:         |
-| vkDestroySurfaceKHR                                   |   :white_check_mark:      |      :white_check_mark:         |
+| Command Name                                          | Capture | Mid-Execution |  Subcommands  |
+|-------------------------------------------------------|:-------:|:-------------:|:-------------:|
+| vkAllocateCommandBuffers                              |   :white_check_mark:      |      :white_check_mark:         |      :heavy_minus_sign:         |
+| vkCreateDevice                                        |   :white_check_mark:      |      :white_check_mark:         |      :heavy_minus_sign:         |
+| vkCreateInstance                                      |   :white_check_mark:      |      :white_check_mark:         |      :heavy_minus_sign:         |
+| vkDestroyDevice                                       |   :white_check_mark:      |      :white_check_mark:         |      :heavy_minus_sign:         |
+| vkDestroyInstance                                     |   :white_check_mark:      |      :white_check_mark:         |      :heavy_minus_sign:         |
+| vkEnumerateDeviceExtensionProperties                  |   :white_check_mark:      |      :heavy_minus_sign:         |      :heavy_minus_sign:         |
+| vkEnumerateDeviceLayerProperties                      |   :white_check_mark:      |      :heavy_minus_sign:         |      :heavy_minus_sign:         |
+| vkEnumerateInstanceExtensionProperties                |   :white_check_mark:      |      :heavy_minus_sign:         |      :heavy_minus_sign:         |
+| vkEnumerateInstanceLayerProperties                    |   :white_check_mark:      |      :heavy_minus_sign:         |      :heavy_minus_sign:         |
+| vkEnumeratePhysicalDevices                            |   :white_check_mark:      |      :heavy_minus_sign:         |      :heavy_minus_sign:         |
+| vkFreeCommandBuffers                                  |   :white_check_mark:      |      :white_check_mark:         |      :heavy_minus_sign:         |
+| vkGetDeviceProcAddr                                   |   :white_check_mark:      |      :heavy_minus_sign:         |      :heavy_minus_sign:         |
+| vkGetDeviceQueue                                      |   :white_check_mark:      |      :white_check_mark:         |      :heavy_minus_sign:         |
+| vkGetInstanceProcAddr                                 |   :white_check_mark:      |      :heavy_minus_sign:         |      :heavy_minus_sign:         |
+| vkGetPhysicalDeviceSparseImageFormatProperties        |   :white_check_mark:      |      :heavy_minus_sign:         |      :heavy_minus_sign:         |
+| vkGetPhysicalDeviceFeatures                           |   :white_check_mark:      |      :heavy_minus_sign:         |      :heavy_minus_sign:         |
+| vkGetPhysicalDeviceFormatProperties                   |   :white_check_mark:      |      :heavy_minus_sign:         |      :heavy_minus_sign:         |
+| vkGetPhysicalDeviceImageFormatProperties              |   :white_check_mark:      |      :heavy_minus_sign:         |      :heavy_minus_sign:         |
+| vkGetPhysicalDeviceMemoryProperties                   |   :white_check_mark:      |      :heavy_minus_sign:         |      :heavy_minus_sign:         |
+| vkGetPhysicalDeviceProperties                         |   :white_check_mark:      |      :heavy_minus_sign:         |      :heavy_minus_sign:         |
+| vkGetPhysicalDeviceQueueFamilyProperties              |   :white_check_mark:      |      :heavy_minus_sign:         |      :heavy_minus_sign:         |
+| vkAcquireNextImageKHR                                 |   :white_check_mark:      |      :heavy_minus_sign:         |      :heavy_minus_sign:         |
+| vkAllocateDescriptorSets                              |   :white_check_mark:      |      :white_check_mark:         |      :heavy_minus_sign:         |
+| vkAllocateMemory                                      |   :white_check_mark:      |      :white_check_mark:         |      :heavy_minus_sign:         |
+| vkBeginCommandBuffer                                  |   :white_check_mark:      |      :white_check_mark:         |      :heavy_minus_sign:         |
+| vkBindBufferMemory                                    |   :white_check_mark:      |      :white_check_mark:         |      :heavy_minus_sign:         |
+| vkBindImageMemory                                     |   :white_check_mark:      |      :white_check_mark:         |      :heavy_minus_sign:         |
+| vkCmdBeginQuery                                       |   :white_check_mark:      |      :white_check_mark:         |      :white_medium_square:      |
+| vkCmdBeginRenderPass                                  |   :white_check_mark:      |      :white_check_mark:         |      :white_medium_square:      |
+| vkCmdBindDescriptorSets                               |   :white_check_mark:      |      :white_check_mark:         |      :white_medium_square:      |
+| vkCmdBindIndexBuffer                                  |   :white_check_mark:      |      :white_check_mark:         |      :white_medium_square:      |
+| vkCmdBindPipeline                                     |   :white_check_mark:      |      :white_check_mark:         |      :white_medium_square:      |
+| vkCmdBindVertexBuffers                                |   :white_check_mark:      |      :white_check_mark:         |      :white_medium_square:      |
+| vkCmdBlitImage                                        |   :white_check_mark:      |      :white_check_mark:         |      :white_medium_square:      |
+| vkCmdClearAttachments                                 |   :white_check_mark:      |      :white_check_mark:         |      :white_medium_square:      |
+| vkCmdClearColorImage                                  |   :white_check_mark:      |      :white_check_mark:         |      :white_medium_square:      |
+| vkCmdClearDepthStencilImage                           |   :white_check_mark:      |      :white_check_mark:         |      :white_medium_square:      |
+| vkCmdCopyBuffer                                       |   :white_check_mark:      |      :white_check_mark:         |      :white_medium_square:      |
+| vkCmdCopyBufferToImage                                |   :white_check_mark:      |      :white_check_mark:         |      :white_medium_square:      |
+| vkCmdCopyImage                                        |   :white_check_mark:      |      :white_check_mark:         |      :white_medium_square:      |
+| vkCmdCopyImageToBuffer                                |   :white_check_mark:      |      :white_check_mark:         |      :white_medium_square:      |
+| vkCmdCopyQueryPoolResults                             |   :white_check_mark:      |      :white_check_mark:         |      :white_medium_square:      |
+| vkCmdDispatch                                         |   :white_check_mark:      |      :white_check_mark:         |      :white_medium_square:      |
+| vkCmdDispatchIndirect                                 |   :white_check_mark:      |      :white_check_mark:         |      :white_medium_square:      |
+| vkCmdDraw                                             |   :white_check_mark:      |      :white_check_mark:         |      :white_medium_square:      |
+| vkCmdDrawIndexed                                      |   :white_check_mark:      |      :white_check_mark:         |      :white_medium_square:      |
+| vkCmdDrawIndexedIndirect                              |   :white_check_mark:      |      :white_check_mark:         |      :white_medium_square:      |
+| vkCmdDrawIndirect                                     |   :white_check_mark:      |      :white_check_mark:         |      :white_medium_square:      |
+| vkCmdEndQuery                                         |   :white_check_mark:      |      :white_check_mark:         |      :white_medium_square:      |
+| vkCmdEndRenderPass                                    |   :white_check_mark:      |      :white_check_mark:         |      :white_medium_square:      |
+| vkCmdExecuteCommands                                  |   :white_check_mark:      |      :white_check_mark:         |      :white_medium_square:      |
+| vkCmdFillBuffer                                       |   :white_check_mark:      |      :white_check_mark:         |      :white_medium_square:      |
+| vkCmdNextSubpass                                      |   :white_medium_square:   |      :white_medium_square:      |      :white_medium_square:      |
+| vkCmdPipelineBarrier                                  |   :white_check_mark:      |      :white_check_mark:         |      :white_medium_square:      |
+| vkCmdPushConstants                                    |   :white_check_mark:      |      :white_check_mark:         |      :white_medium_square:      |
+| vkCmdResetEvent                                       |   :white_medium_square:   |      :white_medium_square:      |      :white_medium_square:      |
+| vkCmdResetQueryPool                                   |   :white_check_mark:      |      :white_check_mark:         |      :white_medium_square:      |
+| vkCmdResolveImage                                     |   :white_check_mark:      |      :white_check_mark:         |      :white_medium_square:      |
+| vkCmdSetBlendConstants                                |   :white_check_mark:      |      :white_check_mark:         |      :white_medium_square:      |
+| vkCmdSetDepthBias                                     |   :white_check_mark:      |      :white_check_mark:         |      :white_medium_square:      |
+| vkCmdSetDepthBounds                                   |   :white_medium_square:   |      :white_medium_square:      |      :white_medium_square:      |
+| vkCmdSetEvent                                         |   :white_medium_square:   |      :white_medium_square:      |      :white_medium_square:      |
+| vkCmdSetLineWidth                                     |   :white_check_mark:      |      :white_check_mark:         |      :white_medium_square:      |
+| vkCmdSetScissor                                       |   :white_check_mark:      |      :white_check_mark:         |      :white_medium_square:      |
+| vkCmdSetStencilCompareMask                            |   :white_medium_square:   |      :white_medium_square:      |      :white_medium_square:      |
+| vkCmdSetStencilReference                              |   :white_medium_square:   |      :white_medium_square:      |      :white_medium_square:      |
+| vkCmdSetStencilWriteMask                              |   :white_medium_square:   |      :white_medium_square:      |      :white_medium_square:      |
+| vkCmdSetViewport                                      |   :white_check_mark:      |      :white_check_mark:         |      :white_medium_square:      |
+| vkCmdUpdateBuffer                                     |   :white_check_mark:      |      :white_check_mark:         |      :white_medium_square:      |
+| vkCmdWaitEvents                                       |   :white_medium_square:   |      :white_medium_square:      |      :white_medium_square:      |
+| vkCmdWriteTimestamp                                   |   :white_medium_square:   |      :white_medium_square:      |      :white_medium_square:      |
+| vkCreateAndroidSurfaceKHR                             |   :white_check_mark:      |      :white_check_mark:         |      :heavy_minus_sign:         |
+| vkCreateBuffer                                        |   :white_check_mark:      |      :white_check_mark:         |      :heavy_minus_sign:         |
+| vkCreateBufferView                                    |   :white_check_mark:      |      :white_check_mark:         |      :heavy_minus_sign:         |
+| vkCreateCommandPool                                   |   :white_check_mark:      |      :white_check_mark:         |      :heavy_minus_sign:         |
+| vkCreateComputePipelines                              |   :white_check_mark:      |      :white_check_mark:         |      :heavy_minus_sign:         |
+| vkCreateDescriptorPool                                |   :white_check_mark:      |      :white_check_mark:         |      :heavy_minus_sign:         |
+| vkCreateDescriptorSetLayout                           |   :white_check_mark:      |      :white_check_mark:         |      :heavy_minus_sign:         |
+| vkCreateDisplayModeKHR                                |   :white_medium_square:   |      :white_medium_square:      |      :heavy_minus_sign:         |
+| vkCreateDisplayPlaneSurfaceKHR                        |   :white_medium_square:   |      :white_medium_square:      |      :heavy_minus_sign:         |
+| vkCreateEvent                                         |   :white_medium_square:   |      :white_medium_square:      |      :heavy_minus_sign:         |
+| vkCreateFramebuffer                                   |   :white_check_mark:      |      :white_check_mark:         |      :heavy_minus_sign:         |
+| vkCreateGraphicsPipelines                             |   :white_check_mark:      |      :white_check_mark:         |      :heavy_minus_sign:         |
+| vkCreateImage                                         |   :white_check_mark:      |      :white_check_mark:         |      :heavy_minus_sign:         |
+| vkCreateImageView                                     |   :white_check_mark:      |      :white_check_mark:         |      :heavy_minus_sign:         |
+| vkCreateMirSurfaceKHR                                 |   :white_medium_square:   |      :white_medium_square:      |      :heavy_minus_sign:         |
+| vkCreatePipelineCache                                 |   :white_check_mark:      |      :white_check_mark:         |      :heavy_minus_sign:         |
+| vkCreatePipelineLayout                                |   :white_check_mark:      |      :white_check_mark:         |      :heavy_minus_sign:         |
+| vkCreateQueryPool                                     |   :white_check_mark:      |      :white_check_mark:         |      :heavy_minus_sign:         |
+| vkCreateRenderPass                                    |   :white_check_mark:      |      :white_check_mark:         |      :heavy_minus_sign:         |
+| vkCreateSampler                                       |   :white_check_mark:      |      :white_check_mark:         |      :heavy_minus_sign:         |
+| vkCreateSemaphore                                     |   :white_check_mark:      |      :white_check_mark:         |      :heavy_minus_sign:         |
+| vkCreateShaderModule                                  |   :white_check_mark:      |      :white_check_mark:         |      :heavy_minus_sign:         |
+| vkCreateSharedSwapchainsKHR                           |   :white_medium_square:   |      :white_medium_square:      |      :heavy_minus_sign:         |
+| vkCreateSwapchainKHR                                  |   :white_check_mark:      |      :white_check_mark:         |      :heavy_minus_sign:         |
+| vkCreateWaylandSurfaceKHR                             |   :white_medium_square:   |      :white_medium_square:      |      :heavy_minus_sign:         |
+| vkCreateWin32SurfaceKHR                               |   :white_check_mark:      |      :white_medium_square:      |      :heavy_minus_sign:         |
+| vkCreateXcbSurfaceKHR                                 |   :white_check_mark:      |      :white_check_mark:         |      :heavy_minus_sign:         |
+| vkCreateXlibSurfaceKHR                                |   :white_medium_square:   |      :white_medium_square:      |      :heavy_minus_sign:         |
+| vkDestroyBuffer                                       |   :white_check_mark:      |      :white_check_mark:         |      :heavy_minus_sign:         |
+| vkDestroyBufferView                                   |   :white_check_mark:      |      :white_check_mark:         |      :heavy_minus_sign:         |
+| vkDestroyCommandPool                                  |   :white_check_mark:      |      :white_check_mark:         |      :heavy_minus_sign:         |
+| vkDestroyDescriptorPool                               |   :white_check_mark:      |      :white_check_mark:         |      :heavy_minus_sign:         |
+| vkDestroyDescriptorSetLayout                          |   :white_check_mark:      |      :white_check_mark:         |      :heavy_minus_sign:         |
+| vkDestroyEvent                                        |   :white_medium_square:   |      :white_medium_square:      |      :heavy_minus_sign:         |
+| vkDestroyFramebuffer                                  |   :white_check_mark:      |      :white_check_mark:         |      :heavy_minus_sign:         |
+| vkDestroyImage                                        |   :white_check_mark:      |      :white_check_mark:         |      :heavy_minus_sign:         |
+| vkDestroyImageView                                    |   :white_check_mark:      |      :white_check_mark:         |      :heavy_minus_sign:         |
+| vkDestroyPipeline                                     |   :white_check_mark:      |      :white_check_mark:         |      :heavy_minus_sign:         |
+| vkDestroyPipelineCache                                |   :white_check_mark:      |      :white_check_mark:         |      :heavy_minus_sign:         |
+| vkDestroyPipelineLayout                               |   :white_check_mark:      |      :white_check_mark:         |      :heavy_minus_sign:         |
+| vkDestroyQueryPool                                    |   :white_check_mark:      |      :white_check_mark:         |      :heavy_minus_sign:         |
+| vkDestroyRenderPass                                   |   :white_check_mark:      |      :white_check_mark:         |      :heavy_minus_sign:         |
+| vkDestroySampler                                      |   :white_check_mark:      |      :white_check_mark:         |      :heavy_minus_sign:         |
+| vkDestroySemaphore                                    |   :white_check_mark:      |      :white_check_mark:         |      :heavy_minus_sign:         |
+| vkDestroyShaderModule                                 |   :white_check_mark:      |      :white_check_mark:         |      :heavy_minus_sign:         |
+| vkDestroySwapchainKHR                                 |   :white_check_mark:      |      :white_check_mark:         |      :heavy_minus_sign:         |
+| vkDeviceWaitIdle                                      |   :white_check_mark:      |      :white_check_mark:         |      :heavy_minus_sign:         |
+| vkEndCommandBuffer                                    |   :white_check_mark:      |      :white_check_mark:         |      :heavy_minus_sign:         |
+| vkFlushMappedMemoryRanges                             |   :white_check_mark:      |      :heavy_minus_sign:         |      :heavy_minus_sign:         |
+| vkFreeDescriptorSets                                  |   :white_check_mark:      |      :white_check_mark:         |      :heavy_minus_sign:         |
+| vkFreeMemory                                          |   :white_check_mark:      |      :white_check_mark:         |      :heavy_minus_sign:         |
+| vkGetBufferMemoryRequirements                         |   :white_check_mark:      |      :heavy_minus_sign:         |      :heavy_minus_sign:         |
+| vkGetDeviceMemoryCommitment                           |   :white_medium_square:   |      :heavy_minus_sign:         |      :heavy_minus_sign:         |
+| vkGetDisplayModePropertiesKHR                         |   :white_medium_square:   |      :heavy_minus_sign:         |      :heavy_minus_sign:         |
+| vkGetDisplayPlaneCapabilitiesKHR                      |   :white_medium_square:   |      :heavy_minus_sign:         |      :heavy_minus_sign:         |
+| vkGetDisplayPlaneSupportedDisplaysKHR                 |   :white_medium_square:   |      :heavy_minus_sign:         |      :heavy_minus_sign:         |
+| vkGetEventStatus                                      |   :white_medium_square:   |      :heavy_minus_sign:         |      :heavy_minus_sign:         |
+| vkGetFenceStatus                                      |   :white_check_mark:      |      :heavy_minus_sign:         |      :heavy_minus_sign:         |
+| vkGetImageMemoryRequirements                          |   :white_check_mark:      |      :heavy_minus_sign:         |      :heavy_minus_sign:         |
+| vkGetImageSparseMemoryRequirements                    |   :white_medium_square:   |      :heavy_minus_sign:         |      :heavy_minus_sign:         |
+| vkGetImageSubresourceLayout                           |   :white_medium_square:   |      :heavy_minus_sign:         |      :heavy_minus_sign:         |
+| vkGetPhysicalDeviceDisplayPlanePropertiesKHR          |   :white_medium_square:   |      :heavy_minus_sign:         |      :heavy_minus_sign:         |
+| vkGetPhysicalDeviceDisplayPropertiesKHR               |   :white_medium_square:   |      :heavy_minus_sign:         |      :heavy_minus_sign:         |
+| vkGetPhysicalDeviceMirPresentationSupportKHR          |   :white_medium_square:   |      :heavy_minus_sign:         |      :heavy_minus_sign:         |
+| vkGetPhysicalDeviceSurfaceCapabilitiesKHR             |   :white_check_mark:      |      :heavy_minus_sign:         |      :heavy_minus_sign:         |
+| vkGetPhysicalDeviceSurfaceFormatsKHR                  |   :white_check_mark:      |      :heavy_minus_sign:         |      :heavy_minus_sign:         |
+| vkGetPhysicalDeviceSurfacePresentModesKHR             |   :white_check_mark:      |      :heavy_minus_sign:         |      :heavy_minus_sign:         |
+| vkGetPhysicalDeviceSurfaceSupportKHR                  |   :white_check_mark:      |      :heavy_minus_sign:         |      :heavy_minus_sign:         |
+| vkGetPhysicalDeviceWaylandPresentationSupportKHR      |   :white_medium_square:   |      :heavy_minus_sign:         |      :heavy_minus_sign:         |
+| vkGetPhysicalDeviceWin32PresentationSupportKHR        |   :white_medium_square:   |      :heavy_minus_sign:         |      :heavy_minus_sign:         |
+| vkGetPhysicalDeviceXcbPresentationSupportKHR          |   :white_medium_square:   |      :heavy_minus_sign:         |      :heavy_minus_sign:         |
+| vkGetPhysicalDeviceXlibPresentationSupportKHR         |   :white_medium_square:   |      :heavy_minus_sign:         |      :heavy_minus_sign:         |
+| vkGetPipelineCacheData                                |   :white_check_mark:      |      :heavy_minus_sign:         |      :heavy_minus_sign:         |
+| vkGetQueryPoolResults                                 |   :white_check_mark:      |      :heavy_minus_sign:         |      :heavy_minus_sign:         |
+| vkGetRenderAreaGranularity                            |   :white_medium_square:   |      :heavy_minus_sign:         |      :heavy_minus_sign:         |
+| vkGetSwapchainImagesKHR                               |   :white_check_mark:      |      :heavy_minus_sign:         |      :heavy_minus_sign:         |
+| vkInvalidateMappedMemoryRanges                        |   :white_check_mark:      |      :heavy_minus_sign:         |      :heavy_minus_sign:         |
+| vkMapMemory                                           |   :white_check_mark:      |      :white_check_mark:         |      :heavy_minus_sign:         |
+| vkMergePipelineCaches                                 |   :white_medium_square:   |      :heavy_minus_sign:         |      :heavy_minus_sign:         |
+| vkQueueBindSparse                                     |   :white_medium_square:   |      :white_medium_square:      |      :heavy_minus_sign:         |
+| vkQueuePresentKHR                                     |   :white_check_mark:      |      :heavy_minus_sign:         |      :heavy_minus_sign:         |
+| vkQueueSubmit                                         |   :white_check_mark:      |      :white_check_mark:         |      :heavy_minus_sign:         |
+| vkQueueWaitIdle                                       |   :white_check_mark:      |      :heavy_minus_sign:         |      :heavy_minus_sign:         |
+| vkResetCommandBuffer                                  |   :white_check_mark:      |      :white_check_mark:         |      :heavy_minus_sign:         |
+| vkResetCommandPool                                    |   :white_medium_square:   |      :white_medium_square:      |      :heavy_minus_sign:         |
+| vkResetDescriptorPool                                 |   :white_check_mark:      |      :white_medium_square:      |      :heavy_minus_sign:         |
+| vkResetEvent                                          |   :white_medium_square:   |      :white_medium_square:      |      :heavy_minus_sign:         |
+| vkResetFences                                         |   :white_check_mark:      |      :white_check_mark:         |      :heavy_minus_sign:         |
+| vkSetEvent                                            |   :white_medium_square:   |      :heavy_minus_sign:         |      :heavy_minus_sign:         |
+| vkUnmapMemory                                         |   :white_check_mark:      |      :white_check_mark:         |      :heavy_minus_sign:         |
+| vkUpdateDescriptorSets                                |   :white_check_mark:      |      :white_check_mark:         |      :heavy_minus_sign:         |
+| vkWaitForFences                                       |   :white_check_mark:      |      :heavy_minus_sign:         |      :heavy_minus_sign:         |
+| vkCreateFence                                         |   :white_check_mark:      |      :white_check_mark:         |      :heavy_minus_sign:         |
+| vkDestroyFence                                        |   :white_check_mark:      |      :white_check_mark:         |      :heavy_minus_sign:         |
+| vkDestroySurfaceKHR                                   |   :white_check_mark:      |      :white_check_mark:         |      :heavy_minus_sign:         |

--- a/gapis/gfxapi/vulkan/buffer_command.go
+++ b/gapis/gfxapi/vulkan/buffer_command.go
@@ -19,8 +19,11 @@ package vulkan
 import "github.com/google/gapid/gapis/atom"
 
 type CommandBufferCommand struct {
-	function func()
-	a        *atom.Atom
+	function         func()
+	submit           *atom.Atom
+	submissionIndex  []uint64
+	recreateData     interface{}
+	actualSubmission bool
 }
 
 type CommandBufferCommands []CommandBufferCommand

--- a/gapis/gfxapi/vulkan/command_buffer_rebuilder.go
+++ b/gapis/gfxapi/vulkan/command_buffer_rebuilder.go
@@ -1,0 +1,299 @@
+// Copyright (C) 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vulkan
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/gapid/gapis/atom"
+	"github.com/google/gapid/gapis/gfxapi"
+	"github.com/google/gapid/gapis/memory"
+)
+
+func rebuildCmdBeginRenderPass(
+	ctx context.Context,
+	commandBuffer VkCommandBuffer,
+	s *gfxapi.State,
+	d *RecreateCmdBeginRenderPassData) (func(), atom.Atom) {
+
+	clearValues := make([]VkClearValue, len(d.ClearValues))
+	for i := 0; i < len(d.ClearValues); i++ {
+		clearValues[i] = d.ClearValues[uint32(i)]
+	}
+
+	clearValuesData := atom.Must(atom.AllocData(ctx, s, clearValues))
+
+	begin := VkRenderPassBeginInfo{
+		VkStructureType_VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO,
+		NewVoidᶜᵖ(memory.Nullptr),
+		d.RenderPass,
+		d.Framebuffer,
+		d.RenderArea,
+		uint32(len(clearValues)),
+		NewVkClearValueᶜᵖ(clearValuesData.Ptr()),
+	}
+	beginData := atom.Must(atom.AllocData(ctx, s, begin))
+
+	return func() {
+			clearValuesData.Free()
+			beginData.Free()
+		}, NewVkCmdBeginRenderPass(
+			commandBuffer,
+			beginData.Ptr(),
+			d.Contents).AddRead(beginData.Data()).AddRead(clearValuesData.Data())
+}
+
+func rebuildCmdEndRenderPass(
+	ctx context.Context,
+	commandBuffer VkCommandBuffer,
+	s *gfxapi.State,
+	d *RecreateCmdEndRenderPassData) (func(), atom.Atom) {
+	return func() {}, NewVkCmdEndRenderPass(commandBuffer)
+}
+
+func rebuildCmdNextSubpass(
+	ctx context.Context,
+	commandBuffer VkCommandBuffer,
+	s *gfxapi.State,
+	d *RecreateCmdNextSubpassData) (func(), atom.Atom) {
+	return func() {}, NewVkCmdNextSubpass(commandBuffer, d.Contents)
+}
+
+func rebuildCmdBindPipeline(
+	ctx context.Context,
+	commandBuffer VkCommandBuffer,
+	s *gfxapi.State,
+	d *RecreateCmdBindPipelineData) (func(), atom.Atom) {
+
+	return func() {}, NewVkCmdBindPipeline(commandBuffer,
+		d.PipelineBindPoint, d.Pipeline)
+}
+
+func rebuildCmdBindIndexBuffer(
+	ctx context.Context,
+	commandBuffer VkCommandBuffer,
+	s *gfxapi.State,
+	d *RecreateCmdBindIndexBufferData) (func(), atom.Atom) {
+
+	return func() {}, NewVkCmdBindIndexBuffer(commandBuffer,
+		d.Buffer, d.Offset, d.IndexType)
+}
+
+func rebuildCmdDrawIndexed(
+	ctx context.Context,
+	commandBuffer VkCommandBuffer,
+	s *gfxapi.State,
+	d *RecreateCmdDrawIndexedData) (func(), atom.Atom) {
+
+	return func() {}, NewVkCmdDrawIndexed(commandBuffer, d.IndexCount,
+		d.InstanceCount, d.FirstIndex, d.VertexOffset, d.FirstInstance)
+}
+
+func rebuildCmdBindDescriptorSets(
+	ctx context.Context,
+	commandBuffer VkCommandBuffer,
+	s *gfxapi.State,
+	d *RecreateCmdBindDescriptorSetsData) (func(), atom.Atom) {
+
+	descriptorSets := make([]VkDescriptorSet, len(d.DescriptorSets))
+	dynamicOffsets := make([]uint32, len(d.DynamicOffsets))
+
+	for i := 0; i < len(d.DescriptorSets); i++ {
+		descriptorSets[i] = d.DescriptorSets[uint32(i)]
+	}
+
+	for i := 0; i < len(d.DynamicOffsets); i++ {
+		dynamicOffsets[i] = d.DynamicOffsets[uint32(i)]
+	}
+
+	descriptorSetData := atom.Must(atom.AllocData(ctx, s, descriptorSets))
+	dynamicOffsetData := atom.Must(atom.AllocData(ctx, s, dynamicOffsets))
+
+	return func() {
+			descriptorSetData.Free()
+			dynamicOffsetData.Free()
+		}, NewVkCmdBindDescriptorSets(commandBuffer,
+			d.PipelineBindPoint,
+			d.Layout,
+			d.FirstSet,
+			uint32(len(d.DescriptorSets)),
+			descriptorSetData.Ptr(),
+			uint32(len(d.DynamicOffsets)),
+			dynamicOffsetData.Ptr(),
+		).AddRead(
+			dynamicOffsetData.Data(),
+		).AddRead(descriptorSetData.Data())
+}
+
+func rebuildCmdBindVertexBuffers(
+	ctx context.Context,
+	commandBuffer VkCommandBuffer,
+	s *gfxapi.State,
+	d *RecreateCmdBindVertexBuffersData) (func(), atom.Atom) {
+
+	buffers := make([]VkBuffer, len(d.Buffers))
+	offsets := make([]VkDeviceSize, len(d.Offsets))
+
+	for i := 0; i < len(d.Buffers); i++ {
+		buffers[i] = d.Buffers[uint32(i)]
+	}
+
+	for i := 0; i < len(d.Offsets); i++ {
+		offsets[i] = d.Offsets[uint32(i)]
+	}
+
+	bufferData := atom.Must(atom.AllocData(ctx, s, buffers))
+	offsetData := atom.Must(atom.AllocData(ctx, s, offsets))
+
+	return func() {
+			bufferData.Free()
+			offsetData.Free()
+		}, NewVkCmdBindVertexBuffers(commandBuffer,
+			d.FirstBinding,
+			d.BindingCount,
+			bufferData.Ptr(),
+			offsetData.Ptr(),
+		).AddRead(offsetData.Data()).AddRead(bufferData.Data())
+}
+
+func rebuildCmdWaitEvents(
+	ctx context.Context,
+	commandBuffer VkCommandBuffer,
+	s *gfxapi.State,
+	d *RecreateCmdWaitEventsData) (func(), atom.Atom) {
+
+	events := make([]VkEvent, len(d.Events))
+	memoryBarriers := make([]VkMemoryBarrier, len(d.MemoryBarriers))
+	bufferMemoryBarriers := make([]VkBufferMemoryBarrier, len(d.BufferMemoryBarriers))
+	imageMemoryBarriers := make([]VkImageMemoryBarrier, len(d.ImageMemoryBarriers))
+
+	for i := 0; i < len(d.Events); i++ {
+		events[i] = d.Events[uint32(i)]
+	}
+
+	for i := 0; i < len(d.MemoryBarriers); i++ {
+		memoryBarriers[i] = d.MemoryBarriers[uint32(i)]
+	}
+
+	for i := 0; i < len(d.BufferMemoryBarriers); i++ {
+		bufferMemoryBarriers[i] = d.BufferMemoryBarriers[uint32(i)]
+	}
+
+	for i := 0; i < len(d.ImageMemoryBarriers); i++ {
+		imageMemoryBarriers[i] = d.ImageMemoryBarriers[uint32(i)]
+	}
+
+	eventData := atom.Must(atom.AllocData(ctx, s, events))
+	memoryBarrierData := atom.Must(atom.AllocData(ctx, s, memoryBarriers))
+	bufferMemoryBarrierData := atom.Must(atom.AllocData(ctx, s, bufferMemoryBarriers))
+	imageMemoryBarrierData := atom.Must(atom.AllocData(ctx, s, imageMemoryBarriers))
+
+	return func() {
+			eventData.Free()
+			memoryBarrierData.Free()
+			bufferMemoryBarrierData.Free()
+			imageMemoryBarrierData.Free()
+		}, NewVkCmdWaitEvents(commandBuffer,
+			uint32(len(events)),
+			eventData.Ptr(),
+			d.SrcStageMask,
+			d.DstStageMask,
+			uint32(len(memoryBarriers)),
+			memoryBarrierData.Ptr(),
+			uint32(len(bufferMemoryBarriers)),
+			bufferMemoryBarrierData.Ptr(),
+			uint32(len(imageMemoryBarriers)),
+			imageMemoryBarrierData.Ptr(),
+		).AddRead(eventData.Data()).AddRead(memoryBarrierData.Data()).AddRead(bufferMemoryBarrierData.Data()).AddRead(imageMemoryBarrierData.Data())
+}
+
+func rebuildCmdPipelineBarrier(
+	ctx context.Context,
+	commandBuffer VkCommandBuffer,
+	s *gfxapi.State,
+	d *RecreateCmdPipelineBarrierData) (func(), atom.Atom) {
+
+	memoryBarriers := make([]VkMemoryBarrier, len(d.MemoryBarriers))
+	bufferMemoryBarriers := make([]VkBufferMemoryBarrier, len(d.BufferMemoryBarriers))
+	imageMemoryBarriers := make([]VkImageMemoryBarrier, len(d.ImageMemoryBarriers))
+
+	for i := 0; i < len(d.MemoryBarriers); i++ {
+		memoryBarriers[i] = d.MemoryBarriers[uint32(i)]
+	}
+
+	for i := 0; i < len(d.BufferMemoryBarriers); i++ {
+		bufferMemoryBarriers[i] = d.BufferMemoryBarriers[uint32(i)]
+	}
+
+	for i := 0; i < len(d.ImageMemoryBarriers); i++ {
+		imageMemoryBarriers[i] = d.ImageMemoryBarriers[uint32(i)]
+	}
+
+	memoryBarrierData := atom.Must(atom.AllocData(ctx, s, memoryBarriers))
+	bufferMemoryBarrierData := atom.Must(atom.AllocData(ctx, s, bufferMemoryBarriers))
+	imageMemoryBarrierData := atom.Must(atom.AllocData(ctx, s, imageMemoryBarriers))
+
+	return func() {
+			memoryBarrierData.Free()
+			bufferMemoryBarrierData.Free()
+			imageMemoryBarrierData.Free()
+		}, NewVkCmdPipelineBarrier(commandBuffer,
+			d.SrcStageMask,
+			d.DstStageMask,
+			d.DependencyFlags,
+			uint32(len(memoryBarriers)),
+			memoryBarrierData.Ptr(),
+			uint32(len(bufferMemoryBarriers)),
+			bufferMemoryBarrierData.Ptr(),
+			uint32(len(imageMemoryBarriers)),
+			imageMemoryBarrierData.Ptr(),
+		).AddRead(memoryBarrierData.Data()).AddRead(bufferMemoryBarrierData.Data()).AddRead(imageMemoryBarrierData.Data())
+}
+
+// AddCommand recreates the command defined by recreateInfo and places it
+// into the given command buffer. It returns the atoms that it
+// had to create in order to satisfy the command. It also returns a function
+// to clean up the data that was allocated during the creation.
+func AddCommand(ctx context.Context,
+	commandBuffer VkCommandBuffer,
+	s *gfxapi.State,
+	rebuildInfo interface{}) (func(), atom.Atom) {
+	switch t := rebuildInfo.(type) {
+	case *RecreateCmdBeginRenderPassData:
+		return rebuildCmdBeginRenderPass(ctx, commandBuffer, s, t)
+	case *RecreateCmdEndRenderPassData:
+		return rebuildCmdEndRenderPass(ctx, commandBuffer, s, t)
+	case *RecreateCmdNextSubpassData:
+		return rebuildCmdNextSubpass(ctx, commandBuffer, s, t)
+	case *RecreateCmdBindPipelineData:
+		return rebuildCmdBindPipeline(ctx, commandBuffer, s, t)
+	case *RecreateCmdBindDescriptorSetsData:
+		return rebuildCmdBindDescriptorSets(ctx, commandBuffer, s, t)
+	case *RecreateCmdBindVertexBuffersData:
+		return rebuildCmdBindVertexBuffers(ctx, commandBuffer, s, t)
+	case *RecreateCmdBindIndexBufferData:
+		return rebuildCmdBindIndexBuffer(ctx, commandBuffer, s, t)
+	case *RecreateCmdDrawIndexedData:
+		return rebuildCmdDrawIndexed(ctx, commandBuffer, s, t)
+	case *RecreateCmdPipelineBarrierData:
+		return rebuildCmdPipelineBarrier(ctx, commandBuffer, s, t)
+	case *RecreateCmdWaitEventsData:
+		return rebuildCmdWaitEvents(ctx, commandBuffer, s, t)
+	default:
+		x := fmt.Sprintf("Should not reach here: %T", t)
+		panic(x)
+	}
+}

--- a/gapis/gfxapi/vulkan/dependency_graph.go
+++ b/gapis/gfxapi/vulkan/dependency_graph.go
@@ -560,6 +560,10 @@ func (g *DependencyGraph) getBehaviour(ctx context.Context, s *gfxapi.State, id 
 		image := a.Image
 		addModify(&b, g, vulkanStateKey(image))
 
+	case *VkGetBufferMemoryRequirements:
+		buffer := a.Buffer
+		addModify(&b, g, vulkanStateKey(buffer))
+
 	case *VkBindImageMemory:
 		image := a.Image
 		memory := a.Memory

--- a/gapis/gfxapi/vulkan/vulkan.api
+++ b/gapis/gfxapi/vulkan/vulkan.api
@@ -2781,6 +2781,7 @@ cmd VkResult vkQueueSubmit(
   submitInfo := pSubmits[0:submitCount]
   LastBoundQueue = Queues[queue]
 
+  enterSubcontext()
   for i in (0 .. submitCount) {
     info := submitInfo[i]
     wait_semaphores := info.pWaitSemaphores[0:info.waitSemaphoreCount]
@@ -2791,16 +2792,20 @@ cmd VkResult vkQueueSubmit(
 
     command_buffers := info.pCommandBuffers[0:info.commandBufferCount]
 
+    enterSubcontext()
     for j in (0 .. info.commandBufferCount) {
       execCommands(command_buffers[j])
+      nextSubcontext()
     }
+    leaveSubcontext()
 
     signal_semaphores := info.pSignalSemaphores[0:info.signalSemaphoreCount]
     for j in (0 .. info.signalSemaphoreCount) {
       recordUpdateSemaphoreSignal(signal_semaphores[j], true)
     }
-
+    nextSubcontext()
   }
+  leaveSubcontext()
   return ?
 }
 
@@ -3379,6 +3384,7 @@ cmd VkResult vkSetEvent(
     // If all pending events are signaled, so all removed from the pending
     // event list in the queue object, we should roll out the pending commands
     if len(q.PendingEvents) == 0 {
+      LastBoundQueue = Queues[queue]
       execPendingCommands(queue)
     }
   }
@@ -5329,6 +5335,9 @@ extern void setSpecData(ref!SpecializationInfo info, size numBytes, const void* 
 extern void resetCmd(VkCommandBuffer cmdBuf)
 extern void execCommands(VkCommandBuffer cmdBuf)
 extern void execPendingCommands(VkQueue queue)
+extern void enterSubcontext()
+extern void nextSubcontext()
+extern void leaveSubcontext()
 extern void recordUpdateSemaphoreSignal(VkSemaphore semaphore, bool Signaled)
 extern void addWords(VkShaderModule module, size numBytes, const u32* pData)
 extern ref!RecreateCmdUpdateBufferData createUpdateBufferData(
@@ -5349,7 +5358,7 @@ sub void doCmdBindPipeline(CmdBindPipeline args) {
     case VK_PIPELINE_BIND_POINT_COMPUTE:
       CurrentComputePipeline = ComputePipelines[args.Pipeline]
     case VK_PIPELINE_BIND_POINT_GRAPHICS:
-      LastDrawInfo.GraphicsPipeline = GraphicsPipelines[args.Pipeline]
+      lastDrawInfo().GraphicsPipeline = GraphicsPipelines[args.Pipeline]
   }
 }
 
@@ -5560,7 +5569,7 @@ sub void doCmdBindDescriptorSets(CmdBindDescriptorSets bind) {
     }
   }
   for _, binding, set in bind.DescriptorSets {
-      LastDrawInfo.DescriptorSets[binding] = set
+      lastDrawInfo().DescriptorSets[binding] = set
   }
 }
 
@@ -5680,7 +5689,7 @@ class CmdBindIndexBuffer {
 }
 
 sub void doCmdBindIndexBuffer(CmdBindIndexBuffer buffer) {
-  LastDrawInfo.BoundIndexBuffer = new!BoundIndexBuffer(buffer.IndexType,
+  lastDrawInfo().BoundIndexBuffer = new!BoundIndexBuffer(buffer.IndexType,
     BoundBuffer(Buffers[buffer.Buffer], buffer.Offset, 0))
   Buffers[buffer.Buffer].LastBoundQueue = LastBoundQueue
 }
@@ -5726,7 +5735,7 @@ class CmdBindBuffer {
 
 sub void doCmdBindVertexBuffers(CmdBindBuffer bind) {
   for _ , k , v in bind.BoundBuffers {
-    LastDrawInfo.BoundVertexBuffers[k] = v
+    lastDrawInfo().BoundVertexBuffers[k] = v
     v.Buffer.LastBoundQueue = LastBoundQueue
   }
 }
@@ -5820,9 +5829,9 @@ sub void readCoherentMemoryInImage(ref!ImageObject image) {
 }
 
 sub void readCoherentMemoryInCurrentPipelineBoundVertexBuffers(u32 vertexCount, u32 instanceCount, u32 firstVertex, u32 firstInstance) {
-  for _, _, vertex_binding in LastDrawInfo.GraphicsPipeline.VertexInputState.BindingDescriptions {
-    if vertex_binding.binding in LastDrawInfo.BoundVertexBuffers {
-      bound_vertex_buffer := LastDrawInfo.BoundVertexBuffers[vertex_binding.binding]
+  for _, _, vertex_binding in lastDrawInfo().GraphicsPipeline.VertexInputState.BindingDescriptions {
+    if vertex_binding.binding in lastDrawInfo().BoundVertexBuffers {
+      bound_vertex_buffer := lastDrawInfo().BoundVertexBuffers[vertex_binding.binding]
       backing_buf := bound_vertex_buffer.Buffer
       if ((backing_buf.Memory != null) && IsMemoryCoherent(backing_buf.Memory)) {
         start_vertex := switch vertex_binding.inputRate {
@@ -5867,7 +5876,7 @@ sub void readCoherentMemoryInCurrentPipelineBoundVertexBuffers(u32 vertexCount, 
 sub void doCmdDraw(CmdDraw draw) {
   readCoherentMemoryInCurrentPipelineBoundVertexBuffers(draw.VertexCount, draw.InstanceCount, draw.FirstVertex, draw.FirstInstance)
   clearLastDrawInfoDrawCommandParameters()
-  LastDrawInfo.CommandParameters.Draw = new!CmdDraw(
+  lastDrawInfo().CommandParameters.Draw = new!CmdDraw(
       draw.VertexCount, draw.InstanceCount, draw.FirstVertex, draw.FirstInstance)
 }
 
@@ -5906,8 +5915,9 @@ cmd void vkCmdDraw(
 sub void doCmdDrawIndexed(CmdDrawIndexed draw) {
   // Loop through the index buffer, and find the low and high
   // vertices. Then read all of the applicable vertex buffers.
-  indexBuffer := LastDrawInfo.BoundIndexBuffer.BoundBuffer.Buffer
-  indexSize := switch (LastDrawInfo.BoundIndexBuffer.Type) {
+  lastDraw := lastDrawInfo()
+  indexBuffer := lastDraw.BoundIndexBuffer.BoundBuffer.Buffer
+  indexSize := switch (lastDraw.BoundIndexBuffer.Type) {
     case VK_INDEX_TYPE_UINT16:
       as!VkDeviceSize(2)
     case VK_INDEX_TYPE_UINT32:
@@ -5915,14 +5925,14 @@ sub void doCmdDrawIndexed(CmdDrawIndexed draw) {
   }
 
   numBytes := as!VkDeviceSize(draw.IndexCount) * indexSize
-  startOffset := LastDrawInfo.BoundIndexBuffer.BoundBuffer.Offset + (indexSize * as!VkDeviceSize(draw.FirstIndex))
+  startOffset := lastDrawInfo().BoundIndexBuffer.BoundBuffer.Offset + (indexSize * as!VkDeviceSize(draw.FirstIndex))
 
   // Read the data of the index buffer if the index buffer is backed with coherent memory.
   readCoherentMemoryInBuffer(indexBuffer, startOffset, numBytes)
   // Read the whole vertex buffer if a buffer is backed with coherent memory.
   readCoherentMemoryInCurrentPipelineBoundVertexBuffers(0xFFFFFFFF, draw.InstanceCount, 0, draw.FirstInstance)
   clearLastDrawInfoDrawCommandParameters()
-  LastDrawInfo.CommandParameters.DrawIndexed = new!CmdDrawIndexed(
+  lastDrawInfo().CommandParameters.DrawIndexed = new!CmdDrawIndexed(
       draw.IndexCount, draw.InstanceCount, draw.FirstIndex, draw.VertexOffset,
       draw.FirstInstance)
 }
@@ -6000,7 +6010,7 @@ sub void doCmdDrawIndirect(CmdDrawIndirect draw) {
     // Read through all the vertex buffers, as we cannot assume the buffer given to indirect draw is host
     readCoherentMemoryInCurrentPipelineBoundVertexBuffers(0xFFFFFFFF, 0xFFFFFFFF, 0, 0)
     clearLastDrawInfoDrawCommandParameters()
-    LastDrawInfo.CommandParameters.DrawIndirect = new!CmdDrawIndirect(
+    lastDrawInfo().CommandParameters.DrawIndirect = new!CmdDrawIndirect(
         draw.Buffer, draw.Offset, draw.DrawCount, draw.Stride)
   }
 }
@@ -6050,12 +6060,12 @@ sub void doCmdDrawIndexedIndirect(CmdDrawIndexedIndirect draw) {
     indirect_buffer_read_size := as!VkDeviceSize((draw.DrawCount - 1) * draw.Stride) + command_size
     readCoherentMemoryInBuffer(Buffers[draw.Buffer], draw.Offset, indirect_buffer_read_size)
     // Read through the whole index buffer if it uses coherent menory.
-    indexBuffer := LastDrawInfo.BoundIndexBuffer.BoundBuffer.Buffer
+    indexBuffer := lastDrawInfo().BoundIndexBuffer.BoundBuffer.Buffer
     readCoherentMemoryInBuffer(indexBuffer, 0, indexBuffer.Info.Size)
     // Read through all the coherent memory vertex buffers, as we cannot assume the buffer given to indirect draw is host
     readCoherentMemoryInCurrentPipelineBoundVertexBuffers(0xFFFFFFFF, 0xFFFFFFFF, 0, 0)
     clearLastDrawInfoDrawCommandParameters()
-    LastDrawInfo.CommandParameters.DrawIndexedIndirect = new!CmdDrawIndexedIndirect(
+    lastDrawInfo().CommandParameters.DrawIndexedIndirect = new!CmdDrawIndexedIndirect(
         draw.Buffer, draw.Offset, draw.DrawCount, draw.Stride)
   }
 }
@@ -7548,52 +7558,53 @@ class CmdBeginRenderPass {
 
 sub void doCmdBeginRenderPass(CmdBeginRenderPass args) {
   VK_ATTACHMENT_UNUSED := as!u32(0xFFFFFFFF)
-  LastDrawInfo.Framebuffer = Framebuffers[args.Framebuffer]
-  LastDrawInfo.LastSubpass = 0
-  LastDrawInfo.RenderPass = RenderPasses[args.RenderPass]
-  for _ , _ , v in LastDrawInfo.Framebuffer.ImageAttachments {
+  lastDrawInfo().Framebuffer = Framebuffers[args.Framebuffer]
+  lastDrawInfo().LastSubpass = 0
+  lastDrawInfo().RenderPass = RenderPasses[args.RenderPass]
+  lastDrawInfo().InRenderPass = true
+  for _ , _ , v in lastDrawInfo().Framebuffer.ImageAttachments {
     v.Image.LastBoundQueue = LastBoundQueue
   }
-  subpass := LastDrawInfo.RenderPass.SubpassDescriptions[0]
+  subpass := lastDrawInfo().RenderPass.SubpassDescriptions[0]
   for _, _, a in subpass.InputAttachments {
     if a.Attachment != VK_ATTACHMENT_UNUSED {
-      LastDrawInfo.Framebuffer.ImageAttachments[a.Attachment].Image.Info.Layout = a.Layout
+      lastDrawInfo().Framebuffer.ImageAttachments[a.Attachment].Image.Info.Layout = a.Layout
     }
   }
   for _, _, a in subpass.ColorAttachments {
     if a.Attachment != VK_ATTACHMENT_UNUSED {
-      LastDrawInfo.Framebuffer.ImageAttachments[a.Attachment].Image.Info.Layout = a.Layout
+      lastDrawInfo().Framebuffer.ImageAttachments[a.Attachment].Image.Info.Layout = a.Layout
     }
   }
   for _, _, a in subpass.ResolveAttachments {
     if a.Attachment != VK_ATTACHMENT_UNUSED {
-      LastDrawInfo.Framebuffer.ImageAttachments[a.Attachment].Image.Info.Layout = a.Layout
+      lastDrawInfo().Framebuffer.ImageAttachments[a.Attachment].Image.Info.Layout = a.Layout
     }
   }
   if subpass.DepthStencilAttachment != null {
     dsRef := subpass.DepthStencilAttachment
     if dsRef.Attachment != VK_ATTACHMENT_UNUSED {
-      LastDrawInfo.Framebuffer.ImageAttachments[dsRef.Attachment].Image.Info.Layout = dsRef.Layout
+      lastDrawInfo().Framebuffer.ImageAttachments[dsRef.Attachment].Image.Info.Layout = dsRef.Layout
     }
   }
 }
 
 sub void doCmdNextSubpass(u32 Unused) {
-  LastDrawInfo.LastSubpass += 1
-  if LastDrawInfo.LastSubpass < len(LastDrawInfo.RenderPass.SubpassDescriptions) {
-  subpass := LastDrawInfo.RenderPass.SubpassDescriptions[LastDrawInfo.LastSubpass]
+  lastDrawInfo().LastSubpass += 1
+  if lastDrawInfo().LastSubpass < len(lastDrawInfo().RenderPass.SubpassDescriptions) {
+  subpass := lastDrawInfo().RenderPass.SubpassDescriptions[lastDrawInfo().LastSubpass]
     for _, _, a in subpass.InputAttachments {
-      LastDrawInfo.Framebuffer.ImageAttachments[a.Attachment].Image.Info.Layout = a.Layout
+      lastDrawInfo().Framebuffer.ImageAttachments[a.Attachment].Image.Info.Layout = a.Layout
     }
     for _, _, a in subpass.ColorAttachments {
-      LastDrawInfo.Framebuffer.ImageAttachments[a.Attachment].Image.Info.Layout = a.Layout
+      lastDrawInfo().Framebuffer.ImageAttachments[a.Attachment].Image.Info.Layout = a.Layout
     }
     for _, _, a in subpass.ResolveAttachments {
-      LastDrawInfo.Framebuffer.ImageAttachments[a.Attachment].Image.Info.Layout = a.Layout
+      lastDrawInfo().Framebuffer.ImageAttachments[a.Attachment].Image.Info.Layout = a.Layout
     }
     if subpass.DepthStencilAttachment != null {
       dsRef := subpass.DepthStencilAttachment
-      LastDrawInfo.Framebuffer.ImageAttachments[dsRef.Attachment].Image.Info.Layout = dsRef.Layout
+      lastDrawInfo().Framebuffer.ImageAttachments[dsRef.Attachment].Image.Info.Layout = dsRef.Layout
     }
   }
 }
@@ -7629,6 +7640,7 @@ RecreateCmdEndRenderPassData {
 }
 
 sub void doCmdEndRenderPass(u32 unused) {
+  lastDrawInfo().InRenderPass = false
 }
 
 @threadSafety("app")
@@ -7644,9 +7656,12 @@ class CmdExecuteCommands {
 }
 
 sub void doCmdExecuteCommands(CmdExecuteCommands cmds) {
+  enterSubcontext()
   for i in (0 .. len(cmds.CommandBuffers)) {
     execCommands(cmds.CommandBuffers[as!u32(i)])
+    nextSubcontext()
   }
+  leaveSubcontext()
 }
 
 @internal
@@ -8590,9 +8605,11 @@ ref!ComputePipelineObject  CurrentComputePipeline
   DrawParameters                      CommandParameters
   // The render pass in which this draw takes place
   ref!RenderPassObject                RenderPass
+  // Whether or not we are in an unclosed render pass
+  bool                                InRenderPass
 }
-// Records the draw information of the last draw.
-DrawInfo LastDrawInfo
+
+map!(VkQueue, ref!DrawInfo)               LastDrawInfos
 
 @internal class PresentInfo {
   // The number of images presented last present
@@ -8610,19 +8627,35 @@ enum LastSubmissionType {
 
 LastSubmissionType LastSubmission
 
+sub ref!DrawInfo lastDrawInfo() {
+  if LastBoundQueue != null {
+    if !(LastBoundQueue.VulkanHandle in LastDrawInfos) {
+      LastDrawInfos[LastBoundQueue.VulkanHandle] = new!DrawInfo()
+    }
+  }
+
+  ldi := switch (LastBoundQueue == null) {
+    case false:
+      LastDrawInfos[LastBoundQueue.VulkanHandle]
+    case true:
+      new!DrawInfo()
+  }
+  return ldi
+}
+
 // Clear the recorded descriptor sets in the last draw
 sub void clearLastDrawInfoDescriptorSets() {
-  for i in (0 .. len(LastDrawInfo.DescriptorSets)) {
-    LastDrawInfo.DescriptorSets[as!u32(i)] = null
+  for i in (0 .. len(lastDrawInfo().DescriptorSets)) {
+    lastDrawInfo().DescriptorSets[as!u32(i)] = null
   }
 }
 
 // Clear the draw command parameters in the last draw info
 sub void clearLastDrawInfoDrawCommandParameters() {
-  LastDrawInfo.CommandParameters.Draw = null
-  LastDrawInfo.CommandParameters.DrawIndexed = null
-  LastDrawInfo.CommandParameters.DrawIndirect = null
-  LastDrawInfo.CommandParameters.DrawIndexedIndirect = null
+  lastDrawInfo().CommandParameters.Draw = null
+  lastDrawInfo().CommandParameters.DrawIndexed = null
+  lastDrawInfo().CommandParameters.DrawIndirect = null
+  lastDrawInfo().CommandParameters.DrawIndexedIndirect = null
 }
 
 // Internal struct for holding useful instance level information from VkInstanceCreateInfo.

--- a/gapis/gfxapi/vulkan/vulkan.go
+++ b/gapis/gfxapi/vulkan/vulkan.go
@@ -19,9 +19,18 @@ import (
 	"fmt"
 
 	"github.com/google/gapid/core/image"
+	"github.com/google/gapid/gapis/atom"
+	"github.com/google/gapid/gapis/capture"
 	"github.com/google/gapid/gapis/gfxapi"
+	"github.com/google/gapid/gapis/resolve"
 	"github.com/google/gapid/gapis/service/path"
 )
+
+type CustomState struct {
+	SubcommandIndex   gfxapi.SubcommandIndex
+	CurrentSubmission *atom.Atom
+	HandleSubcommand  func(interface{}) `nobox:"true"`
+}
 
 func getStateObject(s *gfxapi.State) *State {
 	return GetState(s)
@@ -69,4 +78,48 @@ func (api) Mesh(ctx context.Context, o interface{}, p *path.Mesh) (*gfxapi.Mesh,
 		return drawCallMesh(ctx, dc, p)
 	}
 	return nil, fmt.Errorf("Cannot get the mesh data from %v", o)
+}
+
+func (api) ResolveSynchronization(ctx context.Context, d *gfxapi.SynchronizationData, c *path.Capture) error {
+	ctx = capture.Put(ctx, c)
+	st, err := capture.NewState(ctx)
+	if err != nil {
+		return err
+	}
+	a, err := resolve.Atoms(ctx, c)
+	if err != nil {
+		return err
+	}
+	s := GetState(st)
+	i := gfxapi.SynchronizationIndex(0)
+	submissionMap := make(map[*atom.Atom]gfxapi.SynchronizationIndex)
+
+	s.HandleSubcommand = func(a interface{}) {
+		rootIdx := gfxapi.SynchronizationIndex(i)
+		if k, ok := submissionMap[s.CurrentSubmission]; ok {
+			rootIdx = gfxapi.SynchronizationIndex(k)
+		} else {
+			submissionMap[s.CurrentSubmission] = i
+		}
+
+		if rng, ok := d.CommandRanges[rootIdx]; ok {
+			rng.LastIndex = append(gfxapi.SubcommandIndex(nil), s.SubcommandIndex...)
+			rng.Ranges[i] = rng.LastIndex
+		} else {
+			er := gfxapi.ExecutionRanges{
+				LastIndex: append(gfxapi.SubcommandIndex(nil), s.SubcommandIndex...),
+				Ranges:    make(map[gfxapi.SynchronizationIndex]gfxapi.SubcommandIndex),
+			}
+			er.Ranges[i] = append(gfxapi.SubcommandIndex(nil), s.SubcommandIndex...)
+			d.CommandRanges[rootIdx] = er
+		}
+	}
+
+	for idx, a := range a.Atoms {
+		i = gfxapi.SynchronizationIndex(idx)
+		if err := a.Mutate(ctx, st, nil); err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/gapis/gfxapi/vulkan/vulkan_terminator.go
+++ b/gapis/gfxapi/vulkan/vulkan_terminator.go
@@ -1,0 +1,391 @@
+// Copyright (C) 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vulkan
+
+import (
+	"context"
+
+	"github.com/google/gapid/core/log"
+	"github.com/google/gapid/gapis/atom"
+	"github.com/google/gapid/gapis/atom/transform"
+	"github.com/google/gapid/gapis/database"
+	"github.com/google/gapid/gapis/gfxapi"
+	"github.com/google/gapid/gapis/memory"
+	"github.com/google/gapid/gapis/resolve"
+	"github.com/google/gapid/gapis/service/path"
+)
+
+// VulkanTerminator is very similar to EarlyTerminator.
+// It has 2 additional properties.
+//   1) If a VkQueueSubmit is found, and it contains an event that will be
+//      signaled after the final request, we remove the event from the
+//      command-list, and remove any subsequent events
+//   2) If a request is made to replay until the MIDDLE of a vkQueueSubmit,
+//      then it will patch that command-list to remove any commands after
+//      the command in question.
+//      Furthermore it will continue the replay until that command can be run
+//      i.e. it will make sure to continue to mutate the trace until
+//      all pending events have been successfully completed.
+//      TODO(awoloszyn): Handle #2
+// This takes advantage of the fact that all atoms will be in order.
+type VulkanTerminator struct {
+	lastRequest    atom.ID
+	stopped        bool
+	syncData       *gfxapi.SynchronizationData
+	blockingEvents []VkEvent
+}
+
+func NewVulkanTerminator(ctx context.Context, capture *path.Capture) (*VulkanTerminator, error) {
+	sync, err := database.Build(ctx, &resolve.SynchronizationResolvable{capture})
+	if err != nil {
+		return nil, err
+	}
+	s, ok := sync.(*gfxapi.SynchronizationData)
+	if !ok {
+		return nil, log.Errf(ctx, nil, "Could not get synchronization data")
+	}
+
+	return &VulkanTerminator{atom.ID(0), false, s, []VkEvent(nil)}, nil
+}
+
+// Add adds the atom with identifier id to the set of atoms that must be seen
+// before the VulkanTerminator will consume all atoms (excluding the EOS atom).
+func (t *VulkanTerminator) Add(id atom.ID) {
+	if id > t.lastRequest {
+		t.lastRequest = id
+	}
+}
+
+func walkCommands(s *State,
+	commands CommandBufferCommands,
+	callback func(*CommandBufferCommand)) {
+	for _, c := range commands {
+		callback(&c)
+		if execSub, ok := c.recreateData.(*RecreateCmdExecuteCommandsData); ok {
+			for _, k := range execSub.CommandBuffers.KeysSorted() {
+				cbc := s.CommandBuffers[execSub.CommandBuffers[k]]
+				walkCommands(s, cbc.Commands, callback)
+			}
+		}
+	}
+}
+
+func getExtra(idx gfxapi.SubcommandIndex, loopLevel int) int {
+	if len(idx) == loopLevel+1 {
+		return 1
+	}
+	return 0
+}
+
+func incrementLoopLevel(idx gfxapi.SubcommandIndex, loopLevel *int) bool {
+	if len(idx) == *loopLevel+1 {
+		return false
+	}
+	*loopLevel += 1
+	return true
+}
+
+// resolveCurrentRenderPass walks all of the current and pending commands
+// to determine what renderpass we are in after the idx'th subcommand
+func resolveCurrentRenderPass(ctx context.Context, s *gfxapi.State, submit *VkQueueSubmit,
+	idx gfxapi.SubcommandIndex, lrp *RenderPassObject, subpass uint32) (*RenderPassObject, uint32) {
+	if len(idx) == 0 {
+		return lrp, subpass
+	}
+	a := submit
+	c := GetState(s)
+	queue := c.Queues[submit.Queue]
+	l := s.MemoryLayout
+
+	f := func(o *CommandBufferCommand) {
+		switch t := o.recreateData.(type) {
+		case *RecreateCmdBeginRenderPassData:
+			lrp = c.RenderPasses[t.RenderPass]
+			subpass = 0
+		case *RecreateCmdNextSubpassData:
+			subpass += 1
+		case *RecreateCmdEndRenderPassData:
+			lrp = nil
+			subpass = 0
+		}
+	}
+
+	walkCommands(c, queue.PendingCommands, f)
+	submitInfo := submit.PSubmits.Slice(uint64(0), uint64(submit.SubmitCount), l)
+	loopLevel := 0
+	for sub := 0; sub < int(idx[0])+getExtra(idx, loopLevel); sub++ {
+		info := submitInfo.Index(uint64(sub), l).Read(ctx, a, s, nil)
+		buffers := info.PCommandBuffers.Slice(uint64(0), uint64(info.CommandBufferCount), l)
+		for cmd := 0; cmd < int(info.CommandBufferCount); cmd++ {
+			buffer := buffers.Index(uint64(cmd), l).Read(ctx, a, s, nil)
+			bufferObject := c.CommandBuffers[buffer]
+			walkCommands(c, bufferObject.Commands, f)
+		}
+	}
+	if !incrementLoopLevel(idx, &loopLevel) {
+		return lrp, subpass
+	}
+	lastInfo := submitInfo.Index(uint64(idx[0]), l).Read(ctx, a, s, nil)
+	lastBuffers := lastInfo.PCommandBuffers.Slice(uint64(0), uint64(lastInfo.CommandBufferCount), l)
+	for cmdbuffer := 0; cmdbuffer < int(idx[1])+getExtra(idx, loopLevel); cmdbuffer++ {
+		buffer := lastBuffers.Index(uint64(cmdbuffer), l).Read(ctx, a, s, nil)
+		bufferObject := c.CommandBuffers[buffer]
+		walkCommands(c, bufferObject.Commands, f)
+	}
+	if !incrementLoopLevel(idx, &loopLevel) {
+		return lrp, subpass
+	}
+	lastBuffer := lastBuffers.Index(uint64(idx[1]), l).Read(ctx, a, s, nil)
+	lastBufferObject := c.CommandBuffers[lastBuffer]
+	for cmd := 0; cmd < int(idx[2])+getExtra(idx, loopLevel); cmd++ {
+		f(&lastBufferObject.Commands[cmd])
+	}
+	if !incrementLoopLevel(idx, &loopLevel) {
+		return lrp, subpass
+	}
+	lastCommand := lastBufferObject.Commands[idx[2]]
+	if executeSubcommand, ok := (lastCommand).recreateData.(*RecreateCmdExecuteCommandsData); ok {
+		for subcmdidx := 0; subcmdidx < int(idx[3])+getExtra(idx, loopLevel); subcmdidx++ {
+			buffer := executeSubcommand.CommandBuffers[uint32(subcmdidx)]
+			bufferObject := c.CommandBuffers[buffer]
+			walkCommands(c, bufferObject.Commands, f)
+		}
+		if !incrementLoopLevel(idx, &loopLevel) {
+			return lrp, subpass
+		}
+		lastsubBuffer := executeSubcommand.CommandBuffers[uint32(idx[3])]
+		lastSubBufferObject := c.CommandBuffers[lastsubBuffer]
+		for subcmd := 0; subcmd < int(idx[4]); subcmd++ {
+			f(&lastSubBufferObject.Commands[subcmd])
+		}
+	}
+
+	return lrp, subpass
+}
+
+// rebuildCommandBuffer takes the commands from commandBuffer up to, and
+// including idx. It then appends any recreate* arguments to the end
+// of the command buffer.
+func rebuildCommandBuffer(ctx context.Context,
+	commandBuffer *CommandBufferObject,
+	s *gfxapi.State,
+	idx gfxapi.SubcommandIndex,
+	additionalCommands []interface{}) (VkCommandBuffer, []atom.Atom, []func()) {
+
+	x := make([]atom.Atom, 0)
+	cleanup := make([]func(), 0)
+	// DestroyResourcesAtEndOfFrame will handle this actually removing the
+	// command buffer. We have no way to handle WHEN this will be done
+
+	commandBufferId := VkCommandBuffer(
+		newUnusedID(true,
+			func(x uint64) bool {
+				_, ok := GetState(s).CommandBuffers[VkCommandBuffer(x)]
+				return ok
+			}))
+	allocate := VkCommandBufferAllocateInfo{
+		VkStructureType_VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO,
+		NewVoidᶜᵖ(memory.Nullptr),
+		commandBuffer.Pool,
+		VkCommandBufferLevel_VK_COMMAND_BUFFER_LEVEL_PRIMARY,
+		uint32(1),
+	}
+	allocateData := atom.Must(atom.AllocData(ctx, s, allocate))
+	commandBufferData := atom.Must(atom.AllocData(ctx, s, commandBufferId))
+
+	x = append(x,
+		NewVkAllocateCommandBuffers(commandBuffer.Device,
+			allocateData.Ptr(), commandBufferData.Ptr(), VkResult_VK_SUCCESS,
+		).AddRead(allocateData.Data()).AddWrite(commandBufferData.Data()))
+
+	beginInfo := VkCommandBufferBeginInfo{
+		VkStructureType_VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO,
+		NewVoidᶜᵖ(memory.Nullptr),
+		VkCommandBufferUsageFlags(VkCommandBufferUsageFlagBits_VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT),
+		NewVkCommandBufferInheritanceInfoᶜᵖ(memory.Nullptr),
+	}
+
+	beginInfoData := atom.Must(atom.AllocData(ctx, s, beginInfo))
+	x = append(x,
+		NewVkBeginCommandBuffer(commandBufferId, beginInfoData.Ptr(), VkResult_VK_SUCCESS).AddRead(beginInfoData.Data()))
+
+	// If we have ANY data, then we need to copy up to that point
+	commandsToCopy := uint64(0)
+	if len(idx) > 0 {
+		commandsToCopy = idx[0]
+	}
+	// If we only have 1 index, then we have to copy the last command entirely,
+	// and not re-write. Otherwise the last command is a vkCmdExecuteCommands
+	// and it needs to be modified.
+	if len(idx) == 1 {
+		commandsToCopy += 1
+	}
+
+	for i := 0; i < int(commandsToCopy); i++ {
+		cmd := commandBuffer.Commands[i]
+		c, a := AddCommand(ctx, commandBufferId, s, cmd.recreateData)
+		x = append(x, a)
+		cleanup = append(cleanup, c)
+	}
+	for i := range additionalCommands {
+		c, a := AddCommand(ctx, commandBufferId, s, additionalCommands[i])
+		x = append(x, a)
+		cleanup = append(cleanup, c)
+	}
+	x = append(x,
+		NewVkEndCommandBuffer(commandBufferId, VkResult_VK_SUCCESS))
+	cleanup = append(cleanup, func() {
+		allocateData.Free()
+		commandBufferData.Free()
+		beginInfoData.Free()
+	})
+	return VkCommandBuffer(commandBufferId), x, cleanup
+}
+
+// cutCommandBuffer rebuilds the given VkQueueSubmit atom.
+// It will re-write the submission so that it ends at
+// idx. It writes any new atoms to transform.Writer.
+// It will make sure that if the replay were to stop at the given
+// index it would remain valid. This means closing any open
+// RenderPasses.
+func cutCommandBuffer(ctx context.Context, id atom.ID,
+	a atom.Atom, idx gfxapi.SubcommandIndex, out transform.Writer) {
+	submit := a.(*VkQueueSubmit)
+	s := out.State()
+	c := GetState(s)
+	l := s.MemoryLayout
+	o := a.Extras().Observations()
+	o.ApplyReads(s.Memory[memory.ApplicationPool])
+	submitInfo := submit.PSubmits.Slice(uint64(0), uint64(submit.SubmitCount), l)
+	skipAll := len(idx) == 0
+
+	// Notes:
+	// - We should walk/finish all unfinished render passes
+	// idx[0] is the submission index
+	// idx[1] is the primary command-buffer index in the submission
+	// idx[2] is the command index in the primary command-buffer
+	// idx[3] is the secondary command buffer index inside a vkCmdExecuteCommands
+	// idx[4] is the secondary command inside the secondary command-buffer
+	submitCopy := NewVkQueueSubmit(submit.Queue, submit.SubmitCount, submit.PSubmits,
+		submit.Fence, submit.Result)
+	submitCopy.Extras().Add(a.Extras().All()...)
+
+	newCommandBuffers := make([]VkCommandBuffer, 1)
+	lastSubmit := uint64(0)
+	lastCommandBuffer := uint64(0)
+	if !skipAll {
+		lastSubmit = idx[0]
+		if len(idx) > 1 {
+			lastCommandBuffer = idx[1]
+		}
+	}
+	submitCopy.SubmitCount = uint32(lastSubmit + 1)
+	newSubmits := make([]VkSubmitInfo, lastSubmit+1)
+	for i := 0; i < int(lastSubmit)+1; i++ {
+		newSubmits[i] = submitInfo.Index(uint64(i), l).Read(ctx, a, s, nil)
+	}
+	newSubmits[lastSubmit].CommandBufferCount = uint32(lastCommandBuffer + 1)
+
+	newCommandBuffers = make([]VkCommandBuffer, lastCommandBuffer+1)
+	buffers := newSubmits[lastSubmit].PCommandBuffers.Slice(uint64(0), uint64(newSubmits[lastSubmit].CommandBufferCount), l)
+	for i := 0; i < int(lastCommandBuffer)+1; i++ {
+		newCommandBuffers[i] = buffers.Index(uint64(i), l).Read(ctx, a, s, nil)
+	}
+
+	var lrp *RenderPassObject
+	lsp := uint32(0)
+	if lastDrawInfo, ok := c.LastDrawInfos[submit.Queue]; ok {
+		if lastDrawInfo.InRenderPass {
+			lrp = lastDrawInfo.RenderPass
+			lsp = lastDrawInfo.LastSubpass
+		} else {
+			lrp = nil
+			lsp = 0
+		}
+	}
+	lrp, lsp = resolveCurrentRenderPass(ctx, s, submit, idx, lrp, lsp)
+
+	extraCommands := make([]interface{}, 0)
+	if lrp != nil {
+		numSubpasses := uint32(len(lrp.SubpassDescriptions))
+		for i := 0; uint32(i) < numSubpasses-lsp-1; i++ {
+			extraCommands = append(extraCommands, RecreateCmdNextSubpassData{})
+		}
+		extraCommands = append(extraCommands, RecreateCmdEndRenderPassData{})
+	}
+
+	cmdBuffer := c.CommandBuffers[newCommandBuffers[lastCommandBuffer]]
+	subIdx := make(gfxapi.SubcommandIndex, 0)
+	if !skipAll {
+		subIdx = idx[2:]
+	}
+	b, newCommands, cleanup :=
+		rebuildCommandBuffer(ctx, cmdBuffer, s, subIdx, extraCommands)
+	newCommandBuffers[lastCommandBuffer] = b
+
+	bufferMemory := atom.Must(atom.AllocData(ctx, s, newCommandBuffers))
+	newSubmits[lastSubmit].PCommandBuffers = NewVkCommandBufferᶜᵖ(bufferMemory.Ptr())
+
+	newSubmitData := atom.Must(atom.AllocData(ctx, s, newSubmits))
+	submitCopy.PSubmits = NewVkSubmitInfoᶜᵖ(newSubmitData.Ptr())
+	submitCopy.AddRead(bufferMemory.Data()).AddRead(newSubmitData.Data())
+
+	for _, c := range newCommands {
+		out.MutateAndWrite(ctx, atom.NoID, c)
+	}
+
+	out.MutateAndWrite(ctx, id, submitCopy)
+
+	for _, f := range cleanup {
+		f()
+	}
+
+	bufferMemory.Free()
+	newSubmitData.Free()
+}
+
+func (t *VulkanTerminator) Transform(ctx context.Context, id atom.ID, a atom.Atom, out transform.Writer) {
+	if t.stopped {
+		return
+	}
+
+	doCut := false
+	cutIndex := gfxapi.SubcommandIndex(nil)
+	if rng, ok := t.syncData.CommandRanges[gfxapi.SynchronizationIndex(id)]; ok {
+		for k, v := range rng.Ranges {
+			if atom.ID(k) > t.lastRequest {
+				doCut = true
+			} else {
+				if len(cutIndex) == 0 || cutIndex.LessThan(v) {
+					cutIndex = v
+				}
+			}
+		}
+	}
+
+	// We have to cut somewhere
+	if doCut {
+		cutIndex.Decrement()
+		cutCommandBuffer(ctx, id, a, cutIndex, out)
+	} else {
+		out.MutateAndWrite(ctx, id, a)
+	}
+
+	if id == t.lastRequest {
+		t.stopped = true
+	}
+}
+
+func (t *VulkanTerminator) Flush(ctx context.Context, out transform.Writer) {}

--- a/gapis/resolve/events.go
+++ b/gapis/resolve/events.go
@@ -104,6 +104,13 @@ func Events(ctx context.Context, p *path.Events) (*service.Events, error) {
 				})
 			}
 		}
+
+		if p.AllCommands {
+			events = append(events, &service.Event{
+				Kind:    service.EventKind_AllCommands,
+				Command: p.Capture.Command(uint64(i)),
+			})
+		}
 	}
 
 	return &service.Events{List: events}, nil

--- a/gapis/resolve/resolvables.proto
+++ b/gapis/resolve/resolvables.proto
@@ -103,6 +103,10 @@ message GlobalStateResolvable {
 	path.State path = 1;
 }
 
+message SynchronizationResolvable {
+	path.Capture capture = 1;
+}
+
 message APIStateResolvable {
 	path.State path = 1;
 }

--- a/gapis/resolve/synchronization_data.go
+++ b/gapis/resolve/synchronization_data.go
@@ -12,28 +12,28 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package test
+package resolve
 
 import (
 	"context"
 
-	"github.com/google/gapid/core/image"
-	"github.com/google/gapid/gapis/atom"
+	"github.com/google/gapid/gapis/capture"
 	"github.com/google/gapid/gapis/gfxapi"
-	"github.com/google/gapid/gapis/service/path"
 )
 
-type CustomState struct{}
+// Resolve builds a SynchronizationResolvable object for the given capture
+func (r *SynchronizationResolvable) Resolve(ctx context.Context) (interface{}, error) {
+	capture, err := capture.ResolveFromPath(ctx, r.Capture)
+	if err != nil {
+		return nil, err
+	}
+	s := gfxapi.NewSynchronizationData()
 
-func (api) GetFramebufferAttachmentInfo(*gfxapi.State, gfxapi.FramebufferAttachment) (uint32, uint32, *image.Format, error) {
-	return 0, 0, nil, nil
-}
+	for _, api := range capture.APIs {
+		if err = api.ResolveSynchronization(ctx, s, r.Capture); err != nil {
+			return nil, err
+		}
+	}
 
-func (api) ResolveSynchronization(ctx context.Context, d *gfxapi.SynchronizationData, c *path.Capture) error {
-	return nil
-}
-func (api) Context(*gfxapi.State) gfxapi.Context { return nil }
-
-func (i remapped) remap(a atom.Atom, s *gfxapi.State) (interface{}, bool) {
-	return i, true
+	return s, nil
 }

--- a/gapis/service/path/path.proto
+++ b/gapis/service/path/path.proto
@@ -152,6 +152,7 @@ message Events {
     bool push_user_markers = 8;
     bool pop_user_markers = 9;
     bool framebuffer_observations = 10;
+    bool all_commands = 11;
 }
 
 // Parameter is the path to a single parameter on a command.

--- a/gapis/service/service.proto
+++ b/gapis/service/service.proto
@@ -662,6 +662,9 @@ enum EventKind {
     PushUserMarker = 6;
     PopUserMarker = 7;
     FramebufferObservation = 8;
+    // Note you probably only want to use AllCommands for debugging/testing
+    // purposes.
+    AllCommands = 9;
 }
 
 // StateTree represents a state tree hierarchy.


### PR DESCRIPTION
We now analyze the synchronization events in the Vulkan replay. If we would end up in a case where the replay would block, re-write the command-buffers to avoid this case.

This also prevents these specific cases from being batched with incompatible cases.