### PR TITLE
Added functional include to virtual swapchain

### DIFF
--- a/core/vulkan/vk_virtual_swapchain/cc/layer.cpp
+++ b/core/vulkan/vk_virtual_swapchain/cc/layer.cpp
@@ -512,7 +512,7 @@ vkGetDeviceProcAddr(VkDevice dev, const char *funcName) {
       GetGlobalContext().GetDeviceData(dev)->vkGetDeviceProcAddr;
   return device_proc_addr(dev, funcName);
 }
-}
+} // swapchain
 
 extern "C" {
 

--- a/core/vulkan/vk_virtual_swapchain/cc/swapchain.cpp
+++ b/core/vulkan/vk_virtual_swapchain/cc/swapchain.cpp
@@ -265,8 +265,8 @@ VKAPI_ATTR VkResult VKAPI_CALL vkAcquireNextImageKHR(
                     nullptr,                       // waitDstStageMask
                     0,                             // commandBufferCount
                     nullptr,                       // pCommandBuffers
-                    (has_semaphore ? 1u : 0u),     // waitSemaphoreCount
-                    (has_semaphore ? &semaphore : nullptr)};
+                    (has_semaphore ? 1u : 0u),     // semaphoreCount
+                    (has_semaphore ? &semaphore : nullptr)}; // pSemaphores
   return swapchain::vkQueueSubmit(q, 1, &info, fence);
 
 }
@@ -402,4 +402,4 @@ VKAPI_ATTR VkResult VKAPI_CALL vkCreateRenderPass(
 
   return func(device, &intercepted, pAllocator, pRenderPass);
 }
-}
+} // swapchain

--- a/core/vulkan/vk_virtual_swapchain/cc/swapchain.h
+++ b/core/vulkan/vk_virtual_swapchain/cc/swapchain.h
@@ -102,5 +102,5 @@ VKAPI_ATTR void VKAPI_CALL vkCmdWaitEvents(
 VKAPI_ATTR VkResult VKAPI_CALL vkCreateRenderPass(
     VkDevice device, const VkRenderPassCreateInfo *pCreateInfo,
     const VkAllocationCallbacks *pAllocator, VkRenderPass *pRenderPass);
-}
+} // swapchain
 #endif // VK_VIRTUAL_SWAPCHAIN_SWAPCHAIN_H_

--- a/core/vulkan/vk_virtual_swapchain/cc/threading.h
+++ b/core/vulkan/vk_virtual_swapchain/cc/threading.h
@@ -159,6 +159,6 @@ private:
 #endif
 };
 
-}
-}
+} // threading
+} // swapchain
 #endif // VK_VIRTUAL_SWAPCHAIN_THREADING_H_

--- a/core/vulkan/vk_virtual_swapchain/cc/virtual_swapchain.cpp
+++ b/core/vulkan/vk_virtual_swapchain/cc/virtual_swapchain.cpp
@@ -76,18 +76,18 @@ VirtualSwapchain::VirtualSwapchain(
           nullptr,                             // pNext
           0,                                   // flags
           VK_IMAGE_TYPE_2D,                    // imageType
-          swapchain_info_.imageFormat,        // format
+          swapchain_info_.imageFormat,         // format
           VkExtent3D{swapchain_info_.imageExtent.width,
                      swapchain_info_.imageExtent.height, 1}, // extent
-          1,                                                  // mipLevels
+          1,                                                 // mipLevels
           swapchain_info_.imageArrayLayers,                  // arrayLayers
-          VK_SAMPLE_COUNT_1_BIT,                              // samples
-          VK_IMAGE_TILING_OPTIMAL,                            // tiling
+          VK_SAMPLE_COUNT_1_BIT,                             // samples
+          VK_IMAGE_TILING_OPTIMAL,                           // tiling
           swapchain_info_.imageUsage | VK_IMAGE_USAGE_TRANSFER_SRC_BIT, // usage
           swapchain_info_.imageSharingMode,      // sharingmode
           swapchain_info_.queueFamilyIndexCount, // queueFamilyIndexCount
           swapchain_info_.pQueueFamilyIndices,   // queueFamilyIndices
-          VK_IMAGE_LAYOUT_UNDEFINED,              // initialLayout
+          VK_IMAGE_LAYOUT_UNDEFINED,             // initialLayout
       };
       // The size of the buffer that we need is surprisingly easy.
       // Pixel-width * width * height. The GPU will copy into the
