### PR TITLE
gapii: Connect under thread suspension.

### DIFF
--- a/gapii/cc/connection_header.cpp
+++ b/gapii/cc/connection_header.cpp
@@ -49,35 +49,21 @@ bool ConnectionHeader::read(core::StreamReader* reader) {
         return false;
     }
 
-    const int kMinSupportedVersion = 2;
-    const int kMaxSupportedVersion = 5;
+    const int kMinSupportedVersion = 1;
+    const int kMaxSupportedVersion = 1;
 
     if (mVersion < kMinSupportedVersion || mVersion > kMaxSupportedVersion) {
         GAPID_WARNING("Unsupported ConnectionHeader version %d. Only understand [%d to %d].",
                 mVersion, kMinSupportedVersion, kMaxSupportedVersion);
         return false;
     }
-    if (mVersion >= 2) {
-        if (!reader->read(mObserveFrameFrequency) ||
-            !reader->read(mObserveDrawFrequency)) {
-            return false;
-        }
-    }
-    if (mVersion >= 4) {
-        if (!reader->read(mStartFrame) ||
-            !reader->read(mNumFrames)) {
-            return false;
-        }
-    }
-    if (mVersion >= 5) {
-        if (!reader->read(mAPIs)) {
-            return false;
-        }
-    }
-    if (mVersion >= 3) {
-        if (!reader->read(mFlags)) {
-            return false;
-        }
+    if (!reader->read(mObserveFrameFrequency) ||
+        !reader->read(mObserveDrawFrequency) ||
+        !reader->read(mStartFrame) ||
+        !reader->read(mNumFrames) ||
+        !reader->read(mAPIs) ||
+        !reader->read(mFlags)) {
+        return false;
     }
 
     // Insert new version handling here. Don't forget to bump kMaxSupportedVersion!

--- a/gapii/cc/connection_header.h
+++ b/gapii/cc/connection_header.h
@@ -47,13 +47,13 @@ public:
     bool read(core::StreamReader* reader);
 
     uint8_t  mMagic[4];                     // 's', 'p', 'y', '0'
-    uint32_t mVersion;                      // 2 or 3
-    uint32_t mObserveFrameFrequency;        // non-zero == enabled. Version: 2+
-    uint32_t mObserveDrawFrequency;         // non-zero == enabled. Version: 2+
-    uint32_t mStartFrame;                   // non-zero == Frame to start at. version 4+
-    uint32_t mNumFrames;                    // non-zero == Number of frames to capture. version 4+
-    uint32_t mAPIs;                         // Bitset of APIS to enable. version 5+
-    uint32_t mFlags;                        // Combination of FLAG_XX bits. Version: 3+
+    uint32_t mVersion;                      // 1
+    uint32_t mObserveFrameFrequency;        // non-zero == enabled.
+    uint32_t mObserveDrawFrequency;         // non-zero == enabled.
+    uint32_t mStartFrame;                   // non-zero == Frame to start at.
+    uint32_t mNumFrames;                    // non-zero == Number of frames to capture.
+    uint32_t mAPIs;                         // Bitset of APIS to enable.
+    uint32_t mFlags;                        // Combination of FLAG_XX bits.
 };
 
 } // namespace gapii

