### PR TITLE
Robot: Fix GAPIS busy

### DIFF
--- a/core/os/shell/local.go
+++ b/core/os/shell/local.go
@@ -17,8 +17,6 @@ package shell
 import (
 	"context"
 	"os/exec"
-	"strings"
-	"time"
 
 	"github.com/google/gapid/core/event/task"
 	"github.com/google/gapid/core/log"
@@ -32,43 +30,19 @@ var (
 type localTarget struct{}
 
 type localProcess struct {
-	exec  *exec.Cmd
-	nbusy int
+	exec *exec.Cmd
 }
 
 func (localTarget) Start(cmd Cmd) (Process, error) {
 	p := &localProcess{
-		exec:  exec.Command(cmd.Name, cmd.Args...),
-		nbusy: 0,
+		exec: exec.Command(cmd.Name, cmd.Args...),
 	}
 	p.exec.Dir = cmd.Dir
 	p.exec.Stdout = cmd.Stdout
 	p.exec.Stderr = cmd.Stderr
 	p.exec.Stdin = cmd.Stdin
 	p.exec.Env = cmd.Environment.Vars()
-	// HACK:(baldwinn860)
-	// On Unix systems the fork/exec model can hold a file descriptor open for a
-	// very short amount of time (between the fork and the exec) in the child
-	// process. If another thread has a executable being written before the fork
-	// happens (to avoid the syscall.ForkLock), and before the exec happens it
-	// finishes the write and executes itself, it can give an ETXTBUSY. This is
-	// extremely short lived, but causes bugs in robot where we download and run
-	// many executables in separate threads. Unfortunately the accepted fix for
-	// this sort of issue is to do retry attempts with a wait in order to give
-	// first child time to close-on-exec all of it's fds.
-	// fix source: https://groups.google.com/forum/#!topic/golang-dev/4efaTJ5uA8Y
-	// context: https://golang.org/src/syscall/exec_unix.go?h=StartProcess#L17
-	for {
-		err := p.exec.Start()
-
-		// wait times are 100+200+400ms == 0.7s which seems reasonable.
-		if err != nil && p.nbusy < 3 && strings.Contains(err.Error(), "text file busy") {
-			time.Sleep(100 * time.Millisecond << uint(p.nbusy))
-			p.nbusy++
-		} else {
-			return p, err
-		}
-	}
+	return p, p.exec.Start()
 }
 
 func (p *localProcess) Wait(ctx context.Context) error {
@@ -76,9 +50,6 @@ func (p *localProcess) Wait(ctx context.Context) error {
 	go func() { res <- p.exec.Wait() }()
 	select {
 	case err := <-res:
-		if err == nil && p.nbusy > 0 {
-			log.I(ctx, "Busy process completed successfully after %d retries", p.nbusy)
-		}
 		return err
 	case <-task.ShouldStop(ctx):
 		log.W(ctx, "Killing %v (context cancelled)", p.exec.Path)

--- a/test/robot/replay/client.go
+++ b/test/robot/replay/client.go
@@ -17,6 +17,7 @@ package replay
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/google/gapid/core/app/layout"
 	"github.com/google/gapid/core/log"
@@ -33,6 +34,13 @@ type client struct {
 	tempDir file.Path
 }
 
+type retryError struct {
+}
+
+func (r retryError) Error() string {
+	return "try again"
+}
+
 // Run starts new replay client if any hardware is available.
 func Run(ctx context.Context, store *stash.Client, manager Manager, tempDir file.Path) error {
 	c := &client{store: store, manager: manager, tempDir: tempDir}
@@ -44,17 +52,21 @@ func (c *client) replay(ctx context.Context, t *Task) error {
 	if err := c.manager.Update(ctx, t.Action, job.Running, nil); err != nil {
 		return err
 	}
-	output, err := doReplay(ctx, t.Action, t.Input, c.store, c.tempDir)
-	status := job.Succeeded
-	if err != nil {
-		status = job.Failed
-		log.E(ctx, "Error running replay: %v", err)
-	} else if output.CallError != "" {
-		status = job.Failed
-		log.E(ctx, "Error during replay: %v", output.CallError)
-	}
+	for {
+		output, err := doReplay(ctx, t.Action, t.Input, c.store, c.tempDir)
+		status := job.Succeeded
+		if _, ok := err.(retryError); ok {
+			continue
+		} else if err != nil {
+			status = job.Failed
+			log.E(ctx, "Error running replay: %v", err)
+		} else if output.CallError != "" {
+			status = job.Failed
+			log.E(ctx, "Error during replay: %v", output.CallError)
+		}
 
-	return c.manager.Update(ctx, t.Action, status, output)
+		return c.manager.Update(ctx, t.Action, status, output)
+	}
 }
 
 func doReplay(ctx context.Context, action string, in *Input, store *stash.Client, tempDir file.Path) (*Output, error) {
@@ -113,13 +125,19 @@ func doReplay(ctx context.Context, action string, in *Input, store *stash.Client
 	}
 	cmd := shell.Command(gapit.System(), params...)
 	output, callErr := cmd.Call(ctx)
-	output = fmt.Sprintf("%s\n\n%s", cmd, output)
-	log.I(ctx, output)
+	if strings.Contains(output, "text file busy") || strings.Contains(output, "Failed to connect to the GAPIS server") || (callErr != nil && strings.Contains(callErr.Error(), "text file busy")) {
+		return nil, retryError{}
+	}
 
 	outputObj := &Output{}
 	if callErr != nil {
+		if strings.Contains(callErr.Error(), "text file busy") {
+			return nil, retryError{}
+		}
 		outputObj.CallError = callErr.Error()
 	}
+	output = fmt.Sprintf("%s\n\n%s", cmd, output)
+	log.I(ctx, output)
 	logID, err := store.UploadString(ctx, stash.Upload{Name: []string{"replay.log"}, Type: []string{"text/plain"}}, output)
 	if err != nil {
 		return outputObj, err

--- a/test/robot/report/client.go
+++ b/test/robot/report/client.go
@@ -17,7 +17,7 @@ package report
 import (
 	"context"
 	"fmt"
-	"strings"
+	"time"
 
 	"github.com/google/gapid/core/app/layout"
 	"github.com/google/gapid/core/log"
@@ -25,6 +25,7 @@ import (
 	"github.com/google/gapid/core/os/file"
 	"github.com/google/gapid/core/os/shell"
 	"github.com/google/gapid/test/robot/job"
+	"github.com/google/gapid/test/robot/job/worker"
 	"github.com/google/gapid/test/robot/stash"
 )
 
@@ -32,13 +33,6 @@ type client struct {
 	store   *stash.Client
 	manager Manager
 	tempDir file.Path
-}
-
-type retryError struct {
-}
-
-func (r retryError) Error() string {
-	return "try again"
 }
 
 // Run starts new report client if any hardware is available.
@@ -52,21 +46,21 @@ func (c *client) report(ctx context.Context, t *Task) error {
 	if err := c.manager.Update(ctx, t.Action, job.Running, nil); err != nil {
 		return err
 	}
-	for {
-		output, err := doReport(ctx, t.Action, t.Input, c.store, c.tempDir)
-		status := job.Succeeded
-		if _, ok := err.(retryError); ok {
-			continue
-		} else if err != nil {
-			status = job.Failed
-			log.E(ctx, "Error running report: %v", err)
-		} else if output.CallError != "" {
-			status = job.Failed
-			log.E(ctx, "Error during report: %v", output.CallError)
-		}
-
-		return c.manager.Update(ctx, t.Action, status, output)
+	var output *Output
+	err := worker.RetryFunction(ctx, 4, time.Millisecond*100, func() (err error) {
+		output, err = doReport(ctx, t.Action, t.Input, c.store, c.tempDir)
+		return
+	})
+	status := job.Succeeded
+	if err != nil {
+		status = job.Failed
+		log.E(ctx, "Error running report: %v", err)
+	} else if output.CallError != "" {
+		status = job.Failed
+		log.E(ctx, "Error during report: %v", output.CallError)
 	}
+
+	return c.manager.Update(ctx, t.Action, status, output)
 }
 
 func doReport(ctx context.Context, action string, in *Input, store *stash.Client, tempDir file.Path) (*Output, error) {
@@ -106,14 +100,14 @@ func doReport(ctx context.Context, action string, in *Input, store *stash.Client
 	}
 	cmd := shell.Command(gapit.System(), params...)
 	output, callErr := cmd.Call(ctx)
-	if strings.Contains(output, "text file busy") || strings.Contains(output, "Failed to connect to the GAPIS server") || (callErr != nil && strings.Contains(callErr.Error(), "text file busy")) {
-		return nil, retryError{}
+	if err := worker.NeedsRetry(output, "Failed to connect to the GAPIS server"); err != nil {
+		return nil, err
 	}
 
 	outputObj := &Output{}
 	if callErr != nil {
-		if strings.Contains(callErr.Error(), "text file busy") {
-			return nil, retryError{}
+		if err := worker.NeedsRetry(callErr.Error()); err != nil {
+			return nil, err
 		}
 		outputObj.CallError = callErr.Error()
 	}


### PR DESCRIPTION
This moves retry logic from os.shell and into robot.job.worker. This way the actual output of the underlying call can be checked to see if we need to perform a retry. This is still a hack to get around the actual problem, but this bug seems to be too subtle to spend any more time on when it only happens in the test infra. There is logging to provide insight into how many retries are attempted before the task eventually succeeds.