### PR TITLE
Optimizations

### DIFF
--- a/core/cc/string_writer.h
+++ b/core/cc/string_writer.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef CORE_STRING_WRITER_H
+#define CORE_STRING_WRITER_H
+
+#include <memory>
+#include <string>
+
+namespace core {
+    class StreamWriter;
+
+// StringWriter is a pure virtual class used to write strings to a StreamWriter.
+class StringWriter {
+public:
+    // write attempts to write the string 'data' to the underlying stream,
+    // returning false upon failure.  'data' may be in an unknown state past
+    // this call, as implementations of this interface may use move semantics
+    // as a memory optimization.
+    virtual bool write(std::string& data) = 0;
+
+    // getStream returns the underlying StreamWriter for the StringWriter.
+    virtual std::shared_ptr<StreamWriter> getStream() = 0;
+
+protected:
+    virtual ~StringWriter() {}
+};
+
+}  // namespace core
+
+#endif  // CORE_STRING_WRITER_H

--- a/gapii/cc/CMakeFiles.cmake
+++ b/gapii/cc/CMakeFiles.cmake
@@ -58,6 +58,8 @@ set(files
     gvr_types.h
     pack_encoder.h
     pack_encoder.cpp
+    pack_string_writer.h
+    pack_string_writer.cpp
     pool.cpp
     pool.h
     slice.h

--- a/gapii/cc/pack_encoder.cpp
+++ b/gapii/cc/pack_encoder.cpp
@@ -19,6 +19,7 @@
 #include "core/data/pack/pack.pb.h"
 
 #include <core/cc/stream_writer.h>
+#include "pack_string_writer.h"
 
 #include <google/protobuf/descriptor.pb.h>
 #include <google/protobuf/io/coded_stream.h>
@@ -30,70 +31,77 @@ using ::google::protobuf::Message;
 using ::google::protobuf::Descriptor;
 using ::google::protobuf::DescriptorProto;
 using ::google::protobuf::io::CodedOutputStream;
-using ::google::protobuf::io::StringOutputStream;
 
 namespace {
 
-const int      VERSION_MAJOR       = 1;
-const int      VERSION_MINOR       = 1;
-const int64_t  TAG_FIRST_GROUP     = -1;
-const int64_t  TAG_GROUP_FINALIZER = 0;
-const int64_t  TAG_DECLARE_TYPE    = 1;
-const int64_t  TAG_FIRST_OBJECT    = 2;
-const uint64_t NO_ID               = 0xffffffffffffffff;
+const int      VERSION_MAJOR          = 1;
+const int      VERSION_MINOR          = 1;
+const int64_t  TAG_FIRST_GROUP        = -1;
+const int64_t  TAG_GROUP_FINALIZER    = 0;
+const int64_t  TAG_DECLARE_TYPE       = 1;
+const int64_t  TAG_FIRST_OBJECT       = 2;
+const uint64_t NO_ID                  = 0xffffffffffffffff;
+
+constexpr int TYPE_ID_CACHE_COUNT  = 4;
 
 const char magic[] = "protopack";
 
 // PackEncoderImpl implements the PackEncoder interface.
 class PackEncoderImpl : public gapii::PackEncoder {
 public:
-    PackEncoderImpl(const std::shared_ptr<core::StreamWriter>& output);
+    PackEncoderImpl(const std::shared_ptr<core::StringWriter>& writer);
     ~PackEncoderImpl();
 
     virtual void object(const Message* msg) override;
     virtual SPtr group(const Message* msg) override;
 
 private:
+    struct TypeIDCache {
+        std::mutex mutex;
+        std::unordered_map<const Descriptor*, uint32_t> type_ids;
+    };
+
     struct Shared {
-        Shared(const std::shared_ptr<core::StreamWriter>& writer);
+        Shared(const std::shared_ptr<core::StringWriter>& writer);
 
         std::mutex mutex;
-        std::shared_ptr<core::StreamWriter> writer;
+        std::shared_ptr<core::StringWriter> writer;
         std::unordered_map<const Descriptor*, uint32_t> type_ids;
+        TypeIDCache type_id_caches[TYPE_ID_CACHE_COUNT];
         uint64_t group_id;
     };
 
     PackEncoderImpl(const std::shared_ptr<Shared>& shared, uint64_t group_id);
 
-    void writeGroupID();
+    void writeGroupID(std::string& buffer);
     uint64_t writeTypeIfNew(const Descriptor* desc);
-    void writeString(const std::string& str);
-    void writeVarint32(uint32_t value);
-    void writeZigzag(int64_t value);
-    void writeVarint(uint64_t value);
-    void writeVarintDirect(uint64_t value);
-    void flushChunk();
+    uint64_t writeTypeIfNewBlocking(const Descriptor* desc);
+    void writeString(std::string& buffer, const std::string& str);
+    void writeVarint32(std::string& buffer, uint32_t value);
+    void writeZigzag(std::string& buffer, int64_t value);
+    void writeVarint(std::string& buffer, uint64_t value);
+    void flushBuffer(std::string& buffer);
 
     std::shared_ptr<Shared> mShared;
     uint64_t mGroupId;
-
-    std::string mBuffer; // Flushes to mShared->mWriter
 };
 
-PackEncoderImpl::Shared::Shared(const std::shared_ptr<core::StreamWriter>& writer)
-        : group_id(0)
-        , writer(writer) {}
+PackEncoderImpl::Shared::Shared(const std::shared_ptr<core::StringWriter>& writer)
+        : writer(writer)
+        , group_id(0) {}
 
-PackEncoderImpl::PackEncoderImpl(const std::shared_ptr<core::StreamWriter>& writer)
+PackEncoderImpl::PackEncoderImpl(const std::shared_ptr<core::StringWriter>& writer)
         : mShared(new Shared(writer))
         , mGroupId(NO_ID) {
-    writer->write(magic, sizeof(magic) - 1);
+    auto stream = writer->getStream();
+    stream->write(magic, sizeof(magic) - 1);
     pack::Header header;
     header.mutable_version()->set_major(VERSION_MAJOR);
     header.mutable_version()->set_minor(VERSION_MINOR);
 
-    header.SerializeToString(&mBuffer);
-    flushChunk();
+    std::string buffer;
+    header.SerializeToString(&buffer);
+    flushBuffer(buffer);
 }
 
 PackEncoderImpl::PackEncoderImpl(const std::shared_ptr<Shared>& shared, uint64_t group_id)
@@ -103,31 +111,35 @@ PackEncoderImpl::PackEncoderImpl(const std::shared_ptr<Shared>& shared, uint64_t
 
 PackEncoderImpl::~PackEncoderImpl() {
     if (mGroupId != NO_ID) {
+        std::string buffer;
+        writeZigzag(buffer, TAG_GROUP_FINALIZER);
+
         std::lock_guard<std::mutex> lock(mShared->mutex);
-        writeZigzag(TAG_GROUP_FINALIZER);
-        writeGroupID();
-        flushChunk();
+        writeGroupID(buffer);
+        flushBuffer(buffer);
     }
 }
 
 void PackEncoderImpl::object(const Message* msg) {
-    std::lock_guard<std::mutex> lock(mShared->mutex);
-
+    std::string buffer;
     auto type_id = writeTypeIfNew(msg->GetDescriptor());
-    writeZigzag(TAG_FIRST_OBJECT + (int64_t)type_id);
-    writeGroupID();
-    msg->AppendToString(&mBuffer);
-    flushChunk();
+    writeZigzag(buffer, TAG_FIRST_OBJECT + (int64_t)type_id);
+
+    std::lock_guard<std::mutex> lock(mShared->mutex);
+    writeGroupID(buffer);
+    msg->AppendToString(&buffer);
+    flushBuffer(buffer);
 }
 
 gapii::PackEncoder::SPtr PackEncoderImpl::group(const Message* msg) {
-    std::lock_guard<std::mutex> lock(mShared->mutex);
-
+    std::string buffer;
     auto type_id = writeTypeIfNew(msg->GetDescriptor());
-    writeZigzag(TAG_FIRST_GROUP - (int64_t)type_id);
-    writeGroupID();
-    msg->AppendToString(&mBuffer);
-    flushChunk();
+    writeZigzag(buffer, TAG_FIRST_GROUP - (int64_t)type_id);
+
+    std::lock_guard<std::mutex> lock(mShared->mutex);
+    writeGroupID(buffer);
+    msg->AppendToString(&buffer);
+    flushBuffer(buffer);
 
     auto out = PackEncoder::SPtr(new PackEncoderImpl(mShared, mShared->group_id));
 
@@ -136,11 +148,11 @@ gapii::PackEncoder::SPtr PackEncoderImpl::group(const Message* msg) {
     return out;
 }
 
-void PackEncoderImpl::writeGroupID() {
+void PackEncoderImpl::writeGroupID(std::string& buffer) {
     if (mGroupId == NO_ID) {
-        writeVarint(0);
+        writeVarint(buffer, 0);
     } else {
-        writeVarint(mShared->group_id - mGroupId);
+        writeVarint(buffer, mShared->group_id - mGroupId);
     }
 }
 
@@ -153,49 +165,74 @@ uint64_t PackEncoderImpl::writeTypeIfNew(const Descriptor* desc) {
     for (int i = 0; i < desc->nested_type_count(); i++) {
         writeTypeIfNew(desc->nested_type(i));
     }
+
+    TypeIDCache* type_id_cache = nullptr;
+    std::unique_lock<std::mutex> cache_lock;
+
+    for(int index = 0; !type_id_cache && index < TYPE_ID_CACHE_COUNT; ++index) {
+        if (mShared->type_id_caches[index].mutex.try_lock()) {
+            type_id_cache = &mShared->type_id_caches[index];
+            cache_lock = std::unique_lock<std::mutex>(type_id_cache->mutex, std::adopt_lock);
+        }
+    }
+
+    if (!type_id_cache) {
+        return writeTypeIfNewBlocking(desc);
+    }
+
+    uint64_t type_id;
+
+    auto iter_id = type_id_cache->type_ids.find(desc);
+    if (iter_id == end(type_id_cache->type_ids)) {
+        type_id = writeTypeIfNewBlocking(desc);
+        type_id_cache->type_ids.insert(std::make_pair(desc, type_id));
+    } else {
+        type_id = iter_id->second;
+    }
+
+    return type_id;
+}
+
+uint64_t PackEncoderImpl::writeTypeIfNewBlocking(const Descriptor* desc) {
+    std::lock_guard<std::mutex> lock(mShared->mutex);
+
     auto insert = mShared->type_ids.insert(std::make_pair(desc, mShared->type_ids.size()));
     if (insert.second) {
+        std::string buffer;
         DescriptorProto descMsg;
         desc->CopyTo(&descMsg);
-        writeZigzag(TAG_DECLARE_TYPE);
-        writeString(desc->full_name());
-        descMsg.AppendToString(&mBuffer);
-        flushChunk();
+        writeZigzag(buffer, TAG_DECLARE_TYPE);
+        writeString(buffer, desc->full_name());
+        descMsg.AppendToString(&buffer);
+        flushBuffer(buffer);
     }
     return insert.first->second;
 }
 
-void PackEncoderImpl::writeString(const std::string& str) {
-    writeVarint(str.length());
-    mBuffer.append(str);
+void PackEncoderImpl::writeString(std::string& buffer, const std::string& str) {
+    writeVarint(buffer, str.length());
+    buffer.append(str);
 }
 
-void PackEncoderImpl::writeVarint32(uint32_t value) {
+void PackEncoderImpl::writeVarint32(std::string& buffer, uint32_t value) {
     uint8_t buf[16];
     auto count = CodedOutputStream::WriteVarint32ToArray(value, &buf[0]) - &buf[0];
-    mBuffer.append(reinterpret_cast<char*>(&buf[0]), count);
+    buffer.append(reinterpret_cast<char*>(&buf[0]), count);
 }
 
-void PackEncoderImpl::writeZigzag(int64_t n) {
-    writeVarint(uint64_t((n << 1) ^ (n >> 63)));
+void PackEncoderImpl::writeZigzag(std::string& buffer, int64_t n) {
+    writeVarint(buffer, uint64_t((n << 1) ^ (n >> 63)));
 }
 
-void PackEncoderImpl::writeVarint(uint64_t value) {
+void PackEncoderImpl::writeVarint(std::string& buffer, uint64_t value) {
     uint8_t buf[16];
     auto count = CodedOutputStream::WriteVarint64ToArray(value, &buf[0]) - &buf[0];
-    mBuffer.append(reinterpret_cast<char*>(&buf[0]), count);
+    buffer.append(reinterpret_cast<char*>(&buf[0]), count);
 }
 
-void PackEncoderImpl::writeVarintDirect(uint64_t value) {
-    uint8_t buf[16];
-    auto count = CodedOutputStream::WriteVarint64ToArray(value, &buf[0]) - &buf[0];
-    mShared->writer->write(&buf[0], count);
-}
-
-void PackEncoderImpl::flushChunk() {
-    writeVarintDirect(mBuffer.size());
-    mShared->writer->write(mBuffer.data(), mBuffer.size());
-    mBuffer.clear();
+void PackEncoderImpl::flushBuffer(std::string& buffer) {
+    mShared->writer->write(buffer);
+    buffer.clear();
 }
 
 // PackEncoderNoop is a no-op implementation of the PackEncoder interface.
@@ -216,8 +253,9 @@ gapii::PackEncoder::SPtr PackEncoderNoop::instance = gapii::PackEncoder::SPtr(ne
 namespace gapii {
 
 // create returns a PackEncoder::SPtr that writes to output.
-PackEncoder::SPtr PackEncoder::create(std::shared_ptr<core::StreamWriter> output) {
-    return PackEncoder::SPtr(new PackEncoderImpl(output));
+PackEncoder::SPtr PackEncoder::create(std::shared_ptr<core::StreamWriter> stream) {
+    auto writer = PackStringWriter::create(stream);
+    return PackEncoder::SPtr(new PackEncoderImpl(writer));
 }
 
 // noop returns a PackEncoder::SPtr that does nothing.

--- a/gapii/cc/pack_string_writer.cpp
+++ b/gapii/cc/pack_string_writer.cpp
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+#include "pack_string_writer.h"
+
+#include <core/cc/stream_writer.h>
+
+#include <google/protobuf/io/coded_stream.h>
+
+using ::google::protobuf::io::CodedOutputStream;
+
+namespace {
+
+constexpr size_t kBufferSize = 32*1024;
+
+class PackStringWriterImpl : public gapii::PackStringWriter {
+public:
+    PackStringWriterImpl(const std::shared_ptr<core::StreamWriter>& writer);
+
+    ~PackStringWriterImpl();
+
+    virtual bool write(std::string& s) override;
+
+    virtual std::shared_ptr<core::StreamWriter> getStream() override;
+
+private:
+    void flush();
+
+    std::string mBuffer;
+
+    std::shared_ptr<core::StreamWriter> mWriter;
+
+    bool mStreamGood;
+};
+
+PackStringWriterImpl::PackStringWriterImpl(const std::shared_ptr<core::StreamWriter>& writer)
+        : mWriter(writer)
+        , mStreamGood(true) {
+}
+
+PackStringWriterImpl::~PackStringWriterImpl() {
+    if (mBuffer.size() && mStreamGood) {
+        flush();
+    }
+}
+
+bool PackStringWriterImpl::write(std::string& s) {
+    if (mStreamGood) {
+        uint8_t size_buf[16];
+
+        auto size = s.size();
+        auto size_count = CodedOutputStream::WriteVarint64ToArray(size, &size_buf[0]) - &size_buf[0];
+
+        mBuffer.append(reinterpret_cast<char*>(&size_buf[0]), size_count);
+        mBuffer.append(s);
+
+        if(mBuffer.size() >= kBufferSize) {
+            flush();
+        }
+    }
+
+    return mStreamGood;
+}
+
+std::shared_ptr<core::StreamWriter> PackStringWriterImpl::getStream() {
+    return mWriter;
+}
+
+void PackStringWriterImpl::flush() {
+    mStreamGood = mWriter->write(mBuffer.data(), mBuffer.size());
+    mBuffer.clear();
+}
+
+} // anonymous namespace
+
+namespace gapii {
+
+// create returns a PackStringWriter::SPtr that writes to stream_writer.
+PackStringWriter::SPtr PackStringWriter::create(const std::shared_ptr<core::StreamWriter>& stream_writer) {
+    return PackStringWriter::SPtr(new PackStringWriterImpl(stream_writer));
+}
+
+} // namespace gapii

--- a/gapii/cc/pack_string_writer.h
+++ b/gapii/cc/pack_string_writer.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef GAPII_PACK_STRING_WRITER_H
+#define GAPII_PACK_STRING_WRITER_H
+
+#include "core/cc/string_writer.h"
+
+namespace gapii {
+
+// PackStringWriter is used to write 'Pack' strings to a core::StreamWriter.
+class PackStringWriter : public core::StringWriter {
+public:
+    typedef std::shared_ptr<PackStringWriter> SPtr;
+
+    static SPtr create(const std::shared_ptr<core::StreamWriter>& stream_writer);
+
+protected:
+    ~PackStringWriter() = default;
+};
+
+}  // namespace gapii
+
+#endif  // GAPII_PACK_STRING_WRITER_H


### PR DESCRIPTION
Optimizing message sending by:

- Batching buffers before calling send.

- Reducing the scope of thread interactions, through local caching of type IDs and reducing mutex scope to the bare minimum.