### PR TITLE
Add histogram data to report.

### DIFF
--- a/cmd/gapit/flags.go
+++ b/cmd/gapit/flags.go
@@ -97,9 +97,10 @@ type (
 	InfoFlags struct {
 	}
 	ReportFlags struct {
-		Gapis GapisFlags
-		Gapir GapirFlags
-		Out   string `help:"output report path"`
+		Gapis     GapisFlags
+		Gapir     GapirFlags
+		Out       string `help:"output report path"`
+		Histogram bool   `help:"output observed vs replayed difference histogram"`
 		CommandFilterFlags
 	}
 	VideoFlags struct {

--- a/cmd/gapit/video.go
+++ b/cmd/gapit/video.go
@@ -117,7 +117,7 @@ func (verb *videoVerb) regularVideoSource(
 	for i, e := range eofEvents {
 		i, e := i, e
 		executor(ctx, func(ctx context.Context) error {
-			if frame, err := getFrame(ctx, verb.VideoFlags, e.Command, device, client); err == nil {
+			if frame, err := getFrame(ctx, verb.Max.Width, verb.Max.Height, e.Command, device, client); err == nil {
 				rendered[i] = flipImg(frame)
 			} else {
 				errors[i] = err
@@ -337,9 +337,9 @@ func (verb *videoVerb) encodeVideo(ctx context.Context, filepath string, vidFun 
 	return nil
 }
 
-func getFrame(ctx context.Context, flags VideoFlags, cmd *path.Command, device *path.Device, client service.Service) (*image.NRGBA, error) {
+func getFrame(ctx context.Context, maxWidth, maxHeight int, cmd *path.Command, device *path.Device, client service.Service) (*image.NRGBA, error) {
 	ctx = log.V{"cmd": cmd.Indices}.Bind(ctx)
-	settings := &service.RenderSettings{MaxWidth: uint32(flags.Max.Width), MaxHeight: uint32(flags.Max.Height)}
+	settings := &service.RenderSettings{MaxWidth: uint32(maxWidth), MaxHeight: uint32(maxHeight)}
 	iip, err := client.GetFramebufferAttachment(ctx, device, cmd, api.FramebufferAttachment_Color0, settings, nil)
 	if err != nil {
 		return nil, log.Errf(ctx, err, "GetFramebufferAttachment failed")


### PR DESCRIPTION
Gapit report will now optionally output histogram data with the flag
'-histogram'. This data is in the following format:

[Histogram] frame #{1}, [{2},({3},{4},{5},{6})], ... )]
1 - the number of the captured frame that was tested
2 - the difference bin* of this group.
3 - the number of pixels with red channels in this bin.
4-6 - the number of pixels with green, blue, and alpha channels in 2
* each bin represents a difference range to calculate the range do the
following:
min := (bin-1)*255/(binMax+1)
max := bin*255/(binMax+1)
binMax is the number of bins total (currently 32)

This is a quick and dirty way to get the histogram data over to robot.
Better representations will most likely lead to better performance and
usefulness.