### PR TITLE
gapis: Make sure host is first in GetDevices()

### DIFF
--- a/cmd/gapis/main.go
+++ b/cmd/gapis/main.go
@@ -90,17 +90,17 @@ func run(ctx context.Context) error {
 
 	grpclog.SetLogger(log.From(ctx))
 
+	if *addLocalDevice {
+		host := bind.Host(ctx)
+		r.AddDevice(ctx, host)
+		r.SetDeviceProperty(ctx, host, client.LaunchArgsKey, text.SplitArgs(*gapirArgStr))
+	}
+
 	deviceScanDone, onDeviceScanDone := task.NewSignal()
 	if *scanAndroidDevs {
 		go monitorAndroidDevices(ctx, r, onDeviceScanDone)
 	} else {
 		onDeviceScanDone(ctx)
-	}
-
-	if *addLocalDevice {
-		host := bind.Host(ctx)
-		r.AddDevice(ctx, host)
-		r.SetDeviceProperty(ctx, host, client.LaunchArgsKey, text.SplitArgs(*gapirArgStr))
 	}
 
 	return server.Listen(ctx, *rpc, server.Config{

--- a/gapis/server/server.go
+++ b/gapis/server/server.go
@@ -132,7 +132,7 @@ func (s *server) LoadCapture(ctx context.Context, path string) (*path.Capture, e
 func (s *server) GetDevices(ctx context.Context) ([]*path.Device, error) {
 	ctx = log.Enter(ctx, "GetDevices")
 	s.deviceScanDone.Wait(ctx)
-	devices := devices.Sorted(ctx)
+	devices := bind.GetRegistry(ctx).Devices()
 	paths := make([]*path.Device, len(devices))
 	for i, d := range devices {
 		paths[i] = path.NewDevice(d.Instance().Id.ID())

--- a/gapis/service/service.proto
+++ b/gapis/service/service.proto
@@ -337,8 +337,7 @@ service Gapid {
   // GetDevices returns the full list of replay devices avaliable to the server.
   // These include local replay devices and any connected Android devices.
   // This list may change over time, as devices are connected and disconnected.
-  // If both connected Android and Local replay devices are found,
-  // the local Android devices will be returned first.
+  // The primary device (usually host) will be first.
   rpc GetDevices(GetDevicesRequest) returns (GetDevicesResponse) {}
 
   // GetDevicesForReplay returns the list of replay devices avaliable to the


### PR DESCRIPTION
While Android may have preference for replay, the host should be considered the primary device.