### PR TITLE
Robot: `./do upload` zips local build, Artifacts based on build host.

### DIFF
--- a/cmd/do/upload.go
+++ b/cmd/do/upload.go
@@ -30,9 +30,11 @@ func getPlatform() string {
 
 func doUpload(ctx context.Context, cfg Config, options UploadOptions, args ...string) {
 	pkg := cfg.out().Join(fmt.Sprintf("%s-%s.zip", "gapid", getPlatform()))
-	if !pkg.Exists() {
-		panic(fmt.Errorf("Package %s does not exist", pkg.String()))
+	robotArgs := append([]string{}, args...)
+	if pkg.Exists() {
+		robotArgs = append([]string{"upload", "build", pkg.String()}, robotArgs...)
+	} else {
+		robotArgs = append([]string{"upload", "package", pkg.String()}, robotArgs...)
 	}
-	robotArgs := append([]string{"upload", "build", pkg.String()}, args...)
 	doRunTarget(ctx, cfg, options.BuildAndRunOptions, "robot", robotArgs...)
 }

--- a/cmd/robot/upload.go
+++ b/cmd/robot/upload.go
@@ -41,7 +41,9 @@ func upload(ctx context.Context, flags flag.FlagSet, serverAddress string, u upl
 		if err != nil {
 			return err
 		}
-		u.prepare(ctx, conn)
+		if err := u.prepare(ctx, conn); err != nil {
+			return err
+		}
 		for _, partial := range flags.Args() {
 			id, err := client.UploadFile(ctx, file.Abs(partial))
 			if err != nil {

--- a/core/app/layout/layout.go
+++ b/core/app/layout/layout.go
@@ -70,6 +70,8 @@ func withPlatformSuffix(lib string) string {
 	switch runtime.GOOS {
 	case "windows":
 		return lib + ".dll"
+	case "darwin":
+		return lib + ".dylib"
 	default:
 		return lib + ".so"
 	}

--- a/core/app/layout/pkgdata.go
+++ b/core/app/layout/pkgdata.go
@@ -84,6 +84,11 @@ func Strings(ctx context.Context) (file.Path, error) {
 	return layout(ctx).Strings(ctx)
 }
 
+// Gapis returns the path to the gapis binary.
+func Gapis(ctx context.Context) (file.Path, error) {
+	return layout(ctx).Gapis(ctx)
+}
+
 // GapidApk returns the path to the gapid.apk corresponding to the given abi.
 func GapidApk(ctx context.Context, abi *device.ABI) (file.Path, error) {
 	return layout(ctx).GapidApk(ctx, abi)

--- a/test/robot/build/artifact.go
+++ b/test/robot/build/artifact.go
@@ -162,7 +162,7 @@ func (a *artifacts) get(ctx context.Context, id string, hostABIs []*device.ABI) 
 	if len(hostABIs) != 1 {
 		log.W(ctx, "(*artifacts) get() received multiple host ABIs, taking first one. %v", hostABIs[0])
 	}
-	toolSet := new(ToolSet{Abi: hostABIs[0], Host: new(HostToolSet)})
+	toolSet := ToolSet{Abi: hostABIs[0], Host: new(HostToolSet)}
 	// TODO(baldwinn): move these paths to layout
 	toolSetIdByZipEntry := map[string]*string{
 		"gapid/gapir":                          &toolSet.Host.Gapir,
@@ -174,9 +174,9 @@ func (a *artifacts) get(ctx context.Context, id string, hostABIs []*device.ABI) 
 	for _, f := range zipFile.File {
 		z := &zipEntry{file: f}
 		if dirs := strings.Split(f.Name, "/"); dirs[1] == "android" {
-			toolSet.Android = append(toolset.Android, &AndroidToolSet{Abi: device.ABIByName(dirs[2]), GapidApk: z.GetID(ctx, a)})
+			toolSet.Android = append(toolSet.Android, &AndroidToolSet{Abi: device.ABIByName(dirs[2]), GapidApk: z.GetID(ctx, a)})
 		} else if id, ok := toolSetIdByZipEntry[f.Name]; ok {
-			id = z.GetID(ctx, a)
+			*id = z.GetID(ctx, a)
 		}
 	}
 	entry := &Artifact{Id: id, Tool: &toolSet}

--- a/test/robot/build/build.proto
+++ b/test/robot/build/build.proto
@@ -63,32 +63,42 @@ message Information {
 message Artifact {
   // Id is the id in the stash of the build artifact.
   string id = 1;
-  // Tool is the set of tool entry ids that were inferred from the build on upload.
-  repeated ToolSet tool = 2;
+  // Tool is the set of tools in this artifact
+  ToolSet tool = 2;
 }
 
-// ToolSet is the information for a collction files extracted from a package to perform a specific task.
+// ToolSet is the information for all of the tools extracted from a particular package or artifact.
 message ToolSet {
-  // Abi is the target system this tool set runs on.
+  // Abi is the host system this toolset was built on.
   device.ABI abi = 1;
-  // The stash id of the function interceptor
-  string interceptor = 2;
-  // The stash id of the graphics interceptor
-  string gapii = 3;
-  // The stash id of the replay daemon
-  string gapir = 4;
-  // The stash id of the graphics analysis server
-  string gapis = 5;
-  // The stash id of the graphics analysis command line tool
-  string gapit = 6;
-  // The stash id of the gapid.apk
-  string gapid_apk = 7;
+  // The tools provided from a particular host.
+  HostToolSet host = 2;
+  // The tools provided for each supported android abi.
+  repeated AndroidToolSet android = 3;
+}
+
+// HostToolSet is the information for the tools extracted from a package for a particular host device.
+message HostToolSet {
+  // The stash id of the replay daemon.
+  string gapir = 1;
+  // The stash id of the graphics analysis server.
+  string gapis = 2;
+  // The stash id of the graphics analysis command line tool.
+  string gapit = 3;
   // VirtualSwapChainLib is the stash id of the vulkan virtual-swap-chain loader
   // library.
-  string virtual_swap_chain_lib = 8;
+  string virtual_swap_chain_lib = 4;
   // VirtualSwapChainLib is the stash id of the vulkan virtual-swap-chain loader
   // json file.
-  string virtual_swap_chain_json = 9;
+  string virtual_swap_chain_json = 5;
+}
+
+// AndroidToolSet is the information for the tools extracted from a package for a particular android ABI.
+message AndroidToolSet {
+  // The type of host system this tool set runs on.
+  device.ABI abi = 1;
+  // The stash id of the gapid.apk.
+  string gapid_apk = 2;
 }
 
 // Package represents an entry in a build track.

--- a/test/robot/build/build.proto
+++ b/test/robot/build/build.proto
@@ -95,7 +95,7 @@ message HostToolSet {
 
 // AndroidToolSet is the information for the tools extracted from a package for a particular android ABI.
 message AndroidToolSet {
-  // The type of host system this tool set runs on.
+  // The Android ABI this tool set runs on.
   device.ABI abi = 1;
   // The stash id of the gapid.apk.
   string gapid_apk = 2;

--- a/test/robot/build/local.go
+++ b/test/robot/build/local.go
@@ -67,7 +67,7 @@ func (s *local) SearchTracks(ctx context.Context, query *search.Query, handler T
 // Add implements Store.Add
 // It adds the package to the persisten store, and attempts to add it into the track it should be part of.
 func (s *local) Add(ctx context.Context, id string, info *Information) (string, bool, error) {
-	a, err := s.artifacts.get(ctx, id)
+	a, err := s.artifacts.get(ctx, id, info.Builder.Configuration.ABIs)
 	if err != nil {
 		return "", false, err
 	}

--- a/test/robot/monitor/build.go
+++ b/test/robot/monitor/build.go
@@ -59,7 +59,7 @@ func (p *Package) FindTools(ctx context.Context, d *Device) *build.ToolSet {
 		return nil
 	}
 	for _, abi := range d.Information.Configuration.ABIs {
-		if tools := p.Package.GetTools(abi); tools != nil {
+		if tools := p.Package.GetHostTools(abi); tools != nil {
 			return tools
 		}
 	}
@@ -68,12 +68,17 @@ func (p *Package) FindTools(ctx context.Context, d *Device) *build.ToolSet {
 
 // FindToolsForAPK returns the best matching tool set for a certain apk on a device,
 // if present in the package.
-func (p *Package) FindToolsForAPK(ctx context.Context, d *Device, apkInfo *apk.Information) *build.ToolSet {
-	toolsABI := d.GetInformation().GetConfiguration().PreferredABI(apkInfo.ABI)
-	if toolsABI == nil {
+func (p *Package) FindToolsForAPK(ctx context.Context, host *Device, target *Device, apkInfo *apk.Information) *build.AndroidToolSet {
+	targetToolsAbi := target.GetInformation().GetConfiguration().PreferredABI(apkInfo.ABI)
+	if targetToolsAbi == nil {
 		return nil
 	}
-	return p.Package.GetTools(toolsABI)
+	for _, abi := range host.Information.Configuration.ABIs {
+		if tools := p.Package.GetTargetTools(abi, targetToolsAbi); tools != nil {
+			return tools
+		}
+	}
+	return nil
 }
 
 func (o *DataOwner) updateTrack(ctx context.Context, track *build.Track) error {

--- a/test/robot/scheduler/replay.go
+++ b/test/robot/scheduler/replay.go
@@ -30,7 +30,7 @@ func (s schedule) getReplayTargetTools(ctx context.Context) *build.ToolSet {
 	if tools == nil {
 		return nil
 	}
-	if tools.Gapir == "" {
+	if tools.Host.Gapir == "" {
 		return nil
 	}
 	return tools
@@ -49,11 +49,11 @@ func (s schedule) doReplay(ctx context.Context, t *monitor.Trace) error {
 	}
 	input := &replay.Input{
 		Trace:                t.Action.Output.Trace,
-		Gapit:                hostTools.Gapit,
-		Gapis:                hostTools.Gapis,
-		Gapir:                targetTools.Gapir,
-		VirtualSwapChainLib:  targetTools.VirtualSwapChainLib,
-		VirtualSwapChainJson: targetTools.VirtualSwapChainJson,
+		Gapit:                hostTools.Host.Gapit,
+		Gapis:                hostTools.Host.Gapis,
+		Gapir:                targetTools.Host.Gapir,
+		VirtualSwapChainLib:  targetTools.Host.VirtualSwapChainLib,
+		VirtualSwapChainJson: targetTools.Host.VirtualSwapChainJson,
 	}
 	action := &replay.Action{
 		Input:  input,

--- a/test/robot/scheduler/report.go
+++ b/test/robot/scheduler/report.go
@@ -35,8 +35,8 @@ func (s schedule) doReport(ctx context.Context, t *monitor.Trace) error {
 	}
 	input := &report.Input{
 		Trace: t.Action.Output.Trace,
-		Gapit: hostTools.Gapit,
-		Gapis: hostTools.Gapis,
+		Gapit: hostTools.Host.Gapit,
+		Gapis: hostTools.Host.Gapis,
 	}
 	action := &report.Action{
 		Input:  input,

--- a/test/robot/scheduler/scheduler.go
+++ b/test/robot/scheduler/scheduler.go
@@ -78,10 +78,13 @@ func (s schedule) getHostTools(ctx context.Context) *build.ToolSet {
 	if tools == nil {
 		return nil
 	}
-	if tools.Gapit == "" {
+	if tools.Host.Gapit == "" {
 		return nil
 	}
-	if tools.Gapis == "" {
+	if tools.Host.Gapis == "" {
+		return nil
+	}
+	if tools.Host.Gapir == "" {
 		return nil
 	}
 	return tools

--- a/test/robot/scheduler/trace.go
+++ b/test/robot/scheduler/trace.go
@@ -24,9 +24,9 @@ import (
 	"github.com/google/gapid/test/robot/trace"
 )
 
-func (s schedule) getTraceTargetTools(ctx context.Context, subj *monitor.Subject) *build.ToolSet {
+func (s schedule) getTraceTargetTools(ctx context.Context, subj *monitor.Subject) *build.AndroidToolSet {
 	ctx = log.V{"target": s.worker.Target}.Bind(ctx)
-	tools := s.pkg.FindToolsForAPK(ctx, s.data.FindDevice(s.worker.Target), subj.GetAPK())
+	tools := s.pkg.FindToolsForAPK(ctx, s.data.FindDevice(s.worker.Host), s.data.FindDevice(s.worker.Target), subj.GetAPK())
 
 	if tools == nil {
 		return nil
@@ -50,7 +50,7 @@ func (s schedule) doTrace(ctx context.Context, subj *monitor.Subject) error {
 	}
 	input := &trace.Input{
 		Subject:  subj.Id,
-		Gapit:    hostTools.Gapit,
+		Gapit:    hostTools.Host.Gapit,
 		GapidApk: targetTools.GapidApk,
 		Hints:    subj.Hints,
 		Layout: &trace.ToolingLayout{

--- a/test/robot/stash/client.go
+++ b/test/robot/stash/client.go
@@ -97,6 +97,9 @@ func (c *Client) GetFile(ctx context.Context, id string, filename file.Path) err
 		mode = 0755
 	}
 	f, err := os.OpenFile(filename.System(), os.O_RDWR|os.O_CREATE|os.O_TRUNC, mode)
+	if err != nil {
+		return err
+	}
 	defer f.Close()
 	r, err := c.Open(ctx, id)
 	if err != nil {

--- a/test/robot/trace/client.go
+++ b/test/robot/trace/client.go
@@ -175,7 +175,7 @@ func doTrace(ctx context.Context, action string, in *Input, store *stash.Client,
 	output, err := cmd.Call(ctx)
 	output = fmt.Sprintf("%s\n\n%s", cmd, output)
 	if err != nil {
-		return nil, log.Errf(ctx, err, "gapit call failed %v", output);
+		return nil, log.Errf(ctx, err, "gapit call failed %v", output)
 	}
 
 	outputObj := &Output{}


### PR DESCRIPTION
`./do upload` now produces a zip file of the local build when the expected file does not exist by using a new verb `./do robot upload package <filename>`

Artifacts are now based on the build host rather than merged from multiple hosts with possible overriding android toolsets.

Layouts now support OS X `.dylib` files and finding Gapis.