### PR TITLE
Group subcommands with debug markers

### DIFF
--- a/gapis/api/cmd_id_group_test.go
+++ b/gapis/api/cmd_id_group_test.go
@@ -56,30 +56,30 @@ func buildTestGroup(end uint64) CmdIDGroup {
 			&CmdIDRange{0, 100},
 			&CmdIDGroup{"Sub-group 0", CmdIDRange{100, 200}, Spans{
 				&CmdIDRange{100, 200},
-			}, nil},
+			}, nil, SubCmdIdx{}},
 			&CmdIDRange{200, 300},
 			&CmdIDGroup{"Sub-group 1", CmdIDRange{300, 400}, Spans{
 				&CmdIDRange{310, 320},
 				&CmdIDGroup{"Sub-group 1.0", CmdIDRange{340, 360}, Spans{
 					&CmdIDRange{350, 351},
-				}, nil},
+				}, nil, SubCmdIdx{}},
 				&CmdIDGroup{"Sub-group 1.1", CmdIDRange{360, 370}, Spans{
 					&CmdIDGroup{"Sub-group 1.1.0", CmdIDRange{360, 362}, Spans{
 						&CmdIDRange{360, 362},
-					}, nil},
+					}, nil, SubCmdIdx{}},
 					&CmdIDGroup{"Sub-group 1.1.1", CmdIDRange{362, 365}, Spans{
 						&CmdIDRange{362, 365},
-					}, nil},
-				}, nil},
+					}, nil, SubCmdIdx{}},
+				}, nil, SubCmdIdx{}},
 				&CmdIDRange{370, 380},
-			}, nil},
+			}, nil, SubCmdIdx{}},
 			&CmdIDRange{400, 500},
 			&CmdIDGroup{"Sub-group 2", CmdIDRange{500, 600}, Spans{
 				&CmdIDRange{500, 600},
-			}, nil},
+			}, nil, SubCmdIdx{}},
 			&CmdIDRange{600, CmdID(end - 100)},
 		},
-		nil}
+		nil, SubCmdIdx{}}
 }
 
 func TestGroupFormat(t *testing.T) {
@@ -433,31 +433,31 @@ func TestAddAtomsFill(t *testing.T) {
 			&CmdIDRange{0, 100},
 			&CmdIDGroup{"Sub-group 0", CmdIDRange{100, 200}, Spans{
 				&CmdIDRange{100, 200},
-			}, nil},
+			}, nil, SubCmdIdx{}},
 			&CmdIDRange{200, 300},
 			&CmdIDGroup{"Sub-group 1", CmdIDRange{300, 400}, Spans{
 				&CmdIDRange{300, 340},
 				&CmdIDGroup{"Sub-group 1.0", CmdIDRange{340, 360}, Spans{
 					&CmdIDRange{340, 360},
-				}, nil},
+				}, nil, SubCmdIdx{}},
 				&CmdIDGroup{"Sub-group 1.1", CmdIDRange{360, 370}, Spans{
 					&CmdIDGroup{"Sub-group 1.1.0", CmdIDRange{360, 362}, Spans{
 						&CmdIDRange{360, 362},
-					}, nil},
+					}, nil, SubCmdIdx{}},
 					&CmdIDGroup{"Sub-group 1.1.1", CmdIDRange{362, 365}, Spans{
 						&CmdIDRange{362, 365},
-					}, nil},
+					}, nil, SubCmdIdx{}},
 					&CmdIDRange{365, 370},
-				}, nil},
+				}, nil, SubCmdIdx{}},
 				&CmdIDRange{370, 400},
-			}, nil},
+			}, nil, SubCmdIdx{}},
 			&CmdIDRange{400, 500},
 			&CmdIDGroup{"Sub-group 2", CmdIDRange{500, 600}, Spans{
 				&CmdIDRange{500, 600},
-			}, nil},
+			}, nil, SubCmdIdx{}},
 			&CmdIDRange{600, 1100},
 		},
-		nil}
+		nil, SubCmdIdx{}}
 
 	if !assert.With(ctx).That(got).DeepEquals(expected) {
 		fmt.Printf("Got: %+v\n", got)
@@ -470,16 +470,16 @@ func TestAddAtomsSparse(t *testing.T) {
 	ctx := log.Testing(t)
 	got := CmdIDGroup{
 		"root", CmdIDRange{0, 1100}, Spans{
-			&CmdIDGroup{"Sub-group 0", CmdIDRange{100, 200}, Spans{}, nil},
+			&CmdIDGroup{"Sub-group 0", CmdIDRange{100, 200}, Spans{}, nil, SubCmdIdx{}},
 			&CmdIDGroup{"Sub-group 1", CmdIDRange{300, 400}, Spans{
-				&CmdIDGroup{"Sub-group 1.0", CmdIDRange{340, 360}, Spans{}, nil},
+				&CmdIDGroup{"Sub-group 1.0", CmdIDRange{340, 360}, Spans{}, nil, SubCmdIdx{}},
 				&CmdIDGroup{"Sub-group 1.1", CmdIDRange{360, 370}, Spans{
-					&CmdIDGroup{"Sub-group 1.1.0", CmdIDRange{360, 362}, Spans{}, nil},
-					&CmdIDGroup{"Sub-group 1.1.1", CmdIDRange{362, 365}, Spans{}, nil},
-				}, nil},
-			}, nil},
-			&CmdIDGroup{"Sub-group 2", CmdIDRange{500, 600}, Spans{}, nil},
-		}, nil,
+					&CmdIDGroup{"Sub-group 1.1.0", CmdIDRange{360, 362}, Spans{}, nil, SubCmdIdx{}},
+					&CmdIDGroup{"Sub-group 1.1.1", CmdIDRange{362, 365}, Spans{}, nil, SubCmdIdx{}},
+				}, nil, SubCmdIdx{}},
+			}, nil, SubCmdIdx{}},
+			&CmdIDGroup{"Sub-group 2", CmdIDRange{500, 600}, Spans{}, nil, SubCmdIdx{}},
+		}, nil, SubCmdIdx{},
 	}
 
 	addAtomsAndCluster(&got, 0, 0, func(id CmdID) bool { return (id/50)&1 == 0 })
