### PR TITLE
Fixed some vulkan trace issues.

### DIFF
--- a/gapii/cc/call_observer.h
+++ b/gapii/cc/call_observer.h
@@ -216,7 +216,7 @@ inline void CallObserver::write(const Slice<T>& dst, uint64_t index,
 template <typename T>
 inline Slice<T> CallObserver::copy(const Slice<T>& dst, const Slice<T>& src) {
     read(src);
-    if (!shouldObserve(
+    if (isActive() && !shouldObserve(
             dst)) {  // The spy must not mutate data in the application pool.
         uint64_t c = (src.count() < dst.count()) ? src.count() : dst.count();
         src.copy(dst, 0, c, 0);

--- a/gapii/cc/vulkan_mid_execution.cpp
+++ b/gapii/cc/vulkan_mid_execution.cpp
@@ -1255,7 +1255,7 @@ void VulkanSpy::EnumerateVulkanResources(CallObserver* observer) {
           create_info.mstage.mpSpecializationInfo = &specialization_info;
         }
         RecreateComputePipeline(observer, pipeline.mDevice,
-                                pipeline.mPipelineCache->mVulkanHandle,
+                                pipeline.mPipelineCache ? pipeline.mPipelineCache->mVulkanHandle : 0,
                                 &create_info, &pipeline.mVulkanHandle);
       }
 

--- a/gapis/api/vulkan/templates/vk_spy_helpers.cpp.tmpl
+++ b/gapis/api/vulkan/templates/vk_spy_helpers.cpp.tmpl
@@ -140,7 +140,9 @@ PFN_vkVoidFunction VulkanSpy::SpyOverride_vkGetDeviceProcAddr(VkDevice device, c
                 return reinterpret_cast<PFN_vkVoidFunction>(gapii::{{$name}});
         {{end}}
     {{end}}
-    return nullptr;
+    // This is not strictly correct, but some applications incorrectly
+    // call vkGetDeviceProcAddr, when they actually mean vkGetInstanceProcAddr.
+    return SpyOverride_vkGetInstanceProcAddr(PhysicalDevices[Devices[device]->mPhysicalDevice]->mInstance, pName);
 }
 
 uint32_t VulkanSpy::SpyOverride_vkEnumerateInstanceExtensionProperties(const char *pLayerName, uint32_t *pCount, VkExtensionProperties *pProperties) {

--- a/gapis/api/vulkan/vulkan.api
+++ b/gapis/api/vulkan/vulkan.api
@@ -3000,12 +3000,17 @@ cmd VkResult vkFlushMappedMemoryRanges(
     flushStart := flushRange.offset - memoryObject.MappedOffset
     // TODO: Log errors if flush offset - mapped offset is negative or
     // flushRange.size is out of bounds.
-    if (flushRange.size == 0xFFFFFFFFFFFFFFFF) {
-      // copy() contains an implicit read observation
-      copy(memoryObject.Data[flushRange.offset:memoryObject.MappedOffset + memoryObject.MappedSize], (mappedLocation)[flushStart:memoryObject.MappedSize])
+
+    if (IsMemoryCoherent(memoryObject)) {
+      readCoherentMemory(memoryObject, flushRange.offset, flushRange.size)
     } else {
-      // copy() contains an implicit read observation
-      copy(memoryObject.Data[flushRange.offset:flushRange.offset + flushRange.size], (mappedLocation)[flushStart:flushStart + flushRange.size])
+      if (flushRange.size == 0xFFFFFFFFFFFFFFFF) {
+        // copy() contains an implicit read observation
+        copy(memoryObject.Data[flushRange.offset:memoryObject.MappedOffset + memoryObject.MappedSize], (mappedLocation)[flushStart:memoryObject.MappedSize])
+      } else {
+        // copy() contains an implicit read observation
+        copy(memoryObject.Data[flushRange.offset:flushRange.offset + flushRange.size], (mappedLocation)[flushStart:flushStart + flushRange.size])
+      }
     }
   }
   return ?


### PR DESCRIPTION
Remove some memory that was being copied into shadow memory
even when tracing was disabled.

Handle null PipelineCaches for Compute pipelines.
If we flush mapped coherent memory, then use the coherent memory
tracker, that was we only have to track a subset of all
of the memory.

Work around an application bug where they were calling
vkGetDeviceProcAddr when they really meant vkGetInstanceProcAddr.