### PR TITLE
Add a backup mechanism for port numbers if stdout is consumed.

### DIFF
--- a/cmd/gapit/trace.go
+++ b/cmd/gapit/trace.go
@@ -111,7 +111,7 @@ func (verb *traceVerb) startLocalApp(ctx context.Context) (func(), error) {
 	// VK_DEVICE_LAYERS and LD_PRELOAD set to correct values to load the spy
 	// layer.
 	env := shell.CloneEnv()
-	cleanup, err := loader.SetupTrace(ctx, env)
+	cleanup, tempfile, err := loader.SetupTrace(ctx, env)
 	if err != nil {
 		return cleanup, err
 	}
@@ -120,8 +120,9 @@ func (verb *traceVerb) startLocalApp(ctx context.Context) (func(), error) {
 	args := r.FindAllString(verb.Local.Args, -1)
 	ctx, cancel := context.WithCancel(ctx)
 	boundPort, err := process.Start(ctx, verb.Local.App.System(), process.StartOptions{
-		Env:  env,
-		Args: args,
+		Env:        env,
+		Args:       args,
+		BackupFile: tempfile,
 	})
 
 	if err != nil {

--- a/core/cc/android/get_vulkan_proc_address.cpp
+++ b/core/cc/android/get_vulkan_proc_address.cpp
@@ -34,13 +34,13 @@ void* getVulkanInstanceProcAddress(size_t instance, const char *name, bool bypas
 
     if (VPAPROC vpa = reinterpret_cast<VPAPROC>(dylib.lookup("vkGetInstanceProcAddr"))) {
         if (void* proc = vpa(instance, name)) {
-            GAPID_INFO("GetVulkanInstanceProcAddress(0x%x, %s, %d) -> 0x%x (via %s vkGetInstanceProcAddr)",
+            GAPID_DEBUG("GetVulkanInstanceProcAddress(0x%x, %s, %d) -> 0x%x (via %s vkGetInstanceProcAddr)",
                 instance, name, bypassLocal, proc, (bypassLocal ? "libvulkan" : "local"));
             return proc;
         }
     }
 
-    GAPID_INFO("GetVulkanInstanceProcAddress(0x%x, %s, %d) -> not found", instance, name, bypassLocal);
+    GAPID_DEBUG("GetVulkanInstanceProcAddress(0x%x, %s, %d) -> not found", instance, name, bypassLocal);
     return nullptr;
 }
 
@@ -50,13 +50,13 @@ void* getVulkanDeviceProcAddress(size_t instance, size_t device, const char *nam
     if (auto vpa = reinterpret_cast<VPAPROC>(
         getVulkanInstanceProcAddress(instance, "vkGetDeviceProcAddr", bypassLocal))) {
         if (void* proc = vpa(device, name)) {
-            GAPID_INFO("GetVulkanDeviceProcAddress(0x%x, 0x%x, %s, %d) -> 0x%x (via %s vkGetDeviceProcAddr)",
+            GAPID_DEBUG("GetVulkanDeviceProcAddress(0x%x, 0x%x, %s, %d) -> 0x%x (via %s vkGetDeviceProcAddr)",
                 instance, device, name, bypassLocal, proc, (bypassLocal ? "libvulkan" : "local"));
             return proc;
         }
     }
 
-    GAPID_INFO("GetVulkanDeviceProcAddress(0x%x, 0x%x, %s, %d) -> not found", instance, device, name, bypassLocal);
+    GAPID_DEBUG("GetVulkanDeviceProcAddress(0x%x, 0x%x, %s, %d) -> not found", instance, device, name, bypassLocal);
     return nullptr;
 }
 

--- a/core/cc/archive.cpp
+++ b/core/cc/archive.cpp
@@ -20,6 +20,10 @@
 
 #ifdef _MSC_VER // MSVC
 #   include <io.h>
+#ifndef __GNUC__
+// MSYS GCC allows fileno, MSVC itself does not.
+#define fileno _fileno
+#endif
 #else // not MSVC
 #   include <unistd.h>
 #endif

--- a/core/cc/armlinux/get_vulkan_proc_address.cpp
+++ b/core/cc/armlinux/get_vulkan_proc_address.cpp
@@ -34,13 +34,13 @@ void* getVulkanInstanceProcAddress(size_t instance, const char *name, bool bypas
 
     if (VPAPROC vpa = reinterpret_cast<VPAPROC>(dylib.lookup("vkGetInstanceProcAddr"))) {
         if (void* proc = vpa(instance, name)) {
-            GAPID_INFO("GetVulkanInstanceProcAddress(0x%x, %s, %d) -> 0x%x (via %s vkGetInstanceProcAddr)",
+            GAPID_DEBUG("GetVulkanInstanceProcAddress(0x%x, %s, %d) -> 0x%x (via %s vkGetInstanceProcAddr)",
                 instance, name, bypassLocal, proc, (bypassLocal ? "libvulkan" : "local"));
             return proc;
         }
     }
 
-    GAPID_INFO("GetVulkanInstanceProcAddress(0x%x, %s, %d) -> not found", instance, name, bypassLocal);
+    GAPID_DEBUG("GetVulkanInstanceProcAddress(0x%x, %s, %d) -> not found", instance, name, bypassLocal);
     return nullptr;
 }
 
@@ -50,13 +50,13 @@ void* getVulkanDeviceProcAddress(size_t instance, size_t device, const char *nam
     if (auto vpa = reinterpret_cast<VPAPROC>(
         getVulkanInstanceProcAddress(instance, "vkGetDeviceProcAddr", bypassLocal))) {
         if (void* proc = vpa(device, name)) {
-            GAPID_INFO("GetVulkanDeviceProcAddress(0x%x, 0x%x, %s, %d) -> 0x%x (via %s vkGetDeviceProcAddr)",
+            GAPID_DEBUG("GetVulkanDeviceProcAddress(0x%x, 0x%x, %s, %d) -> 0x%x (via %s vkGetDeviceProcAddr)",
                 instance, device, name, bypassLocal, proc, (bypassLocal ? "libvulkan" : "local"));
             return proc;
         }
     }
 
-    GAPID_INFO("GetVulkanDeviceProcAddress(0x%x, 0x%x, %s, %d) -> not found", instance, device, name, bypassLocal);
+    GAPID_DEBUG("GetVulkanDeviceProcAddress(0x%x, 0x%x, %s, %d) -> not found", instance, device, name, bypassLocal);
     return nullptr;
 }
 

--- a/core/cc/interval_list.h
+++ b/core/cc/interval_list.h
@@ -21,6 +21,12 @@
 #include <algorithm>
 #include <vector>
 
+#if defined(_MSC_VER) and !defined(__GNUC__)
+// MSVC itself does not have ssize_t, although
+// msys mingw does. 
+typedef long long ssize_t;
+#endif
+
 namespace core {
 
 // Interval represents a single interval range of type T.
@@ -196,8 +202,9 @@ inline void CustomIntervalList<T>::merge(const T& i) {
         auto to = mIntervals.begin() + last;
         auto low = std::min(from->start(), i.start());
         auto high = std::max(to->end(), i.end());
+		T* f = &(*from);
         mIntervals.erase(from, to);
-        from->adjust(low, high);
+        f->adjust(low, high);
     } else {
         mIntervals.insert(from, i);
     }
@@ -231,7 +238,7 @@ template<typename T>
 inline const T* CustomIntervalList<T>::end() const {
     size_t c = mIntervals.size();
     if (c > 0) {
-        return &mIntervals[c];
+        return &mIntervals[c-1] + 1;
     } else {
         return nullptr;
     }

--- a/core/cc/supported_abis.h
+++ b/core/cc/supported_abis.h
@@ -23,9 +23,9 @@ namespace core {
 // host machine, starting with the preferred ABI.
 // Must match the definitions in core/os/device/abi.go.
 inline const char* supportedABIs() {
-#ifdef __x86_64
+#if defined __x86_64 || defined _WIN64
     return "x86-64";
-#elif defined __i386
+#elif defined __i386 || defined _WIN32
     return "x86";
 #elif defined __ARM_ARCH_7A__
     return "armeabi-v7a";

--- a/core/cc/target.h
+++ b/core/cc/target.h
@@ -67,7 +67,11 @@
 
 #ifdef _MSC_VER // MSVC
 #   define ftruncate _chsize
+#ifdef __GNUC__
+// MSYS needs this, MSVC will complain
+// if we #define snprintf
 #   define snprintf _snprintf
+#endif
 #   define alignof __alignof
 #   define _ALLOW_KEYWORD_MACROS 1
 #   define LIKELY(expr) expr

--- a/core/cc/windows/get_vulkan_proc_address.cpp
+++ b/core/cc/windows/get_vulkan_proc_address.cpp
@@ -50,13 +50,13 @@ void* getVulkanInstanceProcAddress(size_t instance, const char *name, bool bypas
 
     if (VPAPROC vpa = reinterpret_cast<VPAPROC>(dylib.lookup("vkGetInstanceProcAddr"))) {
         if (void* proc = vpa(instance, name)) {
-            GAPID_INFO("GetVulkanInstanceProcAddress(0x%x, %s, %d) -> 0x%x (via %s Vulkan vkGetInstanceProcAddr)",
+            GAPID_DEBUG("GetVulkanInstanceProcAddress(0x%x, %s, %d) -> 0x%x (via %s Vulkan vkGetInstanceProcAddr)",
                 instance, name, bypassLocal, proc, (bypassLocal ? "system" : "local"));
             return proc;
         }
     }
 
-    GAPID_INFO("GetVulkanInstanceProcAddress(0x%x, %s, %d) -> not found", instance, name, bypassLocal);
+    GAPID_DEBUG("GetVulkanInstanceProcAddress(0x%x, %s, %d) -> not found", instance, name, bypassLocal);
     return nullptr;
 }
 
@@ -66,13 +66,13 @@ void* getVulkanDeviceProcAddress(size_t instance, size_t device, const char *nam
     if (auto vpa = reinterpret_cast<VPAPROC>(
         getVulkanInstanceProcAddress(instance, "vkGetDeviceProcAddr", bypassLocal))) {
         if (void* proc = vpa(device, name)) {
-            GAPID_INFO("GetVulkanDeviceProcAddress(0x%x, 0x%x, %s, %d) -> 0x%x (via %s Vulkan vkGetDeviceProcAddr)",
+            GAPID_DEBUG("GetVulkanDeviceProcAddress(0x%x, 0x%x, %s, %d) -> 0x%x (via %s Vulkan vkGetDeviceProcAddr)",
                 instance, device, name, bypassLocal, proc, (bypassLocal ? "system" : "local"));
             return proc;
         }
     }
 
-    GAPID_INFO("GetVulkanDeviceProcAddress(0x%x, 0x%x, %s, %d) -> not found", instance, device, name, bypassLocal);
+    GAPID_DEBUG("GetVulkanDeviceProcAddress(0x%x, 0x%x, %s, %d) -> not found", instance, device, name, bypassLocal);
     return nullptr;
 }
 

--- a/core/os/device/deviceinfo/cc/cpu.cpp
+++ b/core/os/device/deviceinfo/cc/cpu.cpp
@@ -18,7 +18,8 @@
 
 #include "core/cc/target.h"
 
-#if (defined(__x86_64) || defined(__i386)) && (TARGET_OS != GAPID_OS_ANDROID)
+#if TARGET_OS != GAPID_OS_ANDROID
+#if (defined(__x86_64) || defined(__i386))
 
 #include <cpuid.h>
 
@@ -55,5 +56,25 @@ device::Architecture cpuArchitecture() {
 }
 
 }  // namespace query
+#else
+namespace query {
 
-#endif  // (defined(__x86_64) || defined(__i386)) && (TARGET_OS != GAPID_OS_ANDROID)
+	const char* cpuName() {
+		return "<unknown>";
+	}
+
+	const char* cpuVendor() {
+		
+		return "<unknown>";
+	}
+
+	device::Architecture cpuArchitecture() {
+#ifdef _WIN64
+		return device::X86_64;
+#elif defined _WIN32
+		return device::X86;
+#endif
+	}
+}
+#endif
+#endif

--- a/core/os/device/deviceinfo/cc/windows/query.cpp
+++ b/core/os/device/deviceinfo/cc/windows/query.cpp
@@ -20,6 +20,12 @@
 #include <wingdi.h>
 #include <GL/gl.h>
 
+#ifndef __GNUC__
+// MSVC will fail to compile if we are using 
+// GetVersionEx, this silences that warning
+#pragma warning(disable : 4996)
+#endif
+
 namespace {
 
 static const char* wndClassName = TEXT("opengl-dummy-window");

--- a/core/vulkan/loader/loader.go
+++ b/core/vulkan/loader/loader.go
@@ -28,27 +28,42 @@ import (
 )
 
 // SetupTrace sets up the environment for tracing a local app. Returns a
-// clean-up function to be called after the trace completes, or an error.
-func SetupTrace(ctx context.Context, env *shell.Env) (func(), error) {
+// clean-up function to be called after the trace completes, and a temporary
+// filename that can be used to find the port if stdout fails, or an error.
+func SetupTrace(ctx context.Context, env *shell.Env) (func(), string, error) {
 	lib, json, err := findLibraryAndJSON(ctx, layout.LibGraphicsSpy)
+	var f string
 	if err != nil {
-		return func() {}, err
+		return func() {}, f, err
 	}
 	cleanup, err := setupJSON(lib, json, env)
 	if err == nil {
-		env.Set("LD_PRELOAD", lib.System()).
-			AddPathStart("VK_INSTANCE_LAYERS", "VkGraphicsSpy").
-			AddPathStart("VK_DEVICE_LAYERS", "VkGraphicsSpy")
-		if runtime.GOOS == "windows" {
-			// Adds the extra MSYS DLL dependencies onto the path.
-			// TODO: remove this hacky work-around.
-			gapit, err := layout.Gapit(ctx)
-			if err == nil {
-				env.AddPathStart("PATH", gapit.Parent().System())
+		if fl, e := ioutil.TempFile("", "gapiiport"); e == nil {
+			err = e
+			f = fl.Name()
+			fl.Close()
+			o := cleanup
+			cleanup = func() {
+				o()
+				os.Remove(f)
+			}
+		}
+		if err == nil {
+			env.Set("LD_PRELOAD", lib.System()).
+				AddPathStart("VK_INSTANCE_LAYERS", "VkGraphicsSpy").
+				AddPathStart("VK_DEVICE_LAYERS", "VkGraphicsSpy").
+				Set("GAPII_BACKUP_FILE", f)
+			if runtime.GOOS == "windows" {
+				// Adds the extra MSYS DLL dependencies onto the path.
+				// TODO: remove this hacky work-around.
+				gapit, err := layout.Gapit(ctx)
+				if err == nil {
+					env.AddPathStart("PATH", gapit.Parent().System())
+				}
 			}
 		}
 	}
-	return cleanup, err
+	return cleanup, f, err
 }
 
 // SetupReplay sets up the environment for local replay. Returns a clean-up

--- a/gapii/cc/call_observer.cpp
+++ b/gapii/cc/call_observer.cpp
@@ -32,7 +32,7 @@ const size_t MEMORY_MERGE_THRESHOLD = 256;
 const size_t SCRATCH_BUFFER_SIZE = 512*1024;
 
 // Maximum size of the CallObserver's extras list.
-const size_t MAX_EXTRAS = 16;
+const size_t MAX_EXTRAS = 64;
 
 // Buffer creating function for scratch allocator.
 std::tuple<uint8_t*, size_t> createBuffer(size_t request_size,

--- a/gapii/cc/vulkan_mid_execution.cpp
+++ b/gapii/cc/vulkan_mid_execution.cpp
@@ -1502,8 +1502,9 @@ void VulkanSpy::EnumerateVulkanResources(CallObserver* observer) {
           dynamic_state.mpDynamicStates = dynamic_states.data();
           create_info.mpDynamicState = &dynamic_state;
         }
+        // The pipeline cache is allowed to be VK_NULL_HANDLE.
         RecreateGraphicsPipeline(observer, pipeline.mDevice,
-                                 pipeline.mPipelineCache->mVulkanHandle,
+                                 pipeline.mPipelineCache? pipeline.mPipelineCache->mVulkanHandle: 0,
                                  &create_info, &pipeline.mVulkanHandle);
       }
     }
@@ -1577,14 +1578,6 @@ void VulkanSpy::EnumerateVulkanResources(CallObserver* observer) {
                 write_template.mdstBinding = i;
                 write_template.mdescriptorCount = 1;
                 write_template.mdescriptorType = binding.mBindingType;
-
-                writes.push_back({});
-                writes.back().msType = VkStructureType::VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
-                writes.back().mdstSet = descriptorSet.second->mVulkanHandle;
-                writes.back().mdstBinding = i;
-                writes.back().mdstArrayElement = 0;
-                writes.back().mdescriptorCount = 0;
-                writes.back().mdescriptorType = binding.mBindingType;
 
                 switch(binding.mBindingType) {
                     case VkDescriptorType::VK_DESCRIPTOR_TYPE_SAMPLER:

--- a/gapir/cc/context.cpp
+++ b/gapir/cc/context.cpp
@@ -253,7 +253,7 @@ void Context::registerCallbacks(Interpreter* interpreter) {
 
     interpreter->registerBuiltin(Vulkan::INDEX, Builtins::ReplayCreateVkInstance,
                                  [this, interpreter](Stack* stack, bool pushReturn) {
-        GAPID_INFO("replayCreateVkInstance()");
+        GAPID_DEBUG("replayCreateVkInstance()");
 
         if (mBoundVulkanRenderer != nullptr || interpreter->registerApi(Vulkan::INDEX)) {
             auto* api = mBoundVulkanRenderer->getApi<Vulkan>();
@@ -266,7 +266,7 @@ void Context::registerCallbacks(Interpreter* interpreter) {
 
     interpreter->registerBuiltin(Vulkan::INDEX, Builtins::ReplayCreateVkDevice,
                                  [this, interpreter](Stack* stack, bool pushReturn) {
-        GAPID_INFO("replayCreateVkDevice()");
+        GAPID_DEBUG("replayCreateVkDevice()");
         if (mBoundVulkanRenderer != nullptr) {
             auto* api = mBoundVulkanRenderer->getApi<Vulkan>();
             return api->replayCreateVkDevice(stack, pushReturn);
@@ -278,7 +278,7 @@ void Context::registerCallbacks(Interpreter* interpreter) {
 
     interpreter->registerBuiltin(Vulkan::INDEX, Builtins::ReplayRegisterVkInstance,
                                  [this, interpreter](Stack* stack, bool) {
-        GAPID_INFO("replayRegisterVkInstance()");
+        GAPID_DEBUG("replayRegisterVkInstance()");
         if (mBoundVulkanRenderer != nullptr) {
             auto* api = mBoundVulkanRenderer->getApi<Vulkan>();
             return api->replayRegisterVkInstance(stack);
@@ -290,7 +290,7 @@ void Context::registerCallbacks(Interpreter* interpreter) {
 
     interpreter->registerBuiltin(Vulkan::INDEX, Builtins::ReplayUnregisterVkInstance,
                                  [this, interpreter](Stack* stack, bool) {
-        GAPID_INFO("replayUnregisterVkInstance()");
+        GAPID_DEBUG("replayUnregisterVkInstance()");
         if (mBoundVulkanRenderer != nullptr) {
             auto* api = mBoundVulkanRenderer->getApi<Vulkan>();
             return api->replayUnregisterVkInstance(stack);
@@ -302,7 +302,7 @@ void Context::registerCallbacks(Interpreter* interpreter) {
 
     interpreter->registerBuiltin(Vulkan::INDEX, Builtins::ReplayRegisterVkDevice,
                                  [this, interpreter](Stack* stack, bool) {
-        GAPID_INFO("replayRegisterVkDevice()");
+        GAPID_DEBUG("replayRegisterVkDevice()");
         if (mBoundVulkanRenderer != nullptr) {
             auto* api = mBoundVulkanRenderer->getApi<Vulkan>();
             return api->replayRegisterVkDevice(stack);
@@ -314,7 +314,7 @@ void Context::registerCallbacks(Interpreter* interpreter) {
 
     interpreter->registerBuiltin(Vulkan::INDEX, Builtins::ReplayUnregisterVkDevice,
                                  [this, interpreter](Stack* stack, bool) {
-        GAPID_INFO("replayUnregisterVkDevice()");
+        GAPID_DEBUG("replayUnregisterVkDevice()");
         if (mBoundVulkanRenderer != nullptr) {
             auto* api = mBoundVulkanRenderer->getApi<Vulkan>();
             return api->replayUnregisterVkDevice(stack);
@@ -326,7 +326,7 @@ void Context::registerCallbacks(Interpreter* interpreter) {
 
     interpreter->registerBuiltin(Vulkan::INDEX, Builtins::ReplayRegisterVkCommandBuffers,
                                  [this, interpreter](Stack* stack, bool) {
-        GAPID_INFO("replayRegisterVkCommandBuffers()");
+        GAPID_DEBUG("replayRegisterVkCommandBuffers()");
         if (mBoundVulkanRenderer != nullptr) {
             auto* api = mBoundVulkanRenderer->getApi<Vulkan>();
             return api->replayRegisterVkCommandBuffers(stack);
@@ -338,7 +338,7 @@ void Context::registerCallbacks(Interpreter* interpreter) {
 
     interpreter->registerBuiltin(Vulkan::INDEX, Builtins::ReplayUnregisterVkCommandBuffers,
                                  [this, interpreter](Stack* stack, bool) {
-        GAPID_INFO("replayUnregisterVkCommandBuffers()");
+        GAPID_DEBUG("replayUnregisterVkCommandBuffers()");
         if (mBoundVulkanRenderer != nullptr) {
             auto* api = mBoundVulkanRenderer->getApi<Vulkan>();
             return api->replayUnregisterVkCommandBuffers(stack);
@@ -350,7 +350,7 @@ void Context::registerCallbacks(Interpreter* interpreter) {
 
     interpreter->registerBuiltin(Vulkan::INDEX, Builtins::ToggleVirtualSwapchainReturnAcquiredImage,
                                  [this, interpreter](Stack* stack, bool) {
-        GAPID_INFO("ToggleVirtualSwapchainReturnAcquiredImage()");
+        GAPID_DEBUG("ToggleVirtualSwapchainReturnAcquiredImage()");
         if (mBoundVulkanRenderer != nullptr) {
             auto* api = mBoundVulkanRenderer->getApi<Vulkan>();
             return api->toggleVirtualSwapchainReturnAcquiredImage(stack);
@@ -364,7 +364,7 @@ void Context::registerCallbacks(Interpreter* interpreter) {
         Vulkan::INDEX,
         Builtins::ReplayAllocateImageMemory,
         [this, interpreter](Stack* stack, bool push_return) {
-            GAPID_INFO("replayAllocateImageMemory()");
+            GAPID_DEBUG("replayAllocateImageMemory()");
             if (mBoundVulkanRenderer != nullptr) {
                 auto* api = mBoundVulkanRenderer->getApi<Vulkan>();
                 return api->replayAllocateImageMemory(stack, push_return);
@@ -377,7 +377,7 @@ void Context::registerCallbacks(Interpreter* interpreter) {
 
     interpreter->registerBuiltin(Vulkan::INDEX, Builtins::ReplayGetFenceStatus,
                                  [this, interpreter](Stack* stack, bool push_return) {
-        GAPID_INFO("ReplayGetFenceStatus()");
+        GAPID_DEBUG("ReplayGetFenceStatus()");
         if (mBoundVulkanRenderer != nullptr) {
             auto* api = mBoundVulkanRenderer->getApi<Vulkan>();
             return api->replayGetFenceStatus(stack, push_return);
@@ -389,7 +389,7 @@ void Context::registerCallbacks(Interpreter* interpreter) {
 
     interpreter->registerBuiltin(Vulkan::INDEX, Builtins::ReplayGetEventStatus,
                                  [this, interpreter](Stack* stack, bool push_return) {
-        GAPID_INFO("ReplayGetEventStatus()");
+        GAPID_DEBUG("ReplayGetEventStatus()");
         if (mBoundVulkanRenderer != nullptr) {
             auto* api = mBoundVulkanRenderer->getApi<Vulkan>();
             return api->replayGetEventStatus(stack, push_return);

--- a/gapir/cc/interpreter.cpp
+++ b/gapir/cc/interpreter.cpp
@@ -19,7 +19,12 @@
 
 #include "core/cc/log.h"
 
+#if !defined(_MSC_VER) || defined(__GNUC__) 
+// If compiling wiht MSVC, (rather than MSYS)
+// unistd does not exist.
 #include <unistd.h>
+#endif // !defined(_MSC_VER) || defined(__GNUC__)
+
 #include <utility>
 #include <vector>
 

--- a/gapis/gfxapi/templates/api_types.h.tmpl
+++ b/gapis/gfxapi/templates/api_types.h.tmpl
@@ -35,6 +35,7 @@
 ¶
   #include "core/cc/static_array.h"
 ¶
+  #include <functional>
   #include <memory>
   #include <string>
   #include <unordered_map>

--- a/gapis/gfxapi/templates/cpp_common.tmpl
+++ b/gapis/gfxapi/templates/cpp_common.tmpl
@@ -846,18 +846,26 @@
   {{AssertType $ "Select"}}
 
   /* switch({{Template "C++.Read" $.Value}}) */»
-  {{range $c := $.Choices}}
-    /* case {{range $i, $cond := $c.Conditions}}{{if $i}}, {{end}}{{Template "C++.Read" $cond}}{{end}}: */§
-    ({{range $i, $cond := $c.Conditions}}§
-        {{if $i}} || {{end}}(({{Template "C++.Read" $.Value}}) == ({{Template "C++.Read" $cond}}))§
-    {{end}}) ? ({{Template "C++.Read" $c.Expression}}) :
-  {{end}}
-  /* default: */ §
-  {{if $.Default}}
-    {{Template "C++.Read" $.Default}}«
-  {{else}}
-    {{Template "C++.Null" $.Type}}«
-  {{end}}
+    [&]() -> {{Template "C++.Type" $.Type}} {
+      switch({{Template "C++.Read" $.Value}}) {
+        {{range $c := $.Choices}}
+          /* case {{range $i, $cond := $c.Conditions}}{{if $i}}, {{end}}{{Template "C++.Read" $cond}}{{end}}: */
+          {{range $i, $cond := $c.Conditions}}
+          case {{Template "C++.Read" $cond}}:
+          {{end}} {
+            return ({{Template "C++.Read" $c.Expression}}); 
+          }
+        {{end}}
+        default:
+        {{if $.Default}} {
+          return {{Template "C++.Read" $.Default}};«
+        }
+        {{else}} {
+          return {{Template "C++.Null" $.Type}};«
+        }
+        {{end}}
+      }
+    }()
 {{end}}
 
 

--- a/gapis/gfxapi/templates/vulkan_gfx_api_extras.tmpl
+++ b/gapis/gfxapi/templates/vulkan_gfx_api_extras.tmpl
@@ -142,7 +142,7 @@
   bool Vulkan::replayRegisterVkInstance(Stack* stack) {
     auto instance = static_cast<VkInstance>(stack->pop<size_val>());
     if (stack->isValid()) {
-      GAPID_INFO("replayRegisterVkInstance(%" PRIu64 ")", instance);
+      GAPID_DEBUG("replayRegisterVkInstance(%" PRIu64 ")", instance);
       if (mVkInstanceFunctionStubs.count(instance) > 0) {
         // TODO(antiagainst): The same instance handle returned from the driver. Is this possible?
         return false;
@@ -169,7 +169,7 @@
   bool Vulkan::replayUnregisterVkInstance(Stack* stack) {
     auto instance = static_cast<VkInstance>(stack->pop<size_val>());
     if (stack->isValid()) {
-      GAPID_INFO("replayUnregisterVkInstance(%" PRIu64 ")", instance);
+      GAPID_DEBUG("replayUnregisterVkInstance(%" PRIu64 ")", instance);
       mVkInstanceFunctionStubs.erase(instance);
       auto& pdevMap = mIndirectMaps.VkPhysicalDevicesToVkInstances;
       for (auto it = pdevMap.begin(); it != pdevMap.end();) {
@@ -191,7 +191,7 @@
     auto device = static_cast<VkDevice>(stack->pop<size_val>());
     auto physical_device = static_cast<VkPhysicalDevice>(stack->pop<size_val>());
     if (stack->isValid()) {
-      GAPID_INFO("replayRegisterVkDevice(%" PRIu64 ", %" PRIu64 ", %p)", physical_device, device, createInfo);
+      GAPID_DEBUG("replayRegisterVkDevice(%" PRIu64 ", %" PRIu64 ", %p)", physical_device, device, createInfo);
       if (mVkDeviceFunctionStubs.count(device) > 0) {
         // TODO(antiagainst): The same device handle returned from the driver. Is this possible?
         return false;
@@ -220,7 +220,7 @@
   bool Vulkan::replayUnregisterVkDevice(Stack* stack) {
     auto device = static_cast<VkDevice>(stack->pop<size_val>());
     if (stack->isValid()) {
-      GAPID_INFO("replayUnregisterVkDevice(%" PRIu64 ")", device);
+      GAPID_DEBUG("replayUnregisterVkDevice(%" PRIu64 ")", device);
       mVkDeviceFunctionStubs.erase(device);
       mIndirectMaps.VkDevicesToVkPhysicalDevices.erase(device);
       auto& queueMap = mIndirectMaps.VkQueuesToVkDevices;
@@ -251,7 +251,7 @@
     auto count = stack->pop<uint32_t>();
     auto device = static_cast<VkDevice>(stack->pop<size_val>());
     if (stack->isValid()) {
-      GAPID_INFO("replayRegisterVkCommandBuffers(%" PRIu64 ", %" PRIu32 ", %p)", device, count, commandBuffers);
+      GAPID_DEBUG("replayRegisterVkCommandBuffers(%" PRIu64 ", %" PRIu32 ", %p)", device, count, commandBuffers);
       for (uint32_t i = 0; i < count; ++i) {
         mIndirectMaps.VkCommandBuffersToVkDevices[commandBuffers[i]] = device;
       }
@@ -266,7 +266,7 @@
     auto commandBuffers = stack->pop<VkCommandBuffer*>();
     auto count = stack->pop<uint32_t>();
     if (stack->isValid()) {
-      GAPID_INFO("replayUnregisterVkCommandBuffers(%" PRIu32 ", %p)", count, commandBuffers);
+      GAPID_DEBUG("replayUnregisterVkCommandBuffers(%" PRIu32 ", %p)", count, commandBuffers);
       for (uint32_t i = 0; i < count; ++i) {
         mIndirectMaps.VkCommandBuffersToVkDevices.erase(commandBuffers[i]);
       }
@@ -280,7 +280,7 @@
   bool Vulkan::toggleVirtualSwapchainReturnAcquiredImage(Stack* stack) {
     auto pSwapchain = stack->pop<VkSwapchainKHR*>();
     if (stack->isValid()) {
-      GAPID_INFO("toggleVirtualSwapchainReturnAcquiredImage(%p)", pSwapchain);
+      GAPID_DEBUG("toggleVirtualSwapchainReturnAcquiredImage(%p)", pSwapchain);
       auto virtual_swapchain = reinterpret_cast<swapchain::VirtualSwapchain*>(*pSwapchain);
       virtual_swapchain->SetAlwaysGetAcquiredImage(true);
       return true;
@@ -315,7 +315,7 @@ uint32_t getMemoryTypeIndex(
     auto pPhysicalDeviceMemoryProperties = stack->pop<VkPhysicalDeviceMemoryProperties*>();
     auto device = stack->pop<VkDevice>();
     if (stack->isValid()) {
-      GAPID_INFO("replayAllocateImageMemory(%" PRIsize ", %" PRIsize ", %p", device, image, pMemory);
+      GAPID_DEBUG("replayAllocateImageMemory(%" PRIsize ", %" PRIsize ", %p", device, image, pMemory);
 
       VkMemoryRequirements image_mem_reqs;
       auto GetImageMemReqFuncPtr = mVkDeviceFunctionStubs[device].vkGetImageMemoryRequirements;
@@ -348,7 +348,7 @@ bool Vulkan::replayGetFenceStatus(Stack* stack, bool pushReturn) {
     auto fence = stack->pop<uint64_t>();
     auto device = static_cast<size_val>(stack->pop<size_val>());
     if (stack->isValid()) {
-        GAPID_INFO("vkGetFenceStatus(%" PRIsize ", %" PRIu64 ")", device, fence);
+        GAPID_DEBUG("vkGetFenceStatus(%" PRIsize ", %" PRIu64 ")", device, fence);
         if (mVkDeviceFunctionStubs.find(device) != mVkDeviceFunctionStubs.end() &&
         mVkDeviceFunctionStubs[device].vkGetFenceStatus) {
             VkResult return_value;
@@ -363,7 +363,7 @@ bool Vulkan::replayGetFenceStatus(Stack* stack, bool pushReturn) {
             } else {
               return_value = mVkDeviceFunctionStubs[device].vkGetFenceStatus(device, fence);
             }
-            GAPID_INFO("Returned: %u", return_value);
+            GAPID_DEBUG("Returned: %u", return_value);
             if (pushReturn) {
                 stack->push<VkResult>(return_value);
             }
@@ -383,14 +383,14 @@ bool Vulkan::replayGetEventStatus(Stack* stack, bool pushReturn) {
     auto event = stack->pop<uint64_t>();
     auto device = static_cast<size_val>(stack->pop<size_val>());
     if (stack->isValid()) {
-        GAPID_INFO("vkGetEventStatus(%" PRIsize ", %" PRIu64 ")", device, event);
+        GAPID_DEBUG("vkGetEventStatus(%" PRIsize ", %" PRIu64 ")", device, event);
         if (mVkDeviceFunctionStubs.find(device) != mVkDeviceFunctionStubs.end() &&
         mVkDeviceFunctionStubs[device].vkGetEventStatus) {
             VkResult return_value;
             do {
                 return_value = mVkDeviceFunctionStubs[device].vkGetEventStatus(device, event);
             } while (wait && (return_value != expected));
-            GAPID_INFO("Returned: %u", return_value);
+            GAPID_DEBUG("Returned: %u", return_value);
             if (pushReturn) {
                 stack->push<VkResult>(return_value);
             }

--- a/gapis/gfxapi/vulkan/android/vulkan_android.api
+++ b/gapis/gfxapi/vulkan/android/vulkan_android.api
@@ -74,54 +74,6 @@ cmd VkResult vkCreateAndroidSurfaceKHR(
 }
 
 // ----------------------------------------------------------------------------
-// VK_ANDROID_native_buffer
-// ----------------------------------------------------------------------------
-
-@extension("VK_ANDROID_native_buffer")
-@unused
-class VkNativeBufferANDROID {
-    VkStructureType                             sType
-    const void*                                 pNext
-    buffer_handle_t                             handle
-    int                                         stride
-    int                                         format
-    int                                         usage
-}
-
-
-@extension("VK_ANDROID_native_buffer")
-@indirect("VkDevice")
-cmd VkResult vkGetSwapchainGrallocUsageANDROID(
-        VkDevice                                device,
-        VkFormat                                format,
-        VkImageUsageFlags                       imageUsage,
-        int*                                    grallocUsage) {
-    return ?
-}
-
-@extension("VK_ANDROID_native_buffer")
-@indirect("VkDevice")
-cmd VkResult vkAcquireImageANDROID(
-        VkDevice                                device,
-        VkImage                                 image,
-        int                                     nativeFenceFd,
-        VkSemaphore                             semaphore,
-        VkFence                                 fence) {
-    return ?
-}
-
-@extension("VK_ANDROID_native_buffer")
-@indirect("VkQueue", "VkDevice")
-cmd VkResult vkQueueSignalReleaseImageANDROID(
-        VkQueue                                 queue,
-        u32                                     waitSemaphoreCount,
-        const VkSemaphore*                      pWaitSemaphores,
-        VkImage                                 image,
-        int*                                    pNativeFenceFd) {
-    return ?
-}
-
-// ----------------------------------------------------------------------------
 // Struct subroutines
 // ----------------------------------------------------------------------------
 

--- a/gapis/gfxapi/vulkan/templates/vk_spy_helpers.cpp.tmpl
+++ b/gapis/gfxapi/vulkan/templates/vk_spy_helpers.cpp.tmpl
@@ -67,7 +67,7 @@ gapid_vkEnumerateInstanceExtensionProperties(const char *pLayerName, uint32_t *p
 VK_LAYER_EXPORT VKAPI_ATTR uint32_t VKAPI_CALL
 gapid_vkEnumerateDeviceLayerProperties(gapii::VkPhysicalDevice device, uint32_t *pCount,
 gapii::VkLayerProperties *pProperties) {
-    return gapii::vkEnumerateInstanceLayerProperties(pCount, pProperties);
+    return gapii::vkEnumerateDeviceLayerProperties(device, pCount, pProperties);
 }
 
 // On android this must also be defined, even if we have 0
@@ -75,7 +75,7 @@ gapii::VkLayerProperties *pProperties) {
 VK_LAYER_EXPORT VKAPI_ATTR uint32_t VKAPI_CALL
 gapid_vkEnumerateDeviceExtensionProperties(gapii::VkPhysicalDevice device, const char *pLayerName, uint32_t *pCount,
 gapii::VkExtensionProperties *pProperties) {
-    return gapii::vkEnumerateInstanceExtensionProperties(pLayerName, pCount, pProperties);
+    return gapii::vkEnumerateDeviceExtensionProperties(device, pLayerName, pCount, pProperties);
 }
 }
 


### PR DESCRIPTION
In some circumstances STDOUT can be redirected/swallowed.
If this is the case we will never get the proper port.

This also adds some preprocessor checks if manually building
with CL.exe.

Cleans up a couple tiny Vulkan bugs, and some verbose output.