### PR TITLE
deep.MustClone() was not copying read observations.

### DIFF
--- a/gapis/api/vulkan/vulkan_terminator.go
+++ b/gapis/api/vulkan/vulkan_terminator.go
@@ -17,7 +17,6 @@ package vulkan
 import (
 	"context"
 
-	"github.com/google/gapid/core/data/deep"
 	"github.com/google/gapid/core/log"
 	"github.com/google/gapid/gapis/api"
 	"github.com/google/gapid/gapis/api/sync"
@@ -314,7 +313,8 @@ func cutCommandBuffer(ctx context.Context, id api.CmdID,
 	// idx[2] is the command index in the primary command-buffer
 	// idx[3] is the secondary command buffer index inside a vkCmdExecuteCommands
 	// idx[4] is the secondary command inside the secondary command-buffer
-	submitCopy := deep.MustClone(a).(*VkQueueSubmit)
+	submitCopy := cb.VkQueueSubmit(a.Queue, a.SubmitCount, a.PSubmits, a.Fence, a.Result)
+	submitCopy.Extras().MustClone(a.Extras().All()...)
 
 	newCommandBuffers := make([]VkCommandBuffer, 1)
 	lastSubmit := uint64(0)


### PR DESCRIPTION
Switch out deep.MustClone() for Extras().MustClone() as deep.MustClone()
was not picking up the extras.