### PR TITLE
vulkan: Fix command buffer invocation.

### DIFF
--- a/gapis/api/vulkan/CMakeFiles.cmake
+++ b/gapis/api/vulkan/CMakeFiles.cmake
@@ -29,6 +29,7 @@ set(files
     draw_call_mesh.go
     enum.go
     externs.go
+    externs_test.go
     find_issues.go
     footprint_builder.go
     mutate.go

--- a/gapis/api/vulkan/externs_test.go
+++ b/gapis/api/vulkan/externs_test.go
@@ -12,24 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package vulkan implementes the API interface for the Vulkan graphics library.
-
 package vulkan
 
 import (
-	"context"
+	"testing"
 
+	"github.com/google/gapid/core/log"
+	"github.com/google/gapid/core/os/device"
 	"github.com/google/gapid/gapis/api"
-	"github.com/google/gapid/gapis/replay/builder"
 )
 
-type CommandBufferCommand struct {
-	function         func(context.Context, api.Cmd, api.CmdID, *api.State, *builder.Builder)
-	initialCall      *api.Cmd
-	submit           *api.Cmd
-	submissionIndex  []uint64
-	recreateData     interface{}
-	actualSubmission bool
+func TestCallSub(t *testing.T) {
+	ctx := log.Testing(t)
+	e := externs{}
+	s := api.NewStateWithEmptyAllocator(device.Little32)
+	e.callSub(ctx, &VkCreateBuffer{}, 10, s, nil, subDoCmdNop, Unimplemented{})
 }
-
-type CommandBufferCommands []CommandBufferCommand


### PR DESCRIPTION
This code uses reflection to call a command with dynamic data. This got broken when I changed the subroutine parameter list.

As this keeps on breaking, I've added a test.