### PR TITLE
Make gapir multi-threaded

### DIFF
--- a/core/cc/CMakeFiles.cmake
+++ b/core/cc/CMakeFiles.cmake
@@ -53,6 +53,7 @@ set(files
     null_writer.h
     scratch_allocator.h
     scratch_allocator_test.cpp
+    semaphore.h
     socket_connection.cpp
     socket_connection.h
     static_array.h

--- a/core/cc/semaphore.h
+++ b/core/cc/semaphore.h
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef CORE_SEMAPHORE_H
+#define CORE_SEMAPHORE_H
+
+#include <mutex>
+#include <condition_variable>
+
+namespace core {
+
+class Semaphore {
+public:
+    inline Semaphore(unsigned int count = 0);
+
+    // acquire takes a counter from the semaphore, blocking until one is 
+    // available.
+    inline void acquire();
+
+    // release returns a counter to the semaphore, possibly unblocking a call
+    // to acquire().
+    inline void release();
+
+private:
+    Semaphore(const Semaphore&) = delete;
+    Semaphore& operator = (const Semaphore&) = delete;
+
+    std::mutex mMutex;
+    std::condition_variable mSignal;
+    int mCount;
+};
+
+Semaphore::Semaphore(unsigned int count /* = 0 */) : mCount(count) {}
+
+inline void Semaphore::acquire() {
+    std::unique_lock<std::mutex> lock(mMutex);
+    mSignal.wait(lock, [this]{ return this->mCount > 0; });
+    --mCount;
+}
+
+inline void Semaphore::release() {
+    std::unique_lock<std::mutex> lock(mMutex);
+    ++mCount;
+    mSignal.notify_one();
+}
+
+}  // namespace core
+
+#endif  // CORE_SEMAPHORE_H

--- a/gapir/cc/CMakeFiles.cmake
+++ b/gapir/cc/CMakeFiles.cmake
@@ -63,6 +63,8 @@ set(files
     stack.cpp
     stack.h
     stack_test.cpp
+    thread_pool.h
+    thread_pool.cpp
     test_utilities.h
     test_utilities_test.cpp
     vulkan_gfx_api.cpp

--- a/gapir/cc/context.h
+++ b/gapir/cc/context.h
@@ -117,11 +117,8 @@ private:
     // The constructed GLES renderers.
     std::unordered_map<uint32_t, GlesRenderer*> mGlesRenderers;
 
-    // The currently bound GLES renderer.
-    GlesRenderer* mBoundGlesRenderer;
-
-    // The currently bound Vulkan renderer.
-    VulkanRenderer* mBoundVulkanRenderer;
+    // The lazily-built Vulkan renderer.
+    VulkanRenderer* mVulkanRenderer;
 
     // A buffer for data to be sent back to the server.
     std::unique_ptr<PostBuffer> mPostBuffer;

--- a/gapir/cc/interpreter_test.cpp
+++ b/gapir/cc/interpreter_test.cpp
@@ -58,7 +58,7 @@ TEST_F(InterpreterTest, PushIUint8) {
     std::vector<uint32_t> instructions{
             instruction(Interpreter::InstructionCode::PUSH_I, BaseType::Uint8, 210),
             instruction(Interpreter::InstructionCode::CALL, 0)};
-    bool res = mInterpreter->run({&instructions.front(), instructions.size()});
+    bool res = mInterpreter->run(instructions.data(), instructions.size());
     EXPECT_TRUE(res);
 }
 
@@ -68,7 +68,7 @@ TEST_F(InterpreterTest, PushIInt16Minus1) {
     std::vector<uint32_t> instructions{
             instruction(Interpreter::InstructionCode::PUSH_I, BaseType::Int16, 0xffff),  // -1
             instruction(Interpreter::InstructionCode::CALL, 0)};
-    bool res = mInterpreter->run({&instructions.front(), instructions.size()});
+    bool res = mInterpreter->run(instructions.data(), instructions.size());
     EXPECT_TRUE(res);
 }
 
@@ -78,7 +78,7 @@ TEST_F(InterpreterTest, PushIInt32Minus1) {
     std::vector<uint32_t> instructions{
             instruction(Interpreter::InstructionCode::PUSH_I, BaseType::Int32, 0xfffff),  // -1
             instruction(Interpreter::InstructionCode::CALL, 0)};
-    bool res = mInterpreter->run({&instructions.front(), instructions.size()});
+    bool res = mInterpreter->run(instructions.data(), instructions.size());
     EXPECT_TRUE(res);
 }
 
@@ -88,7 +88,7 @@ TEST_F(InterpreterTest, PushIFloat1) {
     std::vector<uint32_t> instructions{
             instruction(Interpreter::InstructionCode::PUSH_I, BaseType::Float, 0x7f),  // 1.0 exp
             instruction(Interpreter::InstructionCode::CALL, 0)};
-    bool res = mInterpreter->run({&instructions.front(), instructions.size()});
+    bool res = mInterpreter->run(instructions.data(), instructions.size());
     EXPECT_TRUE(res);
 }
 
@@ -98,7 +98,7 @@ TEST_F(InterpreterTest, PushIDouble1) {
     std::vector<uint32_t> instructions{
             instruction(Interpreter::InstructionCode::PUSH_I, BaseType::Double, 0x3ff),  // 1.0 exp
             instruction(Interpreter::InstructionCode::CALL, 0)};
-    bool res = mInterpreter->run({&instructions.front(), instructions.size()});
+    bool res = mInterpreter->run(instructions.data(), instructions.size());
     EXPECT_TRUE(res);
 }
 
@@ -114,7 +114,7 @@ TEST_F(InterpreterTest, LoadC) {
     std::vector<uint32_t> instructions{
             instruction(Interpreter::InstructionCode::LOAD_C, BaseType::Uint16, 4),
             instruction(Interpreter::InstructionCode::CALL, 0)};
-    bool res = mInterpreter->run({&instructions.front(), instructions.size()});
+    bool res = mInterpreter->run(instructions.data(), instructions.size());
     EXPECT_TRUE(res);
 }
 
@@ -125,7 +125,7 @@ TEST_F(InterpreterTest, LoadV) {
     std::vector<uint32_t> instructions{
             instruction(Interpreter::InstructionCode::LOAD_V, BaseType::Int32, 784),
             instruction(Interpreter::InstructionCode::CALL, 0)};
-    bool res = mInterpreter->run({&instructions.front(), instructions.size()});
+    bool res = mInterpreter->run(instructions.data(), instructions.size());
     EXPECT_TRUE(res);
 }
 
@@ -142,7 +142,7 @@ TEST_F(InterpreterTest, LoadConstantAddress) {
             instruction(Interpreter::InstructionCode::PUSH_I, BaseType::ConstantPointer, 4),
             instruction(Interpreter::InstructionCode::LOAD, BaseType::Uint16, 0),
             instruction(Interpreter::InstructionCode::CALL, 0)};
-    bool res = mInterpreter->run({&instructions.front(), instructions.size()});
+    bool res = mInterpreter->run(instructions.data(), instructions.size());
     EXPECT_TRUE(res);
 }
 
@@ -154,7 +154,7 @@ TEST_F(InterpreterTest, LoadVolatileAddress) {
             instruction(Interpreter::InstructionCode::PUSH_I, BaseType::VolatilePointer, 784),
             instruction(Interpreter::InstructionCode::LOAD, BaseType::Int32, 0),
             instruction(Interpreter::InstructionCode::CALL, 0)};
-    bool res = mInterpreter->run({&instructions.front(), instructions.size()});
+    bool res = mInterpreter->run(instructions.data(), instructions.size());
     EXPECT_TRUE(res);
 }
 
