### PR TITLE
core/cc/target.h: Add XXX_ONLY macros.

### DIFF
--- a/core/cc/target.h
+++ b/core/cc/target.h
@@ -22,12 +22,19 @@
 #define GAPID_OS_WINDOWS 3
 #define GAPID_OS_ANDROID 4
 
+#define LINUX_ONLY(x)
+#define OSX_ONLY(x)
+#define WINDOWS_ONLY(x)
+#define ANDROID_ONLY(x)
+
 #if defined(TARGET_OS_LINUX)
 #   define TARGET_OS GAPID_OS_LINUX
 #   define STDCALL
 #   define EXPORT __attribute__ ((visibility ("default")))
 #   define PATH_DELIMITER '/'
 #   define PATH_DELIMITER_STR "/"
+#   undef  LINUX_ONLY
+#   define LINUX_ONLY(x) x
 #endif
 
 #if defined(TARGET_OS_OSX)
@@ -36,6 +43,8 @@
 #   define EXPORT __attribute__ ((visibility ("default")))
 #   define PATH_DELIMITER '/'
 #   define PATH_DELIMITER_STR "/"
+#   undef  OSX_ONLY
+#   define OSX_ONLY(x) x
 #   include <stdint.h>
     using size_val = uint64_t;
 #else  // defined(TARGET_OS_OSX)
@@ -49,6 +58,8 @@
 #   define EXPORT __attribute__ ((visibility ("default")))
 #   define PATH_DELIMITER '/'
 #   define PATH_DELIMITER_STR "/"
+#   undef  ANDROID_ONLY
+#   define ANDROID_ONLY(x) x
 #endif
 
 #if defined(TARGET_OS_WINDOWS)
@@ -57,6 +68,8 @@
 #   define EXPORT __declspec(dllexport)
 #   define PATH_DELIMITER '\\'
 #   define PATH_DELIMITER_STR "\\"
+#   undef  WINDOWS_ONLY
+#   define WINDOWS_ONLY(x) x
 #endif
 
 #ifndef TARGET_OS


### PR DESCRIPTION
Makes platform-dependent one-liners more readable.