### PR TITLE
Improve kokoro build speed

### DIFF
--- a/kokoro/linux/build.sh
+++ b/kokoro/linux/build.sh
@@ -110,3 +110,10 @@ echo "$(date): Building package."
 dpkg-deb -v --build  gapid
 mv gapid.deb gapid-$VERSION.deb
 echo "$(date): Done."
+
+# Clean up - this prevents kokoro from rsyncing many unneeded files
+shopt -s extglob
+cd $BUILD_ROOT
+rm -rf github/src/github.com/google/gapid/third_party
+rm -rf out/release
+rm -rf -- !(github|out)

--- a/kokoro/macos/build.sh
+++ b/kokoro/macos/build.sh
@@ -121,3 +121,10 @@ cp $SRC/kokoro/macos/background\@2x.png .
 sips -z 480 640 background\@2x.png --out background.png
 cp $SRC/kokoro/macos/dmg-settings.py .
 ~/Library/Python/2.7/bin/dmgbuild -s dmg-settings.py GAPID gapid-$VERSION.dmg
+
+# Clean up - this prevents kokoro from rsyncing many unneeded files
+shopt -s extglob
+cd $BUILD_ROOT
+rm -rf github/src/github.com/google/gapid/third_party
+rm -rf out/release
+rm -rf -- !(github|out)

--- a/kokoro/windows/build.bat
+++ b/kokoro/windows/build.bat
@@ -98,3 +98,10 @@ copy %SRC%\kokoro\windows\gapid.wxs .
 %WIX%\heat.exe dir gapid -ag -cg gapid -dr gapid -template fragment -sreg -sfrag -srd -o component.wxs
 %WIX%\candle.exe gapid.wxs component.wxs
 %WIX%\light.exe gapid.wixobj component.wixobj -b gapid -ext WixUIExtension -cultures:en-us -o gapid-%VERSION%.msi
+
+REM Clean up - this prevents kokoro from rsyncing many unneeded files
+cd %BUILD_ROOT%
+rmdir /s /q github\src\github.com\google\gapid\third_party
+rmdir /s /q out\release
+for /d %%f in (*) do if not "%%f"=="github" if not "%%f"=="out" rmdir /s /q %%f
+del /q *.zip


### PR DESCRIPTION
Kokoro will rsync the whole workspace back after build.
This is redundant for us so just delete most files at the end.

This saves about one third of the Windows build time.