@@ -167,7 +167,7 @@ TEST_F(InterpreterTest, Pop) {
             instruction(Interpreter::InstructionCode::PUSH_I, BaseType::Int8, -123),
             instruction(Interpreter::InstructionCode::POP, 2),
             instruction(Interpreter::InstructionCode::CALL, 0)};
-    bool res = mInterpreter->run({&instructions.front(), instructions.size()});
+    bool res = mInterpreter->run(instructions.data(), instructions.size());
     EXPECT_TRUE(res);
 }
 
@@ -175,7 +175,7 @@ TEST_F(InterpreterTest, StoreV) {
     std::vector<uint32_t> instructions{
             instruction(Interpreter::InstructionCode::PUSH_I, BaseType::Uint32, 987654),
             instruction(Interpreter::InstructionCode::STORE_V, 124)};
-    bool res = mInterpreter->run({&instructions.front(), instructions.size()});
+    bool res = mInterpreter->run(instructions.data(), instructions.size());
     EXPECT_TRUE(res);
 
     EXPECT_EQ(987654, *static_cast<uint32_t*>(mMemoryManager->volatileToAbsolute(124)));
@@ -186,7 +186,7 @@ TEST_F(InterpreterTest, Store) {
             instruction(Interpreter::InstructionCode::PUSH_I, BaseType::Uint32, 987654),
             instruction(Interpreter::InstructionCode::PUSH_I, BaseType::VolatilePointer, 260),
             instruction(Interpreter::InstructionCode::STORE, 0)};
-    bool res = mInterpreter->run({&instructions.front(), instructions.size()});
+    bool res = mInterpreter->run(instructions.data(), instructions.size());
     EXPECT_TRUE(res);
 
     EXPECT_EQ(987654, *static_cast<uint32_t*>(mMemoryManager->volatileToAbsolute(260)));
@@ -203,7 +203,7 @@ TEST_F(InterpreterTest, Copy) {
             instruction(Interpreter::InstructionCode::PUSH_I, BaseType::ConstantPointer, 5),
             instruction(Interpreter::InstructionCode::PUSH_I, BaseType::VolatilePointer, 987),
             instruction(Interpreter::InstructionCode::COPY, 3)};
-    bool res = mInterpreter->run({&instructions.front(), instructions.size()});
+    bool res = mInterpreter->run(instructions.data(), instructions.size());
     EXPECT_TRUE(res);
 
     EXPECT_EQ(5, *static_cast<uint8_t*>(mMemoryManager->volatileToAbsolute(987)));
@@ -222,7 +222,7 @@ TEST_F(InterpreterTest, Clone) {
             instruction(Interpreter::InstructionCode::CALL, 0),
             instruction(Interpreter::InstructionCode::POP, 2),
             instruction(Interpreter::InstructionCode::CALL, 0)};
-    bool res = mInterpreter->run({&instructions.front(), instructions.size()});
+    bool res = mInterpreter->run(instructions.data(), instructions.size());
     EXPECT_TRUE(res);
 }
 
