### PR TITLE
Update the tree-view for mid-execution capture.

### DIFF
--- a/gapis/api/vulkan/vulkan.go
+++ b/gapis/api/vulkan/vulkan.go
@@ -158,9 +158,6 @@ func (API) ResolveSynchronization(ctx context.Context, d *sync.Data, c *path.Cap
 	}
 
 	s.AddCommand = func(a interface{}) {
-		if s.IsRebuilding {
-			return
-		}
 		data := a.(CommandBufferCommand)
 		commandMap[data.initialCall] = i
 	}


### PR DESCRIPTION
All subcommands that were recorded before the start of a mid-execution
capture were showing up as "RecreateInstance", now they show up as the
recreate command that generated them.