### PR TITLE
Fix "text file busy" in robot.

### DIFF
--- a/core/os/shell/local.go
+++ b/core/os/shell/local.go
@@ -17,6 +17,8 @@ package shell
 import (
 	"context"
 	"os/exec"
+	"strings"
+	"time"
 
 	"github.com/google/gapid/core/event/task"
 	"github.com/google/gapid/core/log"
@@ -30,19 +32,43 @@ var (
 type localTarget struct{}
 
 type localProcess struct {
-	exec *exec.Cmd
+	exec  *exec.Cmd
+	nbusy int
 }
 
 func (localTarget) Start(cmd Cmd) (Process, error) {
 	p := &localProcess{
-		exec: exec.Command(cmd.Name, cmd.Args...),
+		exec:  exec.Command(cmd.Name, cmd.Args...),
+		nbusy: 0,
 	}
 	p.exec.Dir = cmd.Dir
 	p.exec.Stdout = cmd.Stdout
 	p.exec.Stderr = cmd.Stderr
 	p.exec.Stdin = cmd.Stdin
 	p.exec.Env = cmd.Environment.Vars()
-	return p, p.exec.Start()
+	// HACK:(baldwinn860)
+	// On Unix systems the fork/exec model can hold a file descriptor open for a
+	// very short amount of time (between the fork and the exec) in the child
+	// process. If another thread has a executable being written before the fork
+	// happens (to avoid the syscall.ForkLock), and before the exec happens it
+	// finishes the write and executes itself, it can give an ETXTBUSY. This is
+	// extremely short lived, but causes bugs in robot where we download and run
+	// many executables in separate threads. Unfortunately the accepted fix for
+	// this sort of issue is to do retry attempts with a wait in order to give
+	// first child time to close-on-exec all of it's fds.
+	// fix source: https://groups.google.com/forum/#!topic/golang-dev/4efaTJ5uA8Y
+	// context: https://golang.org/src/syscall/exec_unix.go?h=StartProcess#L17
+	for {
+		err := p.exec.Start()
+
+		// wait times are 100+200+400ms == 0.7s which seems reasonable.
+		if err != nil && p.nbusy < 3 && strings.Contains(err.Error(), "text file busy") {
+			time.Sleep(100 * time.Millisecond << uint(p.nbusy))
+			p.nbusy++
+		} else {
+			return p, err
+		}
+	}
 }
 
 func (p *localProcess) Wait(ctx context.Context) error {
@@ -50,6 +76,9 @@ func (p *localProcess) Wait(ctx context.Context) error {
 	go func() { res <- p.exec.Wait() }()
 	select {
 	case err := <-res:
+		if err == nil && p.nbusy > 0 {
+			log.I(ctx, "Busy process completed successfully after %d retries", p.nbusy)
+		}
 		return err
 	case <-task.ShouldStop(ctx):
 		log.W(ctx, "Killing %v (context cancelled)", p.exec.Path)


### PR DESCRIPTION
An unfortunate side effect of unix' fork/exec model is that between fork
and exec file descriptors marked for close-on-exec are still open in
the child process. This is usually perfectly acceptable, but not when
writing and executing test binaries in quick succession on separate
threads. This fix is very ugly, but is currently the accepted solution
to this problem, more details about it are in the large hack comment in
the file.

Also to see how many processes this fixes, added a log message to Wait
when there are no errors.

There seems to be a related error that occurs far less often where GAPIS 
server starts successfully, but then exits immediately with status 1.