@@ -233,7 +233,7 @@ TEST_F(InterpreterTest, ExtendInt32) {
             instruction(Interpreter::InstructionCode::PUSH_I, BaseType::Int32, 0x1d),
             instruction(Interpreter::InstructionCode::EXTEND, 0x2543210),
             instruction(Interpreter::InstructionCode::CALL, 0)};
-    bool res = mInterpreter->run({&instructions.front(), instructions.size()});
+    bool res = mInterpreter->run(instructions.data(), instructions.size());
     EXPECT_TRUE(res);
 }
 
@@ -244,7 +244,7 @@ TEST_F(InterpreterTest, ExtendFloat) {
             instruction(Interpreter::InstructionCode::PUSH_I, BaseType::Float, 0x7f),
             instruction(Interpreter::InstructionCode::EXTEND, 0x8ccccd),
             instruction(Interpreter::InstructionCode::CALL, 0)};
-    bool res = mInterpreter->run({&instructions.front(), instructions.size()});
+    bool res = mInterpreter->run(instructions.data(), instructions.size());
     EXPECT_TRUE(res);
 }
 
@@ -256,7 +256,7 @@ TEST_F(InterpreterTest, ExtendDouble) {
             instruction(Interpreter::InstructionCode::EXTEND, 0x1999999),
             instruction(Interpreter::InstructionCode::EXTEND, 0x2666666),
             instruction(Interpreter::InstructionCode::CALL, 0)};
