### PR TITLE
Check if the semaphore is valid before we change its state.

### DIFF
--- a/gapis/api/vulkan/externs.go
+++ b/gapis/api/vulkan/externs.go
@@ -199,7 +199,9 @@ func (e externs) execPendingCommands(queue VkQueue) {
 func (e externs) recordUpdateSemaphoreSignal(semaphore VkSemaphore, Signaled bool) {
 	signal_semaphore := CommandBufferCommand{
 		function: func(ctx context.Context, cmd api.Cmd, s *api.State, b *rb.Builder) {
-			GetState(s).Semaphores[semaphore].Signaled = Signaled
+			if s, ok := GetState(s).Semaphores[semaphore]; ok {
+				s.Signaled = Signaled
+			}
 		},
 		actualSubmission: false,
 	}


### PR DESCRIPTION
This allows us to replay slightly incorrect applications without
causing a panic.