### PR TITLE
gapic: Fix exception thrown on shutdown.

### DIFF
--- a/gapic/src/main/com/google/gapid/widgets/ScenePanel.java
+++ b/gapic/src/main/com/google/gapid/widgets/ScenePanel.java
@@ -60,7 +60,6 @@ public class ScenePanel<T> extends GlCanvas {
 
     addListener(SWT.Resize, e -> { /* register to handle resizes in dispatchEvents */ });
     addListener(SWT.Paint, e -> update(true));
-    addListener(SWT.Dispose, e -> terminate());
   }
 
   // Intercept addListener calls so that we can reduce the number of updates per event to one,
@@ -96,17 +95,18 @@ public class ScenePanel<T> extends GlCanvas {
     update(true);
   }
 
+  @Override
+  protected void terminate() {
+    setCurrent();
+    GL.setCapabilities(caps);
+    renderer.terminate();
+  }
+
   private void initialize() {
     renderer.initialize();
     Point size = DPIUtil.autoScaleUp(getSize());
     renderer.setSize(size.x, size.y);
     scene.init(renderer);
-  }
-
-  private void terminate() {
-    setCurrent();
-    GL.setCapabilities(caps);
-    renderer.terminate();
   }
 
   private void dispatchEvents(Event event) {

--- a/gapic/src/platform/linux/com/google/gapid/glcanvas/GlCanvas.java
+++ b/gapic/src/platform/linux/com/google/gapid/glcanvas/GlCanvas.java
@@ -15,6 +15,7 @@
  */
 package com.google.gapid.glcanvas;
 
+import org.eclipse.swt.SWT;
 import org.eclipse.swt.opengl.GLCanvas;
 import org.eclipse.swt.opengl.GLData;
 import org.eclipse.swt.widgets.Composite;
@@ -23,6 +24,7 @@ import org.eclipse.swt.widgets.Composite;
 public class GlCanvas extends GLCanvas {
   public GlCanvas(Composite parent, int style) {
     super(parent, style, getGlData());
+    addListener(SWT.Dispose, e -> terminate());
   }
 
   private static GLData getGlData() {
@@ -32,4 +34,10 @@ public class GlCanvas extends GLCanvas {
     result.samples = 4;
     return result;
   }
+
+  /**
+   * Override to perform GL cleanup handling.
+   * TODO: Actually call this function *before* the context is destroyed. Is this even possible?
+   */
+  protected void terminate() {}
 }

--- a/gapic/src/platform/osx/com/google/gapid/glcanvas/GlCanvas.java
+++ b/gapic/src/platform/osx/com/google/gapid/glcanvas/GlCanvas.java
@@ -84,6 +84,7 @@ public class GlCanvas extends Canvas {
     Listener listener = event -> {
       switch (event.type) {
         case SWT.Dispose:
+          terminate();
           setData(GLCONTEXT_KEY, null);
           NSNotificationCenter.defaultCenter().removeObserver(view);
 
@@ -111,4 +112,7 @@ public class GlCanvas extends Canvas {
     checkWidget();
     context.flushBuffer();
   }
+
+  /** Override to perform GL cleanup handling. */
+  protected void terminate() {}
 }

--- a/gapic/src/platform/windows/com/google/gapid/glcanvas/GlCanvas.java
+++ b/gapic/src/platform/windows/com/google/gapid/glcanvas/GlCanvas.java
@@ -71,7 +71,10 @@ public class GlCanvas extends Canvas {
     dummyContext.release();
     dummy.dispose();
 
-    addListener(SWT.Dispose, e -> WGL.wglDeleteContext(context));
+    addListener(SWT.Dispose, e -> {
+      terminate();
+      WGL.wglDeleteContext(context);
+    });
   }
 
   private static int checkStyle(Composite parent, int style) {
@@ -96,6 +99,9 @@ public class GlCanvas extends Canvas {
     GDI32.SwapBuffers(dc);
     User32.ReleaseDC(handle, dc);
   }
+
+  /** Override to perform GL cleanup handling. */
+  protected void terminate() {}
 
   private static class Context {
     public final long handle;


### PR DESCRIPTION
Still requires call of `terminate()` on Linux.

Fixes: #661 