### PR TITLE
Several single line Robot fixes

### DIFF
--- a/core/os/device/deviceinfo/cc/windows/query.cpp
+++ b/core/os/device/deviceinfo/cc/windows/query.cpp
@@ -174,7 +174,7 @@ int numABIs() { return 1; }
 
 void abi(int idx, device::ABI* abi) {
     abi->set_name("X86_64");
-    abi->set_os(device::OSX);
+    abi->set_os(device::Windows);
     abi->set_architecture(device::X86_64);
     abi->set_allocated_memorylayout(currentMemoryLayout());
 }

--- a/test/robot/build/package.go
+++ b/test/robot/build/package.go
@@ -78,7 +78,7 @@ func (p *packages) apply(ctx context.Context, pkg *Package) error {
 	for _, t := range pkg.Tool {
 		old.mergeTool(ctx, t)
 	}
-	p.onChange.Send(ctx, pkg)
+	p.onChange.Send(ctx, old)
 	return nil
 }
 

--- a/test/robot/replay/client.go
+++ b/test/robot/replay/client.go
@@ -114,6 +114,7 @@ func doReplay(ctx context.Context, action string, in *Input, store *stash.Client
 
 	params := []string{
 		"video",
+		"-type", "sxs",
 		"-out", videofile.System(),
 		tracefile.System(),
 	}


### PR DESCRIPTION
## Fix scheduler issue.

This was a very subtle bug which caused robot to not schedule any reports or replays after a package was added to a track. Package update is called after it is added to a track in order to propogate the parent information. But it is called with only a partial package, expecting the old package to merge (which it does) but then the event is triggered after apply using the new package (which is still only partial) which causes all listeners to recieve (and potentially replace) copies of the package which do not contain any tools.  
Essentially packages in the scheduler were having their tools wiped out whenever they were updated by the track, which meant we could no longer replay or report. Traces only worked because they were scheduled after the package's first event trigger, when they still had tools.

## Fix Windows having the wrong OS kind. 

Windows builds were saying that they were from OSX, thats no good.

## Force robot replay to use sxs video. 

A bug wasn't getting caught because we were relying on default behavior (if there are no FBOs we make a single frame video), instead force side by side behavior for robot so this can get caught in the future.