@@ -489,29 +489,29 @@ func TestAddAtomsSparse(t *testing.T) {
 			&CmdIDRange{0, 50},
 			&CmdIDGroup{"Sub-group 0", CmdIDRange{100, 200}, Spans{
 				&CmdIDRange{100, 150},
-			}, nil},
+			}, nil, SubCmdIdx{}},
 			&CmdIDRange{200, 250},
 			&CmdIDGroup{"Sub-group 1", CmdIDRange{300, 400}, Spans{
 				&CmdIDRange{300, 340},
 				&CmdIDGroup{"Sub-group 1.0", CmdIDRange{340, 360}, Spans{
 					&CmdIDRange{340, 350},
-				}, nil},
+				}, nil, SubCmdIdx{}},
 				&CmdIDGroup{"Sub-group 1.1", CmdIDRange{360, 370}, Spans{
-					&CmdIDGroup{"Sub-group 1.1.0", CmdIDRange{360, 362}, Spans{}, nil},
-					&CmdIDGroup{"Sub-group 1.1.1", CmdIDRange{362, 365}, Spans{}, nil},
-				}, nil},
-			}, nil},
+					&CmdIDGroup{"Sub-group 1.1.0", CmdIDRange{360, 362}, Spans{}, nil, SubCmdIdx{}},
+					&CmdIDGroup{"Sub-group 1.1.1", CmdIDRange{362, 365}, Spans{}, nil, SubCmdIdx{}},
+				}, nil, SubCmdIdx{}},
+			}, nil, SubCmdIdx{}},
 			&CmdIDRange{400, 450},
 			&CmdIDGroup{"Sub-group 2", CmdIDRange{500, 600}, Spans{
 				&CmdIDRange{500, 550},
-			}, nil},
+			}, nil, SubCmdIdx{}},
 			&CmdIDRange{600, 650},
 			&CmdIDRange{700, 750},
 			&CmdIDRange{800, 850},
 			&CmdIDRange{900, 950},
 			&CmdIDRange{1000, 1050},
 		},
-		nil}
+		nil, SubCmdIdx{}}
 
 	if !assert.With(ctx).That(got).DeepEquals(expected) {
 		fmt.Printf("Got: %+v\n", got)
@@ -528,18 +528,18 @@ func TestAddAtomsWithSplitting(t *testing.T) {
 
 	expected := CmdIDGroup{
 		"root", CmdIDRange{0, 700}, Spans{
-			&CmdIDGroup{"Sub Group 1", CmdIDRange{0, 45}, Spans{&CmdIDRange{0, 45}}, nil},
-			&CmdIDGroup{"Sub Group 2", CmdIDRange{45, 90}, Spans{&CmdIDRange{45, 90}}, nil},
+			&CmdIDGroup{"Sub Group 1", CmdIDRange{0, 45}, Spans{&CmdIDRange{0, 45}}, nil, SubCmdIdx{}},
+			&CmdIDGroup{"Sub Group 2", CmdIDRange{45, 90}, Spans{&CmdIDRange{45, 90}}, nil, SubCmdIdx{}},
 			&CmdIDGroup{"Sub Group 3", CmdIDRange{90, 234}, Spans{
 				&CmdIDRange{90, 100},
 				&CmdIDGroup{"Sub-group 0", CmdIDRange{100, 200}, Spans{
-					&CmdIDGroup{"Sub Group 1", CmdIDRange{100, 145}, Spans{&CmdIDRange{100, 145}}, nil},
-					&CmdIDGroup{"Sub Group 2", CmdIDRange{145, 190}, Spans{&CmdIDRange{145, 190}}, nil},
-					&CmdIDGroup{"Sub Group 3", CmdIDRange{190, 200}, Spans{&CmdIDRange{190, 200}}, nil},
-				}, nil},
+					&CmdIDGroup{"Sub Group 1", CmdIDRange{100, 145}, Spans{&CmdIDRange{100, 145}}, nil, SubCmdIdx{}},
+					&CmdIDGroup{"Sub Group 2", CmdIDRange{145, 190}, Spans{&CmdIDRange{145, 190}}, nil, SubCmdIdx{}},
+					&CmdIDGroup{"Sub Group 3", CmdIDRange{190, 200}, Spans{&CmdIDRange{190, 200}}, nil, SubCmdIdx{}},
+				}, nil, SubCmdIdx{}},
 				&CmdIDRange{200, 234},
-			}, nil},
-			&CmdIDGroup{"Sub Group 4", CmdIDRange{234, 279}, Spans{&CmdIDRange{234, 279}}, nil},
+			}, nil, SubCmdIdx{}},
+			&CmdIDGroup{"Sub Group 4", CmdIDRange{234, 279}, Spans{&CmdIDRange{234, 279}}, nil, SubCmdIdx{}},
 			&CmdIDGroup{"Sub Group 5", CmdIDRange{279, 423}, Spans{
 				&CmdIDRange{279, 300},
 				&CmdIDGroup{"Sub-group 1", CmdIDRange{300, 400}, Spans{
@@ -547,36 +547,36 @@ func TestAddAtomsWithSplitting(t *testing.T) {
 						&CmdIDRange{300, 340},
 						&CmdIDGroup{"Sub-group 1.0", CmdIDRange{340, 360}, Spans{
 							&CmdIDRange{340, 360},
-						}, nil},
+						}, nil, SubCmdIdx{}},
 						&CmdIDGroup{"Sub-group 1.1", CmdIDRange{360, 370}, Spans{
 							&CmdIDGroup{"Sub-group 1.1.0", CmdIDRange{360, 362}, Spans{
 								&CmdIDRange{360, 362},
-							}, nil},
+							}, nil, SubCmdIdx{}},
 							&CmdIDGroup{"Sub-group 1.1.1", CmdIDRange{362, 365}, Spans{
 								&CmdIDRange{362, 365},
-							}, nil},
+							}, nil, SubCmdIdx{}},
 							&CmdIDRange{365, 370},
-						}, nil},
+						}, nil, SubCmdIdx{}},
 						&CmdIDRange{370, 373},
