### PR TITLE
gapic: Re-architect the OpenGL rendering.

### DIFF
--- a/gapic/res/shaders/border.glsl
+++ b/gapic/res/shaders/border.glsl
@@ -12,44 +12,23 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! COMMON
-varying vec2 vPos;
-
 //! VERTEX
-in vec2 aVertexPosition;
+in vec3 aVertexPosition;
 
 uniform mat4 uTransform;
-uniform vec2 uPixelSize;
-uniform vec2 uTextureSize;
-uniform vec2 uTextureOffset;
-uniform bool uFlipped;
+uniform vec2 uBorderWidth;
 
 void main(void) {
-  vPos = uTextureOffset + uTextureSize * (aVertexPosition + 1.0) / 2.0;
-  if (uFlipped) {
-    vPos.y = 1 - vPos.y;
-  }
-  gl_Position = uTransform * vec4(aVertexPosition, 0.0, 1.0);
+  gl_Position = uTransform * vec4(aVertexPosition.xy, 0.0, 1.0);
+  gl_Position.xy += aVertexPosition.xy * uBorderWidth * aVertexPosition.z;
   gl_Position.y *= -1.0; // Flip the y-axis so that our 'NDC' space matches SWT.
 }
 
 //! FRAGMENT
-uniform sampler2D uTexture;
-uniform vec4 uChannels;
-uniform vec2 uRange;
+uniform vec4 uColor;
 
 out vec4 fragColor;
 
-void tonemap(inout vec4 color) {
-  color.rgb = (color.rgb - uRange.x) / uRange.y;
-}
-
 void main(void) {
-  vec4 color = vec4(0, 0, 0, 1);
-  color = texture(uTexture, vPos);
-  color.rgb *= uChannels.rgb;
-  color.a = (uChannels.a < 0.5) ? 1.0 : color.a;
-  tonemap(color);
-
-  fragColor = color;
+  fragColor = uColor;
 }

--- a/gapic/res/shaders/checker.glsl
+++ b/gapic/res/shaders/checker.glsl
@@ -12,44 +12,24 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! COMMON
-varying vec2 vPos;
-
 //! VERTEX
 in vec2 aVertexPosition;
 
 uniform mat4 uTransform;
-uniform vec2 uPixelSize;
-uniform vec2 uTextureSize;
-uniform vec2 uTextureOffset;
-uniform bool uFlipped;
 
 void main(void) {
-  vPos = uTextureOffset + uTextureSize * (aVertexPosition + 1.0) / 2.0;
-  if (uFlipped) {
-    vPos.y = 1 - vPos.y;
-  }
   gl_Position = uTransform * vec4(aVertexPosition, 0.0, 1.0);
   gl_Position.y *= -1.0; // Flip the y-axis so that our 'NDC' space matches SWT.
 }
 
 //! FRAGMENT
-uniform sampler2D uTexture;
-uniform vec4 uChannels;
-uniform vec2 uRange;
+uniform vec4 uColorA;
+uniform vec4 uColorB;
+uniform vec2 uCheckerSize;
 
 out vec4 fragColor;
 
-void tonemap(inout vec4 color) {
-  color.rgb = (color.rgb - uRange.x) / uRange.y;
-}
-
 void main(void) {
-  vec4 color = vec4(0, 0, 0, 1);
-  color = texture(uTexture, vPos);
-  color.rgb *= uChannels.rgb;
-  color.a = (uChannels.a < 0.5) ? 1.0 : color.a;
-  tonemap(color);
-
-  fragColor = color;
+  vec2 v = step(fract(gl_FragCoord.xy / uCheckerSize), vec2(0.5));
+  fragColor = mix(vec4(dot(v.xy, 1. - v.yx)), uColorA, uColorB);
 }

--- a/gapic/res/shaders/solid.glsl
+++ b/gapic/res/shaders/solid.glsl
@@ -12,44 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! COMMON
-varying vec2 vPos;
-
 //! VERTEX
 in vec2 aVertexPosition;
 
 uniform mat4 uTransform;
-uniform vec2 uPixelSize;
-uniform vec2 uTextureSize;
-uniform vec2 uTextureOffset;
-uniform bool uFlipped;
 
 void main(void) {
-  vPos = uTextureOffset + uTextureSize * (aVertexPosition + 1.0) / 2.0;
-  if (uFlipped) {
-    vPos.y = 1 - vPos.y;
-  }
   gl_Position = uTransform * vec4(aVertexPosition, 0.0, 1.0);
   gl_Position.y *= -1.0; // Flip the y-axis so that our 'NDC' space matches SWT.
 }
 
 //! FRAGMENT
-uniform sampler2D uTexture;
-uniform vec4 uChannels;
-uniform vec2 uRange;
+uniform vec4 uColor;
 
 out vec4 fragColor;
 
-void tonemap(inout vec4 color) {
-  color.rgb = (color.rgb - uRange.x) / uRange.y;
-}
-
 void main(void) {
-  vec4 color = vec4(0, 0, 0, 1);
-  color = texture(uTexture, vPos);
-  color.rgb *= uChannels.rgb;
-  color.a = (uChannels.a < 0.5) ? 1.0 : color.a;
-  tonemap(color);
-
-  fragColor = color;
+  fragColor = uColor;
 }

