### PR TITLE
gapit: added earlier encoder warning

### DIFF
--- a/cmd/gapit/video.go
+++ b/cmd/gapit/video.go
@@ -211,6 +211,11 @@ func (verb *videoVerb) Run(ctx context.Context, flags flag.FlagSet) error {
 		return log.Errf(ctx, err, "Finding file: %v", flags.Arg(0))
 	}
 
+	_, err = video.GetEncoder()
+	if err != nil {
+		return log.Errf(ctx, err, "No valid encoder found in path")
+	}
+
 	client, err := getGapis(ctx, verb.Gapis, verb.Gapir)
 	if err != nil {
 		return log.Err(ctx, err, "Failed to connect to the GAPIS server")

--- a/core/video/encoder.go
+++ b/core/video/encoder.go
@@ -40,11 +40,20 @@ func init() {
 	}
 }
 
+// Checks to make sure an encoder has been set
+func GetEncoder() (string, error) {
+	if encoder == "" {
+		return encoder, fmt.Errorf("neither avconv nor ffmpeg was found")
+	} else {
+		return encoder, nil
+	}
+}
+
 // Encode will encode the frames written to the returned chan to a video that
 // can be read from the Reader.
 func Encode(ctx context.Context, settings Settings) (chan<- image.Image, io.Reader, error) {
 	if encoder == "" {
-		return nil, nil, fmt.Errorf("neither avconv or ffmpeg was found")
+		return nil, nil, fmt.Errorf("neither avconv nor ffmpeg was found")
 	}
 
 	in := make(chan image.Image, 64)


### PR DESCRIPTION
It is very disheartening to wait 15 minutes for your trace to finish running `gapit video` and then find out you didn't have a valid encoder in your path, simply checking prior to doing all the actual video logic will save someone a lot of time in the future