### PR TITLE
Robot: Add API option to subject upload.

### DIFF
--- a/test/robot/subject/subject.proto
+++ b/test/robot/subject/subject.proto
@@ -35,6 +35,8 @@ message Subject {
 message Hints {
   // traceTime is the preferred duration for tracing this subject.
   google.protobuf.Duration traceTime = 1;
+  // API is the name of the api to capture on this subject, values can be gles and vulkan
+  string API = 4;
 }
 
 // Service is the api to the robot app storage.

--- a/test/robot/trace/client.go
+++ b/test/robot/trace/client.go
@@ -186,6 +186,7 @@ func doTrace(ctx context.Context, action string, in *Input, store *stash.Client,
 		"-observe-frames", "5",
 		"-record-errors",
 		"-gapii-device", d.Instance().Serial,
+		"-api", in.GetHints().GetAPI(),
 	}
 	cmd := shell.Command(gapit.System(), params...)
 	output, callErr := cmd.Call(ctx)


### PR DESCRIPTION
Allows user to specify the API of the uploaded subject as either gles
(the default) or vulkan. Then stores it in the subject's hints to be
used when tracing with gapit.