-					}, nil},
-					&CmdIDGroup{"Sub Group 2", CmdIDRange{373, 400}, Spans{&CmdIDRange{373, 400}}, nil},
-				}, nil},
+					}, nil, SubCmdIdx{}},
+					&CmdIDGroup{"Sub Group 2", CmdIDRange{373, 400}, Spans{&CmdIDRange{373, 400}}, nil, SubCmdIdx{}},
+				}, nil, SubCmdIdx{}},
 				&CmdIDRange{400, 423},
-			}, nil},
-			&CmdIDGroup{"Sub Group 6", CmdIDRange{423, 468}, Spans{&CmdIDRange{423, 468}}, nil},
+			}, nil, SubCmdIdx{}},
+			&CmdIDGroup{"Sub Group 6", CmdIDRange{423, 468}, Spans{&CmdIDRange{423, 468}}, nil, SubCmdIdx{}},
 			&CmdIDGroup{"Sub Group 7", CmdIDRange{468, 612}, Spans{
 				&CmdIDRange{468, 500},
 				&CmdIDGroup{"Sub-group 2", CmdIDRange{500, 600}, Spans{
-					&CmdIDGroup{"Sub Group 1", CmdIDRange{500, 545}, Spans{&CmdIDRange{500, 545}}, nil},
-					&CmdIDGroup{"Sub Group 2", CmdIDRange{545, 590}, Spans{&CmdIDRange{545, 590}}, nil},
-					&CmdIDGroup{"Sub Group 3", CmdIDRange{590, 600}, Spans{&CmdIDRange{590, 600}}, nil},
-				}, nil},
+					&CmdIDGroup{"Sub Group 1", CmdIDRange{500, 545}, Spans{&CmdIDRange{500, 545}}, nil, SubCmdIdx{}},
+					&CmdIDGroup{"Sub Group 2", CmdIDRange{545, 590}, Spans{&CmdIDRange{545, 590}}, nil, SubCmdIdx{}},
+					&CmdIDGroup{"Sub Group 3", CmdIDRange{590, 600}, Spans{&CmdIDRange{590, 600}}, nil, SubCmdIdx{}},
+				}, nil, SubCmdIdx{}},
 				&CmdIDRange{600, 612},
-			}, nil},
-			&CmdIDGroup{"Sub Group 8", CmdIDRange{612, 657}, Spans{&CmdIDRange{612, 657}}, nil},
-			&CmdIDGroup{"Sub Group 9", CmdIDRange{657, 700}, Spans{&CmdIDRange{657, 700}}, nil},
+			}, nil, SubCmdIdx{}},
+			&CmdIDGroup{"Sub Group 8", CmdIDRange{612, 657}, Spans{&CmdIDRange{612, 657}}, nil, SubCmdIdx{}},
+			&CmdIDGroup{"Sub Group 9", CmdIDRange{657, 700}, Spans{&CmdIDRange{657, 700}}, nil, SubCmdIdx{}},
 		},
-		nil}
+		nil, SubCmdIdx{}}
 
 	assert.With(ctx).That(got).DeepEquals(expected)
 }
