### PR TITLE
Fix tracing on multiple devices simultaneously.

### DIFF
--- a/test/robot/job/worker/action.go
+++ b/test/robot/job/worker/action.go
@@ -118,6 +118,8 @@ func (a *Actions) do(ctx context.Context, w *Worker, input Input) (string, error
 
 // update an action, and return the merged action.
 func (a *Actions) update(ctx context.Context, action Action) error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
 	return a.ledger.Add(ctx, action)
 }
 


### PR DESCRIPTION
The mixture of a deferred mutex unlock and a channel receive call made
it so the actions list would wait for one trace task to finish before
starting the next one. Moving the mutex fixed the issue.