### PR TITLE
Throttle 'RPC Unavailable' log messages.

### DIFF
--- a/gapic/src/main/com/google/gapid/models/ApiState.java
+++ b/gapic/src/main/com/google/gapid/models/ApiState.java
@@ -17,9 +17,9 @@ package com.google.gapid.models;
 
 import static com.google.gapid.rpc.UiErrorCallback.error;
 import static com.google.gapid.rpc.UiErrorCallback.success;
+import static com.google.gapid.util.Logging.throttleLogRpcError;
 import static com.google.gapid.util.Paths.stateTree;
 import static com.google.gapid.widgets.Widgets.submitIfNotDisposed;
-import static java.util.logging.Level.SEVERE;
 import static java.util.logging.Level.WARNING;
 
 import com.google.common.util.concurrent.Futures;
@@ -92,7 +92,7 @@ public class ApiState
       return error(Loadable.Message.error(e));
     } catch (ExecutionException e) {
       if (!shell.isDisposed()) {
-        LOG.log(SEVERE, "Failed to load the API state", e);
+        throttleLogRpcError(LOG, "Failed to load the API state", e);
       }
       return error(Loadable.Message.error("Failed to load the state"));
     }

--- a/gapic/src/main/com/google/gapid/models/Capture.java
+++ b/gapic/src/main/com/google/gapid/models/Capture.java
@@ -17,9 +17,9 @@ package com.google.gapid.models;
 
 import static com.google.gapid.rpc.UiErrorCallback.error;
 import static com.google.gapid.rpc.UiErrorCallback.success;
+import static com.google.gapid.util.Logging.throttleLogRpcError;
 import static com.google.gapid.views.ErrorDialog.showErrorDialog;
 import static java.util.logging.Level.INFO;
-import static java.util.logging.Level.WARNING;
 
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
@@ -109,7 +109,7 @@ public class Capture extends ModelBase<Path.Capture, File, Loadable.Message, Cap
     } catch (RpcException e) {
       return error(Loadable.Message.error(e));
     } catch (ExecutionException e) {
-      LOG.log(Level.WARNING, "Failed to load trace", e);
+      throttleLogRpcError(LOG, "Failed to load trace", e);
       return error(Loadable.Message.error(e.getCause().getMessage()));
     }
   }
@@ -171,7 +171,7 @@ public class Capture extends ModelBase<Path.Capture, File, Loadable.Message, Cap
 
       @Override
       protected void onUiThreadError(Exception error) {
-        LOG.log(WARNING, "Couldn't save trace", error);
+        throttleLogRpcError(LOG, "Couldn't save trace", error);
         showErrorDialog(shell, "Failed to save trace:\n  " + error.getMessage(), error);
       }
     });

--- a/gapic/src/main/com/google/gapid/models/Devices.java
+++ b/gapic/src/main/com/google/gapid/models/Devices.java
@@ -15,7 +15,7 @@
  */
 package com.google.gapid.models;
 
-import static java.util.logging.Level.SEVERE;
+import static com.google.gapid.util.Logging.throttleLogRpcError;
 import static java.util.stream.Collectors.toList;
 
 import com.google.common.collect.Lists;
@@ -84,7 +84,7 @@ public class Devices {
           List<Path.Device> devs = result.get();
           return (devs == null || devs.isEmpty()) ? error(null) : success(devs.get(0));
         } catch (RpcException | ExecutionException e) {
-          LOG.log(SEVERE, "LoadData error", e);
+          throttleLogRpcError(LOG, "LoadData error", e);
           return error(null);
         }
       }
@@ -128,7 +128,7 @@ public class Devices {
         try {
           return success(result.get().stream().map(Service.Value::getDevice).collect(toList()));
         } catch (RpcException | ExecutionException e) {
-          LOG.log(SEVERE, "LoadData error", e);
+          throttleLogRpcError(LOG, "LoadData error", e);
           return error(null);
         }
       }

--- a/gapic/src/main/com/google/gapid/models/ModelBase.java
+++ b/gapic/src/main/com/google/gapid/models/ModelBase.java
@@ -17,7 +17,7 @@ package com.google.gapid.models;
 
 import static com.google.gapid.rpc.UiErrorCallback.error;
 import static com.google.gapid.rpc.UiErrorCallback.success;
-import static java.util.logging.Level.SEVERE;
+import static com.google.gapid.util.Logging.throttleLogRpcError;
 
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.gapid.proto.service.path.Path;
@@ -87,7 +87,7 @@ abstract class ModelBase<T, S, E, L extends Events.Listener> {
       return success(result.get());
     } catch (RpcException | ExecutionException e) {
       if (!shell.isDisposed()) {
-        log.log(SEVERE, "LoadData error", e);
+        throttleLogRpcError(log, "LoadData error", e);
       }
       return error(null);
     }

--- a/gapic/src/main/com/google/gapid/rpc/UiCallback.java
+++ b/gapic/src/main/com/google/gapid/rpc/UiCallback.java
@@ -17,7 +17,8 @@ package com.google.gapid.rpc;
 
 import static com.google.gapid.widgets.Widgets.scheduleIfNotDisposed;
 import static java.util.logging.Level.FINE;
