### PR TITLE
Handle go being on the $PATH twice.

### DIFF
--- a/kokoro/linux/build.sh
+++ b/kokoro/linux/build.sh
@@ -29,8 +29,8 @@ tar -xzf go1.8.linux-amd64.tar.gz
 
 # Setup GO paths (remove old, add new).
 export GOROOT=$BUILD_ROOT/go
-export PATH=${PATH/\/usr\/local\/go\/bin:/}
-export PATH=${PATH/\/usr\/local\/go\/packages\/bin:/}
+export PATH=${PATH//:\/usr\/local\/go\/bin/}
+export PATH=${PATH//:\/usr\/local\/go\/packages\/bin/}
 export PATH=$PATH:$GOROOT/bin
 
 # Setup the build config file.

--- a/kokoro/macos/build.sh
+++ b/kokoro/macos/build.sh
@@ -29,7 +29,8 @@ tar -xzf go1.8.darwin-amd64.tar.gz
 
 # Setup GO paths (remove old, add new).
 export GOROOT=$BUILD_ROOT/go
-export PATH=${PATH/\/usr\/local\/go\/bin:/}
+export PATH=${PATH//:\/usr\/local\/go\/bin/}
+export PATH=${PATH//:\/usr\/local\/go\/packages\/bin/}
 export PATH=$PATH:$GOROOT/bin
 
 # Setup the Android SDK and NDK


### PR DESCRIPTION
This is happening on linux, but I'm also "future proofing" osx here.