### PR TITLE
Replace builder info, allow BuildBot when git present.

### DIFF
--- a/test/robot/build/artifact.go
+++ b/test/robot/build/artifact.go
@@ -144,7 +144,7 @@ func (z *zipEntry) GetID(ctx context.Context, a *artifacts) string {
 	return z.id
 }
 
-func (a *artifacts) get(ctx context.Context, id string, hostABIs []*device.ABI) (*Artifact, error) {
+func (a *artifacts) get(ctx context.Context, id string, builderAbi *device.ABI) (*Artifact, error) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 	if entry := a.byID[id]; entry != nil {
@@ -161,10 +161,7 @@ func (a *artifacts) get(ctx context.Context, id string, hostABIs []*device.ABI) 
 	if err != nil {
 		return nil, log.Err(ctx, nil, "File is not a build artifact.")
 	}
-	if len(hostABIs) != 1 {
-		log.W(ctx, "(*artifacts) get() received multiple host ABIs, taking first one. %v", hostABIs[0])
-	}
-	toolSet := ToolSet{Abi: hostABIs[0], Host: new(HostToolSet)}
+	toolSet := ToolSet{Abi: builderAbi, Host: new(HostToolSet)}
 	// TODO(baldwinn): move these paths to layout
 	toolSetIDByZipEntry := map[string]*string{
 		"gapid/gapir":                          &toolSet.Host.Gapir,

--- a/test/robot/build/local.go
+++ b/test/robot/build/local.go
@@ -67,7 +67,7 @@ func (s *local) SearchTracks(ctx context.Context, query *search.Query, handler T
 // Add implements Store.Add
 // It adds the package to the persisten store, and attempts to add it into the track it should be part of.
 func (s *local) Add(ctx context.Context, id string, info *Information) (string, bool, error) {
-	a, err := s.artifacts.get(ctx, id, info.Builder.Configuration.ABIs)
+	a, err := s.artifacts.get(ctx, id, info.Builder.Configuration.ABIs[0])
 	if err != nil {
 		return "", false, err
 	}


### PR DESCRIPTION
We do not need the entire instance information for the builder that came
with every package and in the case of buildbot packages, the builder
info would be incorrect because the uploader is not the builder.
Reducing this information down to just the ABI captures all we need from
the builder info.

Submitting a BuildBot build when git is present would still change the
type to User. Now the test is if a CL is specified in the command line
it keeps the BuildBot type, if prepare needs to ask for the head CL,
then it is a User build.