### PR TITLE
Add update verbs

### DIFF
--- a/test/robot/build/build.go
+++ b/test/robot/build/build.go
@@ -45,6 +45,9 @@ type Store interface {
 
 	// UpdateTrack updates track information.
 	UpdateTrack(ctx context.Context, track *Track) (*Track, error)
+
+	// UpdatePackage updates package information.
+	UpdatePackage(ctx context.Context, pkg *Package) (*Package, error)
 }
 
 const (

--- a/test/robot/build/build.proto
+++ b/test/robot/build/build.proto
@@ -142,6 +142,8 @@ service Service {
   rpc Add(AddRequest) returns(AddResponse) {};
   // UpdateTrack creates or updates a track entry.
   rpc UpdateTrack(UpdateTrackRequest) returns(UpdateTrackResponse) {};
+  // UpdatePackage modifies a package entry.
+  rpc UpdatePackage(UpdatePackageRequest) returns(UpdatePackageResponse) {};
 }
 
 message AddRequest {
@@ -169,4 +171,16 @@ message UpdateTrackRequest {
 message UpdateTrackResponse {
   // Track is the updated track information.
   Track track = 1;
+}
+
+message UpdatePackageRequest {
+  // Package contains the information to merge into the package.
+  // If the id is present, it must match an existing package.
+  // Only updates the Parent and Information.Description fields, only if present
+  Package package = 1;
+}
+
+message UpdatePackageResponse {
+  // Package is the updated package information.
+  Package package = 1;
 }

--- a/test/robot/build/local.go
+++ b/test/robot/build/local.go
@@ -83,7 +83,7 @@ func (s *local) Add(ctx context.Context, id string, info *Information) (string, 
 		return "", false, err
 	}
 	if parent != "" {
-		if err := s.packages.update(ctx, &Package{Id: pkg.Id, Parent: parent}); err != nil {
+		if _, err := s.packages.update(ctx, &Package{Id: pkg.Id, Parent: parent}); err != nil {
 			return "", false, err
 		}
 	}
@@ -96,4 +96,11 @@ func (s *local) Add(ctx context.Context, id string, info *Information) (string, 
 func (s *local) UpdateTrack(ctx context.Context, entry *Track) (*Track, error) {
 	track, _, err := s.tracks.createOrUpdate(ctx, entry)
 	return track, err
+}
+
+// UpdatePackage implements store.UpdatePackage
+// if the package identified by the package id exists, it modifies the package parent pointer,
+// and description.
+func (s *local) UpdatePackage(ctx context.Context, entry *Package) (*Package, error) {
+	return s.packages.update(ctx, entry)
 }

--- a/test/robot/build/package.go
+++ b/test/robot/build/package.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/google/gapid/core/data/id"
 	"github.com/google/gapid/core/event"
+	"github.com/google/gapid/core/log"
 	"github.com/google/gapid/core/os/device"
 	"github.com/google/gapid/test/robot/record"
 	"github.com/google/gapid/test/robot/search"
@@ -91,10 +92,16 @@ func (p *packages) search(ctx context.Context, query *search.Query, handler Pack
 	return event.Feed(ctx, filter, initial)
 }
 
-func (p *packages) update(ctx context.Context, pkg *Package) error {
+func (p *packages) update(ctx context.Context, pkg *Package) (*Package, error) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	return p.ledger.Add(ctx, pkg)
+	if _, found := p.byID[pkg.Id]; !found {
+		return nil, log.Err(ctx, nil, "Package not found")
+	}
+	if err := p.ledger.Add(ctx, pkg); err != nil {
+		return nil, err
+	}
+	return p.byID[pkg.Id], nil
 }
 
 func (p *packages) addArtifact(ctx context.Context, a *Artifact, info *Information) (*Package, bool, error) {

--- a/test/robot/build/remote.go
+++ b/test/robot/build/remote.go
@@ -83,3 +83,14 @@ func (m *remote) UpdateTrack(ctx context.Context, entry *Track) (*Track, error) 
 	}
 	return response.Track, nil
 }
+
+// UpdatePackage implements store.UpdatePackage
+// It forwards the call through grpc to the remote implementation.
+func (m *remote) UpdatePackage(ctx context.Context, entry *Package) (*Package, error) {
+	request := &UpdatePackageRequest{Package: entry}
+	response, err := m.client.UpdatePackage(ctx, request)
+	if err != nil {
+		return nil, err
+	}
+	return response.Package, nil
+}

--- a/test/robot/build/server.go
+++ b/test/robot/build/server.go
@@ -79,3 +79,14 @@ func (s *server) UpdateTrack(outer xctx.Context, request *UpdateTrackRequest) (*
 	}
 	return &UpdateTrackResponse{Track: track}, nil
 }
+
+// UpdatePackage implements ServiceServer.UpdatePackage
+// It delegates the call to the provided Store implementation.
+func (s *server) UpdatePackage(outer xctx.Context, request *UpdatePackageRequest) (*UpdatePackageResponse, error) {
+	ctx := outer
+	pkg, err := s.store.UpdatePackage(ctx, request.Package)
+	if err != nil {
+		return nil, err
+	}
+	return &UpdatePackageResponse{Package: pkg}, nil
+}

--- a/test/robot/subject/remote.go
+++ b/test/robot/subject/remote.go
@@ -54,3 +54,12 @@ func (m *remote) Add(ctx context.Context, id string, hints *Hints) (*Subject, bo
 	}
 	return response.Subject, response.Created, nil
 }
+
+func (m *remote) Update(ctx context.Context, subj *Subject) (*Subject, error) {
+	request := &UpdateRequest{Subject: subj}
+	response, err := m.client.Update(ctx, request)
+	if err != nil {
+		return nil, err
+	}
+	return response.Subject, nil
+}

--- a/test/robot/subject/server.go
+++ b/test/robot/subject/server.go
@@ -50,3 +50,13 @@ func (s *server) Search(query *search.Query, stream Service_SearchServer) error 
 	ctx := stream.Context()
 	return s.subjects.Search(ctx, query, func(ctx context.Context, e *Subject) error { return stream.Send(e) })
 }
+
+// Update implements ServiceServer.Update
+// It delegates the call to the provided Subjects implementation.
+func (s *server) Update(ctx xctx.Context, request *UpdateRequest) (*UpdateResponse, error) {
+	subj, err := s.subjects.Update(ctx, request.Subject)
+	if err != nil {
+		return nil, err
+	}
+	return &UpdateResponse{Subject: subj}, nil
+}

--- a/test/robot/subject/subject.go
+++ b/test/robot/subject/subject.go
@@ -29,4 +29,6 @@ type Subjects interface {
 	Search(context.Context, *search.Query, Handler) error
 	// Add adds a new subject to the set.
 	Add(ctx context.Context, id string, hints *Hints) (*Subject, bool, error)
+	// Update changes the values of a subject.
+	Update(ctx context.Context, subj *Subject) (*Subject, error)
 }

--- a/test/robot/subject/subject.proto
+++ b/test/robot/subject/subject.proto
@@ -46,6 +46,8 @@ service Service {
   // Add pulls the subject from the stash, analyzes it and adds it to the service.
   // If the subject already exists, it will be returned without modification.
   rpc Add(AddRequest) returns(AddResponse) {};
+  // Update modifies a subject entry
+  rpc Update(UpdateRequest) returns(UpdateResponse) {};
 }
 
 message AddRequest {
@@ -61,4 +63,16 @@ message AddResponse {
   // Created is set to true if the subject was added by this call,
   // and false if it was already present
   bool created = 2;
+}
+
+message UpdateRequest {
+  // Subject contains the information to merge into the subject.
+  // If the id is present, it must match an existing subject.
+  // Only updates the Hints field.
+  Subject subject = 1;
+}
+
+message UpdateResponse {
+  // Subject is the updated subject information.
+  Subject subject = 1;
 }


### PR DESCRIPTION
Adds ability to update some entities within robot. Specifically Packages and Subjects. This makes it possible to fix mistakes during initial uploads, like the subject's API or the package's description. Also lets us improve the data of these entities, such as better parentage of packages, and less than useful trace times for subjects.