### PR TITLE
Fixed setprop after using VkGraphicsSpy

### DIFF
--- a/gapii/client/adb.go
+++ b/gapii/client/adb.go
@@ -115,7 +115,7 @@ func StartOrAttach(ctx context.Context, p *android.InstalledPackage, a *android.
 		// Clone context to ignore cancellation.
 		ctx := keys.Clone(context.Background(), ctx)
 		d.RemoveForward(ctx, port)
-		d.Command("shell", "setprop", "debug.vulkan.layers", "\"\"").Run(ctx)
+		d.Command("shell", "setprop", "debug.vulkan.layers", "").Run(ctx)
 	})
 
 	if a != nil {


### PR DESCRIPTION
#1049 

I found this actually lets me trace the [Android Vulkan Tutorials part 5](https://github.com/googlesamples/android-vulkan-tutorials/tree/master/tutorial05_triangle) and also doesn't break all other Vulkan apps. 

I feel this should be verified across multiple devices/OS before merging