### PR TITLE
egl.api: Don't error if calling eglMakeCurrent twice on the same thread.

### DIFF
--- a/gapis/api/gles/api/egl.api
+++ b/gapis/api/gles/api/egl.api
@@ -255,9 +255,8 @@ cmd EGLBoolean eglMakeCurrent(EGLDisplay display,
                               EGLSurface draw,
                               EGLSurface read,
                               EGLContext context) {
-  if (context == null) {
-    SetContext(null)
-  } else if context in EGLContexts {
+  SetContext(null)
+  if context in EGLContexts {
     ctx := EGLContexts[context]
     if ctx.Other.IsBound {
       _ = newMsg(SEVERITY_ERROR, new!ERR_CONTEXT_BOUND(id: as!u64(context)))


### PR DESCRIPTION
It is only an error if the context is bound to multiple threads.