### PR TITLE
gapis/gles: Fix FB requests stalling forever.

### DIFF
--- a/gapis/api/cmd_id.go
+++ b/gapis/api/cmd_id.go
@@ -28,6 +28,11 @@ func (id CmdID) Derived() CmdID {
 	return id | derivedBit
 }
 
+// IsReal returns true if the id is not derived nor CmdNoID.
+func (id CmdID) IsReal() bool {
+	return id != CmdNoID && (id&derivedBit) == 0
+}
+
 const derivedBit = CmdID(1 << 62)
 
 func (id CmdID) String() string {

--- a/gapis/api/gles/replay.go
+++ b/gapis/api/gles/replay.go
@@ -131,14 +131,15 @@ func (a API) Replay(
 			// TODO: Remove this and handle swap-buffers better.
 			deadCodeElimination.Request(req.after - 1)
 
+			thread := cmds[req.after].Thread()
 			switch req.attachment {
 			case api.FramebufferAttachment_Depth:
-				readFramebuffer.Depth(req.after, rr.Result)
+				readFramebuffer.depth(req.after, thread, rr.Result)
 			case api.FramebufferAttachment_Stencil:
 				return fmt.Errorf("Stencil buffer attachments are not currently supported")
 			default:
 				idx := uint32(req.attachment - api.FramebufferAttachment_Color0)
-				readFramebuffer.Color(req.after, req.width, req.height, idx, rr.Result)
+				readFramebuffer.color(req.after, thread, req.width, req.height, idx, rr.Result)
 			}
 
 			cfg := cfg.(drawConfig)


### PR DESCRIPTION
If you request a frame at a command that aborts, the DCE will remove that command from the execution list. The `readFramebuffer` transform then never sees the CmdID it's waiting for, and the request is never completed.

Instead, change `readFramebuffer` to keep an ordered list of requests. If the next command is skipped, read the framebuffer at the next command instead.

Many thanks to @baldwinn860 for the simple repro case.