@@ -586,10 +586,10 @@ func TestAddAtomsWithNeighbours(t *testing.T) {
 	{
 		got := CmdIDGroup{
 			"root", CmdIDRange{0, 52}, Spans{
-				&CmdIDGroup{"Child 1", CmdIDRange{10, 20}, Spans{&CmdIDRange{10, 20}}, nil},
-				&CmdIDGroup{"Child 2", CmdIDRange{31, 50}, Spans{&CmdIDRange{31, 50}}, nil},
+				&CmdIDGroup{"Child 1", CmdIDRange{10, 20}, Spans{&CmdIDRange{10, 20}}, nil, SubCmdIdx{}},
+				&CmdIDGroup{"Child 2", CmdIDRange{31, 50}, Spans{&CmdIDRange{31, 50}}, nil, SubCmdIdx{}},
 			},
-			nil,
+			nil, SubCmdIdx{},
 		}
 
 		addAtomsAndCluster(&got, 0, 10, func(CmdID) bool { return true })
@@ -597,12 +597,12 @@ func TestAddAtomsWithNeighbours(t *testing.T) {
 		expected := CmdIDGroup{
 			"root", CmdIDRange{0, 52}, Spans{
 				&CmdIDRange{0, 10},
-				&CmdIDGroup{"Child 1", CmdIDRange{10, 20}, Spans{&CmdIDRange{10, 20}}, nil},
-				&CmdIDGroup{"Sub Group", CmdIDRange{20, 31}, Spans{&CmdIDRange{20, 31}}, nil},
-				&CmdIDGroup{"Child 2", CmdIDRange{31, 50}, Spans{&CmdIDRange{31, 50}}, nil},
+				&CmdIDGroup{"Child 1", CmdIDRange{10, 20}, Spans{&CmdIDRange{10, 20}}, nil, SubCmdIdx{}},
+				&CmdIDGroup{"Sub Group", CmdIDRange{20, 31}, Spans{&CmdIDRange{20, 31}}, nil, SubCmdIdx{}},
+				&CmdIDGroup{"Child 2", CmdIDRange{31, 50}, Spans{&CmdIDRange{31, 50}}, nil, SubCmdIdx{}},
 				&CmdIDRange{50, 52},
 			},
-			nil,
+			nil, SubCmdIdx{},
 		}
 
 		assert.With(ctx).That(got).DeepEquals(expected)
@@ -620,40 +620,40 @@ func TestSpansSplit(t *testing.T) {
 			&CmdIDRange{9, 11},
 			&CmdIDRange{11, 14},
 			&CmdIDRange{14, 15},
-			&CmdIDGroup{"Child 1", CmdIDRange{15, 16}, Spans{&CmdIDRange{15, 16}}, nil},
-			&CmdIDGroup{"Child 2", CmdIDRange{16, 17}, Spans{&CmdIDRange{16, 17}}, nil},
-			&CmdIDGroup{"Child 3", CmdIDRange{17, 18}, Spans{&CmdIDRange{17, 18}}, nil},
-			&CmdIDGroup{"Child 4", CmdIDRange{18, 19}, Spans{&CmdIDRange{18, 19}}, nil},
-			&CmdIDGroup{"Child 5", CmdIDRange{19, 20}, Spans{&CmdIDRange{19, 20}}, nil},
-			&CmdIDGroup{"Child 6", CmdIDRange{20, 21}, Spans{&CmdIDRange{20, 21}}, nil},
-			&CmdIDGroup{"Child 7", CmdIDRange{21, 22}, Spans{&CmdIDRange{21, 22}}, nil},
+			&CmdIDGroup{"Child 1", CmdIDRange{15, 16}, Spans{&CmdIDRange{15, 16}}, nil, SubCmdIdx{}},
+			&CmdIDGroup{"Child 2", CmdIDRange{16, 17}, Spans{&CmdIDRange{16, 17}}, nil, SubCmdIdx{}},
+			&CmdIDGroup{"Child 3", CmdIDRange{17, 18}, Spans{&CmdIDRange{17, 18}}, nil, SubCmdIdx{}},
+			&CmdIDGroup{"Child 4", CmdIDRange{18, 19}, Spans{&CmdIDRange{18, 19}}, nil, SubCmdIdx{}},
+			&CmdIDGroup{"Child 5", CmdIDRange{19, 20}, Spans{&CmdIDRange{19, 20}}, nil, SubCmdIdx{}},
+			&CmdIDGroup{"Child 6", CmdIDRange{20, 21}, Spans{&CmdIDRange{20, 21}}, nil, SubCmdIdx{}},
+			&CmdIDGroup{"Child 7", CmdIDRange{21, 22}, Spans{&CmdIDRange{21, 22}}, nil, SubCmdIdx{}},
 		},
-		nil}
+		nil, SubCmdIdx{}}
 
 	got.Spans = got.Spans.split(3)
 
 	expected := CmdIDGroup{
 		"root", CmdIDRange{0, 22}, Spans{
-			&CmdIDGroup{"Sub Group 1", CmdIDRange{0, 3}, Spans{&CmdIDRange{0, 3}}, nil},
-			&CmdIDGroup{"Sub Group 2", CmdIDRange{3, 6}, Spans{&CmdIDRange{3, 4}, &CmdIDRange{4, 6}}, nil},
-			&CmdIDGroup{"Sub Group 3", CmdIDRange{6, 9}, Spans{&CmdIDRange{6, 7}, &CmdIDRange{7, 9}}, nil},
-			&CmdIDGroup{"Sub Group 4", CmdIDRange{9, 12}, Spans{&CmdIDRange{9, 11}, &CmdIDRange{11, 12}}, nil},
-			&CmdIDGroup{"Sub Group 5", CmdIDRange{12, 15}, Spans{&CmdIDRange{12, 14}, &CmdIDRange{14, 15}}, nil},
+			&CmdIDGroup{"Sub Group 1", CmdIDRange{0, 3}, Spans{&CmdIDRange{0, 3}}, nil, SubCmdIdx{}},
+			&CmdIDGroup{"Sub Group 2", CmdIDRange{3, 6}, Spans{&CmdIDRange{3, 4}, &CmdIDRange{4, 6}}, nil, SubCmdIdx{}},
+			&CmdIDGroup{"Sub Group 3", CmdIDRange{6, 9}, Spans{&CmdIDRange{6, 7}, &CmdIDRange{7, 9}}, nil, SubCmdIdx{}},
+			&CmdIDGroup{"Sub Group 4", CmdIDRange{9, 12}, Spans{&CmdIDRange{9, 11}, &CmdIDRange{11, 12}}, nil, SubCmdIdx{}},
+			&CmdIDGroup{"Sub Group 5", CmdIDRange{12, 15}, Spans{&CmdIDRange{12, 14}, &CmdIDRange{14, 15}}, nil, SubCmdIdx{}},
 			&CmdIDGroup{"Sub Group 6", CmdIDRange{15, 18}, Spans{
-				&CmdIDGroup{"Child 1", CmdIDRange{15, 16}, Spans{&CmdIDRange{15, 16}}, nil},
-				&CmdIDGroup{"Child 2", CmdIDRange{16, 17}, Spans{&CmdIDRange{16, 17}}, nil},
-				&CmdIDGroup{"Child 3", CmdIDRange{17, 18}, Spans{&CmdIDRange{17, 18}}, nil},
-			}, nil},
+				&CmdIDGroup{"Child 1", CmdIDRange{15, 16}, Spans{&CmdIDRange{15, 16}}, nil, SubCmdIdx{}},
+				&CmdIDGroup{"Child 2", CmdIDRange{16, 17}, Spans{&CmdIDRange{16, 17}}, nil, SubCmdIdx{}},
+				&CmdIDGroup{"Child 3", CmdIDRange{17, 18}, Spans{&CmdIDRange{17, 18}}, nil, SubCmdIdx{}},
+			}, nil, SubCmdIdx{}},
 			&CmdIDGroup{"Sub Group 7", CmdIDRange{18, 21}, Spans{
-				&CmdIDGroup{"Child 4", CmdIDRange{18, 19}, Spans{&CmdIDRange{18, 19}}, nil},
-				&CmdIDGroup{"Child 5", CmdIDRange{19, 20}, Spans{&CmdIDRange{19, 20}}, nil},
-				&CmdIDGroup{"Child 6", CmdIDRange{20, 21}, Spans{&CmdIDRange{20, 21}}, nil},
-			}, nil},
+				&CmdIDGroup{"Child 4", CmdIDRange{18, 19}, Spans{&CmdIDRange{18, 19}}, nil, SubCmdIdx{}},
+				&CmdIDGroup{"Child 5", CmdIDRange{19, 20}, Spans{&CmdIDRange{19, 20}}, nil, SubCmdIdx{}},
+				&CmdIDGroup{"Child 6", CmdIDRange{20, 21}, Spans{&CmdIDRange{20, 21}}, nil, SubCmdIdx{}},
+			}, nil, SubCmdIdx{}},
 			&CmdIDGroup{"Sub Group 8", CmdIDRange{21, 22}, Spans{
-				&CmdIDGroup{"Child 7", CmdIDRange{21, 22}, Spans{&CmdIDRange{21, 22}}, nil},
-			}, nil},
+				&CmdIDGroup{"Child 7", CmdIDRange{21, 22}, Spans{&CmdIDRange{21, 22}}, nil, SubCmdIdx{}},
+			}, nil, SubCmdIdx{}},
 		},
