### PR TITLE
Fix a crash due to interface conversion

### DIFF
--- a/gapis/api/cmd_id_group.go
+++ b/gapis/api/cmd_id_group.go
@@ -406,7 +406,7 @@ func (c *SubCmdRoot) Insert(base []uint64, r []uint64) {
 		if len(c.SubGroup.Spans) == 0 {
 			c.SubGroup.Spans = Spans{&CmdIDRange{CmdID(0), id + 1}}
 		}
-		r := c.SubGroup.Spans[0].(*CmdIDRange)
+		r := c.SubGroup.Spans[0].Bounds()
 		r.End = id + 1
 	}
 }


### PR DESCRIPTION
Not quite sure if this is a correct fix, but otherwise gapis crashes for some cases as:
```
panic: interface conversion: api.Span is *api.SubCmdRoot, not
*api.CmdIDRange [recovered]
```

