### PR TITLE
gapic: Fix gapit arguments.

### DIFF
--- a/gapic/src/main/com/google/gapid/server/Tracer.java
+++ b/gapic/src/main/com/google/gapid/server/Tracer.java
@@ -194,11 +194,9 @@ public class Tracer {
         cmd.add(device.getSerial());
       }
 
-      cmd.add("-clear-cache");
-      cmd.add(Boolean.toString(clearCache));
+      cmd.add("-clear-cache=" + Boolean.toString(clearCache));
 
-      cmd.add("-disable-pcs");
-      cmd.add(Boolean.toString(disablePcs));
+      cmd.add("-disable-pcs=" + Boolean.toString(disablePcs));
 
       if (pkg != null) {
         cmd.add("-android-package");


### PR DESCRIPTION
Booleans are special and require a different style for passing.