### PR TITLE
Fix a bug in Memory tracker

### DIFF
--- a/core/memory_tracker/cc/memory_tracker.cpp
+++ b/core/memory_tracker/cc/memory_tracker.cpp
@@ -88,7 +88,19 @@ bool MemoryTracker::RemoveTrackingRangeImpl(void* start, size_t size) {
   size_t size_aligned = GetAlignedSize(start, size, page_size_);
   dirty_pages_.RecollectIfPossible(size_aligned / page_size_);
   // TODO(qining): Add Windows support
-  return mprotect(start_page_addr, size_aligned, PROT_WRITE | PROT_READ) == 0;
+  bool can_be_removed = true;
+  for (uint8_t* p = reinterpret_cast<uint8_t*>(start_page_addr);
+      p < reinterpret_cast<uint8_t*>(start_page_addr)+size_aligned;
+      p = p + page_size_) {
+    if (IsInRanges(reinterpret_cast<uintptr_t>(p), ranges_, true)) {
+      can_be_removed = false;
+      break;
+    }
+  }
+  if (can_be_removed) {
+    return mprotect(start_page_addr, size_aligned, PROT_WRITE | PROT_READ) == 0;
+  }
+  return true;
 }
 
 bool MemoryTracker::ClearTrackingRangesImpl() {


### PR DESCRIPTION
When removing a range from tracking, if the range shares pages with
other range, the shared page should not be granted with RW permission.

Also add a test for it.

Two other tests are updated too, as the underlying behaviour changed.
