### PR TITLE
2 fixes for Vulkan.

### DIFF
--- a/gapii/cc/vulkan_extras.inl
+++ b/gapii/cc/vulkan_extras.inl
@@ -123,6 +123,7 @@ void SpyOverride_RecreateRenderPass(VkDevice, const VkRenderPassCreateInfo*,
 void SpyOverride_RecreateShaderModule(VkDevice, const VkShaderModuleCreateInfo*,
                                       VkShaderModule*) {}
 void SpyOverride_RecreateDestroyShaderModule(VkDevice, VkShaderModule) {}
+void SpyOverride_RecreateDestroyRenderPass(VkDevice, VkRenderPass) {}
 void SpyOverride_RecreateDescriptorPool(VkDevice,
                                         const VkDescriptorPoolCreateInfo*,
                                         VkDescriptorPool*) {}

--- a/gapis/api/vulkan/custom_replay.go
+++ b/gapis/api/vulkan/custom_replay.go
@@ -1067,6 +1067,15 @@ func (a *RecreateDestroyShaderModule) Mutate(ctx context.Context, s *api.State, 
 	return hijack.Mutate(ctx, s, b)
 }
 
+func (a *RecreateDestroyRenderPass) Mutate(ctx context.Context, s *api.State, b *builder.Builder) error {
+	defer EnterRecreate(ctx, s)()
+	cb := CommandBuilder{Thread: a.thread}
+	allocator := memory.Nullptr
+	hijack := cb.VkDestroyRenderPass(a.Device, a.RenderPass, allocator)
+	hijack.Extras().MustClone(a.Extras().All()...)
+	return hijack.Mutate(ctx, s, b)
+}
+
 func (a *RecreateDescriptorPool) Mutate(ctx context.Context, s *api.State, b *builder.Builder) error {
 	defer EnterRecreate(ctx, s)()
 	cb := CommandBuilder{Thread: a.thread}

--- a/gapis/api/vulkan/footprint_builder.go
+++ b/gapis/api/vulkan/footprint_builder.go
@@ -1666,6 +1666,9 @@ func (vb *FootprintBuilder) BuildFootprint(ctx context.Context,
 	case *VkDestroyShaderModule:
 		read(ctx, bh, vkHandle(cmd.ShaderModule))
 		bh.Alive = true
+	case *RecreateDestroyShaderModule:
+		read(ctx, bh, vkHandle(cmd.ShaderModule))
+		bh.Alive = true
 
 	// create/destroy renderpass
 	case *VkCreateRenderPass:
@@ -1673,6 +1676,9 @@ func (vb *FootprintBuilder) BuildFootprint(ctx context.Context,
 	case *RecreateRenderPass:
 		write(ctx, bh, vkHandle(cmd.PRenderPass.Read(ctx, cmd, s, nil)))
 	case *VkDestroyRenderPass:
+		read(ctx, bh, vkHandle(cmd.RenderPass))
+		bh.Alive = true
+	case *RecreateDestroyRenderPass:
 		read(ctx, bh, vkHandle(cmd.RenderPass))
 		bh.Alive = true
 

--- a/gapis/api/vulkan/vulkan.api
+++ b/gapis/api/vulkan/vulkan.api
@@ -3492,6 +3492,12 @@ cmd void vkDestroyQueryPool(
 @threadSafety("system")
 @indirect("VkDevice")
 @blocking
+@no_replay
+// GetQueryPoolResults has no semantic impact
+// on replay, so avoid replaying it. It can cause
+// hangs depending on the state of the query pool
+// TODO(awoloszyn): Work out all of the cases where this
+// may cause hangs, and fix it for replay.
 cmd VkResult vkGetQueryPoolResults(
     VkDevice           device,
     VkQueryPool        queryPool,
@@ -3906,6 +3912,14 @@ cmd VkResult vkCreateShaderModule(
 cmd void RecreateDestroyShaderModule(
     VkDevice       device,
     VkShaderModule shaderModule) { }
+
+@override
+@custom
+@no_replay
+cmd void RecreateDestroyRenderPass(
+    VkDevice       device,
+    VkRenderPass renderPass) { }
+
 
 @indirect("VkDevice")
 cmd void vkDestroyShaderModule(


### PR DESCRIPTION
1) When capturing pipelines for MEC, the graphics pipeline may have
   been created with a renderpass that has been destroyed, so
   recreate the renderpass temporarily in this case. This is
   similar to how we handle ShaderModules.
2) There are some cases that VkGetQueryPoolResults fails on replay.
   For now, since it has no semantic impact on the replay, remove it
   from replay. TODO: Figure out what the exact cases are an fix them,
   either with a custom_mutate or more correctly resetting the query
   pool results.