### PR TITLE
Added the spy_disabled annotation to slices.

### DIFF
--- a/gapii/cc/call_observer.cpp
+++ b/gapii/cc/call_observer.cpp
@@ -123,8 +123,4 @@ void CallObserver::encodeAndDelete(::google::protobuf::Message* cmd) {
     delete cmd;
 }
 
-bool CallObserver::isActive() const {
-    return mSpy->should_trace(mApi);
-}
-
 }  // namespace gapii

--- a/gapii/cc/call_observer.h
+++ b/gapii/cc/call_observer.h
@@ -157,10 +157,8 @@ private:
     // pool and we are supposed to observe application pool.
     template <class T>
     bool shouldObserve(const Slice<T>& slice) const {
-        return isActive() && mObserveApplicationPool && slice.isApplicationPool();
+        return mObserveApplicationPool && slice.isApplicationPool();
     }
-
-    bool isActive() const;
 
     // Make a slice on a new Pool.
     template <typename T>
@@ -237,7 +235,7 @@ inline void CallObserver::write(const Slice<T>& dst, uint64_t index,
 template <typename T>
 inline Slice<T> CallObserver::copy(const Slice<T>& dst, const Slice<T>& src) {
     read(src);
-    if (isActive() && !shouldObserve(
+    if (!shouldObserve(
             dst)) {  // The spy must not mutate data in the application pool.
         uint64_t c = (src.count() < dst.count()) ? src.count() : dst.count();
         src.copy(dst, 0, c, 0);

--- a/gapil/template/api.go
+++ b/gapil/template/api.go
@@ -160,3 +160,20 @@ func (f *Functions) TokenOf(v semantic.Node) string {
 	}
 	return f.mappings.CST(ast[0]).Token().String()
 }
+
+// TargetField returns the *semantic.Field if e is an expression that refers to
+// a class field, otherwise nil.
+func (f *Functions) TargetField(e semantic.Expression) interface{} {
+	for {
+		switch v := e.(type) {
+		case *semantic.Field:
+			return v
+		case *semantic.Member:
+			return v.Field
+		case *semantic.SliceRange:
+			e = v.Slice
+		default:
+			return nil
+		}
+	}
+}

--- a/gapis/api/templates/api_spy.cpp.tmpl
+++ b/gapis/api/templates/api_spy.cpp.tmpl
@@ -311,6 +311,8 @@
 {{define "Statement"}}
   {{     if IsReturn $}}{{Template "Return" $}}
   {{else if IsFence  $}}{{Template "Fence" $}}
+  {{else if IsCopy   $}}{{Template "Copy" $}}
+  {{else if IsAssign $}}{{Template "Assign" $}}
   {{else              }}{{Template "C++.Statement.Default" $}}
   {{end}}
 {{end}}
@@ -356,5 +358,42 @@
     {{Template "C++.Return" $}}
   {{else}}
     break;
+  {{end}}
+{{end}}
+
+{{/*
+-------------------------------------------------------------------------------
+  An override for the "C++.Copy" macro.
+-------------------------------------------------------------------------------
+*/}}
+{{define "Copy"}}
+  {{AssertType $ "Copy"}}
+  {{if (and (GetAnnotation ($.Src | TargetField) "spy_disabled") ((GetAnnotation ($.Dst | TargetField) "spy_disabled")))}}
+    // @spy_disabled
+  {{else if GetAnnotation ($.Src | TargetField) "spy_disabled"}}
+    {{Error "Attempting to copy from a @spy_disabled slice"}}
+  {{else if GetAnnotation ($.Dst | TargetField) "spy_disabled"}}
+    observer->read({{Template "C++.Read" $.Src}}); // @spy_disabled
+  {{else}}
+    {{Template "C++.Statement.Default" $}}
+  {{end}}
+{{end}}
+
+
+{{/*
+-------------------------------------------------------------------------------
+  An override for the "C++.Assign" macro.
+-------------------------------------------------------------------------------
+*/}}
+{{define "Assign"}}
+  {{AssertType $ "Assign"}}
+  {{if (and (GetAnnotation ($.RHS | TargetField) "spy_disabled") ((GetAnnotation ($.LHS | TargetField) "spy_disabled")))}}
+    // @spy_disabled
+  {{else if GetAnnotation ($.RHS | TargetField) "spy_disabled"}}
+    {{Error "Attempting to assign from a @spy_disabled slice"}}
+  {{else if GetAnnotation ($.LHS | TargetField) "spy_disabled"}}
+    // @spy_disabled
+  {{else}}
+    {{Template "C++.Statement.Default" $}}
   {{end}}
 {{end}}

--- a/gapis/api/vulkan/vulkan.api
+++ b/gapis/api/vulkan/vulkan.api
@@ -2929,9 +2929,9 @@ cmd VkResult vkAllocateMemory(
     MappedOffset:     0,
     MappedSize:       0,
     MappedLocation:   null,
-    MemoryTypeIndex:  allocateInfo.memoryTypeIndex,
-    Data:             make!u8(allocateInfo.allocationSize),
+    MemoryTypeIndex:  allocateInfo.memoryTypeIndex
   )
+  memoryObject.Data = make!u8(allocateInfo.allocationSize)
 
   // Handle pNext
   if allocateInfo.pNext != null {
@@ -6200,9 +6200,6 @@ sub void dovkCmdCopyImage(ref!vkCmdCopyImageArgs args) {
       dstImageLevelWidthInBlocks := as!u64(roundUpTo(dstImageLevel.Width, as!u32(dstBlockWidth)))
       dstImageLevelHeightInBlocks := as!u64(roundUpTo(dstImageLevel.Height, as!u32(dstBlockHeight)))
 
-      srcData := srcImageLevel.Data
-      dstData := dstImageLevel.Data
-
       for z in (0 .. extentZ) {
         for y in (0 .. extentYInBlocks) {
           copySize := as!u64(extentXInBlocks) * srcElementSize
@@ -6212,7 +6209,7 @@ sub void dovkCmdCopyImage(ref!vkCmdCopyImageArgs args) {
           srcZ := srcZStart + as!u64(z)
           dstStart := ((((dstZ * dstImageLevelHeightInBlocks) + dstY) * dstImageLevelWidthInBlocks) + dstXStartInBlocks) * dstElementSize
           srcStart := ((((srcZ * srcImageLevelHeightInBlocks) + srcY) * srcImageLevelWidthInBlocks) + srcXStartInBlocks) * srcElementSize
-          copy(dstData[dstStart:dstStart + copySize], srcData[srcStart:srcStart + copySize])
+          copy(dstImageLevel.Data[dstStart:dstStart + copySize], srcImageLevel.Data[srcStart:srcStart + copySize])
         }
       }
     }
@@ -6585,7 +6582,6 @@ class vkCmdCopyBufferToImageArgs {
 
 sub void dovkCmdCopyBufferToImage(ref!vkCmdCopyBufferToImageArgs args) {
   bufferObject := Buffers[args.SrcBuffer]
-  srcData := bufferObject.Memory.Data
   imageObject := Images[args.DstImage]
   format := imageObject.Info.Format
   elementAndTexelBlockSize := getElementAndTexelBlockSize(format)
@@ -6613,7 +6609,6 @@ sub void dovkCmdCopyBufferToImage(ref!vkCmdCopyBufferToImageArgs args) {
       imageLevel := imageObject.Layers[layerIndex].Levels[region.imageSubresource.mipLevel]
       imageLevelWidthInBlocks := as!u64(imageLevel.Width / elementAndTexelBlockSize.TexelBlockSize.Width)
       imageLevelHeightInBlocks := as!u64(imageLevel.Height / elementAndTexelBlockSize.TexelBlockSize.Height)
-      dstData := imageLevel.Data
       // Iterate through depths and rows to copy
       for z in (zStart .. zEnd) {
         for y in (yStart .. yEnd) {
@@ -6626,7 +6621,7 @@ sub void dovkCmdCopyBufferToImage(ref!vkCmdCopyBufferToImageArgs args) {
           srcStart := as!u64(bufferObject.MemoryOffset) + as!u64(region.bufferOffset) + bufferLayerOffset + rowStartInExtent
           srcEnd := srcStart + copySize
           readCoherentMemoryInBuffer(bufferObject, region.bufferOffset + as!VkDeviceSize(bufferLayerOffset + rowStartInExtent), as!VkDeviceSize(copySize))
-          copy(dstData[dstStart:dstEnd], srcData[srcStart:srcEnd])
+          copy(imageLevel.Data[dstStart:dstEnd], bufferObject.Memory.Data[srcStart:srcEnd])
         }
       }
     }
@@ -8969,6 +8964,7 @@ enum SemaphoreUpdate {
   VkDeviceSize                                MappedSize
   void*                                       MappedLocation
   u32                                         MemoryTypeIndex
+  @spy_disabled
   @hidden @nobox @internal u8[]               Data
   @unused ref!VulkanDebugMarkerInfo           DebugInfo
   ref!DedicatedAllocationMemoryAllocateInfoNV DedicatedAllocationNV
@@ -9041,6 +9037,7 @@ enum SemaphoreUpdate {
   u32                           Width
   u32                           Height
   @unused u32                   Depth
+  @spy_disabled
   @hidden @nobox @internal u8[] Data
   @unused u32                   Size
 }


### PR DESCRIPTION
This allows us to avoid creation/copying of any slices that
are not needed during the trace. This should reduce memory pressure
as we no longer need to keep shadow memory around during the trace
as long as we know how to re-create it for mid-execution capture.