-		nil}
+		nil, SubCmdIdx{}}
 
 	assert.With(ctx).That(got).DeepEquals(expected)
 }
@@ -867,23 +867,23 @@ func TestTraverseBackwards(t *testing.T) {
 			&CmdIDGroup{"Frame 1", CmdIDRange{0, 5}, Spans{
 				&CmdIDGroup{"Draw 1", CmdIDRange{0, 2}, Spans{
 					&CmdIDRange{0, 2},
-				}, nil},
+				}, nil, SubCmdIdx{}},
 				&CmdIDGroup{"Draw 2", CmdIDRange{2, 4}, Spans{
 					&CmdIDRange{2, 4},
-				}, nil},
+				}, nil, SubCmdIdx{}},
 				&CmdIDRange{4, 5},
-			}, nil},
+			}, nil, SubCmdIdx{}},
 			&CmdIDGroup{"Frame 2", CmdIDRange{5, 10}, Spans{
 				&CmdIDGroup{"Draw 1", CmdIDRange{5, 7}, Spans{
 					&CmdIDRange{5, 7},
-				}, nil},
+				}, nil, SubCmdIdx{}},
 				&CmdIDGroup{"Draw 2", CmdIDRange{7, 9}, Spans{
 					&CmdIDRange{7, 9},
-				}, nil},
+				}, nil, SubCmdIdx{}},
 				&CmdIDRange{9, 10},
