### PR TITLE
Integation tests: Propagate memory layout to builder

### DIFF
--- a/test/integration/replay/gles/gles_test.go
+++ b/test/integration/replay/gles/gles_test.go
@@ -330,7 +330,7 @@ func (f *Fixture) makeCurrent(eglSurface, eglContext memory.Pointer, width, heig
 func TestClear(t *testing.T) {
 	ctx, f := newFixture(log.Testing(t))
 
-	atoms, red, green, blue, black := samples.ClearBackbuffer(ctx, f.cb)
+	atoms, red, green, blue, black := samples.ClearBackbuffer(ctx, f.cb, f.memoryLayout)
 
 	capture := f.storeCapture(ctx, atoms)
 
@@ -396,7 +396,7 @@ func (f *Fixture) mergeCaptures(ctx context.Context, captures ...*path.Capture) 
 }
 
 func (f Fixture) generateDrawTexturedSquareCapture(ctx context.Context) (*path.Capture, traceVerifier) {
-	atoms, _, square := samples.DrawTexturedSquare(ctx, f.cb, false)
+	atoms, _, square := samples.DrawTexturedSquare(ctx, f.cb, false, f.memoryLayout)
 
 	verifyTrace := func(ctx context.Context, cap *path.Capture, mgr *replay.Manager, dev bind.Device) {
 		intent := replay.Intent{
@@ -412,7 +412,7 @@ func (f Fixture) generateDrawTexturedSquareCapture(ctx context.Context) (*path.C
 }
 
 func (f Fixture) generateDrawTexturedSquareCaptureWithSharedContext(ctx context.Context) (*path.Capture, traceVerifier) {
-	atoms, _, square := samples.DrawTexturedSquare(ctx, f.cb, true)
+	atoms, _, square := samples.DrawTexturedSquare(ctx, f.cb, true, f.memoryLayout)
 
 	verifyTrace := func(ctx context.Context, cap *path.Capture, mgr *replay.Manager, dev bind.Device) {
 		intent := replay.Intent{

--- a/test/integration/replay/gles/samples/builder.go
+++ b/test/integration/replay/gles/samples/builder.go
@@ -30,9 +30,9 @@ type builder struct {
 	lastID uint
 }
 
-func newBuilder(ctx context.Context) *builder {
+func newBuilder(ctx context.Context, ml *device.MemoryLayout) *builder {
 	return &builder{
-		state: api.NewStateWithEmptyAllocator(device.Little32),
+		state: api.NewStateWithEmptyAllocator(ml),
 	}
 }
 

--- a/test/integration/replay/gles/samples/clear_backbuffer.go
+++ b/test/integration/replay/gles/samples/clear_backbuffer.go
@@ -17,6 +17,7 @@ package samples
 import (
 	"context"
 
+	"github.com/google/gapid/core/os/device"
 	"github.com/google/gapid/gapis/api"
 	"github.com/google/gapid/gapis/api/gles"
 	"github.com/google/gapid/gapis/memory"
@@ -24,8 +25,8 @@ import (
 
 // ClearBackbuffer returns the atom list needed to create a context then clear,
 // sequentially the backbuffer to red, green, blue and black.
-func ClearBackbuffer(ctx context.Context, cb gles.CommandBuilder) (cmds []api.Cmd, red, green, blue, black api.CmdID) {
-	b := newBuilder(ctx)
+func ClearBackbuffer(ctx context.Context, cb gles.CommandBuilder, ml *device.MemoryLayout) (cmds []api.Cmd, red, green, blue, black api.CmdID) {
+	b := newBuilder(ctx, ml)
 	b.newEglContext(64, 64, memory.Nullptr, false)
 	b.cmds = append(b.cmds,
 		cb.GlClearColor(1.0, 0.0, 0.0, 1.0),

--- a/test/integration/replay/gles/samples/draw_textured_square.go
+++ b/test/integration/replay/gles/samples/draw_textured_square.go
@@ -17,6 +17,7 @@ package samples
 import (
 	"context"
 
+	"github.com/google/gapid/core/os/device"
 	"github.com/google/gapid/gapis/api"
 	"github.com/google/gapid/gapis/api/gles"
 	"github.com/google/gapid/gapis/memory"
@@ -24,7 +25,7 @@ import (
 
 // DrawTexturedSquare returns the atom list needed to create a context then
 // draw a textured square.
-func DrawTexturedSquare(ctx context.Context, cb gles.CommandBuilder, sharedContext bool) (cmds []api.Cmd, draw api.CmdID, swap api.CmdID) {
+func DrawTexturedSquare(ctx context.Context, cb gles.CommandBuilder, sharedContext bool, ml *device.MemoryLayout) (cmds []api.Cmd, draw api.CmdID, swap api.CmdID) {
 	squareVertices := []float32{
 		-0.5, -0.5, 0.5,
 		-0.5, +0.5, 0.5,
@@ -53,7 +54,7 @@ func DrawTexturedSquare(ctx context.Context, cb gles.CommandBuilder, sharedConte
 			gl_FragColor = texture2D(tex, texcoord);
 		}`
 
-	b := newBuilder(ctx)
+	b := newBuilder(ctx, ml)
 	vs, fs, prog, pos := b.newShaderID(), b.newShaderID(), b.newProgramID(), gles.AttributeLocation(0)
 	eglContext, eglSurface, eglDisplay := b.newEglContext(128, 128, memory.Nullptr, false)
 	texLoc := gles.UniformLocation(0)

--- a/test/integration/service/service_test.go
+++ b/test/integration/service/service_test.go
@@ -126,8 +126,8 @@ func init() {
 
 	ctx = database.Put(ctx, database.NewInMemory(ctx))
 	cb := gles.CommandBuilder{Thread: 0}
-	cmds, draw, swap := samples.DrawTexturedSquare(ctx, cb, false)
 	h := &capture.Header{Abi: device.WindowsX86_64}
+	cmds, draw, swap := samples.DrawTexturedSquare(ctx, cb, false, h.Abi.MemoryLayout)
 	p, err := capture.New(ctx, "sample", h, cmds)
 	check(err)
 	buf := bytes.Buffer{}


### PR DESCRIPTION
This is needed in compat to create memory observations
with the correct pointer size.