### PR TITLE
Added MIME type to info for log file uploads.

### DIFF
--- a/test/robot/replay/client.go
+++ b/test/robot/replay/client.go
@@ -113,7 +113,7 @@ func doReplay(ctx context.Context, action string, in *Input, store *stash.Client
 	log.I(ctx, output)
 
 	outputObj := &Output{}
-	logID, err := store.UploadString(ctx, stash.Upload{Name: []string{"replay.log"}}, output)
+	logID, err := store.UploadString(ctx, stash.Upload{Name: []string{"replay.log"}, Type: []string{"text/plain"}}, output)
 	if err != nil {
 		return outputObj, err
 	}

--- a/test/robot/report/client.go
+++ b/test/robot/report/client.go
@@ -94,7 +94,7 @@ func doReport(ctx context.Context, action string, in *Input, store *stash.Client
 	log.I(ctx, output)
 
 	outputObj := &Output{}
-	logID, err := store.UploadString(ctx, stash.Upload{Name: []string{"report.log"}}, output)
+	logID, err := store.UploadString(ctx, stash.Upload{Name: []string{"report.log"}, Type: []string{"text/plain"}}, output)
 	if err != nil {
 		return outputObj, err
 	}

--- a/test/robot/trace/client.go
+++ b/test/robot/trace/client.go
@@ -179,7 +179,7 @@ func doTrace(ctx context.Context, action string, in *Input, store *stash.Client,
 	}
 
 	outputObj := &Output{}
-	logID, err := store.UploadString(ctx, stash.Upload{Name: []string{"trace.log"}}, output)
+	logID, err := store.UploadString(ctx, stash.Upload{Name: []string{"trace.log"}, Type: []string{"text/plain"}}, output)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Log files were just getting uploaded as byte streams and most mime
lookup tables don't handle .log as a file extension. Just add the type
manually in the upload call.

This makes it so one can click on a log file in robot without having to 
download it.