### PR TITLE
gapis/shadertools: Standardize error messages.

### DIFF
--- a/cmd/shadertool/main.go
+++ b/cmd/shadertool/main.go
@@ -100,13 +100,13 @@ func convert(source, shaderType string) (result string, err error) {
 	opts.MakeDebuggable = *debug
 	opts.CheckAfterChanges = *check
 	opts.Disassemble = *asm
-	res := shadertools.ConvertGlsl(string(source), &opts)
+	res, err := shadertools.ConvertGlsl(string(source), &opts)
+	if err != nil {
+		return "", err
+	}
 	if *asm {
 		result += "/* Disassembly:\n" + res.DisassemblyString + "\n*/\n"
 		result += "/* Debug info:\n" + shadertools.FormatDebugInfo(res.Info, "  ") + "\n*/\n"
-	}
-	if !res.Ok {
-		return "", fmt.Errorf("Failed to translate GLSL:\n%s\nOriginal source:\n%s\n%s\n", res.Message, source, result)
 	}
 	result += res.SourceCode
 	return result, nil

--- a/gapis/api/gles/compat.go
+++ b/gapis/api/gles/compat.go
@@ -418,11 +418,12 @@ func compat(ctx context.Context, device *device.Instance) (transform.Transformer
 					IsVertexShader:   shader.Type == GLenum_GL_VERTEX_SHADER,
 				}
 
-				res := shadertools.ConvertGlsl(shader.Source, &opts)
-				if !res.Ok {
-					log.E(ctx, "Failed to translate GLSL:\n%s\nSource:%s\n", res.Message, shader.Source)
+				res, err := shadertools.ConvertGlsl(shader.Source, &opts)
+				if err != nil {
+					log.E(ctx, "glShaderSource() compat: %v", err)
 					return
 				}
+
 				src = res.SourceCode
 			} else {
 				lang := ast.LangVertexShader

--- a/gapis/api/gles/find_issues.go
+++ b/gapis/api/gles/find_issues.go
@@ -177,10 +177,8 @@ func (t *findIssues) Transform(ctx context.Context, id api.CmdID, cmd api.Cmd, o
 				Disassemble:       true,
 			}
 
-			res := shadertools.ConvertGlsl(shader.Source, &opts)
-			if !res.Ok {
-				t.onIssue(cmd, id, service.Severity_ErrorLevel, fmt.Errorf("Failed to translate %v. Errors:\n%s\nOriginal source:\n%s",
-					shader.Type, res.Message, text.LineNumber(shader.Source)))
+			if _, err := shadertools.ConvertGlsl(shader.Source, &opts); err != nil {
+				t.onIssue(cmd, id, service.Severity_ErrorLevel, err)
 			}
 		} else {
 			var errs []error

--- a/gapis/shadertools/cc/libmanager.cpp
+++ b/gapis/shadertools/cc/libmanager.cpp
@@ -238,8 +238,7 @@ code_with_debug_info_t* convertGlsl(const char* input, size_t length, const opti
   }
 
   if (!err_msg.empty()) {
-    set_error_msg(result, "Failed to parse modified source code:\n" + err_msg +
-                          "\nModified source code:\n" + result->source_code);
+    set_error_msg(result, "Failed to parse modified source code:\n" + err_msg);
     return result;
   }
 


### PR DESCRIPTION
Has the benefit of having line numbers when we fail to parse generated source.