### PR TITLE
gapir: Fix for synthetic function index collision.

### DIFF
--- a/gapil/template/api.go
+++ b/gapil/template/api.go
@@ -16,6 +16,7 @@ package template
 
 import (
 	"fmt"
+	"reflect"
 
 	"github.com/google/gapid/gapil/semantic"
 )
@@ -36,6 +37,34 @@ func (*Functions) GetAnnotation(ty interface{}, name string) *semantic.Annotatio
 		return nil
 	}
 	return a.GetAnnotation(name)
+}
+
+// WithAnnotation returns the list l filtered to those items with the specified
+// annotation.
+func (*Functions) WithAnnotation(name string, l interface{}) []interface{} {
+	v := reflect.ValueOf(l)
+	out := []interface{}{}
+	for i, c := 0, v.Len(); i < c; i++ {
+		n := v.Index(i).Interface()
+		if n, ok := n.(semantic.Annotated); ok && n.GetAnnotation(name) != nil {
+			out = append(out, n)
+		}
+	}
+	return out
+}
+
+// WithoutAnnotation returns the list l filtered to those items without the
+// specified annotation.
+func (*Functions) WithoutAnnotation(name string, l interface{}) []interface{} {
+	v := reflect.ValueOf(l)
+	out := []interface{}{}
+	for i, c := 0, v.Len(); i < c; i++ {
+		n := v.Index(i).Interface()
+		if n, ok := n.(semantic.Annotated); !ok || n.GetAnnotation(name) == nil {
+			out = append(out, n)
+		}
+	}
+	return out
 }
 
 // Underlying returns the underlying type for ty by recursively traversing the

--- a/gapil/template/types.go
+++ b/gapil/template/types.go
@@ -17,11 +17,9 @@ package template
 import (
 	"errors"
 	"fmt"
-	"unicode"
-
 	"reflect"
-
 	"strings"
+	"unicode"
 
 	"github.com/google/gapid/gapil/semantic"
 )

