### PR TITLE
Fixed preprocessors for disable coherent tracking

### DIFF
--- a/gapii/cc/spy_base.cpp
+++ b/gapii/cc/spy_base.cpp
@@ -30,7 +30,7 @@ SpyBase::SpyBase()
     : mObserveApplicationPool(true)
     , mNullEncoder(PackEncoder::noop())
     , mWatchedApis(0xFFFFFFFF)
-#ifdef COHERENT_TRACKING_ENABLED
+#if COHERENT_TRACKING_ENABLED
     , mMemoryTracker()
 #endif // TARGET_OS
 {

--- a/gapis/api/vulkan/templates/vk_spy_helpers.cpp.tmpl
+++ b/gapis/api/vulkan/templates/vk_spy_helpers.cpp.tmpl
@@ -526,7 +526,7 @@ void VulkanSpy::trackMappedCoherentMemory(CallObserver*, uint64_t start, size_va
   if (is_suspended()) {
       return;
   }
-#ifdef COHERENT_TRACKING_ENABLED
+#if COHERENT_TRACKING_ENABLED
     mMemoryTracker.EnableMemoryTracker();
     void* start_addr = reinterpret_cast<void*>(start);
     mMemoryTracker.AddTrackingRange(start_addr, size);
@@ -539,7 +539,7 @@ void VulkanSpy::readMappedCoherentMemory(CallObserver *observer, VkDeviceMemory 
     const auto mapped_size = memory_object->mMappedSize;
     const auto mapped_location = (uint64_t)(memory_object->mMappedLocation);
     void *offset_addr = (void *)(offset_in_mapped + mapped_location);
-#ifdef COHERENT_TRACKING_ENABLED
+#if COHERENT_TRACKING_ENABLED
     const size_val page_size = mMemoryTracker.page_size();
     // Get the valid mapped range
     const auto dirty_pages = mMemoryTracker.GetAndResetDirtyPagesInRange(offset_addr, readSize);
@@ -554,7 +554,7 @@ void VulkanSpy::readMappedCoherentMemory(CallObserver *observer, VkDeviceMemory 
 }
 
 void VulkanSpy::untrackMappedCoherentMemory(CallObserver*, uint64_t start, size_val size) {
-#ifdef COHERENT_TRACKING_ENABLED
+#if COHERENT_TRACKING_ENABLED
     void* start_addr = reinterpret_cast<void*>(start);
     mMemoryTracker.RemoveTrackingRange(start_addr, size);
 #endif // COHERENT_TRACKING_ENABLED


### PR DESCRIPTION
Currently, if you set `#define  COHERENT_TRACKING_ENABLED 0`
https://github.com/google/gapid/blob/master/core/memory_tracker/cc/memory_tracker.h#L22

You will run into compile errors since there are two spots where it uses `#ifdef` instead of `#if`

All other spots use `#if`