-    bool res = mInterpreter->run({&instructions.front(), instructions.size()});
+    bool res = mInterpreter->run(instructions.data(), instructions.size());
     EXPECT_TRUE(res);
 }
 
@@ -268,7 +268,7 @@ TEST_F(InterpreterTest, Add2xUint32) {
             instruction(Interpreter::InstructionCode::PUSH_I, BaseType::Uint32, 10),
             instruction(Interpreter::InstructionCode::ADD, 2),
             instruction(Interpreter::InstructionCode::CALL, 0)};
-    bool res = mInterpreter->run({&instructions.front(), instructions.size()});
+    bool res = mInterpreter->run(instructions.data(), instructions.size());
     EXPECT_TRUE(res);
 }
 
@@ -281,7 +281,7 @@ TEST_F(InterpreterTest, Add3xFloat) {
             instruction(Interpreter::InstructionCode::PUSH_I, BaseType::Float, 0x80),  // 2.0 exp
             instruction(Interpreter::InstructionCode::ADD, 3),
             instruction(Interpreter::InstructionCode::CALL, 0)};
-    bool res = mInterpreter->run({&instructions.front(), instructions.size()});
+    bool res = mInterpreter->run(instructions.data(), instructions.size());
     EXPECT_TRUE(res);
 }
 
@@ -300,7 +300,7 @@ TEST_F(InterpreterTest, Strcpy) {
             instruction(Interpreter::InstructionCode::PUSH_I, BaseType::ConstantPointer, 0),
             instruction(Interpreter::InstructionCode::PUSH_I, BaseType::VolatilePointer, 100),
             instruction(Interpreter::InstructionCode::STRCPY, 10)};
-    bool res = mInterpreter->run({&instructions.front(), instructions.size()});
+    bool res = mInterpreter->run(instructions.data(), instructions.size());
     EXPECT_TRUE(res);
 
     EXPECT_EQ('a', volatileMemory[0]);
@@ -325,7 +325,7 @@ TEST_F(InterpreterTest, StrcpyShortBuffer) {
             instruction(Interpreter::InstructionCode::PUSH_I, BaseType::ConstantPointer, 0),
             instruction(Interpreter::InstructionCode::PUSH_I, BaseType::VolatilePointer, 100),
             instruction(Interpreter::InstructionCode::STRCPY, 5)};
-    bool res = mInterpreter->run({&instructions.front(), instructions.size()});
+    bool res = mInterpreter->run(instructions.data(), instructions.size());
     EXPECT_TRUE(res);
 
     EXPECT_EQ('a', volatileMemory[0]);
@@ -346,7 +346,7 @@ TEST_F(InterpreterTest, Post) {
     mInterpreter->registerBuiltin(0, Interpreter::POST_FUNCTION_ID, post);
 
     std::vector<uint32_t> instructions{instruction(Interpreter::InstructionCode::POST)};
-    bool res = mInterpreter->run({&instructions.front(), instructions.size()});
+    bool res = mInterpreter->run(instructions.data(), instructions.size());
     EXPECT_TRUE(res);
     EXPECT_EQ(1, callCount);
 }