--- a/gapir/cc/context.cpp
+++ b/gapir/cc/context.cpp
@@ -147,23 +147,23 @@ void Context::onDebugMessage(int severity, const char* msg) {
 
 void Context::registerCallbacks(Interpreter* interpreter) {
     // Custom function for posting and fetching resources to and from the server
-    interpreter->registerBuiltin(Interpreter::POST_FUNCTION_ID,
+    interpreter->registerBuiltin(Interpreter::GLOBAL_INDEX, Interpreter::POST_FUNCTION_ID,
                                  [this](Stack* stack, bool) { return this->postData(stack); });
-    interpreter->registerBuiltin(Interpreter::RESOURCE_FUNCTION_ID,
+    interpreter->registerBuiltin(Interpreter::GLOBAL_INDEX, Interpreter::RESOURCE_FUNCTION_ID,
                                  [this](Stack* stack, bool) { return this->loadResource(stack); });
 
     // Registering custom synthetic functions
-    interpreter->registerBuiltin(Builtins::StartTimer,
+    interpreter->registerBuiltin(Gles::INDEX, Builtins::StartTimer,
                                  [this](Stack* stack, bool) { return this->startTimer(stack); });
-    interpreter->registerBuiltin(Builtins::StopTimer,
+    interpreter->registerBuiltin(Gles::INDEX, Builtins::StopTimer,
                                  [this](Stack* stack, bool pushReturn) {
         return this->stopTimer(stack, pushReturn);
     });
-    interpreter->registerBuiltin(Builtins::FlushPostBuffer, [this](Stack* stack, bool) {
+    interpreter->registerBuiltin(Gles::INDEX, Builtins::FlushPostBuffer, [this](Stack* stack, bool) {
         return this->flushPostBuffer(stack);
     });
 
-    interpreter->registerBuiltin(Builtins::ReplayCreateRenderer, [this](Stack* stack, bool) {
+    interpreter->registerBuiltin(Gles::INDEX, Builtins::ReplayCreateRenderer, [this](Stack* stack, bool) {
         uint32_t id = stack->pop<uint32_t>();
         if (stack->isValid()) {
             GAPID_INFO("replayCreateRenderer(%u)", id);
@@ -189,7 +189,7 @@ void Context::registerCallbacks(Interpreter* interpreter) {
         }
     });
 
-    interpreter->registerBuiltin(Builtins::ReplayBindRenderer, [this, interpreter](Stack* stack, bool) {
+    interpreter->registerBuiltin(Gles::INDEX, Builtins::ReplayBindRenderer, [this, interpreter](Stack* stack, bool) {
         uint32_t id = stack->pop<uint32_t>();
         if (stack->isValid()) {
             GAPID_DEBUG("replayBindRenderer(%u)", id);
@@ -209,7 +209,7 @@ void Context::registerCallbacks(Interpreter* interpreter) {
         }
     });
 
-    interpreter->registerBuiltin(Builtins::ReplayChangeBackbuffer, [this](Stack* stack, bool) {
+    interpreter->registerBuiltin(Gles::INDEX, Builtins::ReplayChangeBackbuffer, [this](Stack* stack, bool) {
         GlesRenderer::Backbuffer backbuffer;
 
         bool resetViewportScissor = stack->pop<bool>();
@@ -251,7 +251,7 @@ void Context::registerCallbacks(Interpreter* interpreter) {
         }
     });
 
-    interpreter->registerBuiltin(Builtins::ReplayCreateVkInstance,
+    interpreter->registerBuiltin(Vulkan::INDEX, Builtins::ReplayCreateVkInstance,
                                  [this, interpreter](Stack* stack, bool pushReturn) {
         GAPID_INFO("replayCreateVkInstance()");
 
@@ -264,7 +264,7 @@ void Context::registerCallbacks(Interpreter* interpreter) {
         }
     });
 
-    interpreter->registerBuiltin(Builtins::ReplayCreateVkDevice,
+    interpreter->registerBuiltin(Vulkan::INDEX, Builtins::ReplayCreateVkDevice,
                                  [this, interpreter](Stack* stack, bool pushReturn) {
         GAPID_INFO("replayCreateVkDevice()");
         if (mBoundVulkanRenderer != nullptr) {
@@ -276,7 +276,7 @@ void Context::registerCallbacks(Interpreter* interpreter) {
         }
     });
 
-    interpreter->registerBuiltin(Builtins::ReplayRegisterVkInstance,
+    interpreter->registerBuiltin(Vulkan::INDEX, Builtins::ReplayRegisterVkInstance,
                                  [this, interpreter](Stack* stack, bool) {
         GAPID_INFO("replayRegisterVkInstance()");
         if (mBoundVulkanRenderer != nullptr) {
@@ -288,7 +288,7 @@ void Context::registerCallbacks(Interpreter* interpreter) {
         }
     });
 
-    interpreter->registerBuiltin(Builtins::ReplayUnregisterVkInstance,
+    interpreter->registerBuiltin(Vulkan::INDEX, Builtins::ReplayUnregisterVkInstance,
                                  [this, interpreter](Stack* stack, bool) {
         GAPID_INFO("replayUnregisterVkInstance()");
         if (mBoundVulkanRenderer != nullptr) {
@@ -300,7 +300,7 @@ void Context::registerCallbacks(Interpreter* interpreter) {
         }
     });
 
-    interpreter->registerBuiltin(Builtins::ReplayRegisterVkDevice,
+    interpreter->registerBuiltin(Vulkan::INDEX, Builtins::ReplayRegisterVkDevice,
                                  [this, interpreter](Stack* stack, bool) {
         GAPID_INFO("replayRegisterVkDevice()");
         if (mBoundVulkanRenderer != nullptr) {
@@ -312,7 +312,7 @@ void Context::registerCallbacks(Interpreter* interpreter) {
         }
     });
 
-    interpreter->registerBuiltin(Builtins::ReplayUnregisterVkDevice,
+    interpreter->registerBuiltin(Vulkan::INDEX, Builtins::ReplayUnregisterVkDevice,
                                  [this, interpreter](Stack* stack, bool) {
         GAPID_INFO("replayUnregisterVkDevice()");
         if (mBoundVulkanRenderer != nullptr) {
@@ -324,7 +324,7 @@ void Context::registerCallbacks(Interpreter* interpreter) {
         }
     });
 
-    interpreter->registerBuiltin(Builtins::ReplayRegisterVkCommandBuffers,
+    interpreter->registerBuiltin(Vulkan::INDEX, Builtins::ReplayRegisterVkCommandBuffers,
                                  [this, interpreter](Stack* stack, bool) {
         GAPID_INFO("replayRegisterVkCommandBuffers()");
         if (mBoundVulkanRenderer != nullptr) {
@@ -336,7 +336,7 @@ void Context::registerCallbacks(Interpreter* interpreter) {
         }
     });
 
-    interpreter->registerBuiltin(Builtins::ReplayUnregisterVkCommandBuffers,
+    interpreter->registerBuiltin(Vulkan::INDEX, Builtins::ReplayUnregisterVkCommandBuffers,
                                  [this, interpreter](Stack* stack, bool) {
         GAPID_INFO("replayUnregisterVkCommandBuffers()");
         if (mBoundVulkanRenderer != nullptr) {
@@ -348,7 +348,7 @@ void Context::registerCallbacks(Interpreter* interpreter) {
         }
     });
 
-    interpreter->registerBuiltin(Builtins::ToggleVirtualSwapchainReturnAcquiredImage,
+    interpreter->registerBuiltin(Vulkan::INDEX, Builtins::ToggleVirtualSwapchainReturnAcquiredImage,
                                  [this, interpreter](Stack* stack, bool) {
         GAPID_INFO("ToggleVirtualSwapchainReturnAcquiredImage()");
         if (mBoundVulkanRenderer != nullptr) {
@@ -361,6 +361,7 @@ void Context::registerCallbacks(Interpreter* interpreter) {
     });
 
     interpreter->registerBuiltin(
+        Vulkan::INDEX,
         Builtins::ReplayAllocateImageMemory,
         [this, interpreter](Stack* stack, bool push_return) {
             GAPID_INFO("replayAllocateImageMemory()");
@@ -374,7 +375,7 @@ void Context::registerCallbacks(Interpreter* interpreter) {
             }
         });
 
-    interpreter->registerBuiltin(Builtins::ReplayGetFenceStatus,
+    interpreter->registerBuiltin(Vulkan::INDEX, Builtins::ReplayGetFenceStatus,
                                  [this, interpreter](Stack* stack, bool push_return) {
         GAPID_INFO("ReplayGetFenceStatus()");
         if (mBoundVulkanRenderer != nullptr) {
@@ -386,7 +387,7 @@ void Context::registerCallbacks(Interpreter* interpreter) {
         }
     });
 
-    interpreter->registerBuiltin(Builtins::ReplayGetEventStatus,
+    interpreter->registerBuiltin(Vulkan::INDEX, Builtins::ReplayGetEventStatus,
                                  [this, interpreter](Stack* stack, bool push_return) {
         GAPID_INFO("ReplayGetEventStatus()");
         if (mBoundVulkanRenderer != nullptr) {

--- a/gapir/cc/function_table.h
+++ b/gapir/cc/function_table.h
@@ -17,8 +17,9 @@
 #ifndef GAPIR_FUNCTION_TABLE_H
 #define GAPIR_FUNCTION_TABLE_H
 
-#include <stdint.h>
+#include "core/cc/log.h"
 
+#include <stdint.h>
 #include <functional>
 #include <unordered_map>
 
@@ -61,6 +62,9 @@ inline FunctionTable::Function* FunctionTable::lookup(Id id) {
 }
 
 inline void FunctionTable::insert(Id id, Function func) {
+    if (mFunctions.count(id) != 0) {
+        GAPID_FATAL("Duplicate functions inserted into table");
+    }
     mFunctions[id] = func;
 }
 

--- a/gapir/cc/interpreter.cpp
+++ b/gapir/cc/interpreter.cpp
@@ -50,14 +50,14 @@ Interpreter::Interpreter(const MemoryManager* memoryManager, uint32_t stackDepth
         apiRequestCallback(std::move(callback)),
         mStack(stackDepth, mMemoryManager),
         mLabel(0) {
-    registerBuiltin(PRINT_STACK_FUNCTION_ID, [](Stack* stack, bool) {
+    registerBuiltin(GLOBAL_INDEX, PRINT_STACK_FUNCTION_ID, [](Stack* stack, bool) {
         stack->printStack();
         return true;
     });
 }
 
-void Interpreter::registerBuiltin(FunctionTable::Id id, FunctionTable::Function func) {
-    mBuiltins.insert(id, func);
+void Interpreter::registerBuiltin(uint8_t api, FunctionTable::Id id, FunctionTable::Function func) {
+    mBuiltins[api].insert(id, func);
 }
 
 void Interpreter::setRendererFunctions(uint8_t api, FunctionTable* functionTable) {
@@ -96,7 +96,7 @@ bool Interpreter::registerApi(uint8_t api) {
 bool Interpreter::call(uint32_t opcode) {
     auto id = opcode & FUNCTION_ID_MASK;
     auto api = (opcode & API_INDEX_MASK) >> API_BIT_SHIFT;
-    auto func = mBuiltins.lookup(id);
+    auto func = mBuiltins[api].lookup(id);
     if (func == nullptr) {
         if (mRendererFunctions.count(api) > 0) {
             func = mRendererFunctions[api]->lookup(id);

--- a/gapir/cc/interpreter.h
+++ b/gapir/cc/interpreter.h
@@ -40,6 +40,11 @@ public:
     // It should return true if the request is fulfilled.
     using ApiRequestCallback = std::function<bool(Interpreter*, uint8_t)>;
 
+    enum : uint32_t {
+        // The API index to use for global builtin functions.
+        GLOBAL_INDEX     = 0,
+    };
+
     // Function ids for implementation specific functions and special debugging functions. These
     // functions shouldn't be called by the opcode stream
     enum FunctionIds : uint16_t {
@@ -78,7 +83,7 @@ public:
                 ApiRequestCallback callback);
 
     // Registers a builtin function to the builtin function table.
-    void registerBuiltin(FunctionTable::Id, FunctionTable::Function);
+    void registerBuiltin(uint8_t api, FunctionTable::Id, FunctionTable::Function);
 
     // Assigns the function table as the renderer functions to use for the given api.
     void setRendererFunctions(uint8_t api, FunctionTable* functionTable);
@@ -153,7 +158,7 @@ private:
     const MemoryManager* mMemoryManager;
 
     // The builtin functions.
-    FunctionTable mBuiltins;
+    std::unordered_map<uint8_t, FunctionTable> mBuiltins;
 
     // The current renderer functions.
     std::unordered_map<uint8_t, FunctionTable*> mRendererFunctions;

--- a/gapir/cc/interpreter_test.cpp
+++ b/gapir/cc/interpreter_test.cpp
@@ -53,7 +53,7 @@ protected:
 }  // anonymous namespace
 
 TEST_F(InterpreterTest, PushIUint8) {
-    mInterpreter->registerBuiltin(0, CheckTopOfStack<uint8_t>{210});
+    mInterpreter->registerBuiltin(0, 0, CheckTopOfStack<uint8_t>{210});
 
     std::vector<uint32_t> instructions{
             instruction(Interpreter::InstructionCode::PUSH_I, BaseType::Uint8, 210),
@@ -63,7 +63,7 @@ TEST_F(InterpreterTest, PushIUint8) {
 }
 
 TEST_F(InterpreterTest, PushIInt16Minus1) {
-    mInterpreter->registerBuiltin(0, CheckTopOfStack<int16_t>{-1});
+    mInterpreter->registerBuiltin(0, 0, CheckTopOfStack<int16_t>{-1});
 
     std::vector<uint32_t> instructions{
             instruction(Interpreter::InstructionCode::PUSH_I, BaseType::Int16, 0xffff),  // -1
@@ -73,7 +73,7 @@ TEST_F(InterpreterTest, PushIInt16Minus1) {
 }
 
 TEST_F(InterpreterTest, PushIInt32Minus1) {
-    mInterpreter->registerBuiltin(0, CheckTopOfStack<int32_t>{-1});
+    mInterpreter->registerBuiltin(0, 0, CheckTopOfStack<int32_t>{-1});
 
     std::vector<uint32_t> instructions{
             instruction(Interpreter::InstructionCode::PUSH_I, BaseType::Int32, 0xfffff),  // -1
@@ -83,7 +83,7 @@ TEST_F(InterpreterTest, PushIInt32Minus1) {
 }
 
 TEST_F(InterpreterTest, PushIFloat1) {
-    mInterpreter->registerBuiltin(0, CheckTopOfStack<float>{1.0f});
+    mInterpreter->registerBuiltin(0, 0, CheckTopOfStack<float>{1.0f});
 
     std::vector<uint32_t> instructions{
             instruction(Interpreter::InstructionCode::PUSH_I, BaseType::Float, 0x7f),  // 1.0 exp
@@ -93,7 +93,7 @@ TEST_F(InterpreterTest, PushIFloat1) {
 }
 
 TEST_F(InterpreterTest, PushIDouble1) {
-    mInterpreter->registerBuiltin(0, CheckTopOfStack<double>{1.0});
+    mInterpreter->registerBuiltin(0, 0, CheckTopOfStack<double>{1.0});
 
     std::vector<uint32_t> instructions{
             instruction(Interpreter::InstructionCode::PUSH_I, BaseType::Double, 0x3ff),  // 1.0 exp
@@ -109,7 +109,7 @@ TEST_F(InterpreterTest, LoadC) {
     memcpy(constantBaseAddress, &constantMemory, sizeof(constantMemory));
     mMemoryManager->setConstantMemory({constantBaseAddress, sizeof(constantMemory)});
 
-    mInterpreter->registerBuiltin(0, CheckTopOfStack<uint16_t>{0x7856});
+    mInterpreter->registerBuiltin(0, 0, CheckTopOfStack<uint16_t>{0x7856});
 
     std::vector<uint32_t> instructions{
             instruction(Interpreter::InstructionCode::LOAD_C, BaseType::Uint16, 4),
@@ -120,7 +120,7 @@ TEST_F(InterpreterTest, LoadC) {
 
 TEST_F(InterpreterTest, LoadV) {
     *static_cast<int32_t*>(mMemoryManager->volatileToAbsolute(784)) = -987654321;
-    mInterpreter->registerBuiltin(0, CheckTopOfStack<int32_t>{-987654321});
+    mInterpreter->registerBuiltin(0, 0, CheckTopOfStack<int32_t>{-987654321});
 
     std::vector<uint32_t> instructions{
             instruction(Interpreter::InstructionCode::LOAD_V, BaseType::Int32, 784),
@@ -136,7 +136,7 @@ TEST_F(InterpreterTest, LoadConstantAddress) {
     memcpy(constantBaseAddress, &constantMemory, 7);
     mMemoryManager->setConstantMemory({constantBaseAddress, 7});
 
-    mInterpreter->registerBuiltin(0, CheckTopOfStack<uint16_t>{0x7856});
+    mInterpreter->registerBuiltin(0, 0, CheckTopOfStack<uint16_t>{0x7856});
 
     std::vector<uint32_t> instructions{
             instruction(Interpreter::InstructionCode::PUSH_I, BaseType::ConstantPointer, 4),
@@ -148,7 +148,7 @@ TEST_F(InterpreterTest, LoadConstantAddress) {
 
 TEST_F(InterpreterTest, LoadVolatileAddress) {
     *static_cast<int32_t*>(mMemoryManager->volatileToAbsolute(784)) = -987654321;
-    mInterpreter->registerBuiltin(0, CheckTopOfStack<int32_t>{-987654321});
+    mInterpreter->registerBuiltin(0, 0, CheckTopOfStack<int32_t>{-987654321});
 
     std::vector<uint32_t> instructions{
             instruction(Interpreter::InstructionCode::PUSH_I, BaseType::VolatilePointer, 784),
@@ -159,7 +159,7 @@ TEST_F(InterpreterTest, LoadVolatileAddress) {
 }
 
 TEST_F(InterpreterTest, Pop) {
-    mInterpreter->registerBuiltin(0, CheckTopOfStack<uint32_t>{123456});
+    mInterpreter->registerBuiltin(0, 0, CheckTopOfStack<uint32_t>{123456});
 
     std::vector<uint32_t> instructions{
             instruction(Interpreter::InstructionCode::PUSH_I, BaseType::Uint32, 123456),
@@ -212,7 +212,7 @@ TEST_F(InterpreterTest, Copy) {
 }
 
 TEST_F(InterpreterTest, Clone) {
-    mInterpreter->registerBuiltin(0, CheckTopOfStack<uint32_t>{123456});
+    mInterpreter->registerBuiltin(0, 0, CheckTopOfStack<uint32_t>{123456});
 
     std::vector<uint32_t> instructions{
             instruction(Interpreter::InstructionCode::PUSH_I, BaseType::Uint32, 123456),
@@ -227,7 +227,7 @@ TEST_F(InterpreterTest, Clone) {
 }
 
 TEST_F(InterpreterTest, ExtendInt32) {
-    mInterpreter->registerBuiltin(0, CheckTopOfStack<int32_t>{0x76543210});
+    mInterpreter->registerBuiltin(0, 0, CheckTopOfStack<int32_t>{0x76543210});
 
     std::vector<uint32_t> instructions{
             instruction(Interpreter::InstructionCode::PUSH_I, BaseType::Int32, 0x1d),
@@ -238,7 +238,7 @@ TEST_F(InterpreterTest, ExtendInt32) {
 }
 
 TEST_F(InterpreterTest, ExtendFloat) {
-    mInterpreter->registerBuiltin(0, CheckTopOfStack<float>{1.1f});
+    mInterpreter->registerBuiltin(0, 0, CheckTopOfStack<float>{1.1f});
 
     std::vector<uint32_t> instructions{
             instruction(Interpreter::InstructionCode::PUSH_I, BaseType::Float, 0x7f),
@@ -249,7 +249,7 @@ TEST_F(InterpreterTest, ExtendFloat) {
 }
 
 TEST_F(InterpreterTest, ExtendDouble) {
-    mInterpreter->registerBuiltin(0, CheckTopOfStack<double>{1.4});
+    mInterpreter->registerBuiltin(0, 0, CheckTopOfStack<double>{1.4});
 
     std::vector<uint32_t> instructions{
             instruction(Interpreter::InstructionCode::PUSH_I, BaseType::Double, 0x3ff),
@@ -261,7 +261,7 @@ TEST_F(InterpreterTest, ExtendDouble) {
 }
 
 TEST_F(InterpreterTest, Add2xUint32) {
-    mInterpreter->registerBuiltin(0, CheckTopOfStack<uint32_t>{15});
+    mInterpreter->registerBuiltin(0, 0, CheckTopOfStack<uint32_t>{15});
 
     std::vector<uint32_t> instructions{
             instruction(Interpreter::InstructionCode::PUSH_I, BaseType::Uint32, 5),
@@ -273,7 +273,7 @@ TEST_F(InterpreterTest, Add2xUint32) {
 }
 
 TEST_F(InterpreterTest, Add3xFloat) {
-    mInterpreter->registerBuiltin(0, CheckTopOfStack<float>{3.5});
+    mInterpreter->registerBuiltin(0, 0, CheckTopOfStack<float>{3.5});
 
     std::vector<uint32_t> instructions{
             instruction(Interpreter::InstructionCode::PUSH_I, BaseType::Float, 0x7f),  // 1.0 exp
@@ -343,7 +343,7 @@ TEST_F(InterpreterTest, Post) {
         return true;
     };
 
-    mInterpreter->registerBuiltin(Interpreter::POST_FUNCTION_ID, post);
+    mInterpreter->registerBuiltin(0, Interpreter::POST_FUNCTION_ID, post);
 
     std::vector<uint32_t> instructions{instruction(Interpreter::InstructionCode::POST)};
     bool res = mInterpreter->run({&instructions.front(), instructions.size()});
@@ -358,8 +358,8 @@ TEST_F(InterpreterTest, Resource) {
         return true;
     };
 
-    mInterpreter->registerBuiltin(0, CheckTopOfStack<uint32_t>{123});
-    mInterpreter->registerBuiltin(Interpreter::RESOURCE_FUNCTION_ID, resource);
+    mInterpreter->registerBuiltin(0, 0, CheckTopOfStack<uint32_t>{123});
+    mInterpreter->registerBuiltin(0, Interpreter::RESOURCE_FUNCTION_ID, resource);
 
     std::vector<uint32_t> instructions{instruction(Interpreter::InstructionCode::RESOURCE, 123),
                                        instruction(Interpreter::InstructionCode::CALL, 0)};

--- a/gapis/gfxapi/templates/mutate.go.tmpl
+++ b/gapis/gfxapi/templates/mutate.go.tmpl
@@ -287,15 +287,22 @@
 {{define "DeclareBuilderFunctionInfos"}}
   {{AssertType $ "API"}}
 
-  {{range $i, $f := $.Functions}}
+  {{$functions  := $.Functions | WithoutAnnotation "synthetic"}}
+  {{$synthetics := $.Functions | WithAnnotation    "synthetic"}}
+
+  {{range $i, $f := $functions}}
     var {{Template "BuilderFunctionInfo" $f}} = builder.FunctionInfo{§
       ApiIndex:   {{$.Index}},§
-      {{if not (GetAnnotation $f "synthetic")}}
-        ID:         {{$i}},§
-      {{else}}
-        {{/* 0xff81..0xffff reserved for synthetic functions */}}
-        ID:         0x10000 - {{len $.Functions}} + {{$i}},§
-      {{end}}
+      ID:         {{$i}},§
+      ReturnType: {{Template "Go.Replay.ReturnType" $f.Return.Type}},§
+      Parameters: {{len $f.CallParameters}},§
+    }
+  {{end}}
+  {{range $i, $f := $synthetics}}
+    var {{Template "BuilderFunctionInfo" $f}} = builder.FunctionInfo{§
+      ApiIndex:   {{$.Index}},§
+      {{/* 0xff81..0xffff reserved for synthetic functions */}}
+      ID:         0x10000 - {{len $synthetics}} + {{$i}},§
       ReturnType: {{Template "Go.Replay.ReturnType" $f.Return.Type}},§
       Parameters: {{len $f.CallParameters}},§
     }

--- a/gapis/gfxapi/templates/specific_gfx_api.h.tmpl
+++ b/gapis/gfxapi/templates/specific_gfx_api.h.tmpl
@@ -118,11 +118,10 @@ class {{Title (Global "API")}} : public Api {
 // TODO(antiagainst): create a separate file for these builtins.
 namespace Builtins {«
 ¶
-  {{range $i, $c := $.Functions}}
-    {{if (GetAnnotation $c "synthetic")}}
-      {{/* 0xff81..0xffff reserved for synthetic functions */}}
-      static const uint16_t {{Template "C++.Public" (Macro "CmdName" $c)}} = 0x10000 - {{len $.Functions}} + {{$i}};
-    {{end}}
+  {{$synthetics := $.Functions | WithAnnotation "synthetic"}}
+  {{range $i, $c := $synthetics}}
+    {{/* 0xff81..0xffff reserved for synthetic functions */}}
+    static const uint16_t {{Template "C++.Public" (Macro "CmdName" $c)}} = 0x10000 - {{len $synthetics}} + {{$i}};
   {{end}}
 ¶
 }  // namespace Builtins


### PR DESCRIPTION
Only allocate function indices downwards from 0xffff if the function is `@synthetic`.
Namespace the synthetics by API.