--- a/gapic/src/main/com/google/gapid/Main.java
+++ b/gapic/src/main/com/google/gapid/Main.java
@@ -23,6 +23,7 @@ import com.google.gapid.models.Models;
 import com.google.gapid.models.Settings;
 import com.google.gapid.server.Client;
 import com.google.gapid.server.GapiPaths;
+import com.google.gapid.server.GapisProcess;
 import com.google.gapid.util.Flags;
 import com.google.gapid.util.Flags.Flag;
 import com.google.gapid.util.Logging;
@@ -173,6 +174,7 @@ public class Main {
     Flags.version,
     GapiPaths.gapidPath,
     GapiPaths.adbPath,
+    GapisProcess.disableGapisTimeout,
     Server.gapis,
     Server.gapisAuthToken,
     Logging.logLevel,

--- a/gapic/src/main/com/google/gapid/glviewer/Renderable.java
+++ b/gapic/src/main/com/google/gapid/glviewer/Renderable.java
@@ -15,6 +15,7 @@
  */
 package com.google.gapid.glviewer;
 
+import com.google.gapid.glviewer.gl.Renderer;
 import com.google.gapid.glviewer.gl.Shader;
 
 /**
@@ -23,35 +24,35 @@ import com.google.gapid.glviewer.gl.Shader;
 public interface Renderable {
   public static final Renderable NOOP = new Renderable() {
     @Override
-    public void init() {
+    public void init(Renderer renderer) {
       // No op.
     }
 
     @Override
-    public void render(State state) {
+    public void render(Renderer renderer, State state) {
       // No op.
     }
 
     @Override
-    public void dispose() {
+    public void dispose(Renderer renderer) {
       // No op.
     }
   };
 
   /**
-   * Called once to initialize this {@link Renderable} before any calls to {@link #render(State)}.
+   * Called once to initialize this {@link Renderable} before any calls to {@link #render(Renderer, State)}.
    */
-  public void init();
+  public void init(Renderer renderer);
 
   /**
    * Renders this object with the given state.
    */
-  public void render(State state);
+  public void render(Renderer renderer, State state);
 
   /**
-   * Called once to dispose this {@link Renderable} after the last call to {@link #render(State)}.
+   * Called once to dispose this {@link Renderable} after the last call to {@link #render(Renderer, State)}.
    */
-  public void dispose();
+  public void dispose(Renderer renderer);
 
   /**
    * Current render state, consisting of the current shader and view transforms.

--- a/gapic/src/main/com/google/gapid/glviewer/geo/BoundingBox.java
+++ b/gapic/src/main/com/google/gapid/glviewer/geo/BoundingBox.java
@@ -40,6 +40,20 @@ public class BoundingBox {
     VecD.max(max, x, y, z);
   }
 
+  public BoundingBox() {
+    this(Double.MAX_VALUE, Double.MAX_VALUE, Double.MAX_VALUE,
+        Double.MIN_VALUE, Double.MIN_VALUE, Double.MIN_VALUE);
+  }
+
+  public BoundingBox(double minX, double minY, double minZ, double maxX, double maxY, double maxZ) {
+    min[0] = minX;
+    min[1] = minY;
+    min[2] = minZ;
+    max[0] = maxX;
+    max[1] = maxY;
+    max[2] = maxZ;
+  }
+
   /**
    * @return a matrix that will center the model at the origin and scale it to the given size.
    */

--- a/gapic/src/main/com/google/gapid/glviewer/gl/GlObject.java
+++ b/gapic/src/main/com/google/gapid/glviewer/gl/GlObject.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.gapid.glviewer.gl;
+
+/**
+ * Base class for OpenGL objects owned by a {@link Renderer}.
+ */
+public abstract class GlObject {
+  private final Renderer owner;
+
+  private boolean deleted = false;
+
+  GlObject(Renderer owner) {
+    this.owner = owner;
+  }
+
+  /**
+   * Frees the underlying object.
+   * Once deleted the object should no longer be used.
+   */
+  public void delete() {
+    if (!deleted) {
+      owner.unregister(this);
+      deleted = true;
+      release();
+    }
+  }
+
+  /** Delete the underlying OpenGL object */
+  protected abstract void release();
+}

--- a/gapic/src/main/com/google/gapid/glviewer/gl/IndexBuffer.java
+++ b/gapic/src/main/com/google/gapid/glviewer/gl/IndexBuffer.java
@@ -15,43 +15,34 @@
  */
 package com.google.gapid.glviewer.gl;
 
+import org.lwjgl.opengl.GL11;
 import org.lwjgl.opengl.GL15;
 
 /**
- * Helper object for GL buffers.
+ * An OpenGL GL_ELEMENT_ARRAY_BUFFER buffer.
  */
-public class Buffer {
-  private final int target;
-  private final int handle;
-  private int size;
+public class IndexBuffer extends GlObject {
+  final int handle;
+  final int count;
+  final int type;
 
-  public Buffer(int target) {
-    this.target = target;
+  IndexBuffer(Renderer owner, int[] data) {
+    super(owner);
     this.handle = GL15.glGenBuffers();
+    this.count = data.length;
+    this.type = GL11.GL_UNSIGNED_INT;
+    owner.register(this);
+
+    bind();
+    GL15.glBufferData(GL15.GL_ELEMENT_ARRAY_BUFFER, data, GL15.GL_STATIC_DRAW);
   }
 
-  public Buffer bind() {
-    GL15.glBindBuffer(target, handle);
-    return this;
+  void bind() {
+    GL15.glBindBuffer(GL15.GL_ELEMENT_ARRAY_BUFFER, handle);
   }
 
-  public Buffer loadData(float[] data) {
-    this.size = data.length * 4;
-    GL15.glBufferData(target, data, GL15.GL_STATIC_DRAW);
-    return this;
-  }
-
-  public Buffer loadData(int[] data) {
-    this.size = data.length * 4;
-    GL15.glBufferData(target, data, GL15.GL_STATIC_DRAW);
-    return this;
-  }
-
-  public int getSize() {
-    return size;
-  }
-
-  public void delete() {
+  @Override
+  protected void release() {
     GL15.glDeleteBuffers(handle);
   }
 }

--- a/gapic/src/main/com/google/gapid/glviewer/gl/Renderer.java
+++ b/gapic/src/main/com/google/gapid/glviewer/gl/Renderer.java
@@ -1,0 +1,281 @@
+/*
+ * Copyright (C) 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.gapid.glviewer.gl;
+
+import com.google.common.base.Preconditions;
+import com.google.gapid.glviewer.Constants;
+import com.google.gapid.glviewer.ShaderSource;
+import com.google.gapid.glviewer.vec.MatD;
+import com.google.gapid.glviewer.vec.VecD;
+import org.eclipse.swt.graphics.Color;
+import org.eclipse.swt.internal.DPIUtil;
+import org.lwjgl.opengl.GL11;
+import org.lwjgl.opengl.GL30;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Renderer maintains the objects and state for an OpenGL context.
+ */
+public final class Renderer {
+  /** The set of {@link GlObject}s owned by this renderer */
+  private final Set<GlObject> objects = new HashSet<>();
+
+  // The primitive shaders, vertex-buffers and index-buffers.
+  private Shader solidShader;
+  private Shader checkerShader;
+  private Shader borderShader;
+  private VertexBuffer quadVB;
+  private VertexBuffer borderVB;
+  private IndexBuffer borderIB;
+
+  /** Width of the canvas in pixels. */
+  private int physicalWidth;
+  /** Height of the canvas in pixels. */
+  private int physicalHeight;
+
+  /** Width of the canvas in device-independent pixels. */
+  private int dipWidth;
+  /** Height of the canvas in device-independent pixels. */
+  private int dipHeight;
+
+  /**
+   * Initializes the renderer for use.
+   * Must be called before any other methods.
+   */
+  public void initialize() {
+    GL30.glBindVertexArray(GL30.glGenVertexArrays());
+    buildPrimitives();
+  }
+
+  /**
+   * Releases the objects allocated by the renderer.
+   * It is not safe to call any other methods after calling terminate.
+   */
+  public void terminate() {
+    deleteOwnedObjects();
+  }
+
+  /**
+   * Updates the size of the back-buffer.
+   * @param width of the back-buffer in real pixels.
+   * @param height of the back-buffer in real pixels.
+   */
+  public void setSize(int width, int height) {
+    physicalWidth = width;
+    physicalHeight = height;
+    dipWidth = DPIUtil.autoScaleDown(width);
+    dipHeight = DPIUtil.autoScaleDown(height);
+    GL11.glViewport(0, 0, physicalWidth, physicalHeight);
+  }
+
+  /** @return the size of the viewport in device-independent pixels. */
+  public VecD getViewSize() {
+    return new VecD(dipWidth, dipHeight, 0);
+  }
+
+  /** @return the width of the viewport in device-independent pixels. */
+  public int getViewWidth() {
+    return dipWidth;
+  }
+
+  /** @return the height of the viewport in device-independent pixels. */
+  public int getViewHeight() {
+    return dipHeight;
+  }
+
+  /**
+   * Constructs and returns a new {@link VertexBuffer} filled with {@param data}.
+   * The returned {@link VertexBuffer} must only be used with this {@link Renderer}.
+   *
+   * @param data the vertex data.
+   * @param elementsPerVertex number of data elements per vertex.
+   */
+  public VertexBuffer newVertexBuffer(float[] data, int elementsPerVertex) {
+    return new VertexBuffer(this, data, elementsPerVertex);
+  }
+
+  /**
+   * Constructs and returns a new {@link IndexBuffer} filled with {@param data}.
+   * The returned {@link IndexBuffer} must only be used with this {@link Renderer}.
+   *
+   * @param data the index data.
+   */
+  public IndexBuffer newIndexBuffer(int[] data) {
+    return new IndexBuffer(this, data);
+  }
+
+  /**
+   * Constructs and returns a new {@link Texture}.
+   * The returned {@link Texture} must only be used with this {@link Renderer}.
+   */
+  public Texture newTexture(int target) {
+    return new Texture(this, target);
+  }
+
+  /**
+   * Loads a new {@link Shader} with the shader source file {@param name}.
+   * The returned {@link Shader} must only be used with this {@link Renderer}.
+   */
+  public Shader loadShader(String name) {
+    ShaderSource source = ShaderSource.load(name);
+    Shader shader = new Shader(this);
+    if (!shader.link(source.vertex, source.fragment)) {
+      shader.delete();
+    }
+    return shader;
+  }
+
+  /** Clears the viewport with the solid color {@param c} */
+  public void clear(Color c) {
+    GL11.glClearColor(c.getRed() / 255f, c.getGreen() / 255f, c.getBlue() / 255f, 1f);
+    GL11.glClear(GL11.GL_COLOR_BUFFER_BIT);
+  }
+
+  /** draws primitives using the vertex data bound to {@param shader}. */
+  public void draw(Shader shader, int primitive, int vertexCount) {
+    shader.bind();
+    GL11.glDrawArrays(primitive, 0, vertexCount);
+  }
+
+  /** draws primitives using the vertex data bound to {@param shader} indexed from {@param indices}. */
+  public void draw(Shader shader, int primitive, IndexBuffer indices) {
+    shader.bind();
+    indices.bind();
+    GL11.glDrawElements(primitive, indices.count, indices.type, 0);
+  }
+
+  /**
+   * draws a normalized (-1 to 1) 2D quad transformed by {@param transform} with {@param shader}.
+   * The shader is expected to use a {@code uniform mat4 uTransform} for transforming the positions
+   * passed in the {@link Constants#POSITION_ATTRIBUTE}.
+   */
+  public void drawQuad(MatD transform, Shader shader) {
+    shader.setUniform("uTransform", transform.toFloatArray());
+    shader.setAttribute(Constants.POSITION_ATTRIBUTE, quadVB);
+    shader.bind();
+    draw(shader, GL11.GL_TRIANGLE_FAN, 4);
+  }
+
+  /**
+   * draws a 2D quad using the device-independent coordinates with {@param shader}.
+   * The shader is expected to use a {@code uniform mat4 uTransform} for transforming the positions
+   * passed in the {@link Constants#POSITION_ATTRIBUTE}.
+   */
+  public void drawQuad(int x, int y, int w, int h, Shader shader) {
+    drawQuad(rectTransform(x, y, w, h), shader);
+  }
+
+  public void drawSolid(MatD transform, Color color) {
+    solidShader.setUniform("uTransform", transform.toFloatArray());
+    solidShader.setUniform("uColor", color);
+    solidShader.setAttribute(Constants.POSITION_ATTRIBUTE, quadVB);
+    solidShader.bind();
+    drawQuad(transform, solidShader);
+  }
+
+  /** draws a 2D solid color quad using the device-independent coordinates. */
+  public void drawSolid(int x, int y, int w, int h, Color color) {
+    drawSolid(rectTransform(x, y, w, h), color);
+  }
+
+  /** draws a 2D checkered-color quad using the device-independent coordinates. */
+  public void drawChecker(MatD transform, Color colorA, Color colorB, int blockSize) {
+    checkerShader.setUniform("uTransform", transform.toFloatArray());
+    checkerShader.setUniform("uColorA", colorA);
+    checkerShader.setUniform("uColorB", colorB);
+    checkerShader.setUniform("uCheckerSize", new float[]{blockSize, blockSize});
+    checkerShader.setAttribute(Constants.POSITION_ATTRIBUTE, quadVB);
+    checkerShader.bind();
+    drawQuad(transform, checkerShader);
+  }
+
+  /**
+   * draws a normalized (-1 to 1) 2D border transformed by {@param transform} with {@param shader}.
+   * The border is extruded by {@param width} pixels outward.
+   * The shader is expected to use a {@code uniform mat4 uTransform} for transforming the positions
+   * passed in the {@link Constants#POSITION_ATTRIBUTE}.
+   */
+  public void drawBorder(MatD transform, Color color, int width) {
+    borderShader.setUniform("uTransform", transform.toFloatArray());
+    borderShader.setUniform("uColor", color);
+    borderShader.setUniform("uBorderWidth", new float[]{
+        2 * width / (float) dipWidth,
+        2 * width / (float) dipHeight
+    });
+    borderShader.setAttribute(Constants.POSITION_ATTRIBUTE, borderVB);
+    borderShader.bind();
+    draw(borderShader, GL11.GL_TRIANGLES, borderIB);
+  }
+
+  /** draws a 2D solid color border quad using the device-independent coordinates. */
+  public void drawBorder(int x, int y, int w, int h, Color color, int width) {
+    drawBorder(rectTransform(x, y, w, h), color, width);
+  }
+
+  /**
+   * registers the object with this renderer.
+   * The object will be freed when the renderer is destroyed.
+   */
+  void register(GlObject object) {
+    Preconditions.checkState(objects.add(object), "Object was already owned by this renderer");
+  }
+
+  /**
+   * unregisters the object with this renderer.
+   * Should only be called by the object when it is destroyed.
+   */
+  void unregister(GlObject object) {
+    Preconditions.checkState(objects.remove(object), "Object was not owned by this renderer");
+  }
+
+  private void buildPrimitives() {
+    solidShader = loadShader("solid");
+    checkerShader = loadShader("checker");
+    borderShader = loadShader("border");
+
+    quadVB = newVertexBuffer(new float[]{-1f, -1f, 1f, -1f, 1f, 1f, -1f, 1f}, 2);
+
+    borderVB = newVertexBuffer(new float[]{
+        // x, y, extrude
+        -1, -1, 0, /**/ 1, -1, 0, /**/ 1, 1, 0, /**/ -1, 1, 0,
+        -1, -1, 1, /**/ 1, -1, 1, /**/ 1, 1, 1, /**/ -1, 1, 1,
+    }, 3);
+
+    borderIB = newIndexBuffer(new int[]{
+        0, 4, 1, /**/ 1, 4, 5,
+        1, 5, 2, /**/ 2, 5, 6,
+        2, 6, 3, /**/ 3, 6, 7,
+        3, 7, 0, /**/ 0, 7, 4,
+    });
+  }
+
+  private void deleteOwnedObjects() {
+    for (GlObject object : objects.toArray(new GlObject[objects.size()])) {
+      object.delete();
+    }
+    assert(objects.isEmpty());
+  }
+
+  private MatD rectTransform(int x, int y, int w, int h) {
+    double dx = (x + 0.5 * w) * (2. / dipWidth) - 1;
+    double dy = (y + 0.5 * h) * (2. / dipHeight) - 1;
+    return MatD
+        .translation(dx, dy, 0)
+        .scale(w / (double)dipWidth, h / (double)dipHeight, 1);
+  }
+}

--- a/gapic/src/main/com/google/gapid/glviewer/gl/Scene.java
+++ b/gapic/src/main/com/google/gapid/glviewer/gl/Scene.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.gapid.glviewer.gl;
+
+/**
+ * The interface implemented by classes that render 3D scenes.
+ *
+ * @param <T> the immutable scene data.
+ */
+public interface Scene<T> {
+  /** Called before any other methods to initialize the scene. */
+  public void init(Renderer renderer);
+
+  /** Updates the scene with new data. */
+  public void update(Renderer renderer, T data);
+
+  /** Renders the scene. */
+  public void render(Renderer renderer);
+
+  /**
+   * Called when the back-buffer has been resized.
+   * TODO: Move as a listener on the renderer?
+   */
+  public void resize(Renderer renderer, int width, int height);
+}

--- a/gapic/src/main/com/google/gapid/glviewer/gl/VertexBuffer.java
+++ b/gapic/src/main/com/google/gapid/glviewer/gl/VertexBuffer.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.gapid.glviewer.gl;
+
+import org.lwjgl.opengl.GL11;
+import org.lwjgl.opengl.GL15;
+
+/**
+ * An OpenGL vertex buffer.
+ */
+public class VertexBuffer extends GlObject {
+  final int handle;
+  final int vertexCount;
+  final int elementsPerVertex;
+  final int elementType;
+
+  VertexBuffer(Renderer owner, float[] data, int elementsPerVertex) {
+    super(owner);
+    this.handle = GL15.glGenBuffers();
+    this.elementsPerVertex = elementsPerVertex;
+    this.vertexCount = data.length / elementsPerVertex;
+    this.elementType = GL11.GL_FLOAT;
+    owner.register(this);
+
+    bind();
+    GL15.glBufferData(GL15.GL_ARRAY_BUFFER, data, GL15.GL_STATIC_DRAW);
+  }
+
+  void bind() {
+    GL15.glBindBuffer(GL15.GL_ARRAY_BUFFER, handle);
+  }
+
+  @Override
+  protected void release() {
+    GL15.glDeleteBuffers(handle);
+  }
+}

--- a/gapic/src/main/com/google/gapid/glviewer/vec/MatD.java
+++ b/gapic/src/main/com/google/gapid/glviewer/vec/MatD.java
@@ -40,6 +40,18 @@ public class MatD {
     return new MatD(Arrays.copyOf(m, 16));
   }
 
+  public static MatD of(
+      double a, double b, double c, double d,
+      double e, double f, double g, double h,
+      double i, double j, double k, double l,
+      double m, double n, double o, double p) {
+    return new MatD(new double[] { a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p});
+  }
+
+  public static MatD copyOf(MatD m) {
+    return new MatD(Arrays.copyOf(m.m, 16));
+  }
+
   public float[] toFloatArray() {
     return new float[] {
         (float)m[0], (float)m[1], (float)m[2], (float)m[3], (float)m[4], (float)m[5], (float)m[6],
@@ -64,12 +76,28 @@ public class MatD {
     };
   }
 
+  public MatD translate(VecD v) {
+    return translate(v.x, v.y, v.z);
+  }
+
   public MatD translate(double tx, double ty, double tz) {
     double[] r = m.clone();
     r[12] = m[0] * tx + m[4] * ty + m[8] * tz;
     r[13] = m[1] * tx + m[5] * ty + m[9] * tz;
     r[14] = m[2] * tx + m[6] * ty + m[10] * tz;
     return new MatD(r);
+  }
+
+  public MatD scale(double s) {
+    return scale(s, s, s);
+  }
+
+  public MatD scale(double sx, double sy, double sz) {
+    return multiply(makeScale(sx, sy, sz));
+  }
+
+  public MatD scale(VecD v) {
+    return scale(v.x, v.y, v.z);
   }
 
   public double[] inverseOfTop3x3() {
@@ -182,6 +210,37 @@ public class MatD {
       sinY, -sinX * cosY, cosX * cosY, 0,
       tx, ty, tz, 1
     });
+  }
+
+  /**
+   * Creates a scale matrix.
+   */
+  public static MatD makeScale(double scale) {
+    return new MatD(new double[] {
+        scale, 0, 0, 0,
+        0, scale, 0, 0,
+        0, 0, scale, 0,
+        0, 0, 0, 1
+    });
+  }
+
+  /**
+   * Creates a scale matrix.
+   */
+  public static MatD makeScale(double sx, double sy, double sz) {
+    return new MatD(new double[] {
+        sx, 0, 0, 0,
+        0, sy, 0, 0,
+        0, 0, sz, 0,
+        0, 0, 0, 1
+    });
+  }
+
+  /**
+   * Creates a scale matrix.
+   */
+  public static MatD makeScale(VecD v) {
+    return makeScale(v.x, v.y, v.z);
   }
 
   /**

--- a/gapic/src/main/com/google/gapid/glviewer/vec/MatD.java
+++ b/gapic/src/main/com/google/gapid/glviewer/vec/MatD.java
@@ -45,7 +45,7 @@ public class MatD {
       double e, double f, double g, double h,
       double i, double j, double k, double l,
       double m, double n, double o, double p) {
-    return new MatD(new double[] { a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p});
+    return new MatD(new double[] { a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p });
   }
 
   public static MatD copyOf(MatD m) {

--- a/gapic/src/main/com/google/gapid/glviewer/vec/VecD.java
+++ b/gapic/src/main/com/google/gapid/glviewer/vec/VecD.java
@@ -21,6 +21,11 @@ import static java.lang.Double.doubleToLongBits;
  * A 3 element double precision vector.
  */
 public class VecD {
+  public final static VecD ZERO = new VecD();
+  public final static VecD ONE = new VecD(1, 1, 1);
+  public final static VecD MIN = new VecD(Double.MIN_VALUE, Double.MIN_VALUE, Double.MIN_VALUE);
+  public final static VecD MAX = new VecD(Double.MAX_VALUE, Double.MAX_VALUE, Double.MAX_VALUE);
+
   public final double x, y, z;
   private final int h;
 
@@ -35,6 +40,11 @@ public class VecD {
 
     long hl = doubleToLongBits(x) + 31 * (doubleToLongBits(y) + 31 * doubleToLongBits(z));
     this.h = (int)(hl ^ (hl >>> 32));
+  }
+
+  @Override
+  public String toString() {
+    return String.format("[%f, %f, %f]", x, y, z);
   }
 
   @Override
@@ -60,12 +70,33 @@ public class VecD {
     }
   }
 
+  public VecD set(int idx, double value) {
+    switch (idx) {
+      case 0: return new VecD(value, y, z);
+      case 1: return new VecD(x, value, z);
+      case 2: return new VecD(x, y, value);
+      default: throw new IndexOutOfBoundsException();
+    }
+  }
+
+  public VecD negate() {
+    return new VecD(-x, -y, -z);
+  }
+
+  public VecD clamp(VecD min, VecD max) {
+    return this.max(min).min(max);
+  }
+
   public VecD add(VecD v) {
     return new VecD(x + v.x, y + v.y, z + v.z);
   }
 
   public VecD add(double v) {
     return new VecD(x + v, y + v, z + v);
+  }
+
+  public VecD add(double x, double y, double z) {
+    return new VecD(this.x + x, this.y + y, this.z + z);
   }
 
   public VecD addScaled(VecD v, double s) {
@@ -80,16 +111,42 @@ public class VecD {
     return new VecD(x - v, y - v, z - v);
   }
 
+  public VecD subtract(double x, double y, double z) {
+    return new VecD(this.x - x, this.y - y, this.z - z);
+  }
+
   public VecD multiply(VecD v) {
     return new VecD(x * v.x, y * v.y, z * v.z);
+  }
+
+  public VecD multiply(double x, double y, double z) {
+    return new VecD(this.x * x, this.y * y, this.z * z);
   }
 
   public VecD scale(double v) {
     return new VecD(x * v, y * v, z * v);
   }
 
+  public VecD divide(VecD v) {
+    return new VecD(x / v.x, y / v.y, z / v.z);
+  }
+
   public VecD divide(double v) {
     return new VecD(x / v, y / v, z / v);
+  }
+
+  public VecD divide(double x, double y, double z) {
+    return new VecD(this.x / x, this.y / y, this.z / z);
+  }
+
+  /**
+   * Like {@link #divide(VecD)}, but divide by zeros result in zero.
+   */
+  public VecD safeDivide(VecD v) {
+    return new VecD(
+        (v.x == 0) ? 0 : (x / v.x),
+        (v.y == 0) ? 0 : (y / v.y),
+        (v.z == 0) ? 0 : (z / v.z));
   }
 
   public double magnitudeSquared() {
@@ -120,12 +177,28 @@ public class VecD {
     return new VecD(Math.abs(x), Math.abs(y), Math.abs(z));
   }
 
+  public double min() {
+    return Math.min(minXY(), z);
+  }
+
+  public double minXY() {
+    return Math.min(x, y);
+  }
+
   public VecD min(VecD v) {
     return new VecD(Math.min(x, v.x), Math.min(y, v.y), Math.min(z, v.z));
   }
 
   public VecD min(double v) {
     return new VecD(Math.min(x, v), Math.min(y, v), Math.min(z, v));
+  }
+
+  public double max() {
+    return Math.max(maxXY(), z);
+  }
+
+  public double maxXY() {
+    return Math.max(x, y);
   }
 
   public VecD max(VecD v) {

--- a/gapic/src/main/com/google/gapid/server/GapisProcess.java
+++ b/gapic/src/main/com/google/gapid/server/GapisProcess.java
@@ -23,6 +23,8 @@ import com.google.common.collect.Lists;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.gapid.models.Settings;
+import com.google.gapid.util.Flags;
+import com.google.gapid.util.Flags.Flag;
 import com.google.gapid.util.Logging;
 
 import java.io.File;
@@ -41,6 +43,9 @@ import java.util.regex.Pattern;
  * future returned by {@link #start()} is the port the GAPIS server listens to.
  */
 public class GapisProcess extends ChildProcess<Integer> {
+  public static final Flag<Boolean> disableGapisTimeout = Flags.value(
+      "disable-gapis-timeout", false, "Disables the GAPIS timeout. Useful for debugging.");
+
   private static final Logger LOG = Logger.getLogger(GapisProcess.class.getName());
 
   private static final Pattern PORT_PATTERN = Pattern.compile("^Bound on port '(\\d+)'$", 0);
@@ -97,8 +102,10 @@ public class GapisProcess extends ChildProcess<Integer> {
     args.add("--gapis-auth-token");
     args.add(authToken);
 
-    args.add("--idle-timeout");
-    args.add(IDLE_TIMEOUT_MS + "ms");
+    if (!disableGapisTimeout.get()) {
+      args.add("--idle-timeout");
+      args.add(IDLE_TIMEOUT_MS + "ms");
+    }
 
     String adb = GapiPaths.adb(settings);
     if (!adb.isEmpty()) {

--- a/gapic/src/main/com/google/gapid/views/FramebufferView.java
+++ b/gapic/src/main/com/google/gapid/views/FramebufferView.java
@@ -102,13 +102,13 @@ public class FramebufferView extends Composite
     setLayout(new GridLayout(2, false));
 
     ToolBar toolBar = createToolBar(widgets.theme);
-    imagePanel = new ImagePanel(this, widgets);
+    imagePanel = new ImagePanel(this, widgets, true);
     loading = imagePanel.getLoading();
 
     toolBar.setLayoutData(new GridData(SWT.LEFT, SWT.FILL, false, true));
     imagePanel.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
 
-    imagePanel.createToolbar(toolBar, widgets.theme, true);
+    imagePanel.createToolbar(toolBar, widgets.theme);
     // Work around for https://bugs.eclipse.org/bugs/show_bug.cgi?id=517480
     Widgets.createSeparator(toolBar);
 

--- a/gapic/src/main/com/google/gapid/views/TextureView.java
+++ b/gapic/src/main/com/google/gapid/views/TextureView.java
@@ -129,7 +129,7 @@ public class TextureView extends Composite
     toolBar.setLayoutData(new GridData(SWT.LEFT, SWT.FILL, false, true));
     imagePanel.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
 
-    imagePanel.createToolbar(toolBar, widgets.theme, true);
+    imagePanel.createToolbar(toolBar, widgets.theme);
     gotoAction.createToolItem(toolBar);
 
     models.capture.addListener(this);
@@ -172,7 +172,7 @@ public class TextureView extends Composite
   }
 
   private static ImagePanel createImagePanel(Composite parent, Widgets widgets) {
-    ImagePanel panel = new ImagePanel(parent, widgets);
+    ImagePanel panel = new ImagePanel(parent, widgets, false);
     return panel;
   }
 

--- a/gapic/src/main/com/google/gapid/widgets/ScenePanel.java
+++ b/gapic/src/main/com/google/gapid/widgets/ScenePanel.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright (C) 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.gapid.widgets;
+
+import com.google.gapid.glcanvas.GlCanvas;
+
+import com.google.gapid.glviewer.gl.Renderer;
+import com.google.gapid.glviewer.gl.Scene;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.graphics.Point;
+import org.eclipse.swt.internal.DPIUtil;
+import org.eclipse.swt.layout.FillLayout;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Event;
+import org.eclipse.swt.widgets.Listener;
+import org.lwjgl.opengl.GL;
+import org.lwjgl.opengl.GLCapabilities;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * {@link GlCanvas} used to render a {@link Scene}.
+ */
+public class ScenePanel<T> extends GlCanvas {
+  private final GLCapabilities caps;
+  private final Renderer renderer;
+  private final Scene scene;
+  private final AtomicReference<T> sceneData = new AtomicReference<>();
+  private Map<Integer, List<Listener>> eventListeners;
+  private int numSuspendedUpdates;
+  private boolean isPendingUpdate;
+  private boolean isPendingRender;
+
+  public ScenePanel(Composite parent, Scene<T> scene) {
+    super(parent, SWT.NO_BACKGROUND);
+    setLayout(new FillLayout(SWT.VERTICAL));
+    this.scene = scene;
+    renderer = new Renderer();
+
+    setCurrent();
+    caps = GL.createCapabilities();
+    initialize();
+
+    addListener(SWT.Resize, e -> { /* register to handle resizes in dispatchEvents */ });
+    addListener(SWT.Paint, e -> update(true));
+    addListener(SWT.Dispose, e -> terminate());
+  }
+
+  // Intercept addListener calls so that we can reduce the number of updates per event to one,
+  // regardless of the number of listeners that request renders.
+  @Override
+  public void addListener(int eventType, Listener listener) {
+    if (eventListeners == null) {
+      eventListeners = new HashMap<>();
+    }
+    List<Listener> existing = eventListeners.get(eventType);
+    if (existing != null) {
+      existing.add(listener);
+      return;
+    }
+    List<Listener> list = new ArrayList<>();
+    list.add(listener);
+    super.addListener(eventType, this::dispatchEvents);
+    eventListeners.put(eventType, list);
+  }
+
+  /**
+   * Request the scene to be redrawn.
+   */
+  public void paint() {
+    notifyListeners(SWT.Paint, new Event());
+  }
+
+  /**
+   * Change the scene data and redraw.
+   */
+  public void setSceneData(T data) {
+    sceneData.set(data);
+    update(true);
+  }
+
+  private void initialize() {
+    renderer.initialize();
+    Point size = DPIUtil.autoScaleUp(getSize());
+    renderer.setSize(size.x, size.y);
+    scene.init(renderer);
+  }
+
+  private void terminate() {
+    setCurrent();
+    GL.setCapabilities(caps);
+    renderer.terminate();
+  }
+
+  private void dispatchEvents(Event event) {
+    withSuspendedUpdate(() -> {
+      if (event.type == SWT.Resize) {
+        Point size = DPIUtil.autoScaleUp(getSize());
+        setCurrent();
+        renderer.setSize(size.x, size.y);
+        scene.resize(renderer, size.x, size.y);
+      }
+      for (Listener listener : eventListeners.get(event.type)) {
+        listener.handleEvent(event);
+      }
+    });
+  }
+
+  private void withSuspendedUpdate(Runnable r) {
+    try {
+      numSuspendedUpdates++;
+      r.run();
+    } finally {
+      numSuspendedUpdates--;
+    }
+    if (numSuspendedUpdates == 0 && isPendingUpdate) {
+      update(isPendingRender);
+      isPendingUpdate = false;
+      isPendingRender = false;
+    }
+  }
+
+  private void update(boolean render) {
+    if (numSuspendedUpdates > 0) {
+      isPendingRender |= render;
+      isPendingUpdate = true;
+      return;
+    }
+
+    setCurrent();
+    GL.setCapabilities(caps);
+    T newData = sceneData.getAndSet(null);
+    if (newData != null) {
+      scene.update(renderer, newData);
+    }
+    if (render) {
+      scene.render(renderer);
+      swapBuffers();
+    }
+  }
+}

--- a/gapic/src/main/com/google/gapid/widgets/Theme.java
+++ b/gapic/src/main/com/google/gapid/widgets/Theme.java
@@ -126,6 +126,11 @@ public interface Theme {
   @RGB(argb = 0xff4c0100) public Color errorForeground();
   @RGB(argb = 0xff1b004c) public Color fatalForeground();
 
+  @RGB(argb = 0xffc0c0c0) public Color imageCheckerDark();
+  @RGB(argb = 0xffffffff) public Color imageCheckerLight();
+  @RGB(argb = 0xff000000) public Color imageCursorDark();
+  @RGB(argb = 0xffffffff) public Color imageCursorLight();
+
   @TextStyle(foreground = 0xa9a9a9) public Styler structureStyler();
   @TextStyle(foreground = 0x0000ee) public Styler identifierStyler();
   @TextStyle(bold = true) public Styler labelStyler();


### PR DESCRIPTION
Add Renderer class that manages the GL objects and context.
It also has a number of methods to simplify 2D drawing.

Abstract the GL objects further. They now contain more of their state,
without requiring explict binding to use.

Use new Scene model to separate rendering logic from data. If we move
back to a threaded renderer, this cleanly separates data that could
cause race issues.

ImageViewer now has sticky zoom-to-fit and zoom settings. Lets you zoom
in to an area and change commands.