### PR TITLE
Fix crash in deviceinfo query.

### DIFF
--- a/core/os/device/deviceinfo/cc/instance.cpp
+++ b/core/os/device/deviceinfo/cc/instance.cpp
@@ -20,10 +20,14 @@
 extern "C" {
 
 device_instance get_device_instance(void* platform_data) {
+    device_instance out = {};
+
     auto instance = query::getDeviceInstance(platform_data);
+    if (!instance) {
+        return out;
+    }
 
     // Reserialize the instance with the ID field.
-    device_instance out;
     out.size = instance->ByteSize();
     out.data = new uint8_t[out.size];
     instance->SerializeToArray(out.data, out.size);


### PR DESCRIPTION
query::getDeviceInstance could return null, but was never checked in
get_device_instance before dereferencing, causing a crash when it
failed.

Test case is calling host.getHostDevice while accessing a headless
instance, which causes glXCreateNewContext to fail from within
createContext.