### PR TITLE
Robot: Fix error handling in trace client

### DIFF
--- a/test/robot/replay/replay.proto
+++ b/test/robot/replay/replay.proto
@@ -44,6 +44,8 @@ message Output {
   string log = 1;
   // Video is the movie of the replay frame capture output.
   string video = 2;
+  // CallError is the error string returned by the call to gapit.
+  string call_error = 3;
 }
 
 // Action holds the information about an execution of a task.

--- a/test/robot/report/client.go
+++ b/test/robot/report/client.go
@@ -49,7 +49,11 @@ func (c *client) report(ctx context.Context, t *Task) error {
 	if err != nil {
 		status = job.Failed
 		log.E(ctx, "Error running report: %v", err)
+	} else if output.CallError != "" {
+		status = job.Failed
+		log.E(ctx, "Error during report: %v", output.CallError)
 	}
+
 	return c.manager.Update(ctx, t.Action, status, output)
 }
 
@@ -94,6 +98,9 @@ func doReport(ctx context.Context, action string, in *Input, store *stash.Client
 	log.I(ctx, output)
 
 	outputObj := &Output{}
+	if callErr != nil {
+		outputObj.CallError = callErr.Error()
+	}
 	logID, err := store.UploadString(ctx, stash.Upload{Name: []string{"report.log"}, Type: []string{"text/plain"}}, output)
 	if err != nil {
 		return outputObj, err
@@ -104,5 +111,5 @@ func doReport(ctx context.Context, action string, in *Input, store *stash.Client
 		return outputObj, err
 	}
 	outputObj.Report = reportID
-	return outputObj, callErr
+	return outputObj, nil
 }

--- a/test/robot/report/report.proto
+++ b/test/robot/report/report.proto
@@ -36,6 +36,8 @@ message Output{
   string log = 1;
   // Report is the stash id of the generated report file.
   string report = 2;
+  // CallError is the error string returned by the call to gapit.
+  string call_error = 3;
 }
 
 // Action holds the information about an execution of a task.

--- a/test/robot/trace/client.go
+++ b/test/robot/trace/client.go
@@ -121,7 +121,7 @@ func (r *runner) trace(ctx context.Context, t *Task) (err error) {
 	status := job.Succeeded
 	if err != nil {
 		status = job.Failed
-		log.F(ctx, "Error running trace: %v", err)
+		log.E(ctx, "Error running trace: %v", err)
 	}
 	return r.manager.Update(ctx, t.Action, status, output)
 }

--- a/test/robot/trace/client.go
+++ b/test/robot/trace/client.go
@@ -122,6 +122,9 @@ func (r *runner) trace(ctx context.Context, t *Task) (err error) {
 	if err != nil {
 		status = job.Failed
 		log.E(ctx, "Error running trace: %v", err)
+	} else if output.CallError != "" {
+		status = job.Failed
+		log.E(ctx, "Error during trace: %v", output.CallError)
 	}
 	return r.manager.Update(ctx, t.Action, status, output)
 }
@@ -177,6 +180,9 @@ func doTrace(ctx context.Context, action string, in *Input, store *stash.Client,
 	log.I(ctx, output)
 
 	outputObj := &Output{}
+	if callErr != nil {
+		outputObj.CallError = callErr.Error()
+	}
 	logID, err := store.UploadString(ctx, stash.Upload{Name: []string{"trace.log"}, Type: []string{"text/plain"}}, output)
 	if err != nil {
 		return nil, err
@@ -187,7 +193,7 @@ func doTrace(ctx context.Context, action string, in *Input, store *stash.Client,
 		return nil, err
 	}
 	outputObj.Trace = traceID
-	return outputObj, callErr
+	return outputObj, nil
 }
 
 type offlineDevice struct {

--- a/test/robot/trace/client.go
+++ b/test/robot/trace/client.go
@@ -172,11 +172,9 @@ func doTrace(ctx context.Context, action string, in *Input, store *stash.Client,
 		"-gapii-device", d.Instance().Serial,
 	}
 	cmd := shell.Command(gapit.System(), params...)
-	output, err := cmd.Call(ctx)
+	output, callErr := cmd.Call(ctx)
 	output = fmt.Sprintf("%s\n\n%s", cmd, output)
-	if err != nil {
-		return nil, log.Errf(ctx, err, "gapit call failed %v", output)
-	}
+	log.I(ctx, output)
 
 	outputObj := &Output{}
 	logID, err := store.UploadString(ctx, stash.Upload{Name: []string{"trace.log"}, Type: []string{"text/plain"}}, output)
@@ -189,7 +187,7 @@ func doTrace(ctx context.Context, action string, in *Input, store *stash.Client,
 		return nil, err
 	}
 	outputObj.Trace = traceID
-	return outputObj, nil
+	return outputObj, callErr
 }
 
 type offlineDevice struct {

--- a/test/robot/trace/trace.proto
+++ b/test/robot/trace/trace.proto
@@ -47,6 +47,8 @@ message Output {
   string log = 1;
   // Trace is the stash id of the generated trace file.
   string trace = 2;
+  // CallError is the error string returned by the call to gapit.
+  string call_error = 3;
 }
 
 // Action holds the information about an execution of a task.


### PR DESCRIPTION
When traces failed we would get no logs, because of the way the error codes were being handled, and then crash, because of the way errors from doTrace were handled. This fixes those.