### PR TITLE
Fork the context for command mutation.

### DIFF
--- a/gapis/api/CMakeFiles.cmake
+++ b/gapis/api/CMakeFiles.cmake
@@ -25,6 +25,7 @@ set(files
     cmd_errors.go
     cmd_extras.go
     cmd_flags.go
+    cmd_foreach.go
     cmd_id_group_test.go
     cmd_id_group.go
     cmd_id_range.go

--- a/gapis/api/cmd_foreach.go
+++ b/gapis/api/cmd_foreach.go
@@ -1,0 +1,52 @@
+// Copyright (C) 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/gapid/core/context/keys"
+	"github.com/google/gapid/core/event/task"
+)
+
+// ForeachCmd calls the callback cb for each command in cmds.
+// ForeachCmd creates a non-cancellable sub-context to reduce cancellation
+// complexity in the callback function.
+// If cb panics, the error will be annotated with the panicing command index and
+// command.
+func ForeachCmd(ctx context.Context, cmds []Cmd, cb func(context.Context, CmdID, Cmd) error) error {
+	var idx CmdID
+	var cmd Cmd
+	defer func() {
+		if r := recover(); r != nil {
+			panic(fmt.Errorf("Panic at command %v:%v:\n%v", idx, cmd, r))
+		}
+	}()
+
+	subctx := keys.Clone(context.Background(), ctx)
+
+	for i, c := range cmds {
+		idx, cmd = CmdID(i), c
+		if err := cb(subctx, idx, cmd); err != nil {
+			return err
+		}
+		if err := task.StopReason(ctx); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/gapis/api/sync/sync.go
+++ b/gapis/api/sync/sync.go
@@ -107,18 +107,13 @@ func MutateWithSubcommands(ctx context.Context, c *path.Capture, cmds []api.Cmd,
 	}
 	s := rc.NewState()
 
-	for i, cmd := range cmds {
+	return api.ForeachCmd(ctx, cmds, func(ctx context.Context, id api.CmdID, cmd api.Cmd) error {
 		if sync, ok := cmd.API().(SynchronizedAPI); ok {
-			if err := sync.MutateSubcommands(ctx, api.CmdID(i), cmd, s, callback); err != nil && err == context.Canceled {
-				return err
-			}
+			sync.MutateSubcommands(ctx, id, cmd, s, callback)
 		} else {
-			if err := cmd.Mutate(ctx, s, nil); err != nil && err == context.Canceled {
-				return err
-			}
+			cmd.Mutate(ctx, s, nil)
 		}
-		callback(s, api.SubCmdIdx{uint64(i)}, cmd)
-	}
-
-	return nil
+		callback(s, api.SubCmdIdx{uint64(id)}, cmd)
+		return nil
+	})
 }

--- a/gapis/api/templates/api.go.tmpl
+++ b/gapis/api/templates/api.go.tmpl
@@ -79,12 +79,9 @@
     api.Register(API{})
   }
 
-  func panicIfNotCtxCancel(err error) {
-    switch errors.Cause(err) {
-      case nil:
-      case context.Canceled:
-      default:
-        panic(err)
+  func panicOnError(err error) {
+    if err != nil {
+      panic(err)
     }
   }
 {{end}}
@@ -336,7 +333,7 @@
     for i := uint64(0); i < s.count; i++ {
       {{Template "ReadStructFieldsWithRemapping" $}}
     }
-    panicIfNotCtxCancel(d.Error())
+    panicOnError(d.Error())
   {{end}}
 {{end}}
 
@@ -514,7 +511,7 @@
       res := make([]{{$el_ty}}, s.count)
       d := s.Decoder(ϟctx, ϟs)
       ϟmem.Read(d, &res)
-      panicIfNotCtxCancel(d.Error())
+      panicOnError(d.Error())
       return res
     }
 
@@ -525,7 +522,7 @@
       e := s.Slice(0, count, ϟs.MemoryLayout).Encoder(ϟs)
       ϟmem.Write(e, src[:count])
       s.OnWrite(ϟctx, ϟa, ϟs, ϟb)
-      panicIfNotCtxCancel(e.Error())
+      panicOnError(e.Error())
       return count
     }
 
@@ -579,7 +576,7 @@
           ϟb.StorePointer(dst, ptr)
           dst++
         }
-        panicIfNotCtxCancel(d.Error())
+        panicOnError(d.Error())
       {{else if IsClass ($s.To | Underlying)}}
         {{Template "ReadStructWithRemapping" $s.To}}
       {{else}}
