### PR TITLE
Robot: Fix error handling in retry procedure.

### DIFF
--- a/test/robot/job/worker/worker.go
+++ b/test/robot/job/worker/worker.go
@@ -76,11 +76,11 @@ type TaskRetryError struct {
 // This is the idiomatic method of creating a TaskRetryError and if no need for a retry exists it returns nil.
 func NeedsRetry(reason string, retryStrings ...string) error {
 	if strings.Contains(reason, "text file busy") {
-		return &TaskRetryError{Reason: reason}
+		return TaskRetryError{Reason: reason}
 	}
 	for _, retryString := range retryStrings {
 		if strings.Contains(reason, retryString) {
-			return &TaskRetryError{Reason: reason}
+			return TaskRetryError{Reason: reason}
 		}
 	}
 	return nil


### PR DESCRIPTION
The NeedsRetry call was returning pointers to TaskRetryErrors, which
does not fulfil the type assertion checked for in RetryFunction.
Bug manifested as retries causing immediate failure, and no output
generated for failing calls.