### PR TITLE
Load GL commands from libhwgl.so

### DIFF
--- a/gapii/cc/android/installer.cpp
+++ b/gapii/cc/android/installer.cpp
@@ -81,6 +81,7 @@ void*                                  gInterceptor = nullptr;
 InterceptFunctionFunc*                 gInterceptFunction = nullptr;
 std::unordered_map<std::string, void*> gCallbacks;
 const char*                            gDriverPaths[] = {
+  SYSTEM_LIB_PATH "libhwgl.so", // Huawei specific, must be first.
   SYSTEM_LIB_PATH "libGLES.so",
   SYSTEM_LIB_PATH "libEGL.so",
   SYSTEM_LIB_PATH "libGLESv1_CM.so",
@@ -197,7 +198,19 @@ void Installer::install_gles() {
         const char* name = gapii::kGLESExports[i].mName;
         void* func_export = gapii::kGLESExports[i].mFunc;
         bool import_found = false;
-        for (int i = 0; i < NELEM(gDriverPaths); ++i) {
+        if (drivers[0] != nullptr) { // libhwgl.so
+            // Huawei implements all functions in this library with prefix,
+            // all GL functions in libGLES*.so are just trampolines to his.
+            // However, we do not support trampoline interception for now,
+            // so try to intercept the internal implementation instead.
+            std::string hwName = "hw_" + std::string(name);
+            if (void* func_import = dlsym(drivers[0], hwName.c_str())) {
+                import_found = true;
+                functions[func_import] = func{name, func_export};
+                continue; // Do not do any other lookups.
+            }
+        }
+        for (int i = 1; i < NELEM(gDriverPaths); ++i) {
             if (void* func_import = dlsym(drivers[i], name)) {
                 import_found = true;
                 functions[func_import] = func{name, func_export};

--- a/gapii/interceptor-lib/cc/lib/ARM/target_arm.cc
+++ b/gapii/interceptor-lib/cc/lib/ARM/target_arm.cc
@@ -172,15 +172,43 @@ Error TargetARM::RewriteInstruction(const llvm::MCInst &inst,
       break;
     }
     case llvm::ARM::CMPrr:
+    case llvm::ARM::LDR_PRE_IMM:
+    case llvm::ARM::LDR_PRE_REG:
+    case llvm::ARM::LDR_POST_IMM:
+    case llvm::ARM::LDR_POST_REG:
     case llvm::ARM::LDRi12:
+    case llvm::ARM::LDRH_PRE:
+    case llvm::ARM::LDRH_POST:
+    case llvm::ARM::LDRH:
+    case llvm::ARM::LDRB_PRE_IMM:
+    case llvm::ARM::LDRB_PRE_REG:
+    case llvm::ARM::LDRB_POST_IMM:
+    case llvm::ARM::LDRB_POST_REG:
+    case llvm::ARM::LDRBi12:
+    case llvm::ARM::LDRSH_PRE:
+    case llvm::ARM::LDRSH_POST:
+    case llvm::ARM::LDRSH:
+    case llvm::ARM::LDRSB_PRE:
+    case llvm::ARM::LDRSB_POST:
+    case llvm::ARM::LDRSB:
+    case llvm::ARM::STR_PRE_IMM:
+    case llvm::ARM::STR_PRE_REG:
+    case llvm::ARM::STR_POST_IMM:
+    case llvm::ARM::STR_POST_REG:
+    case llvm::ARM::STRi12:
+    case llvm::ARM::STRH_PRE:
+    case llvm::ARM::STRH_POST:
+    case llvm::ARM::STRH:
+    case llvm::ARM::STRB_PRE_IMM:
+    case llvm::ARM::STRB_PRE_REG:
+    case llvm::ARM::STRB_POST_IMM:
+    case llvm::ARM::STRB_POST_REG:
+    case llvm::ARM::STRBi12:
     case llvm::ARM::MOVr:
     case llvm::ARM::STMDA_UPD:
     case llvm::ARM::STMDB_UPD:
-    case llvm::ARM::STRB_POST_REG:
     case llvm::ARM::STRD:
     case llvm::ARM::STRD_PRE:
-    case llvm::ARM::STR_POST_REG:
-    case llvm::ARM::STR_PRE_IMM:
     case llvm::ARM::SUBri:
     case llvm::ARM::tADDi3:
     case llvm::ARM::tADDi8:


### PR DESCRIPTION
Related to #355

This significantly improves the situation (we can trace and replay).

However many functions still can not be patched (seems likely all just because they are "not-implemented" stubs, so not really essential).

A few valid functions (e.g. glScissor) fail to trace due to use of PC-relative instructions, which is not implemented yet.