### PR TITLE
Remove duplicated macro from gles template.

### DIFF
--- a/gapis/api/gles/templates/api_imports.cpp.tmpl
+++ b/gapis/api/gles/templates/api_imports.cpp.tmpl
@@ -46,23 +46,11 @@ namespace gapii {
     {{range $c := AllCommands $}}
       {{if not (GetAnnotation $c "synthetic")}}
         {{$name := Macro "CmdName" $c}}
-        {{$name}} = reinterpret_cast<{{Template "FunctionPtrType" $c}}>(GetGlesProcAddress("{{$name}}", true));
+        {{$name}} = reinterpret_cast<{{Template "C++.FunctionPtrType" $c}}>(GetGlesProcAddress("{{$name}}", true));
       {{end}}
     {{end}}
   }
 ¶
 } // namespace gapii
 ¶
-{{end}}
-
-
-{{/*
--------------------------------------------------------------------------------
-  Emits the typedef function-pointer name for a given command.
--------------------------------------------------------------------------------
-*/}}
-{{define "FunctionPtrType"}}
-  {{AssertType $ "Function"}}
-
-  PFN{{Upper (Macro "CmdName" $)}}
 {{end}}


### PR DESCRIPTION
Already exists in the common templates.