### PR TITLE
Fix a crash due to grouping in SubCmdRoot

### DIFF
--- a/gapis/api/cmd_id_group.go
+++ b/gapis/api/cmd_id_group.go
@@ -375,15 +375,13 @@ func (g *CmdIDGroup) AddRoot(rootidx []uint64) *SubCmdRoot {
 		case *CmdIDGroup:
 			return first.AddRoot(rootidx)
 		case *CmdIDRange:
-			firstHalf := &CmdIDRange{first.Start, first.End}
-			firstHalf.End = CmdID(rootidx[len(rootidx)-1])
+			firstHalf := &CmdIDRange{first.Start, CmdID(rootidx[len(rootidx)-1]}
 			if firstHalf.End > firstHalf.Start {
 				slice.InsertBefore(&g.Spans, s, firstHalf)
 				s++
 			}
 			slice.Replace(&g.Spans, s, 1, NewRoot(rootidx))
-			secondHalf := &CmdIDRange{first.Start, first.End}
-			secondHalf.Start = CmdID(rootidx[len(rootidx)-1] + 1)
+			secondHalf := &CmdIDRange{CmdID(rootidx[len(rootidx)-1] + 1), first.End}
 			slice.InsertBefore(&g.Spans, s+1, secondHalf)
 			return g.Spans[s].(*SubCmdRoot)
 		default:

--- a/gapis/resolve/command_tree.go
+++ b/gapis/resolve/command_tree.go
@@ -17,6 +17,7 @@ package resolve
 import (
 	"context"
 	"fmt"
+	"sort"
 
 	"github.com/google/gapid/core/context/keys"
 	"github.com/google/gapid/core/log"
@@ -114,7 +115,8 @@ func CommandTreeNode(ctx context.Context, c *path.CommandTreeNode) (*service.Com
 			NumCommands: count,
 		}, nil
 	default:
-		panic(fmt.Errorf("Unexpected type: %T", item))
+		panic(fmt.Errorf("Unexpected type: %T, cmdTree.index(c.Indices): %v, indices: %v",
+			item, cmdTree.index(c.Indices), c.Indices))
 	}
 }
 
@@ -319,6 +321,8 @@ func (r *CommandTreeResolvable) Resolve(ctx context.Context) (interface{}, error
 
 	for k, v := range snc.SubcommandGroups {
 		r := out.root.AddRoot([]uint64{uint64(k)})
+		// subcommands are added before nested SubCmdRoots.
+		sort.SliceStable(v, func(i, j int) bool { return len(v[i]) < len(v[j]) })
 		for _, x := range v {
 			r.Insert([]uint64{uint64(k)}, append([]uint64{}, x...))
 		}


### PR DESCRIPTION
Otherwise gapis crash as:
```
panic: interface conversion: api.Span is *api.SubCmdRoot, not
*api.CmdIDRange [recovered]
```

Fix issue #880 

Generally, for SubCmdRoot, Subcommand should be added first (this only expand the single range of the subcommands in SubCmdRoot) and nested SubCmdRoots are added later (to divides the single range into multiple pieces).

Also, for SubCmdRoot, the Bounds() function should returns the inner-most index range. For a SubCmdRoot of vkQueueSubmit, the length of its ID is just 1, and we add this SubCmdRoot by intersecting with the top-level CmdIDGroup (the root), using the inner-most index (as there is only one) is correct.

For subcommand in a vkQueueSubmit, its SubCmdRoot (e.g. vkCmdExecuteCommands) will be intersected with the corresponding nesting sub group of vkQueueSubmit. We still should be using the inner-most index of the subcommand as the return of Bounds(). It is not right to use the outer-most index (which is the index of the vkQueueSubmit command) to locate the subcommand in the nesting sub group of vkQueueSubmit.