### PR TITLE
gles: Fix fallback path for pre-complied shaders

### DIFF
--- a/gapis/api/gles/stub_program.go
+++ b/gapis/api/gles/stub_program.go
@@ -31,7 +31,8 @@ var (
 )
 
 func buildStubProgram(ctx context.Context, thread uint64, e *api.CmdExtras, s *api.State, programID ProgramId) []api.Cmd {
-	vss, fss, err := stubShaderSource(FindProgramInfo(e))
+	programInfo := FindProgramInfo(e)
+	vss, fss, err := stubShaderSource(programInfo)
 	if err != nil {
 		log.E(ctx, "Unable to build stub shader: %v", err)
 	}
@@ -45,9 +46,11 @@ func buildStubProgram(ctx context.Context, thread uint64, e *api.CmdExtras, s *a
 		return ok || x == uint32(vertexShaderID)
 	}))
 	cb := CommandBuilder{Thread: thread}
+	glLinkProgram := cb.GlLinkProgram(programID)
+	glLinkProgram.Extras().Add(programInfo)
 	return append(
 		CompileProgram(ctx, s, cb, vertexShaderID, fragmentShaderID, programID, vss, fss),
-		cb.GlLinkProgram(programID),
+		glLinkProgram,
 	)
 }
 
@@ -92,15 +95,23 @@ func stubShaderSource(pi *ProgramInfo) (vertexShaderSource, fragmentShaderSource
 		sort.Strings(vsTickles)
 		sort.Strings(fsTickles)
 	}
-	return fmt.Sprintf(`// GAPII stub vertex shader
-#version 110
+	return fmt.Sprintf(`#version 150
+
+/////////////////////////////////////////////
+// GAPID stub shader (no source available) //
+/////////////////////////////////////////////
+
 precision highp float;
 %svoid main() {
     float no_strip = 0.0;
     %sgl_Position = vec4(no_strip * 0.000001, 0., 0., 1.);
 }`, strings.Join(vsDecls, ""), strings.Join(vsTickles, "")),
-		fmt.Sprintf(`// GAPII stub fragment shader
-#version 110
+		fmt.Sprintf(`#version 150
+
+/////////////////////////////////////////////
+// GAPID stub shader (no source available) //
+/////////////////////////////////////////////
+
 precision highp float;
 %svoid main() {
     float no_strip = 0.0;

--- a/gapis/api/gles/stub_program_test.go
+++ b/gapis/api/gles/stub_program_test.go
@@ -40,8 +40,12 @@ func TestStubShaderSource(t *testing.T) {
 					},
 				},
 			},
-			vs: `// GAPII stub vertex shader
-#version 110
+			vs: `#version 150
+
+/////////////////////////////////////////////
+// GAPID stub shader (no source available) //
+/////////////////////////////////////////////
+
 precision highp float;
 uniform vec4 foo;
 void main() {
@@ -49,8 +53,12 @@ void main() {
     no_strip += foo.x;
     gl_Position = vec4(no_strip * 0.000001, 0., 0., 1.);
 }`,
-			fs: `// GAPII stub fragment shader
-#version 110
+			fs: `#version 150
+
+/////////////////////////////////////////////
+// GAPID stub shader (no source available) //
+/////////////////////////////////////////////
+
 precision highp float;
 uniform sampler2D bar;
 void main() {
@@ -74,8 +82,12 @@ void main() {
 					},
 				},
 			},
-			vs: `// GAPII stub vertex shader
-#version 110
+			vs: `#version 150
+
+/////////////////////////////////////////////
+// GAPID stub shader (no source available) //
+/////////////////////////////////////////////
+
 precision highp float;
 uniform vec4 bar[3];
 uniform vec4 foo[3];
@@ -89,8 +101,12 @@ void main() {
     no_strip += foo[2].x;
     gl_Position = vec4(no_strip * 0.000001, 0., 0., 1.);
 }`,
-			fs: `// GAPII stub fragment shader
-#version 110
+			fs: `#version 150
+
+/////////////////////////////////////////////
+// GAPID stub shader (no source available) //
+/////////////////////////////////////////////
+
 precision highp float;
 void main() {
     float no_strip = 0.0;

--- a/gapis/replay/batch.go
+++ b/gapis/replay/batch.go
@@ -190,6 +190,6 @@ func (w *adapter) MutateAndWrite(ctx context.Context, id api.CmdID, cmd api.Cmd)
 		w.builder.CommitCommand()
 	} else {
 		w.builder.RevertCommand(err)
-		log.W(ctx, "Failed to write command %v (%T) for replay: %v", id, cmd, err)
+		log.W(ctx, "Failed to write command %v %v for replay: %v", id, cmd, err)
 	}
 }


### PR DESCRIPTION
This got borked a while back, causing massive replay error spew if PCS are enabled.

You can now see the report items saying that PCS aren't supported.

Fixes: #727