### PR TITLE
Always show free-form text box when editing enums.

### DIFF
--- a/gapic/src/main/com/google/gapid/util/Paths.java
+++ b/gapic/src/main/com/google/gapid/util/Paths.java
@@ -51,7 +51,10 @@ public class Paths {
 
   public static Path.Any commandTree(Path.Capture capture, FilteringContext context) {
     return Path.Any.newBuilder().setCommandTree(
-        context.commandTree(Path.CommandTree.newBuilder()).setCapture(capture).setMaxChildren(2000).setMaxNeighbours(20))
+        context.commandTree(Path.CommandTree.newBuilder())
+            .setCapture(capture)
+            .setMaxChildren(2000)
+            .setMaxNeighbours(20))
         .build();
   }
 

--- a/gapic/src/main/com/google/gapid/widgets/Widgets.java
+++ b/gapic/src/main/com/google/gapid/widgets/Widgets.java
@@ -556,6 +556,12 @@ public class Widgets {
     return combo;
   }
 
+  public static Combo createEditDropDown(Composite parent) {
+    Combo combo = new Combo(parent, SWT.DROP_DOWN);
+    combo.setVisibleItemCount(10);
+    return combo;
+  }
+
   public static ComboViewer createDropDownViewer(Composite parent) {
     return createDropDownViewer(createDropDown(parent));
   }


### PR DESCRIPTION
Show the free-form text box along with the drop down when editing an enum to allow the application to show and the user to type a value that is not part of the known constants.

Fixes #764