@@ -111,8 +111,9 @@ VirtualSwapchain::VirtualSwapchain(
           buffer_memory_size,                   // size
           VK_BUFFER_USAGE_TRANSFER_DST_BIT,     // usage
           VK_SHARING_MODE_EXCLUSIVE,            // sharingMode
-          0,
-          nullptr};
+          0,                                    // queueFamilyIndexCount
+          nullptr                               // pQueueFamilyIndices
+        };
 
       VkCommandPoolCreateInfo command_pool_info{
           VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO,      // sType
@@ -203,12 +204,13 @@ VirtualSwapchain::VirtualSwapchain(
           VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER, // sType
           nullptr,                                 // pNext
           VK_ACCESS_TRANSFER_WRITE_BIT,            // srcAccessMask
-          VK_ACCESS_HOST_READ_BIT,                 // dstAccessMask,
-          VK_QUEUE_FAMILY_IGNORED,
-          VK_QUEUE_FAMILY_IGNORED,
-          image_data.buffer_,
-          0,
-          VK_WHOLE_SIZE};
+          VK_ACCESS_HOST_READ_BIT,                 // dstAccessMask
+          VK_QUEUE_FAMILY_IGNORED,                 // srcQueueFamilyIndex
+          VK_QUEUE_FAMILY_IGNORED,                 // dstQueueFamilyIndex
+          image_data.buffer_,                      // buffer
+          0,                                       // offset
+          VK_WHOLE_SIZE                            // size
+      };
 
       VkBufferImageCopy region{
           0, // Start of the buffer
@@ -218,10 +220,11 @@ VirtualSwapchain::VirtualSwapchain(
               VK_IMAGE_ASPECT_COLOR_BIT,          // aspectMask
               0,                                  // mipLevel
               0,                                  // baseArrayLayer
-              swapchain_info_.imageArrayLayers}, // imageSubresourceLayers
+              swapchain_info_.imageArrayLayers},  // imageSubresourceLayers
           VkOffset3D{0, 0, 0},
           VkExtent3D{swapchain_info_.imageExtent.width,
-                     swapchain_info_.imageExtent.height, 1}};
+                     swapchain_info_.imageExtent.height, 1}
+      };
 
       VkCommandBufferBeginInfo cbegin{
           VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO, // sType
@@ -392,4 +395,4 @@ uint32_t VirtualSwapchain::ImageByteSize() const {
   // more dynamic.
   return width_ * height_ * 4;
 }
-}
+} // swapchain

--- a/core/vulkan/vk_virtual_swapchain/cc/virtual_swapchain.h
+++ b/core/vulkan/vk_virtual_swapchain/cc/virtual_swapchain.h
@@ -184,6 +184,6 @@ private:
   // Function to build swapchain images
   std::function<SwapchainImageData()> build_swapchain_image_data_;
 };
-}
+} // swapchain
 
 #endif //  VK_VIRTUAL_SWAPCHAIN_VIRTUAL_SWAPCHAIN_H_

--- a/core/vulkan/vk_virtual_swapchain/cc/virtual_swapchain.h
+++ b/core/vulkan/vk_virtual_swapchain/cc/virtual_swapchain.h
@@ -21,6 +21,7 @@
 #include <atomic>
 #include <deque>
 #include <mutex>
+#include <functional>
 #include <vulkan/vulkan.h>
 
 namespace swapchain {


### PR DESCRIPTION
When trying to compile you get 

```
.\core\vulkan\vk_virtual_swapchain\cc\virtual_swapchain.h:184:8: error: 'function' in namespace 'std' does not name a template type
   std::function<SwapchainImageData()> build_swapchain_image_data_;
        ^~~~~~~~
.\core\vulkan\vk_virtual_swapchain\cc\virtual_swapchain.h: In member function 'std::vector<VkImage_T*> swapchain::VirtualSwapchain::GetImages(uint32_t, bool)':
.\core\vulkan\vk_virtual_swapchain\cc\virtual_swapchain.h:59:29: error: 'build_swapchain_image_data_' was not declared in this scope
       image_data_.push_back(build_swapchain_image_data_());
                             ^~~~~~~~~~~~~~~~~~~~~~~~~~~
.\core\vulkan\vk_virtual_swapchain\cc\virtual_swapchain.h:59:29: note: suggested alternative: 'SwapchainImageData'
       image_data_.push_back(build_swapchain_image_data_());
                             ^~~~~~~~~~~~~~~~~~~~~~~~~~~
                             SwapchainImageData
```