### PR TITLE
Fixed vulkan mid-execution capture.

### DIFF
--- a/gapii/cc/spy.h
+++ b/gapii/cc/spy.h
@@ -68,9 +68,9 @@ class Spy : public GlesSpy, public GvrSpy, public VulkanSpy {
 
   void onPostDrawCall(CallObserver* observer, uint8_t api) override;
   void onPreStartOfFrame(CallObserver* observer, uint8_t api) override;
-  void onPostStartOfFrame(CallObserver* observer) override;
+  void onPostStartOfFrame() override;
   void onPreEndOfFrame(CallObserver* observer, uint8_t api) override;
-  void onPostEndOfFrame(CallObserver* observer) override;
+  void onPostEndOfFrame() override;
   void onPostFence(CallObserver* observer) override;
 
   inline void RegisterSymbol(const std::string& name, void* symbol) {

--- a/gapii/cc/spy_base.h
+++ b/gapii/cc/spy_base.h
@@ -131,14 +131,13 @@ protected:
     inline virtual void onPreStartOfFrame(CallObserver*, uint8_t) {}
 
     // onPostStrartOfFrame is after any command annotated with @frame_start
-    inline virtual void onPostStartOfFrame(CallObserver* observer) {}
+    inline virtual void onPostStartOfFrame() {}
 
     // onPreEndOfFrame is before any command annotated with @frame_end
     inline virtual void onPreEndOfFrame(CallObserver*, uint8_t) {}
 
     // onPostEndOfFrame is after any command annotated with @frame_end
-    inline virtual void onPostEndOfFrame(CallObserver* observer) {}
-
+    inline virtual void onPostEndOfFrame() {}
     // onPostFence is called immediately after the driver call.
     inline virtual void onPostFence(CallObserver* observer) {}
 

--- a/gapii/cc/vulkan_extras.inl
+++ b/gapii/cc/vulkan_extras.inl
@@ -71,6 +71,7 @@ uint32_t SpyOverride_vkCreateSwapchainKHR(VkDevice device,
                                           VkAllocationCallbacks* pAllocator,
                                           VkSwapchainKHR* pImage);
 void SpyOverride_RecreateInstance(const VkInstanceCreateInfo*, VkInstance*) {}
+void SpyOverride_RecreateState() {}
 void SpyOverride_RecreatePhysicalDevices(VkInstance, uint32_t*,
                                          VkPhysicalDevice*) {}
 void SpyOverride_RecreateDevice(VkPhysicalDevice, const VkDeviceCreateInfo*,

--- a/gapis/api/templates/api_spy.cpp.tmpl
+++ b/gapis/api/templates/api_spy.cpp.tmpl
@@ -250,12 +250,12 @@
       }
 ¶
       {{if GetAnnotation $ "draw_call"}}onPostDrawCall(observer, {{Global "ApiIndex"}});{{end}}
-      {{if GetAnnotation $ "frame_start"}}onPostStartOfFrame(observer);{{end}}
-      {{if GetAnnotation $ "frame_end"}}onPostEndOfFrame(observer);{{end}}
 
       observer->observePending();
       observer->exit();
 
+      {{if GetAnnotation $ "frame_start"}}onPostStartOfFrame();{{end}}
+      {{if GetAnnotation $ "frame_end"}}onPostEndOfFrame();{{end}}
       {{if not (IsVoid $.Return.Type)}}¶
         return result;
       {{end}}

--- a/gapis/api/vulkan/custom_replay.go
+++ b/gapis/api/vulkan/custom_replay.go
@@ -280,6 +280,10 @@ func (a *RecreateInstance) Mutate(ctx context.Context, s *api.State, b *builder.
 	return hijack.Mutate(ctx, s, b)
 }
 
+func (a *RecreateState) Mutate(ctx context.Context, s *api.State, b *builder.Builder) error {
+	return nil
+}
+
 func (a *RecreatePhysicalDevices) Mutate(ctx context.Context, s *api.State, b *builder.Builder) error {
 	defer EnterRecreate(ctx, s)()
 	cb := CommandBuilder{Thread: a.thread}

--- a/gapis/api/vulkan/vulkan.api
+++ b/gapis/api/vulkan/vulkan.api
@@ -3058,6 +3058,13 @@ cmd void vkGetDeviceMemoryCommitment(
   _ = pCommittedMemoryInBytes[0]
 }
 
+
+@override
+@custom
+@no_replay
+cmd void RecreateState() {
+}
+
 @override
 @custom
 @no_replay


### PR DESCRIPTION
The change to the file-format broke Vulkan MEC.
The main cause was allowing recursive calls. We were treating
the vulkan recreation as a recursive call, now that we support them
properly, they were getting culled (with the culled parent).
Now we correctly create the state in it's own call.