### PR TITLE
core/app: Fix tail of log getting dropped.

### DIFF
--- a/core/app/log.go
+++ b/core/app/log.go
@@ -83,19 +83,19 @@ func updateContext(ctx context.Context, flags *LogFlags, closeLogs func()) (cont
 		}
 		log.I(ctx, "Logging to: %v", flags.File)
 		// Build the logging context
-		handler := flags.Style.Handler(func(s string, _ log.Severity) {
+		handler := wrapHandler(flags.Style.Handler(func(s string, _ log.Severity) {
 			file.WriteString(s)
 			file.WriteString("\n")
-		})
-		ctx = log.PutHandler(ctx, wrapHandler(handler))
+		}))
+		ctx = log.PutHandler(ctx, handler)
 		closeLogs()
 		closeLogs = func() {
 			handler.Close()
 			file.Close()
 		}
 	} else {
-		handler := flags.Style.Handler(log.Std())
-		ctx = log.PutHandler(ctx, wrapHandler(handler))
+		handler := wrapHandler(flags.Style.Handler(log.Std()))
+		ctx = log.PutHandler(ctx, handler)
 		closeLogs()
 		closeLogs = handler.Close
 	}

--- a/core/app/run.go
+++ b/core/app/run.go
@@ -133,6 +133,7 @@ func Run(main task.Task) {
 		return
 	}
 	ctx, closeLogs = updateContext(ctx, &flags.Log, closeLogs)
+	defer closeLogs()
 	endProfile := applyProfiler(ctx, &flags.Profile)
 	// Defer the shutdown code
 	defer func() {


### PR DESCRIPTION
`wrapHandler()` creates a channel which needs to be closed.
The closing logic was acting on the inner log handler, resulting in the channel never getting flushed.

Fixes: #752