### PR TITLE
Ensure GLSL variables are initialized

### DIFF
--- a/gapis/shadertools/cc/libmanager.cpp
+++ b/gapis/shadertools/cc/libmanager.cpp
@@ -211,6 +211,7 @@ code_with_debug_info_t* convertGlsl(const char* input, size_t length, const opti
   }
   my_manager.renameViewIndex();
   my_manager.removeLayoutLocations();
+  my_manager.initLocals();
 
   std::vector<unsigned int> spirv_new = my_manager.getSpvBinary();
 

--- a/gapis/shadertools/cc/spv_manager.h
+++ b/gapis/shadertools/cc/spv_manager.h
@@ -90,6 +90,7 @@ class SpvManager {
   void mapDeclarationNames(std::string = "x");
   void renameViewIndex();
   void removeLayoutLocations();
+  void initLocals();
   void makeSpvDebuggable();
   std::vector<unsigned int> getSpvBinary();
   debug_instructions_t* getDebugInstructions();


### PR DESCRIPTION
The compat layer sometimes creates code which uses uninitialized
variables.  Although the output is technically correct, it makes
my driver complain a lot.