### PR TITLE
jdwp_loader: Fallback to loadNativeGvrLibrary(Context)

### DIFF
--- a/core/java/jdbg/failure.go
+++ b/core/java/jdbg/failure.go
@@ -35,9 +35,8 @@ func (j *JDbg) err(err error) {
 	panic(failure{err})
 }
 
-// catchFailures calls f, returning the error. If f panics with a failure then
-// these will be caught and the inner error will be returned immediately.
-func catchFailures(f func() error) (err error) {
+// Try calls f, catching and returning any exceptions thrown.
+func Try(f func() error) (err error) {
 	defer func() {
 		switch r := recover().(type) {
 		case nil:

--- a/core/java/jdbg/jdbg.go
+++ b/core/java/jdbg/jdbg.go
@@ -80,7 +80,7 @@ func Do(conn *jdwp.Connection, thread jdwp.ThreadID, f func(jdbg *JDbg) error) e
 		}
 	}()
 
-	err := catchFailures(func() error {
+	return Try(func() error {
 		// Prime the cache with basic types.
 		j.cache.voidTy = &Simple{j: j, ty: jdwp.TagVoid}
 		j.cache.boolTy = &Simple{j: j, ty: jdwp.TagBoolean}
@@ -106,8 +106,6 @@ func Do(conn *jdwp.Connection, thread jdwp.ThreadID, f func(jdbg *JDbg) error) e
 		// Call f
 		return f(j)
 	})
-
-	return err
 }
 
 // ObjectType returns the Java java.lang.Object type.


### PR DESCRIPTION
... if loadNativeGvrLibrary(Context, int major, int minor, int point) does not exist.

This is the newer signature.

Fixes: #1093