### PR TITLE
Allow do upload to specify flags to robot, branch->track.

### DIFF
--- a/cmd/do/do.go
+++ b/cmd/do/do.go
@@ -95,9 +95,17 @@ type (
 	}
 	RobotOptions struct {
 		BuildAndRunOptions
+		ServerAddress string `help:"The master server address"`
 	}
 	UploadOptions struct {
-		BuildAndRunOptions
+		RobotOptions
+		CL           string `help:"The build CL, will be guessed if not set"`
+		Description  string `help:"An optional build description"`
+		Tag          string `help:"The optional build tag"`
+		Track        string `help:"The package's track, will be guessed if not set"`
+		Uploader     string `help:"The uploading entity, will be guessed if not set"`
+		BuilderAbi   string `help:"The abi of the builder device, will assume this device if not set"`
+		ArtifactPath string `help:"The file path where the zipped artifact will be stored"`
 	}
 	initVerb   struct{ InitOptions }
 	configVerb struct{ ConfigOptions }

--- a/cmd/do/run.go
+++ b/cmd/do/run.go
@@ -30,7 +30,12 @@ func doRobot(ctx context.Context, cfg Config, options RobotOptions, args ...stri
 	if options.WD.IsEmpty() {
 		options.WD = cfg.OutRoot.Join("robot")
 	}
-	doRunTarget(ctx, cfg, options.BuildAndRunOptions, "robot", args...)
+	robotArgs := []string{}
+	if options.ServerAddress != "" {
+		robotArgs = append(robotArgs, "-serveraddress", options.ServerAddress)
+	}
+	robotArgs = append(robotArgs, args...)
+	doRunTarget(ctx, cfg, options.BuildAndRunOptions, "robot", robotArgs...)
 }
 
 func doRunTarget(ctx context.Context, cfg Config, options BuildAndRunOptions, target string, args ...string) {

--- a/cmd/do/upload.go
+++ b/cmd/do/upload.go
@@ -30,6 +30,29 @@ func getPlatform() string {
 
 func doUpload(ctx context.Context, cfg Config, options UploadOptions, args ...string) {
 	pkg := cfg.out().Join(fmt.Sprintf("%s-%s.zip", "gapid", getPlatform()))
-	robotArgs := append([]string{"upload", "package", pkg.String()}, args...)
-	doRunTarget(ctx, cfg, options.BuildAndRunOptions, "robot", robotArgs...)
+	robotArgs := []string{"upload", "package"}
+	if options.CL != "" {
+		robotArgs = append(robotArgs, "-cl", options.CL)
+	}
+	if options.Description != "" {
+		robotArgs = append(robotArgs, "-description", options.Description)
+	}
+	if options.Tag != "" {
+		robotArgs = append(robotArgs, "-tag", options.Tag)
+	}
+	if options.Track != "" {
+		robotArgs = append(robotArgs, "-track", options.Track)
+	}
+	if options.Uploader != "" {
+		robotArgs = append(robotArgs, "-uploader", options.Uploader)
+	}
+	if options.BuilderAbi != "" {
+		robotArgs = append(robotArgs, "-builderabi", options.BuilderAbi)
+	}
+	if options.ArtifactPath != "" {
+		robotArgs = append(robotArgs, "-artifactpath", options.ArtifactPath)
+	}
+	robotArgs = append(robotArgs, pkg.String())
+	robotArgs = append(robotArgs, args...)
+	doRobot(ctx, cfg, options.RobotOptions, robotArgs...)
 }

--- a/cmd/robot/actions.go
+++ b/cmd/robot/actions.go
@@ -24,6 +24,10 @@ import (
 	"google.golang.org/grpc"
 )
 
+type RobotOptions struct {
+	ServerAddress string `help:"The master server address"`
+}
+
 var (
 	startVerb = app.AddVerb(&app.Verb{
 		Name:      "start",
@@ -41,24 +45,26 @@ var (
 		Name:      "set",
 		ShortHelp: "Sets a value in a server",
 	})
+	defaultRobotOptions = RobotOptions{ServerAddress: defaultMasterAddress}
 )
 
 func init() {
 	app.AddVerb(&app.Verb{
 		Name:      "stop",
 		ShortHelp: "Stop a server",
-		Action:    &stopVerb{ServerAddress: defaultMasterAddress},
+		Action:    &stopVerb{RobotOptions: defaultRobotOptions},
 	})
 	app.AddVerb(&app.Verb{
 		Name:      "restart",
 		ShortHelp: "Restart a server",
-		Action:    &restartVerb{ServerAddress: defaultMasterAddress},
+		Action:    &restartVerb{RobotOptions: defaultRobotOptions},
 	})
 }
 
 type stopVerb struct {
-	ServerAddress string `help:"The master server address"`
-	Now           bool   `help:"Immediate shutdown"`
+	RobotOptions
+
+	Now bool `help:"Immediate shutdown"`
 }
 
 func (v *stopVerb) Run(ctx context.Context, flags flag.FlagSet) error {
@@ -72,7 +78,7 @@ func (v *stopVerb) Run(ctx context.Context, flags flag.FlagSet) error {
 }
 
 type restartVerb struct {
-	ServerAddress string `help:"The master server address"`
+	RobotOptions
 }
 
 func (v *restartVerb) Run(ctx context.Context, flags flag.FlagSet) error {

--- a/cmd/robot/job.go
+++ b/cmd/robot/job.go
@@ -42,23 +42,23 @@ func init() {
 		Name:       "device",
 		ShortHelp:  "List the devices",
 		ShortUsage: "<query>",
-		Action:     &deviceSearchFlags{ServerAddress: defaultMasterAddress},
+		Action:     &deviceSearchFlags{RobotOptions: defaultRobotOptions},
 	})
 	searchVerb.Add(&app.Verb{
 		Name:       "worker",
 		ShortHelp:  "List the workers",
 		ShortUsage: "<query>",
-		Action:     &workerSearchFlags{ServerAddress: defaultMasterAddress},
+		Action:     &workerSearchFlags{RobotOptions: defaultRobotOptions},
 	})
 	startVerb.Add(&app.Verb{
 		Name:      "worker",
 		ShortHelp: "Starts a robot worker",
-		Action:    &workerStartFlags{ServerAddress: defaultMasterAddress},
+		Action:    &workerStartFlags{RobotOptions: defaultRobotOptions},
 	})
 }
 
 type deviceSearchFlags struct {
-	ServerAddress string `help:"The master server address"`
+	RobotOptions
 }
 
 func (v *deviceSearchFlags) Run(ctx context.Context, flags flag.FlagSet) error {
@@ -78,7 +78,7 @@ func (v *deviceSearchFlags) Run(ctx context.Context, flags flag.FlagSet) error {
 }
 
 type workerSearchFlags struct {
-	ServerAddress string `help:"The master server address"`
+	RobotOptions
 }
 
 func (v *workerSearchFlags) Run(ctx context.Context, flags flag.FlagSet) error {
@@ -98,7 +98,7 @@ func (v *workerSearchFlags) Run(ctx context.Context, flags flag.FlagSet) error {
 }
 
 type workerStartFlags struct {
-	ServerAddress string `help:"The master server address"`
+	RobotOptions
 }
 
 func (v *workerStartFlags) Run(ctx context.Context, flags flag.FlagSet) error {

--- a/cmd/robot/master.go
+++ b/cmd/robot/master.go
@@ -66,7 +66,7 @@ func init() {
 		Name:       "master",
 		ShortHelp:  "List satellites registered with the master",
 		ShortUsage: "<query>",
-		Action:     &masterSearchVerb{ServerAddress: defaultMasterAddress},
+		Action:     &masterSearchVerb{RobotOptions: defaultRobotOptions},
 	})
 }
 
@@ -218,7 +218,7 @@ func serveAll(ctx context.Context, server *grpc.Server, managers monitor.Manager
 }
 
 type masterSearchVerb struct {
-	ServerAddress string `help:"The master server address"`
+	RobotOptions
 }
 
 func (v *masterSearchVerb) Run(ctx context.Context, flags flag.FlagSet) error {

--- a/cmd/robot/replay.go
+++ b/cmd/robot/replay.go
@@ -34,12 +34,12 @@ func init() {
 		Name:       "replay",
 		ShortHelp:  "List build replays in the server",
 		ShortUsage: "<query>",
-		Action:     &replaySearchFlags{ServerAddress: defaultMasterAddress},
+		Action:     &replaySearchFlags{RobotOptions: defaultRobotOptions},
 	})
 }
 
 type replaySearchFlags struct {
-	ServerAddress string `help:"The master server address"`
+	RobotOptions
 }
 
 func (v *replaySearchFlags) Run(ctx context.Context, flags flag.FlagSet) error {

--- a/cmd/robot/report.go
+++ b/cmd/robot/report.go
@@ -34,12 +34,12 @@ func init() {
 		Name:       "report",
 		ShortHelp:  "List build reports in the server",
 		ShortUsage: "<query>",
-		Action:     &reportSearchFlags{ServerAddress: defaultMasterAddress},
+		Action:     &reportSearchFlags{RobotOptions: defaultRobotOptions},
 	})
 }
 
 type reportSearchFlags struct {
-	ServerAddress string `help:"The master server address"`
+	RobotOptions
 }
 
 func (v *reportSearchFlags) Run(ctx context.Context, flags flag.FlagSet) error {

--- a/cmd/robot/stash.go
+++ b/cmd/robot/stash.go
@@ -35,18 +35,18 @@ func init() {
 		Name:       "stash",
 		ShortHelp:  "Upload a file to the stash",
 		ShortUsage: "<filenames>",
-		Action:     &stashUploadVerb{ServerAddress: defaultMasterAddress},
+		Action:     &stashUploadVerb{RobotOptions: defaultRobotOptions},
 	})
 	searchVerb.Add(&app.Verb{
 		Name:       "stash",
 		ShortHelp:  "List entries in the stash",
 		ShortUsage: "<query>",
-		Action:     &stashSearchVerb{ServerAddress: defaultMasterAddress},
+		Action:     &stashSearchVerb{RobotOptions: defaultRobotOptions},
 	})
 }
 
 type stashUploadVerb struct {
-	ServerAddress string `help:"The master server address"`
+	RobotOptions
 }
 
 func (v *stashUploadVerb) Run(ctx context.Context, flags flag.FlagSet) error {
@@ -56,7 +56,7 @@ func (stashUploadVerb) prepare(context.Context, *grpc.ClientConn) error { return
 func (stashUploadVerb) process(context.Context, string) error           { return nil }
 
 type stashSearchVerb struct {
-	ServerAddress string `help:"The master server address"`
+	RobotOptions
 }
 
 func (v *stashSearchVerb) Run(ctx context.Context, flags flag.FlagSet) error {

--- a/cmd/robot/subject.go
+++ b/cmd/robot/subject.go
@@ -36,20 +36,20 @@ func init() {
 		Name:       "subject",
 		ShortHelp:  "Upload a traceable application to the server",
 		ShortUsage: "<filenames>",
-		Action:     &subjectUploadVerb{ServerAddress: defaultMasterAddress},
+		Action:     &subjectUploadVerb{RobotOptions: defaultRobotOptions},
 	})
 	searchVerb.Add(&app.Verb{
 		Name:       "subject",
 		ShortHelp:  "List traceable applications in the server",
 		ShortUsage: "<query>",
-		Action:     &subjectSearchVerb{ServerAddress: defaultMasterAddress},
+		Action:     &subjectSearchVerb{RobotOptions: defaultRobotOptions},
 	})
 }
 
 type subjectUploadVerb struct {
-	TraceTime     time.Duration `help:"trace time override (if non-zero)"`
-	ServerAddress string        `help:"The master server address"`
-	subjects      subject.Subjects
+	RobotOptions
+	TraceTime time.Duration `help:"trace time override (if non-zero)"`
+	subjects  subject.Subjects
 }
 
 func (v *subjectUploadVerb) Run(ctx context.Context, flags flag.FlagSet) error {
@@ -79,7 +79,7 @@ func (v *subjectUploadVerb) process(ctx context.Context, id string) error {
 }
 
 type subjectSearchVerb struct {
-	ServerAddress string `help:"The master server address"`
+	RobotOptions
 }
 
 func (v *subjectSearchVerb) Run(ctx context.Context, flags flag.FlagSet) error {

--- a/cmd/robot/trace.go
+++ b/cmd/robot/trace.go
@@ -35,19 +35,20 @@ func init() {
 		Name:       "trace",
 		ShortHelp:  "Upload a gfx trace to the server",
 		ShortUsage: "<filenames>",
-		Action:     &traceUploadVerb{ServerAddress: defaultMasterAddress},
+		Action:     &traceUploadVerb{RobotOptions: defaultRobotOptions},
 	})
 	searchVerb.Add(&app.Verb{
 		Name:       "trace",
 		ShortHelp:  "List build traces in the server",
 		ShortUsage: "<query>",
-		Action:     &traceSearchVerb{ServerAddress: defaultMasterAddress},
+		Action:     &traceSearchVerb{RobotOptions: defaultRobotOptions},
 	})
 }
 
 type traceUploadVerb struct {
-	ServerAddress string `help:"The master server address"`
-	traces        trace.Manager
+	RobotOptions
+
+	traces trace.Manager
 }
 
 func (v *traceUploadVerb) Run(ctx context.Context, flags flag.FlagSet) error {
@@ -62,7 +63,7 @@ func (v *traceUploadVerb) process(ctx context.Context, id string) error {
 }
 
 type traceSearchVerb struct {
-	ServerAddress string `help:"The master server address"`
+	RobotOptions
 }
 
 func (v *traceSearchVerb) Run(ctx context.Context, flags flag.FlagSet) error {

--- a/cmd/robot/web.go
+++ b/cmd/robot/web.go
@@ -40,16 +40,17 @@ func init() {
 		Name:      "web",
 		ShortHelp: "Starts a robot web server",
 		Action: &webVerb{
-			Port:          8080,
-			ServerAddress: defaultMasterAddress,
+			RobotOptions: defaultRobotOptions,
+			Port:         8080,
 		},
 	})
 }
 
 type webVerb struct {
-	Port          int       `help:"The port to serve the website on"`
-	Root          file.Path `help:"The directory to use as the root of static content"`
-	ServerAddress string    `help:"The master server address"`
+	RobotOptions
+
+	Port int       `help:"The port to serve the website on"`
+	Root file.Path `help:"The directory to use as the root of static content"`
 }
 
 func (v *webVerb) Run(ctx context.Context, flags flag.FlagSet) error {


### PR DESCRIPTION
In order to allow `do upload` to forward command line options to the
underlying `do robot` commands they must be represented in the original
verb or else `do` will cause an error for unknown flags. This change
factors out those flags into UploadOptions and RobotOptions and replaces
the necessary verbs on `do` and `do robot`.

This also changes the cli flag of branch to track as that is the true
meaning of the flag, it just uses the branch when a user build does not
specify a track manually.