### PR TITLE
Migrate build dimension

### DIFF
--- a/test/robot/monitor/trace.go
+++ b/test/robot/monitor/trace.go
@@ -36,6 +36,17 @@ func (t *Traces) All() []*Trace {
 	return t.entries
 }
 
+// MatchPackage returns the set of Trace objects that were traced with a specific package.
+func (t *Traces) MatchPackage(p *Package) []*Trace {
+	result := []*Trace{}
+	for _, trace := range t.entries {
+		if trace.Input.Package == p.Id {
+			result = append(result, trace)
+		}
+	}
+	return result
+}
+
 func (o *DataOwner) updateTrace(ctx context.Context, action *trace.Action) error {
 	o.Write(func(data *Data) {
 		entry, _ := data.Traces.FindOrCreate(ctx, action)

--- a/test/robot/replay/replay.proto
+++ b/test/robot/replay/replay.proto
@@ -36,6 +36,8 @@ message Input {
   // VirtualSwapChainLib is the stash id of the vulkan virtual-swap-chain loader
   // json file.
   string virtual_swap_chain_json = 6;
+  // Package is the stash id of the package used to generate the report.
+  string package = 7;
 }
 
 // Output holds the outputs of a replay action.

--- a/test/robot/report/report.proto
+++ b/test/robot/report/report.proto
@@ -28,6 +28,8 @@ message Input{
   string gapit = 2;
   // Gapis is the stash id of the graphics analysis server to use.
   string gapis = 3;
+  // Package is the stash id of the package used to generate the report.
+  string package = 4;
 }
 
 // Output describes the outputs of a report action.

--- a/test/robot/scheduler/replay.go
+++ b/test/robot/scheduler/replay.go
@@ -24,36 +24,20 @@ import (
 	"github.com/google/gapid/test/robot/replay"
 )
 
-func (s schedule) getReplayTargetTools(ctx context.Context) *build.ToolSet {
-	ctx = log.V{"target": s.worker.Target}.Bind(ctx)
-	tools := s.pkg.FindTools(ctx, s.data.FindDevice(s.worker.Target))
-	if tools == nil {
-		return nil
-	}
-	if tools.Host.Gapir == "" {
-		return nil
-	}
-	return tools
-}
-
-func (s schedule) doReplay(ctx context.Context, t *monitor.Trace) error {
+func (s schedule) doReplay(ctx context.Context, t *monitor.Trace, tools *build.ToolSet) error {
 	if !s.worker.Supports(job.Replay) {
 		return nil
 	}
 	ctx = log.Enter(ctx, "Replay")
 	ctx = log.V{"Package": s.pkg.Id}.Bind(ctx)
-	hostTools := s.getHostTools(ctx)
-	targetTools := s.getReplayTargetTools(ctx)
-	if hostTools == nil || targetTools == nil {
-		return log.Err(ctx, nil, "Failed to find tools for report!")
-	}
 	input := &replay.Input{
 		Trace:                t.Action.Output.Trace,
-		Gapit:                hostTools.Host.Gapit,
-		Gapis:                hostTools.Host.Gapis,
-		Gapir:                targetTools.Host.Gapir,
-		VirtualSwapChainLib:  targetTools.Host.VirtualSwapChainLib,
-		VirtualSwapChainJson: targetTools.Host.VirtualSwapChainJson,
+		Gapit:                tools.Host.Gapit,
+		Gapis:                tools.Host.Gapis,
+		Gapir:                tools.Host.Gapir,
+		VirtualSwapChainLib:  tools.Host.VirtualSwapChainLib,
+		VirtualSwapChainJson: tools.Host.VirtualSwapChainJson,
+		Package:                s.pkg.Id,
 	}
 	action := &replay.Action{
 		Input:  input,

--- a/test/robot/scheduler/replay.go
+++ b/test/robot/scheduler/replay.go
@@ -37,7 +37,7 @@ func (s schedule) doReplay(ctx context.Context, t *monitor.Trace, tools *build.T
 		Gapir:                tools.Host.Gapir,
 		VirtualSwapChainLib:  tools.Host.VirtualSwapChainLib,
 		VirtualSwapChainJson: tools.Host.VirtualSwapChainJson,
-		Package:                s.pkg.Id,
+		Package:              s.pkg.Id,
 	}
 	action := &replay.Action{
 		Input:  input,

--- a/test/robot/scheduler/report.go
+++ b/test/robot/scheduler/report.go
@@ -18,25 +18,23 @@ import (
 	"context"
 
 	"github.com/google/gapid/core/log"
+	"github.com/google/gapid/test/robot/build"
 	"github.com/google/gapid/test/robot/job"
 	"github.com/google/gapid/test/robot/monitor"
 	"github.com/google/gapid/test/robot/report"
 )
 
-func (s schedule) doReport(ctx context.Context, t *monitor.Trace) error {
+func (s schedule) doReport(ctx context.Context, t *monitor.Trace, tools *build.ToolSet) error {
 	if !s.worker.Supports(job.Report) {
 		return nil
 	}
 	ctx = log.Enter(ctx, "Report")
 	ctx = log.V{"Package": s.pkg.Id}.Bind(ctx)
-	hostTools := s.getHostTools(ctx)
-	if hostTools == nil {
-		return log.Err(ctx, nil, "Failed to find tools for report!")
-	}
 	input := &report.Input{
-		Trace: t.Action.Output.Trace,
-		Gapit: hostTools.Host.Gapit,
-		Gapis: hostTools.Host.Gapis,
+		Trace:   t.Action.Output.Trace,
+		Gapit:   tools.Host.Gapit,
+		Gapis:   tools.Host.Gapis,
+		Package: s.pkg.Id,
 	}
 	action := &report.Action{
 		Input:  input,

--- a/test/robot/scheduler/scheduler.go
+++ b/test/robot/scheduler/scheduler.go
@@ -49,23 +49,27 @@ func Tick(ctx context.Context, managers *monitor.Managers, data *monitor.Data) [
 		s.pkg = pkg
 		for _, w := range data.Workers.All() {
 			s.worker = w
-			for _, subj := range data.Subjects.All() {
-				if err := s.doTrace(ctx, subj); err != nil {
-					errs = append(errs, err)
+			if tools := s.getHostTools(ctx); tools != nil {
+				for _, subj := range data.Subjects.All() {
+					if android_tools := s.getAndroidTools(ctx, subj); android_tools != nil {
+						if err := s.doTrace(ctx, subj, tools, android_tools); err != nil {
+							errs = append(errs, err)
+						}
+					}
 				}
-			}
-			for _, t := range data.Traces.All() {
-				if t.Status != job.Succeeded {
-					continue
-				}
-				if t.Output == nil {
-					continue
-				}
-				if err := s.doReport(ctx, t); err != nil {
-					errs = append(errs, err)
-				}
-				if err := s.doReplay(ctx, t); err != nil {
-					errs = append(errs, err)
+				for _, t := range data.Traces.All() {
+					if t.Status != job.Succeeded {
+						continue
+					}
+					if t.Output == nil {
+						continue
+					}
+					if err := s.doReport(ctx, t, tools); err != nil {
+						errs = append(errs, err)
+					}
+					if err := s.doReplay(ctx, t, tools); err != nil {
+						errs = append(errs, err)
+					}
 				}
 			}
 		}
@@ -86,6 +90,24 @@ func (s schedule) getHostTools(ctx context.Context) *build.ToolSet {
 		return nil
 	}
 	if tools.Host.Gapir == "" {
+		return nil
+	}
+	if tools.Host.VirtualSwapChainLib == "" {
+		return nil
+	}
+	if tools.Host.VirtualSwapChainJson == "" {
+		return nil
+	}
+	return tools
+}
+
+func (s schedule) getAndroidTools(ctx context.Context, subj *monitor.Subject) *build.AndroidToolSet {
+	ctx = log.V{"target": s.worker.Target}.Bind(ctx)
+	tools := s.pkg.FindToolsForAPK(ctx, s.data.FindDevice(s.worker.Host), s.data.FindDevice(s.worker.Target), subj.GetAPK())
+	if tools == nil {
+		return nil
+	}
+	if tools.GapidApk == "" {
 		return nil
 	}
 	return tools

--- a/test/robot/trace/trace.proto
+++ b/test/robot/trace/trace.proto
@@ -34,6 +34,8 @@ message Input {
   subject.Hints hints = 4;
   // layout represents details about what tools we're using to trace.
   ToolingLayout layout = 5;
+  // Package is the stash id of the package used to trace.
+  string package = 6;
 }
 
 // ToolingLayout describes tools we use for tracing.

--- a/test/robot/web/client/client.go
+++ b/test/robot/web/client/client.go
@@ -25,17 +25,17 @@ import (
 )
 
 type traceInfo struct {
-	target   Item
-	gapidApk Item
-	gapit    Item
-	subject  Item
-	host     Item
+	target  Item
+	pkg     Item
+	subject Item
 }
 
 type task struct {
 	trace traceInfo
 
 	kind   Item
+	host   Item
+	pkg    Item
 	result grid.Result
 	status grid.Status
 
@@ -45,10 +45,10 @@ type task struct {
 func (t *task) Representation() interface{} {
 	tr := map[string]interface{}{}
 	tr["trace target"] = t.trace.target.Underlying()
-	tr["trace host"] = t.trace.host.Underlying()
 	tr["trace subject"] = t.trace.subject.Underlying()
-	tr["trace gapid.apk"] = t.trace.gapidApk.Underlying()
-	tr["trace gapit"] = t.trace.gapit.Underlying()
+	tr["trace package"] = t.trace.pkg.Underlying()
+	tr["host"] = t.host.Underlying()
+	tr["package"] = t.pkg.Underlying()
 	return []interface{}{tr, t.underlying}
 }
 

--- a/test/robot/web/client/client.go
+++ b/test/robot/web/client/client.go
@@ -26,7 +26,6 @@ import (
 
 type traceInfo struct {
 	target  Item
-	pkg     Item
 	subject Item
 }
 
@@ -46,7 +45,6 @@ func (t *task) Representation() interface{} {
 	tr := map[string]interface{}{}
 	tr["trace target"] = t.trace.target.Underlying()
 	tr["trace subject"] = t.trace.subject.Underlying()
-	tr["trace package"] = t.trace.pkg.Underlying()
 	tr["host"] = t.host.Underlying()
 	tr["package"] = t.pkg.Underlying()
 	return []interface{}{tr, t.underlying}

--- a/test/robot/web/client/data.go
+++ b/test/robot/web/client/data.go
@@ -170,7 +170,7 @@ func clearDimensionData() {
 func newTask(entry map[string]interface{}, kind Item) *task {
 	t := &task{
 		underlying: entry,
-		trace:      traceInfo{target: nilItem, pkg: nilItem, subject: nilItem},
+		trace:      traceInfo{target: nilItem, subject: nilItem},
 		kind:       kind,
 		host:       nilItem,
 		pkg:        nilItem,


### PR DESCRIPTION
This change removes the gapit and gapid_apk dimensions from the grid and adds a single package dimension. There is a bit of fallout from this change, workers now must match the package that created the input (i.e. replay/report must have the same package that created the tracefile) and packages are treated as complete sets of tools rather than piecemeal subsets. 