-			}, nil},
+			}, nil, SubCmdIdx{}},
 		},
-		nil}
+		nil, SubCmdIdx{}}
 
 	for ti, test := range []struct {
 		root     CmdIDGroup

--- a/gapis/api/sync/data.go
+++ b/gapis/api/sync/data.go
@@ -56,15 +56,40 @@ type Data struct {
 	// Hidden contains all the commands that should be hidden from the regular
 	// command tree as they exist as a subcommand of another command.
 	Hidden api.CmdIDSet
+	// SubCommandMarkerGroups contains all the marker groups in the subcommands,
+	// indexed by the immediate parent of the subcommands in the group.
+	// e.g.: group: [73, 1, 4, 5~6] should be indexed by [73, 1, 4]
+	SubCommandMarkerGroups *subCommandMarkerGroupTrie
+}
+
+type subCommandMarkerGroupTrie struct {
+	api.SubCmdIdxTrie
+}
+
+// NewMarkerGroup creates a new SubCmdMarkerGroup in the marker group trie
+// with the specified name and parent SubCmdIdx, and returns a pointer to the
+// created SubCmdMarkerGroup.
+func (t *subCommandMarkerGroupTrie) NewMarkerGroup(parent api.SubCmdIdx, name string) *api.SubCmdMarkerGroup {
+	// Intentionally not using interval.U64SpanList as groups here can be nested
+	// and overlapped in between.
+	l := []*api.SubCmdMarkerGroup{}
+	if o, ok := t.Value(parent).([]*api.SubCmdMarkerGroup); ok {
+		l = o
+	}
+	group := &api.SubCmdMarkerGroup{Name: name, Parent: parent}
+	l = append(l, group)
+	t.SetValue(parent, l)
+	return group
 }
 
 // NewData creates a new clean Data object
 func NewData() *Data {
 	return &Data{
-		CommandRanges:        map[api.CmdID]ExecutionRanges{},
-		SubcommandReferences: map[api.CmdID][]SubcommandReference{},
-		SubcommandGroups:     map[api.CmdID][]api.SubCmdIdx{},
-		Hidden:               api.CmdIDSet{},
+		CommandRanges:          map[api.CmdID]ExecutionRanges{},
+		SubcommandReferences:   map[api.CmdID][]SubcommandReference{},
+		SubcommandGroups:       map[api.CmdID][]api.SubCmdIdx{},
+		Hidden:                 api.CmdIDSet{},
+		SubCommandMarkerGroups: &subCommandMarkerGroupTrie{},
 	}
 }
 

--- a/gapis/api/transform/dce.go
+++ b/gapis/api/transform/dce.go
@@ -142,9 +142,6 @@ func (t *DCE) Flush(ctx context.Context, out Writer) {
 
 			out.MutateAndWrite(ctx, api.CmdID(fci[0]), aliveCmd)
 		} else {
-			if t.requestCount == uint64(1) && !aliveCmds.contains(fci) {
-				log.W(ctx, "Dead command/subcommand: %v", fci)
-			}
 			if len(fci) == 1 && !aliveCmds.contains(fci) {
 				// logging the DCE result of dead commands
 				deadCmd := t.footprint.Commands[fci[0]]

--- a/gapis/api/vulkan/externs.go
+++ b/gapis/api/vulkan/externs.go
@@ -297,3 +297,15 @@ func (e externs) numberOfPNext(pNext Voidᶜᵖ) uint32 {
 	}
 	return counter
 }
+
+func (e externs) pushDebugMarker(name string) {
+	if GetState(e.s).pushDebugMarkerGroup != nil {
+		GetState(e.s).pushDebugMarkerGroup(name)
+	}
+}
+
+func (e externs) popDebugMarker() {
+	if GetState(e.s).popDebugMarkerGroup != nil {
+		GetState(e.s).popDebugMarkerGroup()
+	}
+}

--- a/gapis/api/vulkan/templates/vk_spy_helpers.cpp.tmpl
+++ b/gapis/api/vulkan/templates/vk_spy_helpers.cpp.tmpl
@@ -585,5 +585,8 @@ uint32_t VulkanSpy::numberOfPNext(CallObserver* observer, void* pNext) {
   }
   return counter;
 }
+
+void VulkanSpy::pushDebugMarker(CallObserver*, std::string) {}
+void VulkanSpy::popDebugMarker(CallObserver*) {}
 }
 {{end}}

--- a/gapis/api/vulkan/vulkan.api
+++ b/gapis/api/vulkan/vulkan.api
@@ -83,7 +83,7 @@ define NULL_HANDLE 0
 @extension("VK_EXT_debug_report") define VK_EXT_DEBUG_REPORT_SPEC_VERSION   1
 @extension("VK_EXT_debug_report") define VK_EXT_DEBUG_REPORT_EXTENSION_NAME "VK_EXT_debug_report"
 
-@extension("VK_EXT_debug_marker") define VK_EXT_DEBUG_MARKER_SPEC_VERSION 4
+@extension("VK_EXT_debug_marker") define VK_EXT_DEBUG_MARKER_SPEC_VERSION   4
 @extension("VK_EXT_debug_marker") define VK_EXT_DEBUG_MARKER_EXTENSION_NAME "VK_EXT_debug_marker"
 
 /////////////
