### PR TITLE
Fix object view in robot webserver and uploads.

### DIFF
--- a/cmd/robot/master.go
+++ b/cmd/robot/master.go
@@ -88,7 +88,7 @@ func (v *masterVerb) Run(ctx context.Context, flags flag.FlagSet) error {
 	}
 	tempDir := file.Abs(tempName)
 	restart := false
-	serverAddress := fmt.Sprintf("localhost:%v", v.Port)
+	serverAddress := fmt.Sprintf(":%v", v.Port)
 	err = grpcutil.Serve(ctx, serverAddress, func(ctx context.Context, listener net.Listener, server *grpc.Server) error {
 		managers := monitor.Managers{}
 		err := error(nil)


### PR DESCRIPTION
When the format of build ToolSets changed it broke a part of the data
gathering functionality in the webserver. There was already a TODO to
change it to use the proto directly rather than using the json and
assuming the format doesn't change so I took it as mine for the future.

The master server was only listening from localhost for uploading
subjects and artifacts. Now it accepts from any valid connection, so I
can upload from another computer.