### PR TITLE
gapii: Pass the path of libinterceptor down in the header.

### DIFF
--- a/core/event/task/task.go
+++ b/core/event/task/task.go
@@ -35,17 +35,17 @@ func Once(task Task) Task {
 	}
 }
 
-// Retry repeatedly calls task until task returns a nil error, the number
-// attempts reaches maxAttempts or the context is cancelled. Retry will sleep
-// for retryDelay between retry attempts.
+// Retry repeatedly calls f until f returns a true, the number of attempts
+// reaches maxAttempts or the context is cancelled. Retry will sleep for
+// retryDelay between retry attempts.
 // if maxAttempts <= 0, then there is no maximum limit to the number of times
-// task will be called.
-func Retry(ctx context.Context, maxAttempts int, retryDelay time.Duration, task Task) error {
+// f will be called.
+func Retry(ctx context.Context, maxAttempts int, retryDelay time.Duration, f func(context.Context) (retry bool, err error)) error {
 	var count int
 	for {
-		err := task(ctx)
-		if err == nil {
-			return nil
+		done, err := f(ctx)
+		if done {
+			return err
 		}
 		count++
 		if maxAttempts > 0 && count >= maxAttempts {

--- a/gapii/cc/android/gvr_install.h
+++ b/gapii/cc/android/gvr_install.h
@@ -20,10 +20,11 @@
 
 namespace gapii {
 
+class Installer;
 class GvrImports;
 
 // install_gvr installs interceptor hooks into all the GVR functions.
-bool install_gvr(void* gvr_lib, GvrImports* imports);
+bool install_gvr(Installer* installer, void* gvr_lib, GvrImports* imports);
 
 } // namespace gapii
 

--- a/gapii/cc/android/installer.h
+++ b/gapii/cc/android/installer.h
@@ -19,10 +19,19 @@
 
 namespace gapii {
 
-// install_function installs a hook into func_import to call func_export.
-// The returned function allows func_export to call back to the original
-// function that was at func_import.
-void* install_function(void* func_import, const void* func_export);
+class Installer {
+public:
+    Installer(const char* libInterceptorPath);
+    ~Installer();
+
+    // install_function installs a hook into func_import to call func_export.
+    // The returned function allows func_export to call back to the original
+    // function that was at func_import.
+    void* install(void* func_import, const void* func_export);
+
+private:
+    void install_gles();
+};
 
 } // namespace gapii
 

--- a/gapii/cc/connection_header.cpp
+++ b/gapii/cc/connection_header.cpp
@@ -64,7 +64,8 @@ bool ConnectionHeader::read(core::StreamReader* reader) {
         !reader->read(mNumFrames) ||
         !reader->read(mAPIs) ||
         !reader->read(mFlags) ||
-        !reader->read(mGvrHandle)) {
+        !reader->read(mGvrHandle) ||
+        !reader->read(mLibInterceptorPath)) {
         return false;
     }
 

--- a/gapii/cc/connection_header.h
+++ b/gapii/cc/connection_header.h
@@ -17,6 +17,7 @@
 #ifndef GAPII_CONNECTION_HEADER_H
 #define GAPII_CONNECTION_HEADER_H
 
+#include <stddef.h>
 #include <stdint.h>
 
 namespace core {
@@ -35,6 +36,8 @@ class ConnectionHeader {
 public:
     ConnectionHeader();
 
+    static const size_t MAX_PATH = 512;
+
     // Fakes no support for PCS, forcing the app to share shader source.
     static const uint32_t FLAG_DISABLE_PRECOMPILED_SHADERS = 0x00000001;
     // Driver errors are queried after each call and stored as extras.
@@ -46,15 +49,16 @@ public:
     // on success or false on error.
     bool read(core::StreamReader* reader);
 
-    uint8_t  mMagic[4];              // 's', 'p', 'y', '0'
-    uint32_t mVersion;               // 1
-    uint32_t mObserveFrameFrequency; // non-zero == enabled.
-    uint32_t mObserveDrawFrequency;  // non-zero == enabled.
-    uint32_t mStartFrame;            // non-zero == Frame to start at.
-    uint32_t mNumFrames;             // non-zero == Number of frames to capture.
-    uint32_t mAPIs;                  // Bitset of APIS to enable.
-    uint32_t mFlags;                 // Combination of FLAG_XX bits.
-    uint64_t mGvrHandle;             // Handle of GVR library.
+    uint8_t  mMagic[4];                     // 's', 'p', 'y', '0'
+    uint32_t mVersion;                      // 1
+    uint32_t mObserveFrameFrequency;        // non-zero == enabled.
+    uint32_t mObserveDrawFrequency;         // non-zero == enabled.
+    uint32_t mStartFrame;                   // non-zero == Frame to start at.
+    uint32_t mNumFrames;                    // non-zero == Number of frames to capture.
+    uint32_t mAPIs;                         // Bitset of APIS to enable.
+    uint32_t mFlags;                        // Combination of FLAG_XX bits.
+    uint64_t mGvrHandle;                    // Handle of GVR library.
+    char     mLibInterceptorPath[MAX_PATH]; // Path of libinterceptor.so.
 };
 
 } // namespace gapii

--- a/gapii/client/capture.go
+++ b/gapii/client/capture.go
@@ -91,7 +91,7 @@ func (s siSize) String() string {
 	return fmt.Sprintf(f, v)
 }
 
-func (p *Process) connect(ctx context.Context, gvrHandle uint64) error {
+func (p *Process) connect(ctx context.Context, gvrHandle uint64, interceptorPath string) error {
 	log.I(ctx, "Waiting for connection to localhost:%d...", p.Port)
 
 	// ADB has an annoying tendancy to insta-close forwarded sockets when
@@ -103,7 +103,7 @@ func (p *Process) connect(ctx context.Context, gvrHandle uint64) error {
 			log.D(ctx, "Dial failed: %v", err)
 			return err
 		}
-		if err := sendHeader(conn, p.Options, gvrHandle); err != nil {
+		if err := sendHeader(conn, p.Options, gvrHandle, interceptorPath); err != nil {
 			log.D(ctx, "Failed to send header: %v", err)
 			conn.Close()
 			return err
@@ -134,7 +134,7 @@ func (c bufConn) Read(b []byte) (n int, err error) { return c.r.Read(b) }
 // until s is fired.
 func (p *Process) Capture(ctx context.Context, s task.Signal, w io.Writer) (int64, error) {
 	if p.conn == nil {
-		if err := p.connect(ctx, 0); err != nil {
+		if err := p.connect(ctx, 0, ""); err != nil {
 			return 0, err
 		}
 	}

--- a/gapii/client/header.go
+++ b/gapii/client/header.go
@@ -27,22 +27,26 @@ const version = 1
 
 // The GAPII header is defined as:
 //
+// const size_t MAX_PATH = 512;
+//
 // struct ConnectionHeader {
-//     uint8_t  mMagic[4];                    // 's', 'p', 'y', '0'
-//     uint32_t mVersion;                     // 1
-//     uint32_t mObserveFrameFrequency;       // non-zero == enabled.
-//     uint32_t mObserveDrawFrequency;        // non-zero == enabled.
-//     uint32_t mStartFrame;                  // non-zero == Frame to start at.
-//     uint32_t mNumFrames;                   // non-zero == Number of frames to capture.
-//     uint32_t mAPIs;                        // Bitset of APIS to enable.
-//     uint32_t mFlags;                       // Combination of FLAG_XX bits.
+//     uint8_t  mMagic[4];                     // 's', 'p', 'y', '0'
+//     uint32_t mVersion;                      // 1
+//     uint32_t mObserveFrameFrequency;        // non-zero == enabled.
+//     uint32_t mObserveDrawFrequency;         // non-zero == enabled.
+//     uint32_t mStartFrame;                   // non-zero == Frame to start at.
+//     uint32_t mNumFrames;                    // non-zero == Number of frames to capture.
+//     uint32_t mAPIs;                         // Bitset of APIS to enable.
+//     uint32_t mFlags;                        // Combination of FLAG_XX bits.
+//     char     mLibInterceptorPath[MAX_PATH]; // Path to libinterceptor.so
 // };
 //
 // All fields are encoded little-endian with no compression, regardless of
 // architecture. All changes must be kept in sync with:
 //   platform/tools/gpu/gapii/cc/connection_header.h
 
-func sendHeader(out io.Writer, options Options, gvrHandle uint64) error {
+func sendHeader(out io.Writer, options Options, gvrHandle uint64, libInterceptorPath string) error {
+	const maxPath = 512
 	w := endian.Writer(out, device.LittleEndian)
 	for _, m := range magic {
 		w.Uint8(m)
@@ -55,6 +59,8 @@ func sendHeader(out io.Writer, options Options, gvrHandle uint64) error {
 	w.Uint32(options.APIs)
 	w.Uint32(uint32(options.Flags))
 	w.Uint64(gvrHandle)
-
+	var path [maxPath]byte
+	copy(path[:], libInterceptorPath)
+	w.Data(path[:])
 	return w.Error()
 }

--- a/gapii/client/jdwp_loader.go
+++ b/gapii/client/jdwp_loader.go
@@ -116,15 +116,15 @@ func (p *Process) loadAndConnectViaJDWP(
 	// Create a JDWP connection with the application.
 	var sock net.Conn
 	var conn *jdwp.Connection
-	err = task.Retry(ctx, reconnectAttempts, reconnectDelay, func(ctx context.Context) error {
+	err = task.Retry(ctx, reconnectAttempts, reconnectDelay, func(ctx context.Context) (bool, error) {
 		if sock, err = net.Dial("tcp", fmt.Sprintf("localhost:%v", jdwpPort)); err != nil {
-			return err
+			return false, err
 		}
 		if conn, err = jdwp.Open(ctx, sock); err != nil {
 			sock.Close()
-			return err
+			return false, err
 		}
-		return nil
+		return true, nil
 	})
 	if err != nil {
 		return log.Err(ctx, err, "Connecting to JDWP")

--- a/gapis/api/gvr/templates/api_install.cpp.tmpl
+++ b/gapis/api/gvr/templates/api_install.cpp.tmpl
@@ -37,7 +37,7 @@
 ¶
 namespace gapii {«
 ¶
-bool install_gvr(void* gvr_lib, GvrImports* imports) {
+bool install_gvr(Installer* installer, void* gvr_lib, GvrImports* imports) {
   struct func_t {
     const char* name;
     void**      imp;
@@ -54,7 +54,7 @@ bool install_gvr(void* gvr_lib, GvrImports* imports) {
   for (auto func : funcs) {
     if (auto import = dlsym(gvr_lib, func.name)) {
       GAPID_INFO("Installing '%s'...", func.name);
-      *func.imp = gapii::install_function(import, func.exp);
+      *func.imp = installer->install(import, func.exp);
     } else {
       GAPID_WARNING("Could not find GVR function '%s'", func.name);
     }


### PR DESCRIPTION
This moves the loading of `libinteceptor.so` from `jdwp_loader.go` (gapit) to gapii.

It appears that on some devices dlopen() will not find libraries loaded by a prior call to `System.loadLibrary()`. Instead, pass the absolute path of `libinteceptor.so` down to `libgapii.so` and load it directly there.

Fixes: #1026