### PR TITLE
Add Package Ordering to robot website

### DIFF
--- a/test/robot/web/client/client.go
+++ b/test/robot/web/client/client.go
@@ -38,6 +38,8 @@ type task struct {
 	result grid.Result
 	status grid.Status
 
+	parent *task
+
 	underlying map[string]interface{}
 }
 

--- a/test/robot/web/client/client.go
+++ b/test/robot/web/client/client.go
@@ -69,6 +69,7 @@ type dimension struct {
 	valueOf  func(*task) Item
 	itemMap  map[string]Item
 	enumSrc  func() enum
+	enumSort func(a, b string) bool
 }
 
 func (d *dimension) getEnum() enum {
@@ -306,7 +307,7 @@ func (p *page) refresh() {
 		}
 	}
 
-	p.grid.SetData(data)
+	p.grid.SetData(data, p.rowDimension.enumSort, p.columnDimension.enumSort)
 }
 
 func robotEntityLink(path string, s interface{}) interface{} {

--- a/test/robot/web/client/data.go
+++ b/test/robot/web/client/data.go
@@ -236,6 +236,7 @@ func newTask(entry map[string]interface{}, kind Item) *task {
 }
 
 func compareTasksSimilar(t1 *task, t2 *task) bool {
+	// similar tasks can have different packages, but have the same target, subject, and host.
 	if t1.trace.target.Id() == t2.trace.target.Id() && t1.trace.subject.Id() == t2.trace.subject.Id() && t1.host.Id() == t2.host.Id() {
 		return true
 	}
@@ -244,6 +245,7 @@ func compareTasksSimilar(t1 *task, t2 *task) bool {
 
 func connectTaskParentChild(childListMap map[string][]*task, parentListMap map[string][]*task, t *task) {
 	findParentPkgIdInList := func(idList []string, childId string) string {
+		// it is the index of id's parent.
 		for it, id := range idList[1:] {
 			if childId == id {
 				return idList[it]
@@ -282,6 +284,7 @@ func connectTaskParentChild(childListMap map[string][]*task, parentListMap map[s
 func robotTasksPerKind(kind Item, path string, fun func(map[string]interface{}, *task)) []*task {
 	tasks := []*task{}
 	notCurrentTasks := []*task{}
+	currentTasks := []*task{}
 	childMap := map[string][]*task{}
 	parentMap := map[string][]*task{}
 
@@ -293,11 +296,18 @@ func robotTasksPerKind(kind Item, path string, fun func(map[string]interface{}, 
 		tasks = append(tasks, t)
 		if t.status != grid.Current {
 			notCurrentTasks = append(notCurrentTasks, t)
+		} else {
+			currentTasks = append(currentTasks, t)
 		}
 	}
 	for _, t := range notCurrentTasks {
 		if t.parent != nil {
 			t.result = t.parent.result
+		}
+	}
+	for _, t := range currentTasks {
+		if t.parent != nil && t.parent.result != t.result {
+			t.status = grid.Changed
 		}
 	}
 	return tasks

--- a/test/robot/web/client/widgets/grid/data.go
+++ b/test/robot/web/client/widgets/grid/data.go
@@ -93,6 +93,9 @@ const (
 	// InProgress represents a task that is currently being run.
 	// The task's result will be for data that is not current.
 	InProgress
+
+	// Changed represents a task with a result for the latest data that is different from its stale data
+	Changed
 )
 
 // TaskList is a list of tasks.
@@ -114,10 +117,12 @@ func (l TaskList) stats() taskStats {
 		numCurrentSucceeded:       l.Count(taskCurrentSucceeded),
 		numStaleSucceeded:         l.Count(taskStaleSucceeded),
 		numInProgressWasSucceeded: l.Count(taskInProgressWasSucceeded),
+		numFixed:                  l.Count(taskFixed),
 		numInProgressWasUnknown:   l.Count(taskInProgressWasUnknown),
 		numInProgressWasFailed:    l.Count(taskInProgressWasFailed),
 		numStaleFailed:            l.Count(taskStaleFailed),
 		numCurrentFailed:          l.Count(taskCurrentFailed),
+		numRegressed:              l.Count(taskRegressed),
 		numTasks:                  len(l),
 	}
 }
@@ -125,9 +130,11 @@ func (l TaskList) stats() taskStats {
 func taskCurrentSucceeded(t Task) bool       { return t.Result == Succeeded && t.Status == Current }
 func taskStaleSucceeded(t Task) bool         { return t.Result == Succeeded && t.Status == Stale }
 func taskInProgressWasSucceeded(t Task) bool { return t.Result == Succeeded && t.Status == InProgress }
+func taskFixed(t Task) bool                  { return t.Result == Succeeded && t.Status == Changed }
 func taskCurrentFailed(t Task) bool          { return t.Result == Failed && t.Status == Current }
 func taskStaleFailed(t Task) bool            { return t.Result == Failed && t.Status == Stale }
 func taskInProgressWasFailed(t Task) bool    { return t.Result == Failed && t.Status == InProgress }
+func taskRegressed(t Task) bool              { return t.Result == Failed && t.Status == Changed }
 func taskInProgressWasUnknown(t Task) bool   { return t.Result == Unknown && t.Status == InProgress }
 
 type cell struct {
@@ -154,10 +161,12 @@ type taskStats struct {
 	numCurrentSucceeded       int
 	numStaleSucceeded         int
 	numInProgressWasSucceeded int
+	numFixed                  int
 	numInProgressWasUnknown   int
 	numInProgressWasFailed    int
 	numStaleFailed            int
 	numCurrentFailed          int
+	numRegressed              int
 	numTasks                  int
 }
 

--- a/test/robot/web/client/widgets/grid/data.go
+++ b/test/robot/web/client/widgets/grid/data.go
@@ -304,15 +304,27 @@ func buildData(in Data, rowSort, columnSort headerLess) *dataset {
 }
 
 // SetData assigns the data to the grid.
-func (g *Grid) SetData(data Data) {
-	new, old := buildData(data, g.rowSort, g.columnSort), g.topDataset()
+func (g *Grid) SetData(data Data, rowSort, columnSort func(a, b string) bool) {
+	if rowSort == nil {
+		rowSort = sortAlphabetic
+	}
+	if columnSort == nil {
+		columnSort = sortAlphabetic
+	}
+	new, old := buildData(data, makeHeaderLess(rowSort), makeHeaderLess(columnSort)), g.topDataset()
 	g.setTransition(old, new)
 	g.tick()
 }
 
 type headerLess func(a, b *header) bool
 
-func sortAlphabetic(a, b *header) bool { return a.data.Name < b.data.Name }
+func sortAlphabetic(a, b string) bool { return a < b }
+
+func makeHeaderLess(sort func(a, b string) bool) headerLess {
+	return func(a, b *header) bool {
+		return sort(a.data.Name, b.data.Name)
+	}
+}
 
 type headerSorter struct {
 	list []*header

--- a/test/robot/web/client/widgets/grid/data.go
+++ b/test/robot/web/client/widgets/grid/data.go
@@ -117,12 +117,12 @@ func (l TaskList) stats() taskStats {
 		numCurrentSucceeded:       l.Count(taskCurrentSucceeded),
 		numStaleSucceeded:         l.Count(taskStaleSucceeded),
 		numInProgressWasSucceeded: l.Count(taskInProgressWasSucceeded),
-		numFixed:                  l.Count(taskFixed),
+		numSucceededWasFailed:     l.Count(taskSucceededWasFailed),
 		numInProgressWasUnknown:   l.Count(taskInProgressWasUnknown),
 		numInProgressWasFailed:    l.Count(taskInProgressWasFailed),
 		numStaleFailed:            l.Count(taskStaleFailed),
 		numCurrentFailed:          l.Count(taskCurrentFailed),
-		numRegressed:              l.Count(taskRegressed),
+		numFailedWasSucceeded:     l.Count(taskFailedWasSucceeded),
 		numTasks:                  len(l),
 	}
 }
@@ -130,11 +130,11 @@ func (l TaskList) stats() taskStats {
 func taskCurrentSucceeded(t Task) bool       { return t.Result == Succeeded && t.Status == Current }
 func taskStaleSucceeded(t Task) bool         { return t.Result == Succeeded && t.Status == Stale }
 func taskInProgressWasSucceeded(t Task) bool { return t.Result == Succeeded && t.Status == InProgress }
-func taskFixed(t Task) bool                  { return t.Result == Succeeded && t.Status == Changed }
+func taskSucceededWasFailed(t Task) bool     { return t.Result == Succeeded && t.Status == Changed }
 func taskCurrentFailed(t Task) bool          { return t.Result == Failed && t.Status == Current }
 func taskStaleFailed(t Task) bool            { return t.Result == Failed && t.Status == Stale }
 func taskInProgressWasFailed(t Task) bool    { return t.Result == Failed && t.Status == InProgress }
-func taskRegressed(t Task) bool              { return t.Result == Failed && t.Status == Changed }
+func taskFailedWasSucceeded(t Task) bool     { return t.Result == Failed && t.Status == Changed }
 func taskInProgressWasUnknown(t Task) bool   { return t.Result == Unknown && t.Status == InProgress }
 
 type cell struct {
@@ -161,12 +161,12 @@ type taskStats struct {
 	numCurrentSucceeded       int
 	numStaleSucceeded         int
 	numInProgressWasSucceeded int
-	numFixed                  int
+	numSucceededWasFailed     int
 	numInProgressWasUnknown   int
 	numInProgressWasFailed    int
 	numStaleFailed            int
 	numCurrentFailed          int
-	numRegressed              int
+	numFailedWasSucceeded     int
 	numTasks                  int
 }
 

--- a/test/robot/web/client/widgets/grid/draw.go
+++ b/test/robot/web/client/widgets/grid/draw.go
@@ -304,8 +304,8 @@ func (g *Grid) drawCluster(ctx *dom.Context2D, c *cluster, r *dom.Rect) {
 	drawSegment(g.Style.StaleFailedForegroundColor, false, c.stats.numStaleFailed)
 	drawSegment(g.Style.StaleFailedForegroundColor, true, c.stats.numInProgressWasFailed)
 	drawSegment(g.Style.CurrentFailedForegroundColor, false, c.stats.numCurrentFailed)
-	drawSegment(g.Style.FixedForegroundColor, false, c.stats.numFixed)
-	drawSegment(g.Style.RegressedForegroundColor, false, c.stats.numRegressed)
+	drawSegment(g.Style.FixedForegroundColor, false, c.stats.numSucceededWasFailed)
+	drawSegment(g.Style.RegressedForegroundColor, false, c.stats.numFailedWasSucceeded)
 
 	if icon != 0 {
 		ctx.Translate(centre)

--- a/test/robot/web/client/widgets/grid/draw.go
+++ b/test/robot/web/client/widgets/grid/draw.go
@@ -304,6 +304,8 @@ func (g *Grid) drawCluster(ctx *dom.Context2D, c *cluster, r *dom.Rect) {
 	drawSegment(g.Style.StaleFailedForegroundColor, false, c.stats.numStaleFailed)
 	drawSegment(g.Style.StaleFailedForegroundColor, true, c.stats.numInProgressWasFailed)
 	drawSegment(g.Style.CurrentFailedForegroundColor, false, c.stats.numCurrentFailed)
+	drawSegment(g.Style.FixedForegroundColor, false, c.stats.numFixed)
+	drawSegment(g.Style.RegressedForegroundColor, false, c.stats.numRegressed)
 
 	if icon != 0 {
 		ctx.Translate(centre)

--- a/test/robot/web/client/widgets/grid/grid.go
+++ b/test/robot/web/client/widgets/grid/grid.go
@@ -67,6 +67,8 @@ func New() *Grid {
 		StaleFailedBackgroundColor:      dom.RGBA(1.00, 0.80, 0.82, 0.3),
 		StaleFailedForegroundColor:      dom.RGBA(0.95, 0.26, 0.21, 0.3),
 		InProgressForegroundColor:       dom.RGBA(0.00, 0.50, 1.00, 0.9),
+		RegressedForegroundColor:        dom.RGBA(1.00, 0.40, 0.41, 0.9),
+		FixedForegroundColor:            dom.RGBA(0.18, 0.85, 0.20, 0.9),
 		UnknownBackgroundColor:          dom.RGBA(1.00, 1.00, 1.00, 1.0),
 		UnknownForegroundColor:          dom.RGBA(0.60, 0.60, 0.60, 0.9),
 		SelectedBackgroundColor:         dom.RGB(0.89, 0.95, 0.97),

--- a/test/robot/web/client/widgets/grid/grid.go
+++ b/test/robot/web/client/widgets/grid/grid.go
@@ -25,8 +25,6 @@ import (
 type Grid struct {
 	canvas         *dom.Canvas
 	datasets       []*dataset  // The grid dataset(s).
-	rowSort        headerLess  // Sorting function for rows
-	columnSort     headerLess  // Sorting function for rows
 	animating      bool        // If true then the grid will repeatedly redraw
 	time           float64     // time in seconds since the grid was created
 	startTime      time.Time   // time when the grid was created
@@ -80,11 +78,9 @@ func New() *Grid {
 		},
 	}
 	grid := &Grid{
-		canvas:     dom.NewCanvas(4, 4),
-		rowSort:    sortAlphabetic,
-		columnSort: sortAlphabetic,
-		startTime:  time.Now(),
-		Style:      style,
+		canvas:    dom.NewCanvas(4, 4),
+		startTime: time.Now(),
+		Style:     style,
 	}
 	grid.canvas.OnMouseDown(grid.onMouseDown)
 	grid.canvas.OnMouseUp(grid.onMouseUp)

--- a/test/robot/web/client/widgets/grid/style.go
+++ b/test/robot/web/client/widgets/grid/style.go
@@ -53,11 +53,11 @@ type Style struct {
 
 func (s *Style) statsStyle(stats taskStats) (icon rune, backgroundColor, foregroundColor dom.Color) {
 	switch {
-	case stats.numRegressed > 0:
+	case stats.numFailedWasSucceeded > 0:
 		return s.Icons.Failed, s.CurrentFailedBackgroundColor, s.RegressedForegroundColor
 	case stats.numCurrentFailed > 0:
 		return s.Icons.Failed, s.CurrentFailedBackgroundColor, s.CurrentFailedForegroundColor
-	case stats.numFixed > 0:
+	case stats.numSucceededWasFailed > 0:
 		return s.Icons.Succeeded, s.CurrentSucceededBackgroundColor, s.FixedForegroundColor
 	case stats.numInProgressWasFailed+stats.numStaleFailed > 0:
 		return s.Icons.Failed, s.StaleFailedBackgroundColor, s.StaleFailedForegroundColor

--- a/test/robot/web/client/widgets/grid/style.go
+++ b/test/robot/web/client/widgets/grid/style.go
@@ -42,6 +42,8 @@ type Style struct {
 	StaleFailedBackgroundColor      dom.Color // The background color used for tasks that have failed and are stale.
 	StaleFailedForegroundColor      dom.Color // The foreground color used for tasks that have failed and are stale.
 	InProgressForegroundColor       dom.Color // The foreground color used for tasks that last failed and are currently in progress.
+	RegressedForegroundColor        dom.Color // The foreground color used for tasks that last succeeded and now are failing.
+	FixedForegroundColor            dom.Color // The foreground color used for tasks that last failed and now are succeeding.
 	UnknownBackgroundColor          dom.Color // The background color used for tasks that are in an unknown state.
 	UnknownForegroundColor          dom.Color // The foreground color used for tasks that are in an unknown state.
 	SelectedBackgroundColor         dom.Color // The background color used for cells and headers when selected.
@@ -51,8 +53,12 @@ type Style struct {
 
 func (s *Style) statsStyle(stats taskStats) (icon rune, backgroundColor, foregroundColor dom.Color) {
 	switch {
+	case stats.numRegressed > 0:
+		return s.Icons.Failed, s.CurrentFailedBackgroundColor, s.RegressedForegroundColor
 	case stats.numCurrentFailed > 0:
 		return s.Icons.Failed, s.CurrentFailedBackgroundColor, s.CurrentFailedForegroundColor
+	case stats.numFixed > 0:
+		return s.Icons.Succeeded, s.CurrentSucceededBackgroundColor, s.FixedForegroundColor
 	case stats.numInProgressWasFailed+stats.numStaleFailed > 0:
 		return s.Icons.Failed, s.StaleFailedBackgroundColor, s.StaleFailedForegroundColor
 	case stats.numInProgressWasSucceeded+stats.numStaleSucceeded > 0:


### PR DESCRIPTION
We want to be able to see at a glance the state of our packages in relation to their predecessors. These changes add several features to the webserver to get us that support. 
 - Tasks know which tasks were spawned from their parent packages.
 - Tasks update their status to "Stale" when they know the status and result of their parents, but not themselves. (as desaturated colors)
 - Tasks update their status to "Changed" when they have a different result than their parents. (as bright colors)
 - Packages are ordered by their ancestry with the newest package listed last.