### PR TITLE
Fix panic during robot trace.

### DIFF
--- a/test/robot/trace/client.go
+++ b/test/robot/trace/client.go
@@ -108,6 +108,7 @@ func Run(ctx context.Context, store *stash.Client, manager Manager, tempDir file
 	c.registry.Listen(c)
 
 	go func() {
+		ctx = bind.PutRegistry(ctx, c.registry)
 		if err := adb.Monitor(ctx, c.registry, 15*time.Second); err != nil {
 			log.E(ctx, "adb.Monitor failed: %v", err)
 		}


### PR DESCRIPTION
Using adb now expects bind to have stored a registry, and if it has not
it will panic. Adding PutRegistry before the adb.Monitor in the trace
client's Run proc fixes this panic.