### PR TITLE
Fix dependency graph for non-supported APIs

### DIFF
--- a/gapis/resolve/dependencygraph/dependency_graph.go
+++ b/gapis/resolve/dependencygraph/dependency_graph.go
@@ -163,7 +163,7 @@ func (r *DependencyGraphResolvable) Resolve(ctx context.Context) (interface{}, e
 
 	s := c.NewState()
 	t0 := dependencyGraphBuildCounter.Start()
-	err = api.ForeachCmd(ctx, cmds, func(ctx context.Context, id api.CmdID, cmd api.Cmd) error {
+	api.ForeachCmd(ctx, cmds, func(ctx context.Context, id api.CmdID, cmd api.Cmd) error {
 		a := cmd.API()
 		if _, ok := behaviourProviders[a]; !ok {
 			if bp, ok := a.(DependencyGraphBehaviourProvider); ok {
@@ -176,15 +176,16 @@ func (r *DependencyGraphResolvable) Resolve(ctx context.Context) (interface{}, e
 				// info, we still need to mutate it in the new state, because following
 				// atoms in other APIs may depends on the side effect of the current
 				// atom.
-				return cmd.Mutate(ctx, s, nil /* builder */)
+				if err := cmd.Mutate(ctx, s, nil /* builder */); err != nil {
+					log.W(ctx, "Command %v %v: %v", id, cmd, err)
+					g.Behaviours[id].Aborted = true
+				}
+				return nil
 			}
 		}
 		g.Behaviours[id] = behaviourProviders[a].GetBehaviourForAtom(ctx, s, id, cmd, g)
 		return nil
 	})
-	if err != nil {
-		return AtomBehaviour{Aborted: true}, nil
-	}
 	dependencyGraphBuildCounter.Stop(t0)
 	return g, nil
 }


### PR DESCRIPTION
The return value from the function was obviously wrong