### PR TITLE
Don't crash, trying to clean up GL, when the app exits.

### DIFF
--- a/gapic/src/platform/linux/com/google/gapid/glcanvas/GlCanvas.java
+++ b/gapic/src/platform/linux/com/google/gapid/glcanvas/GlCanvas.java
@@ -15,7 +15,6 @@
  */
 package com.google.gapid.glcanvas;
 
-import org.eclipse.swt.SWT;
 import org.eclipse.swt.opengl.GLCanvas;
 import org.eclipse.swt.opengl.GLData;
 import org.eclipse.swt.widgets.Composite;
@@ -24,7 +23,11 @@ import org.eclipse.swt.widgets.Composite;
 public class GlCanvas extends GLCanvas {
   public GlCanvas(Composite parent, int style) {
     super(parent, style, getGlData());
-    addListener(SWT.Dispose, e -> terminate());
+    // TODO: hook in the the terminate - currently the dispose event would always be *after* the
+    // parent's dispose handling, which destroys the context and looses the context pointer. The
+    // below can thus lead to crashes if any context is bound on the current thread (UI thread, so
+    // this does indeed happen).
+    //addListener(SWT.Dispose, e -> terminate());
   }
 
   private static GLData getGlData() {
@@ -37,7 +40,6 @@ public class GlCanvas extends GLCanvas {
 
   /**
    * Override to perform GL cleanup handling.
-   * TODO: Actually call this function *before* the context is destroyed. Is this even possible?
    */
   protected void terminate() {}
 }


### PR DESCRIPTION
This is just to avoid the crash, which causes things like the settings to
not be persistent, but does not fix the underlying problem. We may need
to fork and alter SWT's GLCanvas on Linux as well after all, to fix it.