### PR TITLE
Attempt to fix flakey mac build

### DIFF
--- a/core/app/CMakeBuild.cmake
+++ b/core/app/CMakeBuild.cmake
@@ -12,6 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+if(DISABLED_GO)
+    return()
+endif()
+
 configure_file(
     "${CMAKE_CURRENT_SOURCE_DIR}/default_version.go.in"
     "${CMAKE_CURRENT_SOURCE_DIR}/default_version.go"

--- a/gapic/CMakeBuild.cmake
+++ b/gapic/CMakeBuild.cmake
@@ -12,6 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+if(ANDROID)
+    return()
+endif()
+
 configure_file(
     "${CMAKE_CURRENT_SOURCE_DIR}/Version.java.in"
     "${JAVA_GENERATED}/com/google/gapid/Version.java"


### PR DESCRIPTION
I believe multiple CMake instances attempt to write `default_version.go` leading to the very unhelpful error: 

```
-- Setting install path to /Users/kbuilder/gapid
-- Found STL: /tmpfs/src/android/ndk-bundle/sources/cxx-stl/gnu-libstdc++/4.9/libs/armeabi/libgnustl_static.a  
CMake Error at core/app/CMakeBuild.cmake:15 (configure_file):
  configure_file Problem configuring file
Call Stack (most recent call first):
  cmake/Utils.cmake:75 (include)
  core/CMakeBuild.cmake:15 (build_subdirectory)
  cmake/Utils.cmake:75 (include)
  CMakeLists.txt:76 (build_subdirectory)
```