### PR TITLE
Remove variable names from error messages.

### DIFF
--- a/gapis/api/gles/gles.api
+++ b/gapis/api/gles/gles.api
@@ -53,31 +53,32 @@ sub void supportsBits(GLbitfield seenBits, GLbitfield validBits) {
   if (seenBits & validBits) != seenBits { glErrorInvalidValue() }
 }
 
-sub void glErrorInvalidEnum(GLenum param) {
+sub void glErrorInvalidEnum(GLenum value) {
+  glErrorInvalidEnumMsg(new!ERR_INVALID_ENUM(value: as!u32(value)))
+}
+
+sub void glErrorInvalidEnumMsg(message m) {
   onGlError(GL_INVALID_ENUM)
-  // TODO: be more specific in callers
-  _ = newMsg(SEVERITY_ERROR, new!ERR_INVALID_ENUM_VALUE(value: 0,variable:  "variable"))
-  abort
-}
-
-sub void glErrorInvalidValue() {
-  onGlError(GL_INVALID_VALUE)
-  _ = newMsg(SEVERITY_ERROR, new!ERR_INVALID_VALUE(value: "value",variable:  "variable"))
-  abort
-}
-
-sub void glErrorInvalidOperation() {
-  glErrorInvalidOperationMsg(new!ERR_INVALID_OPERATION(operation: "operation"))
-}
-
-sub void glErrorInvalidOperationMsg(message m) {
-  onGlError(GL_INVALID_OPERATION)
   _ = newMsg(SEVERITY_ERROR, m)
   abort
 }
 
+sub void glErrorInvalidValue() {
+  glErrorInvalidValueMsg(new!ERR_INVALID_VALUE())
+}
+
 sub void glErrorInvalidValueMsg(message m) {
   onGlError(GL_INVALID_VALUE)
+  _ = newMsg(SEVERITY_ERROR, m)
+  abort
+}
+
+sub void glErrorInvalidOperation() {
+  glErrorInvalidOperationMsg(new!ERR_INVALID_OPERATION())
+}
+
+sub void glErrorInvalidOperationMsg(message m) {
+  onGlError(GL_INVALID_OPERATION)
   _ = newMsg(SEVERITY_ERROR, m)
   abort
 }

--- a/gapis/messages/en-us.stb.md
+++ b/gapis/messages/en-us.stb.md
@@ -25,15 +25,15 @@ The slice {{from_value}}:{{to_value}} for {{from_variable}}:{{to_variable}} is o
 
 # ERR_INVALID_VALUE
 
-Invalid value {{value}} for {{variable}}.
+Invalid value.
 
-# ERR_INVALID_ENUM_VALUE
+# ERR_INVALID_ENUM
 
-Invalid enum value {{value:u32}} for {{variable:string}}.
+Invalid enum {{value:u32}}.
 
 # ERR_INVALID_OPERATION
 
-Invalid operation: {{operation}}.
+Invalid operation.
 
 # ERR_CONTEXT_DOES_NOT_EXIST
 

--- a/gapis/resolve/framebuffer_attachment_data.go
+++ b/gapis/resolve/framebuffer_attachment_data.go
@@ -56,7 +56,7 @@ func (r *FramebufferAttachmentBytesResolvable) Resolve(ctx context.Context) (int
 	case service.WireframeMode_Overlay:
 		wireframeMode = replay.WireframeMode_Overlay
 	default:
-		return nil, &service.ErrInvalidArgument{Reason: messages.ErrInvalidEnumValue(wireframeMode, "WireframeMode")}
+		return nil, &service.ErrInvalidArgument{Reason: messages.ErrInvalidEnum(wireframeMode)}
 	}
 
 	mgr := replay.GetManager(ctx)


### PR DESCRIPTION
We never set them to anything meaningful.