### PR TITLE
gapis/vulkan: Don't propagate ErrCmdAborted in ResolveSynchronization.

### DIFF
--- a/gapis/api/vulkan/vulkan.go
+++ b/gapis/api/vulkan/vulkan.go
@@ -164,7 +164,8 @@ func (API) ResolveSynchronization(ctx context.Context, d *sync.Data, c *path.Cap
 
 	err = api.ForeachCmd(ctx, cmds, func(ctx context.Context, id api.CmdID, cmd api.Cmd) error {
 		i = id
-		return cmd.Mutate(ctx, st, nil)
+		cmd.Mutate(ctx, st, nil)
+		return nil
 	})
 	if err != nil {
 		return err

--- a/gapis/resolve/command_tree.go
+++ b/gapis/resolve/command_tree.go
@@ -235,7 +235,7 @@ func (r *CommandTreeResolvable) Resolve(ctx context.Context) (interface{}, error
 
 	syncData, err := database.Build(ctx, &SynchronizationResolvable{p.Capture})
 	if err != nil {
-		return nil, err
+		return nil, log.Errf(ctx, nil, "Error building sync data")
 	}
 	snc, ok := syncData.(*sync.Data)
 	if !ok {


### PR DESCRIPTION
This error will bubble all the way up to the RPC, preventing the command tree from loading.