@@ -363,26 +363,26 @@ TEST_F(InterpreterTest, Resource) {
 
     std::vector<uint32_t> instructions{instruction(Interpreter::InstructionCode::RESOURCE, 123),
                                        instruction(Interpreter::InstructionCode::CALL, 0)};
-    bool res = mInterpreter->run({&instructions.front(), instructions.size()});
+    bool res = mInterpreter->run(instructions.data(), instructions.size());
     EXPECT_TRUE(res);
     EXPECT_EQ(1, callCount);
 }
 
 TEST_F(InterpreterTest, InvalidOpcode) {
     std::vector<uint32_t> instructions{63U << 26};
-    bool res = mInterpreter->run({&instructions.front(), instructions.size()});
+    bool res = mInterpreter->run(instructions.data(), instructions.size());
     EXPECT_FALSE(res);
 }
 
 TEST_F(InterpreterTest, InvalidFunctionId) {
     std::vector<uint32_t> instructions{instruction(Interpreter::InstructionCode::CALL, 0xffff)};
-    bool res = mInterpreter->run({&instructions.front(), instructions.size()});
+    bool res = mInterpreter->run(instructions.data(), instructions.size());
     EXPECT_FALSE(res);
 }
 
 TEST_F(InterpreterTest, UnknownApi) {
     std::vector<uint32_t> instructions{instruction(Interpreter::InstructionCode::CALL, 1 << 16)};
-    bool res = mInterpreter->run({&instructions.front(), instructions.size()});
+    bool res = mInterpreter->run(instructions.data(), instructions.size());
     EXPECT_FALSE(res);
 }
 

--- a/gapir/cc/thread_pool.cpp
+++ b/gapir/cc/thread_pool.cpp
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "thread_pool.h"
+
+#include <functional>
+#include <queue>
+
+namespace gapir {
+
+ThreadPool::ThreadPool() {
+
+}
+
+ThreadPool::~ThreadPool() {
+    for (auto it : mThreads) {
+        delete it.second;
+    }
+}
+
+void ThreadPool::enqueue(ThreadID id, const F& work) {
+    std::lock_guard<std::mutex> lock(mMutex);
+    auto it = mThreads.find(id);
+    if (it == mThreads.end()) {
+        auto thread = new Thread();
+        thread->enqueue(work);
+        mThreads[id] = thread;
+    } else {
+        it->second->enqueue(work);
+    }
+}
+
+void ThreadPool::Thread::worker(Thread* thread) {
+    while (true) {
+        thread->mSemaphore.acquire();
+
+        std::unique_lock<std::mutex> lock(thread->mMutex);
+        if (thread->mWork.size() == 0) {
+            return; // Semaphore signal with no work means exit thread.
+        }
+        auto work = thread->mWork.front();
+        thread->mWork.pop();
+        lock.unlock();
+
+        work();
+    };
+}
+
+ThreadPool::Thread::Thread() {
+    mThread = new std::thread(Thread::worker, this);
+}
+
+ThreadPool::Thread::~Thread() {
+    mSemaphore.release();
+    mThread->join();
+    delete mThread;
+}
+
+void ThreadPool::Thread::enqueue(const F& work) {
+    mMutex.lock();
+    mWork.push(work);
+    mMutex.unlock();
+    mSemaphore.release();
+}
+
+}  // namespace gapir

--- a/gapir/cc/thread_pool.h
+++ b/gapir/cc/thread_pool.h
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef GAPIR_THREAD_POOL_H
+#define GAPIR_THREAD_POOL_H
+
+#include "core/cc/semaphore.h"
+
+#include <mutex>
+#include <functional>
+#include <thread>
+#include <queue>
+#include <unordered_map>
+
+namespace gapir {
+
+typedef uint64_t ThreadID;
+
+// ThreadPool holds a number of threads that can have work assigned to them.
+class ThreadPool {
+public:
+    typedef std::function<void()> F;
+
+    ThreadPool();
+
+    // Destructor. Waits for all threads to finish their work before returning.
+    ~ThreadPool();
+
+    // Appends F to the queue of work for the thread with the given ID.
+    // If this is the first time enqueue has been called with the given thread
+    // ID then it is created.
+    void enqueue(ThreadID, const F&);
+
+private:
+    class Thread {
+    public:
+        Thread();
+        ~Thread();
+        void enqueue(const F&);
+    private:
+        Thread(const Thread&) = delete;
+        Thread& operator = (const Thread&) = delete;
+
+        static void worker(Thread*);
+
+        std::thread* mThread; // The thread.
+        std::queue<F> mWork;  // The queue of pending work.
+        std::mutex mMutex;    // Guards mWork.
+        core::Semaphore mSemaphore; // Number of work items.
+    };
+
+    ThreadPool(const ThreadPool&) = delete;
+    ThreadPool& operator = (const ThreadPool&) = delete;
+
+    std::mutex mMutex; // Guards mThreads
+    std::unordered_map<ThreadID, Thread*> mThreads;
+};
+
+}  // namespace gapir
+
+#endif  // GAPIR_THREAD_POOL_H