--- a/gapii/cc/spy.cpp
+++ b/gapii/cc/spy.cpp
@@ -51,6 +51,7 @@ extern "C"
 jint JNI_OnLoad(JavaVM *vm, void *reserved) {
     GAPID_INFO("JNI_OnLoad() was called. vm = %p", vm);
     gJavaVM = vm;
+    gapii::Spy::get(); // Construct the spy.
     return JNI_VERSION_1_6;
 }
 void* queryPlatformData() {

--- a/gapii/client/capture.go
+++ b/gapii/client/capture.go
@@ -15,6 +15,7 @@
 package client
 
 import (
+	"bufio"
 	"context"
 	"fmt"
 	"io"
@@ -90,18 +91,56 @@ func (s siSize) String() string {
 	return fmt.Sprintf(f, v)
 }
 
-func capture(ctx context.Context, port int, s task.Signal, w io.Writer, o Options) (int64, error) {
-	if task.Stopped(ctx) {
-		return 0, nil
+func (p *Process) connect(ctx context.Context) error {
+	log.I(ctx, "Waiting for connection to localhost:%d...", p.Port)
+
+	// ADB has an annoying tendancy to insta-close forwarded sockets when
+	// there's no application waiting for the connection. Treat errors as
+	// another waiting-for-connection case.
+	return task.Retry(ctx, 0, 500*time.Millisecond, func(ctx context.Context) error {
+		conn, err := net.Dial("tcp", fmt.Sprintf("localhost:%d", p.Port))
+		if err != nil {
+			log.D(ctx, "Dial failed: %v", err)
+			return err
+		}
+		if err := sendHeader(conn, p.Options); err != nil {
+			log.D(ctx, "Failed to send header: %v", err)
+			conn.Close()
+			return err
+		}
+		r := bufio.NewReader(conn)
+		conn.SetReadDeadline(time.Now().Add(time.Millisecond * 500))
+		if _, err := r.Peek(4); err != nil {
+			log.D(ctx, "Failed to read data: %v", err)
+			conn.Close()
+			return err
+		}
+		p.conn = bufConn{conn, r}
+		return nil
+	})
+}
+
+type bufConn struct {
+	net.Conn
+	r io.Reader
+}
+
+func (c bufConn) Read(b []byte) (n int, err error) { return c.r.Read(b) }
+
+// Capture opens up the specified port and then waits for a capture to be
+// delivered using the specified capture options o.
+// It copies the capture into the supplied writer.
+// If the process was started with the DeferStart flag, then tracing will wait
+// until s is fired.
+func (p *Process) Capture(ctx context.Context, s task.Signal, w io.Writer) (int64, error) {
+	if p.conn == nil {
+		if err := p.connect(ctx); err != nil {
+			return 0, err
+		}
 	}
-	conn, err := net.Dial("tcp", fmt.Sprintf("localhost:%d", port))
-	if err != nil {
-		return 0, nil // Treat failure-to-connect as target-not-ready instead of an error.
-	}
+
+	conn := p.conn
 	defer conn.Close()
-	if err := sendHeader(conn, o); err != nil {
-		return 0, log.Err(ctx, err, "Header send failed")
-	}
 
 	var count, nextSize siSize
 	startTime := time.Now()
@@ -112,7 +151,7 @@ func capture(ctx context.Context, port int, s task.Signal, w io.Writer, o Option
 			log.I(ctx, "Stop: %v", count)
 			break
 		}
-		if (o.Flags & DeferStart) != 0 {
+		if (p.Options.Flags & DeferStart) != 0 {
 			if !started && s.Fired() {
 				started = true
 				w := endian.Writer(conn, device.LittleEndian)
@@ -148,30 +187,4 @@ func capture(ctx context.Context, port int, s task.Signal, w io.Writer, o Option
 		}
 	}
 	return int64(count), nil
-}
-
-// Capture opens up the specified port and then waits for a capture to be
-// delivered using the specified capture options.
-// It copies the capture into the supplied writer.
-func Capture(ctx context.Context, port int, s task.Signal, w io.Writer, options Options) (int64, error) {
-	log.I(ctx, "Waiting for connection to localhost:%d...", port)
-	for {
-		count, err := capture(ctx, port, s, w, options)
-		if err != nil {
-			return count, err
-		}
-		if count != 0 {
-			return count, nil
-		}
-		// ADB has an annoying tendancy to insta-close forwarded sockets when
-		// there's no application waiting for the connection. Treat this as
-		// another waiting-for-connection case.
-		select {
-		case <-task.ShouldStop(ctx):
-			log.I(ctx, "Aborted.")
-			return 0, nil
-		case <-time.After(500 * time.Millisecond):
-			log.I(ctx, "Retry...")
-		}
-	}
 }

--- a/gapii/client/header.go
+++ b/gapii/client/header.go
@@ -23,19 +23,19 @@ import (
 
 var magic = [4]byte{'s', 'p', 'y', '0'}
 
-const version = 5
+const version = 1
 
 // The GAPII header is defined as:
 //
 // struct ConnectionHeader {
-//   uint8_t  mMagic[4];                     // 's', 'p', 'y', '0'
-//   uint32_t mVersion;                      // 2+
-//   uint32_t mObserveFrameFrequency;        // non-zero == enabled. Version: 2+
-//   uint32_t mObserveDrawFrequency;         // non-zero == enabled. Version: 2+
-//   uint32_t mStartFrame;                   // non-zero == Frame to start at. version 4+
-//   uint32_t mNumFrames;                    // non-zero == Number of frames to capture. version 4+
-//   uint32_t mAPIs;                         // Bitset of APIS to enable. version 5+
-//   uint32_t mFlags;                        // Combination of FLAG_XX bits. Version: 3+
+//     uint8_t  mMagic[4];                    // 's', 'p', 'y', '0'
+//     uint32_t mVersion;                     // 1
+//     uint32_t mObserveFrameFrequency;       // non-zero == enabled.
+//     uint32_t mObserveDrawFrequency;        // non-zero == enabled.
+//     uint32_t mStartFrame;                  // non-zero == Frame to start at.
+//     uint32_t mNumFrames;                   // non-zero == Number of frames to capture.
+//     uint32_t mAPIs;                        // Bitset of APIS to enable.
+//     uint32_t mFlags;                       // Combination of FLAG_XX bits.
 // };
 //
 // All fields are encoded little-endian with no compression, regardless of
@@ -54,5 +54,6 @@ func sendHeader(out io.Writer, options Options) error {
 	w.Uint32(options.FramesToCapture)
 	w.Uint32(options.APIs)
 	w.Uint32(uint32(options.Flags))
+
 	return w.Error()
 }


### PR DESCRIPTION
I believe some traces were failing as we were attempting to connect after we had let threads continue execution. Instead connect while the debugger is still attached. 

There's no point dealing with versioning in the connection header at this point, so remove the conditional logic.



