### PR TITLE
Reduce integration test verbosity.

### DIFF
--- a/core/log/testing.go
+++ b/core/log/testing.go
@@ -19,7 +19,7 @@ import "context"
 // Testing returns a default context with a TestHandler installed.
 func Testing(t delegate) context.Context {
 	ctx := context.Background()
-	return PutHandler(ctx, TestHandler(t, Detailed))
+	return PutHandler(ctx, TestHandler(t, Normal))
 }
 
 // TestHandler is a Writer that uses the style to write records to t's using the


### PR DESCRIPTION
I missed critical in the output which would have saved me a lot time.