### PR TITLE
Fix the debug marker object name for MEC

### DIFF
--- a/gapis/api/vulkan/custom_replay.go
+++ b/gapis/api/vulkan/custom_replay.go
@@ -1361,6 +1361,28 @@ func (a *VkGetEventStatus) Mutate(ctx context.Context, s *api.State, b *builder.
 	return cb.ReplayGetEventStatus(a.Device, a.Event, a.Result, wait, a.Result).Mutate(ctx, s, b)
 }
 
+func (a *RecreateDebugMarkerSetObjectNameEXT) Mutate(ctx context.Context, s *api.State, b *builder.Builder) error {
+	o := a.Extras().Observations()
+	o.ApplyReads(s.Memory.ApplicationPool())
+	nameInfo := a.PNameInfo.Read(ctx, a, s, nil)
+	err := subSetDebugMarkerObjectName(ctx, a, o, s, GetState(s), a.thread, nil, nameInfo)
+	if err != nil {
+		return err
+	}
+	return a.mutate(ctx, s, b)
+}
+
+func (a *RecreateDebugMarkerSetObjectTagEXT) Mutate(ctx context.Context, s *api.State, b *builder.Builder) error {
+	o := a.Extras().Observations()
+	o.ApplyReads(s.Memory.ApplicationPool())
+	tagInfo := a.PTagInfo.Read(ctx, a, s, nil)
+	err := subSetDebugMarkerObjectTag(ctx, a, o, s, GetState(s), a.thread, nil, tagInfo)
+	if err != nil {
+		return err
+	}
+	return a.mutate(ctx, s, b)
+}
+
 func (a *ReplayAllocateImageMemory) Mutate(ctx context.Context, s *api.State, b *builder.Builder) error {
 	if err := a.mutate(ctx, s, b); err != nil {
 		return err

--- a/gapis/api/vulkan/vulkan.api
+++ b/gapis/api/vulkan/vulkan.api
@@ -8918,11 +8918,12 @@ sub void setDebugMarkerObjectName(VkDebugMarkerObjectNameInfoEXT nameInfo) {
 
 @override
 @no_replay
+@custom
 cmd void RecreateDebugMarkerSetObjectTagEXT(
   VkDevice device,
   VkDebugMarkerObjectTagInfoEXT* pTagInfo) {
   tagInfo := pTagInfo[0]
-  setDebugMarkerObjectTag(tagInfo)
+  read(as!u8*(tagInfo.pTag)[0:tagInfo.tagSize])
 }
 
 @threadSafety("app")
@@ -8941,11 +8942,12 @@ cmd VkResult vkDebugMarkerSetObjectTagEXT(
 
 @override
 @no_replay
+@custom
 cmd void RecreateDebugMarkerSetObjectNameEXT(
   VkDevice device,
   VkDebugMarkerObjectNameInfoEXT* pNameInfo) {
   nameInfo := pNameInfo[0]
-  setDebugMarkerObjectName(nameInfo)
+  _ = as!string(nameInfo.pObjectName)
 }
 
 @threadSafety("app")


### PR DESCRIPTION
It turns out having the RecreateXXX command not annotated with @custom
is not a good idea