-import static java.util.logging.Level.SEVERE;
+
+import com.google.gapid.util.Logging;
 
 import org.eclipse.swt.widgets.Widget;
 
@@ -47,7 +48,7 @@ public abstract class UiCallback<T, U> implements Rpc.Callback<T> {
       logger.log(FINE, "RPC future was cancelled: " + cancel.getMessage());
       // Not an error, don't log.
     } catch (Exception e) {
-      logger.log(SEVERE, "error in " + getClass().getName() + ".onRpcThread", e);
+      Logging.throttleLogRpcError(logger, "error in " + getClass().getName() + ".onRpcThread", e);
     }
   }
 

--- a/gapic/src/main/com/google/gapid/util/Logging.java
+++ b/gapic/src/main/com/google/gapid/util/Logging.java
@@ -39,6 +39,8 @@ import java.util.logging.Logger;
 import java.util.logging.SimpleFormatter;
 import java.util.logging.StreamHandler;
 
+import io.grpc.Status;
+
 /**
  * Logging setup and utilities.
  */
@@ -106,12 +108,14 @@ public class Logging {
       "gapir-log-level", LogLevel.INFO, "Gapir log level [OFF, ERROR, WARNING, INFO, DEBUG, ALL].");
 
   private static final int BUFFER_SIZE = 1000;
+  private static final long THROTTLE_TIME_MS = 5000;
 
   private static final RingBuffer buffer = new RingBuffer(BUFFER_SIZE);
 
   private static final Listener NULL_LISTENER = (m) -> { /* do nothing */ };
 
   private static Listener listener = NULL_LISTENER;
+  private static long timeOfLastThrottledMessage = 0;
 
   /**
    * Initializes the Java logging system.
@@ -172,6 +176,24 @@ public class Logging {
   public static void logMessage(Log.Message message) {
     buffer.add(message);
     listener.onNewMessage(message);
+  }
+
+  /**
+   * Throttles logging of certain RPC errors. This is primarily used to prevent the logs from
+   * exploding when GAPIS dies, or the connection goes away.
+   */
+  public static void throttleLogRpcError(Logger log, String message, Throwable exception) {
+    Status status = Status.fromThrowable(exception);
+    if (status.getCode() == Status.Code.UNAVAILABLE) {
+      synchronized (Logging.class) {
+        long now = System.currentTimeMillis();
+        if ((now - timeOfLastThrottledMessage) < THROTTLE_TIME_MS) {
+          return;
+        }
+        timeOfLastThrottledMessage = now;
+      }
+    }
+    log.log(Level.WARNING, message, exception);
   }
 
   /**

--- a/gapic/src/main/com/google/gapid/views/MemoryView.java
+++ b/gapic/src/main/com/google/gapid/views/MemoryView.java
@@ -20,6 +20,7 @@ import static com.google.gapid.util.Loadable.Message.error;
 import static com.google.gapid.util.Loadable.Message.info;
 import static com.google.gapid.util.Loadable.MessageType.Error;
 import static com.google.gapid.util.Loadable.MessageType.Info;
+import static com.google.gapid.util.Logging.throttleLogRpcError;
 import static com.google.gapid.util.Ranges.memory;
 import static com.google.gapid.widgets.Widgets.createDropDown;
 import static com.google.gapid.widgets.Widgets.createDropDownViewer;
@@ -27,7 +28,6 @@ import static com.google.gapid.widgets.Widgets.createLabel;
 import static com.google.gapid.widgets.Widgets.ifNotDisposed;
 import static com.google.gapid.widgets.Widgets.scheduleIfNotDisposed;
 import static java.util.Collections.emptyList;
-import static java.util.logging.Level.WARNING;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -909,7 +909,7 @@ public class MemoryView extends Composite
         } catch (TimeoutException e) {
           throw new AssertionError(); // Should not happen.
         } catch (ExecutionException e) {
-          LOG.log(WARNING, "Unexpected error fetching memory", e);
+          throttleLogRpcError(LOG, "Unexpected error fetching memory", e);
           loadable.showMessage(error("Unexpected error: " + e.getCause()));
         }
       } else {

--- a/gapic/src/main/com/google/gapid/widgets/LoadableImage.java
+++ b/gapic/src/main/com/google/gapid/widgets/LoadableImage.java
@@ -15,6 +15,8 @@
  */
 package com.google.gapid.widgets;
 
+import static com.google.gapid.util.Logging.throttleLogRpcError;
+
 import com.google.common.base.Preconditions;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.gapid.image.Images;
@@ -32,7 +34,6 @@ import org.eclipse.swt.widgets.Widget;
 
 import java.util.concurrent.ExecutionException;
 import java.util.function.Supplier;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
@@ -262,7 +263,7 @@ public class LoadableImage {
 
     private static void logImageError(Exception e) {
       if (!(e instanceof DataUnavailableException)) {
-        LOG.log(Level.WARNING, "Failed to load image", e);
+        throttleLogRpcError(LOG, "Failed to load image", e);
       }
     }
 


### PR DESCRIPTION
gRPC returns this status if the server end point goes away.
Fixes #755