### PR TITLE
gapir/windows/gles_renderer: Don't rage-quit if tear-down errors.

### DIFF
--- a/gapir/cc/windows/gles_renderer.cpp
+++ b/gapir/cc/windows/gles_renderer.cpp
@@ -99,13 +99,13 @@ WGL::PBuffer::PBuffer(HPBUFFERARB pbuf, HGLRC ctx, HDC hdc) : mPBuf(pbuf), mCtx(
 WGL::PBuffer::~PBuffer() {
     auto wgl = WGL::get();
     if (!wgl.ReleasePbufferDCARB(mPBuf, mHDC)) {
-        GAPID_FATAL("Failed to release HDC. Error: 0x%x", GetLastError());
+        GAPID_ERROR("Failed to release HDC. Error: 0x%x", GetLastError());
     }
     if (!wgl.DestroyPbufferARB(mPBuf)) {
-        GAPID_FATAL("Failed to destroy pbuffer. Error: 0x%x", GetLastError());
+        GAPID_ERROR("Failed to destroy pbuffer. Error: 0x%x", GetLastError());
     }
     if (!wglDeleteContext(mCtx)) {
-        GAPID_FATAL("Failed to delete GL context. Error: 0x%x", GetLastError());
+        GAPID_ERROR("Failed to delete GL context. Error: 0x%x", GetLastError());
     }
 }
 
@@ -155,6 +155,9 @@ WGL::WGL() {
     }
 
     mHDC = GetDC(mWindow);
+    if (mHDC == nullptr) {
+        GAPID_FATAL("GetDC failed. Error: 0x%x", GetLastError());
+    }
 
     PIXELFORMATDESCRIPTOR pfd;
     memset(&pfd, 0, sizeof(pfd));


### PR DESCRIPTION
There's not much to gain by quitting GAPIR at this point. In my experience tear-down functions tend to be more buggy than setup & core functions.

Assuming there's a real error being raised, these still get logged. Setup errors are still fatal, so assuming context creation succeeded, there's now at least the possibility that something renders.

Issue: #834