### PR TITLE
gapis: Filter SubcommandGroups too

### DIFF
--- a/core/data/slice/slice.go
+++ b/core/data/slice/slice.go
@@ -50,6 +50,20 @@ func Remove(s, v interface{}) {
 	ptr.Elem().Set(out)
 }
 
+// RemoveAt removes n elements from s starting at i.
+// s must be a pointer to a slice.
+func RemoveAt(s interface{}, i, n int) {
+	ptr, slice := getSlicePtr(s)
+	out := New(slice.Type(), 0, slice.Len()-n)
+	//  aaaaa XXXXXX bbbbbb
+	// 0     i      j      e
+	e := slice.Len()
+	j := i + n
+	out = reflect.AppendSlice(out, slice.Slice(0, i))
+	out = reflect.AppendSlice(out, slice.Slice(j, e))
+	ptr.Elem().Set(out)
+}
+
 // InsertBefore inserts v before the i'th element in s.
 // s must be a pointer to a slice.
 // v can be a slice or a single element.

--- a/core/data/slice/slice_test.go
+++ b/core/data/slice/slice_test.go
@@ -85,6 +85,39 @@ func TestRemove(t *testing.T) {
 	}
 }
 
+func TestRemoveAt(t *testing.T) {
+	ctx := log.Testing(t)
+
+	for _, test := range []struct {
+		data     []int
+		i, n     int
+		expected []int
+	}{
+		// No removal.
+		{[]int{1, 2, 3}, 0, 0, []int{1, 2, 3}},
+		{[]int{1, 2, 3}, 1, 0, []int{1, 2, 3}},
+		{[]int{1, 2, 3}, 2, 0, []int{1, 2, 3}},
+
+		// Single removal.
+		{[]int{1, 2, 3}, 0, 1, []int{2, 3}},
+		{[]int{1, 2, 3}, 1, 1, []int{1, 3}},
+		{[]int{1, 2, 3}, 2, 1, []int{1, 2}},
+
+		// Double removal.
+		{[]int{1, 2, 3}, 0, 2, []int{3}},
+		{[]int{1, 2, 3}, 1, 2, []int{1}},
+
+		// All.
+		{[]int{1, 2, 3}, 0, 3, []int{}},
+	} {
+		got := make([]int, len(test.data))
+		copy(got, test.data)
+		slice.RemoveAt(&got, test.i, test.n)
+		assert.For(ctx, "RemoveAt(%v, %v, %v)", test.data, test.i, test.n).
+			That(got).DeepEquals(test.expected)
+	}
+}
+
 func TestInsertBefore(t *testing.T) {
 	ctx := log.Testing(t)
 

--- a/gapis/api/cmd_id_group.go
+++ b/gapis/api/cmd_id_group.go
@@ -520,9 +520,10 @@ func (g *CmdIDGroup) Cluster(maxChildren, maxNeighbours uint64) {
 			}
 		}
 		for _, s := range g.Spans {
-			if _, isCmdIDRange := s.(*CmdIDRange); isCmdIDRange {
+			switch s.(type) {
+			case *CmdIDRange, *SubCmdRoot:
 				accum = append(accum, s)
-			} else {
+			default:
 				flush()
 				spans = append(spans, s)
 			}


### PR DESCRIPTION
These were being added with no consideration for the filtering.

To implement this I changed `CmdIDGroup.AddAtoms()` into `AddCommand()` and `Cluster()`.
This is a cleaner API anyway.