### PR TITLE
Simplify error handling for report.

### DIFF
--- a/gapis/api/cmd_errors.go
+++ b/gapis/api/cmd_errors.go
@@ -32,6 +32,6 @@ func Abort(msg string) *ErrCmdAborted {
 // IsErrCmdAborted returns true if the cause of the error err was due to an
 // abort() in the command.
 func IsErrCmdAborted(err error) bool {
-	_, ok := errors.Cause(err).(ErrCmdAborted)
+	_, ok := errors.Cause(err).(*ErrCmdAborted)
 	return ok
 }

--- a/gapis/api/gles/find_issues.go
+++ b/gapis/api/gles/find_issues.go
@@ -93,13 +93,6 @@ func (t *findIssues) Transform(ctx context.Context, id api.CmdID, cmd api.Cmd, o
 	cb := CommandBuilder{Thread: cmd.Thread()}
 	t.lastGlError = GLenum_GL_NO_ERROR
 	mutateErr := cmd.Mutate(ctx, id, t.state, nil /* no builder */)
-	if mutateErr != nil {
-		if api.IsErrCmdAborted(mutateErr) && t.lastGlError != GLenum_GL_NO_ERROR {
-			// GL errors have already been reported - so do not log it again.
-		} else {
-			t.onIssue(cmd, id, service.Severity_ErrorLevel, mutateErr)
-		}
-	}
 
 	mutatorsGlError := t.lastGlError
 	if e := FindErrorState(cmd.Extras()); e != nil {

--- a/gapis/api/gles/gles.go
+++ b/gapis/api/gles/gles.go
@@ -44,7 +44,7 @@ func (c *State) preMutate(ctx context.Context, s *api.State, cmd api.Cmd) error 
 		if f := s.NewMessage; f != nil {
 			f(log.Error, messages.ErrNoContextBound(cmd.Thread()))
 		}
-		return api.ErrCmdAborted{Reason: "No context bound"}
+		return &api.ErrCmdAborted{Reason: "No context bound"}
 	}
 	return nil
 }

--- a/gapis/messages/en-us.stb.md
+++ b/gapis/messages/en-us.stb.md
@@ -115,6 +115,10 @@ Internal error in trace assert: {{reason}}
 
 {{error}}
 
+# ERR_INTERNAL_ERROR
+
+Internal error: {{error}}
+
 # ERR_REPLAY_DRIVER
 
 Error during replay: {{replayError}}


### PR DESCRIPTION
Aborts are assumed to be ok. The api is responsible for generating a
message together with the abort if it wants to communicate an issue.

All non-abort errors returned from mutate are internal errors.

Fixes #1082