### PR TITLE
Fix issues with mid-execution capture in Vulkan.

### DIFF
--- a/gapis/api/templates/api_types.h.tmpl
+++ b/gapis/api/templates/api_types.h.tmpl
@@ -162,7 +162,7 @@
 
     {{if $is_cmd_buffer}}
       std::vector<std::function<void(CallObserver* observer)>> commands;
-      std::vector<std::function<void(CallObserver* observer)>> recreateCommands;
+      std::vector<std::function<bool(CallObserver* observer)>> recreateCommands;
     {{end}}
     {{if $is_shader_module}}
       std::vector<uint32_t> shaderWords;


### PR DESCRIPTION
There were 2 issues here that were fixed.
First, sometimes if we were reacreating descriptor sets, we
would not correctly check for validitiy for COMBINED_IMAGE_SAMPLER

Secondly if we could not correctly recreate a command-buffer,
i.e. it contains a command that is no longer valid. (Referencing
a deleted resource), we would just skip the invalid commands, now
we stop recording the command buffer at that point, since we can
get into invalid states otherwise.