### PR TITLE
gapic: Implement a shared future.

### DIFF
--- a/gapic/src/main/com/google/gapid/models/AtomStream.java
+++ b/gapic/src/main/com/google/gapid/models/AtomStream.java
@@ -16,6 +16,7 @@
 package com.google.gapid.models;
 
 import static com.google.gapid.proto.service.memory.MemoryProtos.PoolNames.Application_VALUE;
+import static com.google.gapid.rpc.SharedFuture.shared;
 import static com.google.gapid.util.Paths.any;
 import static com.google.gapid.util.Paths.commandTree;
 import static com.google.gapid.util.Paths.lastCommand;
@@ -33,9 +34,10 @@ import com.google.gapid.proto.service.Service.CommandTreeNode;
 import com.google.gapid.proto.service.Service.Value;
 import com.google.gapid.proto.service.path.Path;
 import com.google.gapid.rpc.Rpc;
-import com.google.gapid.rpc.RpcException;
-import com.google.gapid.rpc.UiCallback;
 import com.google.gapid.rpc.Rpc.Result;
+import com.google.gapid.rpc.RpcException;
+import com.google.gapid.rpc.SharedFuture;
+import com.google.gapid.rpc.UiCallback;
 import com.google.gapid.server.Client;
 import com.google.gapid.util.Events;
 import com.google.gapid.util.Loadable;
@@ -440,7 +442,7 @@ public class AtomStream extends ModelBase.ForPath<AtomStream.Node, Void, AtomStr
     private Node[] children;
     private CommandTreeNode data;
     private Command command;
-    private ListenableFuture<Node> loadFuture;
+    private SharedFuture<Node> loadFuture;
 
     public Node(CommandTreeNode data) {
       this(null, 0);
@@ -495,17 +497,17 @@ public class AtomStream extends ModelBase.ForPath<AtomStream.Node, Void, AtomStr
         // Already loaded.
         return null;
       } else if (loadFuture != null && !loadFuture.isCancelled()) {
-        return loadFuture;
+        return loadFuture.share();
       }
 
-      return loadFuture = Futures.transformAsync(loader.get(), newData ->
+      return loadFuture = shared(Futures.transformAsync(loader.get(), newData ->
         submitIfNotDisposed(shell, () -> {
           data = newData.data;
           command = newData.command;
           children = new Node[(int)data.getNumChildren()];
           loadFuture = null; // Don't hang on to listeners.
           return Node.this;
-        }));
+        })));
     }
 
     @Override

--- a/gapic/src/main/com/google/gapid/rpc/SharedFuture.java
+++ b/gapic/src/main/com/google/gapid/rpc/SharedFuture.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.gapid.rpc;
+
+import com.google.common.util.concurrent.ListenableFuture;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Wraps a {link {@link ListenableFuture} with a reference count. Calling {@link #cancel(boolean)}
+ * will only cancel the underlying future, once the reference count hits 0.
+ */
+public class SharedFuture<V> implements ListenableFuture<V> {
+  private final ListenableFuture<V> delegate;
+  private final AtomicInteger refCount = new AtomicInteger(1);
+
+  public SharedFuture(ListenableFuture<V> delegate) {
+    this.delegate = delegate;
+  }
+
+  public static <V> SharedFuture<V> shared(ListenableFuture<V> future) {
+    return new SharedFuture<V>(future);
+  }
+
+  public ListenableFuture<V> share() {
+    refCount.incrementAndGet();
+    return this;
+  }
+
+  @Override
+  public boolean cancel(boolean mayInterruptIfRunning) {
+    if (refCount.decrementAndGet() == 0) {
+      return delegate.cancel(mayInterruptIfRunning);
+    }
+    return false;
+  }
+
+  @Override
+  public boolean isCancelled() {
+    return delegate.isCancelled();
+  }
+
+  @Override
+  public boolean isDone() {
+    return delegate.isDone();
+  }
+
+  @Override
+  public V get() throws InterruptedException, ExecutionException {
+    return delegate.get();
+  }
+
+  @Override
+  public V get(long timeout, TimeUnit unit)
+      throws InterruptedException, ExecutionException, TimeoutException {
+    return delegate.get(timeout, unit);
+  }
+
+  @Override
+  public void addListener(Runnable listener, Executor executor) {
+    delegate.addListener(listener, executor);
+  }
+}


### PR DESCRIPTION
A shared future wraps a future with a ref count. Canceling a shared future will decrement the count and only cancel the delegate if the count reaches 0.