@@ -597,7 +594,7 @@
             ϟb.Store(ptr)
             ptr += step
           }
-          panicIfNotCtxCancel(d.Error())
+          panicOnError(d.Error())
         {{else}}
           ϟb.Write(s.Range(ϟl), s.ResourceID(ϟctx, ϟs))
         {{end}}
@@ -631,7 +628,7 @@
           }
           ptr += step
         }
-        panicIfNotCtxCancel(d.Error())
+        panicOnError(d.Error())
       {{end}}
     }
     return s

--- a/gapis/api/transform/dead_code_elimination.go
+++ b/gapis/api/transform/dead_code_elimination.go
@@ -75,11 +75,12 @@ func (t *DeadCodeElimination) Flush(ctx context.Context, out Writer) {
 	t0 := deadCodeEliminationCounter.Start()
 	isLive := t.propagateLiveness(ctx)
 	deadCodeEliminationCounter.Stop(t0)
-	for i, live := range isLive {
-		if live {
-			out.MutateAndWrite(ctx, api.CmdID(i), t.depGraph.Commands[i])
+	api.ForeachCmd(ctx, t.depGraph.Commands[:len(isLive)], func(ctx context.Context, id api.CmdID, cmd api.Cmd) error {
+		if isLive[id] {
+			out.MutateAndWrite(ctx, id, cmd)
 		}
-	}
+		return nil
+	})
 }
 
 // See https://en.wikipedia.org/wiki/Live_variable_analysis

--- a/gapis/api/vulkan/vulkan.go
+++ b/gapis/api/vulkan/vulkan.go
@@ -162,11 +162,12 @@ func (API) ResolveSynchronization(ctx context.Context, d *sync.Data, c *path.Cap
 		commandMap[data.initialCall] = i
 	}
 
-	for idx, cmd := range cmds {
-		i = api.CmdID(idx)
-		if err := cmd.Mutate(ctx, st, nil); err != nil {
-			return err
-		}
+	err = api.ForeachCmd(ctx, cmds, func(ctx context.Context, id api.CmdID, cmd api.Cmd) error {
+		i = id
+		return cmd.Mutate(ctx, st, nil)
+	})
+	if err != nil {
+		return err
 	}
 
 	if lastCmdIndex != api.CmdID(0) {

--- a/gapis/resolve/memory.go
+++ b/gapis/resolve/memory.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 
 	"github.com/google/gapid/core/math/interval"
+	"github.com/google/gapid/gapis/api"
 	"github.com/google/gapid/gapis/capture"
 	"github.com/google/gapid/gapis/memory"
 	"github.com/google/gapid/gapis/service"
@@ -43,10 +44,13 @@ func Memory(ctx context.Context, p *path.Memory) (*service.Memory, error) {
 	if err != nil {
 		return nil, err
 	}
-	for _, a := range cmds[:cmdIdx] {
-		if err := a.Mutate(ctx, s, nil); err != nil && err == context.Canceled {
-			return nil, err
-		}
+
+	err = api.ForeachCmd(ctx, cmds[:cmdIdx], func(ctx context.Context, id api.CmdID, cmd api.Cmd) error {
+		cmd.Mutate(ctx, s, nil)
+		return nil
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	pool, ok := s.Memory[memory.PoolID(p.Pool)]

--- a/gapis/resolve/resource_data.go
+++ b/gapis/resolve/resource_data.go
@@ -77,20 +77,14 @@ func buildResources(ctx context.Context, p *path.Command) (*ResolvedResources, e
 		resources[i] = r
 	}
 
-	for i, cmd := range cmds {
+	err = api.ForeachCmd(ctx, cmds, func(ctx context.Context, id api.CmdID, cmd api.Cmd) error {
 		currentCmdResourceCount = 0
-		currentCmdIndex = uint64(i)
-		if err := cmd.Mutate(ctx, state, nil); err != nil && err == context.Canceled {
-			return nil, err
-		}
-	}
-
-	for i, a := range cmds {
-		currentCmdResourceCount = 0
-		currentCmdIndex = uint64(i)
-		if err := a.Mutate(ctx, state, nil); err != nil && err == context.Canceled {
-			return nil, err
-		}
+		currentCmdIndex = uint64(id)
+		cmd.Mutate(ctx, state, nil)
+		return nil
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	resourceData := make(map[id.ID]interface{})


### PR DESCRIPTION
Removes the need to handle cancellation in the state mutators.

By creating a function that deals with general state mutation loops, we can put the ugliness of context-forking in a single place.

Related to the discussion in the thread of #479.