--- a/gapis/api/gles/synthetic.api
+++ b/gapis/api/gles/synthetic.api
@@ -31,15 +31,20 @@ cmd void contextInfo(u32     constant_count,
 
 // replayCreateRenderer constructs a GLES renderer for replay without making it active.
 @synthetic
-cmd void replayCreateRenderer(u32 id) { }
+cmd void replayCreateRenderer(u32 rendererID) { }
 
 // replayBindRenderer makes the renderer constructed with replayCreateRenderer active.
 @synthetic
-cmd void replayBindRenderer(u32 id) { }
+cmd void replayBindRenderer(u32 rendererID) { }
+
+// replayUnbindRenderer makes the renderer constructed with replayCreateRenderer inactive.
+@synthetic
+cmd void replayUnbindRenderer(u32 rendererID) { }
 
 // replayChangeBackbuffer alters the backbuffer dimensions and format.
 @synthetic
-cmd void replayChangeBackbuffer(GLsizei backbuffer_width,
+cmd void replayChangeBackbuffer(u32     rendererID,
+                                GLsizei backbuffer_width,
                                 GLsizei backbuffer_height,
                                 GLenum  backbuffer_color_fmt,
                                 GLenum  backbuffer_depth_fmt,

--- a/gapis/api/test/mutate_test.go
+++ b/gapis/api/test/mutate_test.go
@@ -69,9 +69,9 @@ func (test test) check(ctx context.Context, ca, ra *device.MemoryLayout) {
 				}
 			}()
 			id := api.CmdID(i)
-			b.BeginAtom(uint64(id))
+			b.BeginCommand(uint64(id), 0)
 			cmd.Mutate(ctx, s, b)
-			b.CommitAtom()
+			b.CommitCommand()
 		}()
 	}
 