@@ -283,8 +283,8 @@ enum VkStructureType {
 
   //@extension("VK_EXT_debug_marker")
   VK_STRUCTURE_TYPE_DEBUG_MARKER_OBJECT_NAME_INFO_EXT = 1000022000
-  VK_STRUCTURE_TYPE_DEBUG_MARKER_OBJECT_TAG_INFO_EXT = 1000022001
-  VK_STRUCTURE_TYPE_DEBUG_MARKER_MARKER_INFO_EXT = 1000022002
+  VK_STRUCTURE_TYPE_DEBUG_MARKER_OBJECT_TAG_INFO_EXT  = 1000022001
+  VK_STRUCTURE_TYPE_DEBUG_MARKER_MARKER_INFO_EXT      = 1000022002
 
   //@extension("VK_NV_dedicated_allocation")
   VK_STRUCTURE_TYPE_DEDICATED_ALLOCATION_IMAGE_CREATE_INFO_NV    = 1000026000,
@@ -3917,7 +3917,7 @@ cmd void RecreateDestroyShaderModule(
 @custom
 @no_replay
 cmd void RecreateDestroyRenderPass(
-    VkDevice       device,
+    VkDevice     device,
     VkRenderPass renderPass) { }
 
 
@@ -4634,7 +4634,7 @@ cmd VkResult vkResetDescriptorPool(
   // while iterating is safe for Go. So the code here should behave as we
   // expect.
   sets := DescriptorPools[descriptorPool].DescriptorSets
-  for _, s, _ in sets {
+  for _ , s , _ in sets {
     delete(DescriptorSets, s)
     delete(DescriptorPools[descriptorPool].DescriptorSets, s)
   }
@@ -5423,6 +5423,8 @@ extern void leaveSubcontext()
 extern void recordUpdateSemaphoreSignal(VkSemaphore semaphore, bool Signaled)
 extern void addWords(VkShaderModule module, size numBytes, const u32* pData)
 extern void addDebugMarkerTagBytes(ref!VulkanDebugMarkerInfo debugInfo, size numBytes, u8* pTag)
+extern void pushDebugMarker(string name)
+extern void popDebugMarker()
 extern ref!RecreateCmdUpdateBufferData createUpdateBufferData(
     VkBuffer     dstBuffer
     VkDeviceSize dstOffset
@@ -8970,17 +8972,25 @@ cmd VkResult vkDebugMarkerSetObjectNameEXT(
 cmd void RecreateCmdDebugMarkerBeginEXT(
     VkCommandBuffer             commandBuffer,
     VkDebugMarkerMarkerInfoEXT* pMarkerInfo) {
-    markerInfo := pMarkerInfo[0]
-    _ = as!string(markerInfo.pMarkerName)
-    for i in (0 .. 4) {
-      _ = markerInfo.color[i]
-    }
+  markerInfo := pMarkerInfo[0]
+  _ = as!string(markerInfo.pMarkerName)
+  for i in (0 .. 4) {
+    _ = markerInfo.color[i]
+  }
+}
+
+@internal class CmdDebugMarkerBegin {
+  string MarkerName
+}
+
+sub void doCmdDebugMarkerBegin(CmdDebugMarkerBegin args) {
+  pushDebugMarker(args.MarkerName)
 }
 
 @internal class
 RecreateCmdDebugMarkerBeginEXTData {
   @unused string MarkerName,
-  @unused f32[4] Color,
+  @unused f32[4] Color     ,
 }
 
 @threadSafety("app")
@@ -8993,21 +9003,26 @@ cmd void vkCmdDebugMarkerBeginEXT(
     VkCommandBuffer                             commandBuffer,
     VkDebugMarkerMarkerInfoEXT*                 pMarkerInfo) {
   markerInfo := pMarkerInfo[0]
+  markerName := as!string(markerInfo.pMarkerName)
   recreate_data := new!RecreateCmdDebugMarkerBeginEXTData(
-    MarkerName: as!string(markerInfo.pMarkerName),
+    MarkerName: markerName,
   )
   recreate_data.Color[0] = markerInfo.color[0]
   recreate_data.Color[1] = markerInfo.color[1]
   recreate_data.Color[2] = markerInfo.color[2]
   recreate_data.Color[3] = markerInfo.color[3]
-  addCmd(commandBuffer, recreate_data, Unimplemented(), doCmdNop)
+  addCmd(commandBuffer, recreate_data, CmdDebugMarkerBegin(markerName), doCmdDebugMarkerBegin)
 }
 
 @override
 @custom
 @no_replay
 cmd void RecreateCmdDebugMarkerEndEXT(
-    VkCommandBuffer             commandBuffer) {
+    VkCommandBuffer commandBuffer) {
+}
+
+sub void doCmdDebugMarkerEnd(u32 unused) {
+  popDebugMarker()
 }
 
 @internal class
@@ -9020,19 +9035,18 @@ RecreateCmdDebugMarkerEndEXTData {}
 @override
 @no_replay
 cmd void vkCmdDebugMarkerEndEXT(
-    VkCommandBuffer                             commandBuffer) {
-    addCmd(commandBuffer, new!RecreateCmdDebugMarkerEndEXTData(),
-      Unimplemented(), doCmdNop)
+    VkCommandBuffer commandBuffer) {
+  addCmd(commandBuffer, new!RecreateCmdDebugMarkerEndEXTData(),as!u32(0), doCmdDebugMarkerEnd)
 }
 
 @override
 @custom
 @no_replay
 cmd void RecreateCmdDebugMarkerInsertEXT(
-  VkCommandBuffer             commandBuffer,
-  VkDebugMarkerMarkerInfoEXT* pMarkerInfo) {
+    VkCommandBuffer             commandBuffer,
+    VkDebugMarkerMarkerInfoEXT* pMarkerInfo) {
   markerInfo := pMarkerInfo[0]
-   _ = as!string(markerInfo.pMarkerName)
+  _ = as!string(markerInfo.pMarkerName)
   for i in (0 .. 4) {
     _ = markerInfo.color[i]
   }
@@ -9041,7 +9055,7 @@ cmd void RecreateCmdDebugMarkerInsertEXT(
 @internal class
 RecreateCmdDebugMarkerInsertEXTData {
   @unused string MarkerName,
-  @unused f32[4] Color,
+  @unused f32[4] Color     ,
 }
 
 @threadSafety("app")
@@ -9266,9 +9280,9 @@ sub void clearLastDrawInfoDrawCommandParameters() {
 }
 
 @internal class VulkanDebugMarkerInfo {
-  @unused string  ObjectName
-  @unused u64     TagName
-  @internal u8[]  Tag
+  @unused string ObjectName
+  @unused u64    TagName
+  @internal u8[] Tag
 }
 
 // Internal struct for holding useful instance level information from VkInstanceCreateInfo.
@@ -9727,10 +9741,10 @@ enum SurfaceType {
   SURFACE_TYPE_UNKNOWN = 0
   SURFACE_TYPE_XCB     = 1
   SURFACE_TYPE_ANDROID = 2
-  SURFACE_TYPE_WIN32 = 3
+  SURFACE_TYPE_WIN32   = 3
   SURFACE_TYPE_WAYLAND = 4
-  SURFACE_TYPE_XLIB = 5
-  SURFACE_TYPE_MIR = 6
+  SURFACE_TYPE_XLIB    = 5
+  SURFACE_TYPE_MIR     = 6
 }
 
 @internal class SurfaceObject {

--- a/gapis/resolve/command_tree.go
+++ b/gapis/resolve/command_tree.go
@@ -96,6 +96,19 @@ func CommandTreeNode(ctx context.Context, c *path.CommandTreeNode) (*service.Com
 			Commands:    cmdTree.path.Capture.SubCommandRange(item, item),
 		}, nil
 	case api.CmdIDGroup:
+		// If this CmdIDGroup has a parent SubCmdRoot, it should be processed as
+		// differently.
+		if len(item.Parent) != 0 {
+			parent := item.Parent
+			commandStart := append([]uint64(parent), uint64(item.Range.First()))
+			commandEnd := append([]uint64(parent), uint64(item.Range.Last()))
+			return &service.CommandTreeNode{
+				NumChildren: item.Count(),
+				Commands:    cmdTree.path.Capture.SubCommandRange(commandStart, commandEnd),
+				Group:       item.Name,
+				NumCommands: item.Count(),
+			}, nil
+		}
 		return &service.CommandTreeNode{
 			NumChildren: item.Count(),
 			Commands:    cmdTree.path.Capture.CommandRange(uint64(item.Range.First()), uint64(item.Range.Last())),
@@ -114,12 +127,13 @@ func CommandTreeNode(ctx context.Context, c *path.CommandTreeNode) (*service.Com
 			count = uint64(item.SubGroup.Count())
 		}
 		return &service.CommandTreeNode{
-			NumChildren: item.SubGroup.Bounds().Length(),
+			NumChildren: item.SubGroup.Count(),
 			Commands:    cmdTree.path.Capture.SubCommandRange(commandStart, commandEnd),
 			Group:       g,
 			NumCommands: count,
 		}, nil
 	default:
+		return nil, nil
 		panic(fmt.Errorf("Unexpected type: %T, cmdTree.index(c.Indices): %v, indices: %v",
 			item, cmdTree.index(c.Indices), c.Indices))
 	}
@@ -280,6 +294,15 @@ func (r *CommandTreeResolvable) Resolve(ctx context.Context) (interface{}, error
 			cv := append([]api.SubCmdIdx{}, v...)
 			sort.SliceStable(cv, func(i, j int) bool { return len(cv[i]) < len(cv[j]) })
 			for _, x := range cv {
+				markerGroupParent := []uint64{uint64(id)}
+				markerGroupParent = append(markerGroupParent, x[0:len(x)-1]...)
+				// subcommand marker groups are added before subcommands. And groups with
+				// shorter indices are added before groups with longer indices.
+				// SubCmdRoot will be created when necessary.
+				if snc.SubCommandMarkerGroups.Value(markerGroupParent) != nil {
+					markers := snc.SubCommandMarkerGroups.Value(markerGroupParent).([]*api.SubCmdMarkerGroup)
+					r.AddSubCmdMarkerGroups(markerGroupParent, markers)
+				}
 				r.Insert([]uint64{uint64(id)}, append([]uint64{}, x...))
 			}
 			return nil


### PR DESCRIPTION
Use CmdIDGroup in SubCmdRoot's SubGroup to group the subcommands