--- a/gapis/replay/asm/instructions.go
+++ b/gapis/replay/asm/instructions.go
@@ -342,3 +342,12 @@ type Label struct {
 func (a Label) Encode(r value.PointerResolver, w binary.Writer) error {
 	return opcode.Label{Value: a.Value}.Encode(w)
 }
+
+// SwitchThread is an Instruction that changes execution to a different thread.
+type SwitchThread struct {
+	Index uint32
+}
+
+func (a SwitchThread) Encode(r value.PointerResolver, w binary.Writer) error {
+	return opcode.SwitchThread{Index: a.Index}.Encode(w)
+}

--- a/gapis/replay/batch.go
+++ b/gapis/replay/batch.go
@@ -173,8 +173,8 @@ func (m *Manager) execute(
 	return err
 }
 
-// adapter conforms to the the atom Writer interface, performing replay writes
-// on each atom.
+// adapter conforms to the the transformer.Writer interface, performing replay
+// writes on each command.
 type adapter struct {
 	state   *api.State
 	builder *builder.Builder
@@ -185,11 +185,11 @@ func (w *adapter) State() *api.State {
 }
 
 func (w *adapter) MutateAndWrite(ctx context.Context, id api.CmdID, cmd api.Cmd) {
-	w.builder.BeginAtom(uint64(id))
+	w.builder.BeginCommand(uint64(id), cmd.Thread())
 	if err := cmd.Mutate(ctx, w.state, w.builder); err == nil {
-		w.builder.CommitAtom()
+		w.builder.CommitCommand()
 	} else {
-		w.builder.RevertAtom(err)
+		w.builder.RevertCommand(err)
 		log.W(ctx, "Failed to write command %v (%T) for replay: %v", id, cmd, err)
 	}
 }

--- a/gapis/replay/opcode/opcodes.go
+++ b/gapis/replay/opcode/opcodes.go
@@ -243,13 +243,23 @@ func (c Add) Encode(w binary.Writer) error {
 	return w.Error()
 }
 
-// Extend represents the LABEL virtual machine opcode.
+// Label represents the LABEL virtual machine opcode.
 type Label struct {
 	Value uint32 // 26 bit label name.
 }
 
 func (c Label) Encode(w binary.Writer) error {
 	w.Uint32(packCX(protocol.OpLabel, c.Value))
+	return w.Error()
+}
+
+// SwitchThread represents the SwitchThread virtual machine opcode.
+type SwitchThread struct {
+	Index uint32 // 26 bit thread index.
+}
+
+func (c SwitchThread) Encode(w binary.Writer) error {
+	w.Uint32(packCX(protocol.OpSwitchThread, c.Index))
 	return w.Error()
 }
 
@@ -293,6 +303,8 @@ func Decode(r binary.Reader) (interface{}, error) {
 		return Add{Count: unpackX(i)}, nil
 	case protocol.OpLabel:
 		return Label{Value: unpackX(i)}, nil
+	case protocol.OpSwitchThread:
+		return SwitchThread{Index: unpackX(i)}, nil
 	default:
 		return nil, fmt.Errorf("Unknown opcode with code %v", code)
 	}

--- a/gapis/replay/protocol/opcode.go
+++ b/gapis/replay/protocol/opcode.go
@@ -20,22 +20,23 @@ import "fmt"
 type Opcode int
 
 const (
-	OpCall     = 0
-	OpPushI    = 1
-	OpLoadC    = 2
-	OpLoadV    = 3
-	OpLoad     = 4
-	OpPop      = 5
-	OpStoreV   = 6
-	OpStore    = 7
-	OpResource = 8
-	OpPost     = 9
-	OpCopy     = 10
-	OpClone    = 11
-	OpStrcpy   = 12
-	OpExtend   = 13
-	OpAdd      = 14
-	OpLabel    = 15
+	OpCall         = 0
+	OpPushI        = 1
+	OpLoadC        = 2
+	OpLoadV        = 3
+	OpLoad         = 4
+	OpPop          = 5
+	OpStoreV       = 6
+	OpStore        = 7
+	OpResource     = 8
+	OpPost         = 9
+	OpCopy         = 10
+	OpClone        = 11
+	OpStrcpy       = 12
+	OpExtend       = 13
+	OpAdd          = 14
+	OpLabel        = 15
+	OpSwitchThread = 16
 )
 
 // String returns the human-readable name of the opcode.
@@ -73,6 +74,8 @@ func (t Opcode) String() string {
 		return "Add"
 	case OpLabel:
 		return "Label"
+	case OpSwitchThread:
+		return "SwitchThread"
 	default:
 		panic(fmt.Errorf("Unknown ValueType %d", uint32(t)))
 	}

--- a/kokoro/macos/build.sh
+++ b/kokoro/macos/build.sh
@@ -69,6 +69,9 @@ git submodule update --init
 # Disable ccache as it seems to be flaky on mac build server
 export CCACHE_DISABLE=1
 
+# Specify the version of XCode
+export DEVELOPER_DIR=/Applications/Xcode_8.2.app/Contents/Developer
+
 # Invoke the build. At this point, only ensure that the tests build, but don't
 # execute the tests.
 BUILD_SHA=${KOKORO_GITHUB_COMMIT:-$KOKORO_GITHUB_PULL_REQUEST_COMMIT}


### PR DESCRIPTION
The goal here isn't to make replay concurrent - instead this is to avoid funnling all traced threads on to a single thread for replay. While this works (and always has), it involves adding a [egl,cgl,glx]MakeCurrent call between each interleaved thread switch. As it turns out, these context switches are expensive - on Windows, these calls can easily take the majority of the replay time.

Significantly speeds up GLES replay on Windows (3x for some traces), noticeable performance improvements on Linux and OSX too.