### PR TITLE
Fixed tracing on Windows in MINGW.

### DIFF
--- a/gapii/cc/vulkan_inlines.inl
+++ b/gapii/cc/vulkan_inlines.inl
@@ -714,8 +714,9 @@ inline void AppendCommand(VkCommandBuffer buffer, VulkanSpy* spy, std::shared_pt
     auto& map = spy->CommandBuffers[buffer]->mBufferCommands.mvkCmdBindPipeline;
     map[map.size()] = args;
     auto& references = spy->CommandBuffers[buffer]->mCommandReferences;
-    references[references.size()] = CommandReference(
-        buffer, references.size(), CommandType::cmd_vkCmdBindPipeline, map.size() - 1, 0, 0
+    const uint32_t reference_idx = references.size();
+    references[reference_idx] = CommandReference(
+        buffer, reference_idx, CommandType::cmd_vkCmdBindPipeline, map.size() - 1, 0, 0
     );
 }
 template<>
@@ -723,8 +724,9 @@ inline void AppendCommand(VkCommandBuffer buffer, VulkanSpy* spy, std::shared_pt
     auto& map = spy->CommandBuffers[buffer]->mBufferCommands.mvkCmdSetViewport;
     map[map.size()] = args;
     auto& references = spy->CommandBuffers[buffer]->mCommandReferences;
-    references[references.size()] = CommandReference(
-        buffer, references.size(), CommandType::cmd_vkCmdSetViewport, map.size() - 1, 0, 0
+    const uint32_t reference_idx = references.size();
+    references[reference_idx] = CommandReference(
+        buffer, reference_idx, CommandType::cmd_vkCmdSetViewport, map.size() - 1, 0, 0
     );
 }
 template<>
@@ -732,8 +734,9 @@ inline void AppendCommand(VkCommandBuffer buffer, VulkanSpy* spy, std::shared_pt
     auto& map = spy->CommandBuffers[buffer]->mBufferCommands.mvkCmdSetScissor;
     map[map.size()] = args;
     auto& references = spy->CommandBuffers[buffer]->mCommandReferences;
-    references[references.size()] = CommandReference(
-        buffer, references.size(), CommandType::cmd_vkCmdSetScissor, map.size() - 1, 0, 0
+    const uint32_t reference_idx = references.size();
+    references[reference_idx] = CommandReference(
+        buffer, reference_idx, CommandType::cmd_vkCmdSetScissor, map.size() - 1, 0, 0
     );
 }
 template<>
@@ -741,8 +744,9 @@ inline void AppendCommand(VkCommandBuffer buffer, VulkanSpy* spy, std::shared_pt
     auto& map = spy->CommandBuffers[buffer]->mBufferCommands.mvkCmdSetLineWidth;
     map[map.size()] = args;
     auto& references = spy->CommandBuffers[buffer]->mCommandReferences;
-    references[references.size()] = CommandReference(
-        buffer, references.size(), CommandType::cmd_vkCmdSetLineWidth, map.size() - 1, 0, 0
+    const uint32_t reference_idx = references.size();
+    references[reference_idx] = CommandReference(
+        buffer, reference_idx, CommandType::cmd_vkCmdSetLineWidth, map.size() - 1, 0, 0
     );
 }
 template<>
@@ -750,8 +754,9 @@ inline void AppendCommand(VkCommandBuffer buffer, VulkanSpy* spy, std::shared_pt
     auto& map = spy->CommandBuffers[buffer]->mBufferCommands.mvkCmdSetDepthBias;
     map[map.size()] = args;
     auto& references = spy->CommandBuffers[buffer]->mCommandReferences;
-    references[references.size()] = CommandReference(
-        buffer, references.size(), CommandType::cmd_vkCmdSetDepthBias, map.size() - 1, 0, 0
+    const uint32_t reference_idx = references.size();
+    references[reference_idx] = CommandReference(
+        buffer, reference_idx, CommandType::cmd_vkCmdSetDepthBias, map.size() - 1, 0, 0
     );
 }
 template<>
@@ -759,8 +764,9 @@ inline void AppendCommand(VkCommandBuffer buffer, VulkanSpy* spy, std::shared_pt
     auto& map = spy->CommandBuffers[buffer]->mBufferCommands.mvkCmdSetBlendConstants;
     map[map.size()] = args;
     auto& references = spy->CommandBuffers[buffer]->mCommandReferences;
-    references[references.size()] = CommandReference(
-        buffer, references.size(), CommandType::cmd_vkCmdSetBlendConstants, map.size() - 1, 0, 0
+    const uint32_t reference_idx = references.size();
+    references[reference_idx] = CommandReference(
+        buffer, reference_idx, CommandType::cmd_vkCmdSetBlendConstants, map.size() - 1, 0, 0
     );
 }
 template<>
@@ -768,8 +774,9 @@ inline void AppendCommand(VkCommandBuffer buffer, VulkanSpy* spy, std::shared_pt
     auto& map = spy->CommandBuffers[buffer]->mBufferCommands.mvkCmdSetDepthBounds;
     map[map.size()] = args;
     auto& references = spy->CommandBuffers[buffer]->mCommandReferences;
-    references[references.size()] = CommandReference(
-        buffer, references.size(), CommandType::cmd_vkCmdSetDepthBounds, map.size() - 1, 0, 0
+    const uint32_t reference_idx = references.size();
+    references[reference_idx] = CommandReference(
+        buffer, reference_idx, CommandType::cmd_vkCmdSetDepthBounds, map.size() - 1, 0, 0
     );
 }
 template<>
@@ -777,8 +784,9 @@ inline void AppendCommand(VkCommandBuffer buffer, VulkanSpy* spy, std::shared_pt
     auto& map = spy->CommandBuffers[buffer]->mBufferCommands.mvkCmdSetStencilCompareMask;
     map[map.size()] = args;
     auto& references = spy->CommandBuffers[buffer]->mCommandReferences;
-    references[references.size()] = CommandReference(
-        buffer, references.size(), CommandType::cmd_vkCmdSetStencilCompareMask, map.size() - 1, 0, 0
+    const uint32_t reference_idx = references.size();
+    references[reference_idx] = CommandReference(
+        buffer, reference_idx, CommandType::cmd_vkCmdSetStencilCompareMask, map.size() - 1, 0, 0
     );
 }
 template<>
@@ -786,8 +794,9 @@ inline void AppendCommand(VkCommandBuffer buffer, VulkanSpy* spy, std::shared_pt
     auto& map = spy->CommandBuffers[buffer]->mBufferCommands.mvkCmdSetStencilWriteMask;
     map[map.size()] = args;
     auto& references = spy->CommandBuffers[buffer]->mCommandReferences;
-    references[references.size()] = CommandReference(
-        buffer, references.size(), CommandType::cmd_vkCmdSetStencilWriteMask, map.size() - 1, 0, 0
+    const uint32_t reference_idx = references.size();
+    references[reference_idx] = CommandReference(
+        buffer, reference_idx, CommandType::cmd_vkCmdSetStencilWriteMask, map.size() - 1, 0, 0
     );
 }
 template<>
@@ -795,8 +804,9 @@ inline void AppendCommand(VkCommandBuffer buffer, VulkanSpy* spy, std::shared_pt
     auto& map = spy->CommandBuffers[buffer]->mBufferCommands.mvkCmdSetStencilReference;
     map[map.size()] = args;
     auto& references = spy->CommandBuffers[buffer]->mCommandReferences;
-    references[references.size()] = CommandReference(
-        buffer, references.size(), CommandType::cmd_vkCmdSetStencilReference, map.size() - 1, 0, 0
+    const uint32_t reference_idx = references.size();
+    references[reference_idx] = CommandReference(
+        buffer, reference_idx, CommandType::cmd_vkCmdSetStencilReference, map.size() - 1, 0, 0
     );
 }
 template<>
@@ -804,8 +814,9 @@ inline void AppendCommand(VkCommandBuffer buffer, VulkanSpy* spy, std::shared_pt
     auto& map = spy->CommandBuffers[buffer]->mBufferCommands.mvkCmdBindDescriptorSets;
     map[map.size()] = args;
     auto& references = spy->CommandBuffers[buffer]->mCommandReferences;
-    references[references.size()] = CommandReference(
-        buffer, references.size(), CommandType::cmd_vkCmdBindDescriptorSets, map.size() - 1, 0, 0
+    const uint32_t reference_idx = references.size();
+    references[reference_idx] = CommandReference(
+        buffer, reference_idx, CommandType::cmd_vkCmdBindDescriptorSets, map.size() - 1, 0, 0
     );
 }
 template<>
@@ -813,8 +824,9 @@ inline void AppendCommand(VkCommandBuffer buffer, VulkanSpy* spy, std::shared_pt
     auto& map = spy->CommandBuffers[buffer]->mBufferCommands.mvkCmdBindIndexBuffer;
     map[map.size()] = args;
     auto& references = spy->CommandBuffers[buffer]->mCommandReferences;
-    references[references.size()] = CommandReference(
-        buffer, references.size(), CommandType::cmd_vkCmdBindIndexBuffer, map.size() - 1, 0, 0
+    const uint32_t reference_idx = references.size();
+    references[reference_idx] = CommandReference(
+        buffer, reference_idx, CommandType::cmd_vkCmdBindIndexBuffer, map.size() - 1, 0, 0
     );
 }
 template<>
@@ -822,8 +834,9 @@ inline void AppendCommand(VkCommandBuffer buffer, VulkanSpy* spy, std::shared_pt
     auto& map = spy->CommandBuffers[buffer]->mBufferCommands.mvkCmdBindVertexBuffers;
     map[map.size()] = args;
     auto& references = spy->CommandBuffers[buffer]->mCommandReferences;
-    references[references.size()] = CommandReference(
-        buffer, references.size(), CommandType::cmd_vkCmdBindVertexBuffers, map.size() - 1, 0, 0
+    const uint32_t reference_idx = references.size();
+    references[reference_idx] = CommandReference(
+        buffer, reference_idx, CommandType::cmd_vkCmdBindVertexBuffers, map.size() - 1, 0, 0
     );
 }
 template<>
@@ -831,8 +844,9 @@ inline void AppendCommand(VkCommandBuffer buffer, VulkanSpy* spy, std::shared_pt
     auto& map = spy->CommandBuffers[buffer]->mBufferCommands.mvkCmdDraw;
     map[map.size()] = args;
     auto& references = spy->CommandBuffers[buffer]->mCommandReferences;
-    references[references.size()] = CommandReference(
-        buffer, references.size(), CommandType::cmd_vkCmdDraw, map.size() - 1, 0, 0
+    const uint32_t reference_idx = references.size();
+    references[reference_idx] = CommandReference(
+        buffer, reference_idx, CommandType::cmd_vkCmdDraw, map.size() - 1, 0, 0
     );
 }
 template<>
@@ -840,8 +854,9 @@ inline void AppendCommand(VkCommandBuffer buffer, VulkanSpy* spy, std::shared_pt
     auto& map = spy->CommandBuffers[buffer]->mBufferCommands.mvkCmdDrawIndexed;
     map[map.size()] = args;
     auto& references = spy->CommandBuffers[buffer]->mCommandReferences;
-    references[references.size()] = CommandReference(
-        buffer, references.size(), CommandType::cmd_vkCmdDrawIndexed, map.size() - 1, 0, 0
+    const uint32_t reference_idx = references.size();
+    references[reference_idx] = CommandReference(
+        buffer, reference_idx, CommandType::cmd_vkCmdDrawIndexed, map.size() - 1, 0, 0
     );
 }
 template<>
@@ -849,8 +864,9 @@ inline void AppendCommand(VkCommandBuffer buffer, VulkanSpy* spy, std::shared_pt
     auto& map = spy->CommandBuffers[buffer]->mBufferCommands.mvkCmdDrawIndirect;
     map[map.size()] = args;
     auto& references = spy->CommandBuffers[buffer]->mCommandReferences;
-    references[references.size()] = CommandReference(
-        buffer, references.size(), CommandType::cmd_vkCmdDrawIndirect, map.size() - 1, 0, 0
+    const uint32_t reference_idx = references.size();
+    references[reference_idx] = CommandReference(
+        buffer, reference_idx, CommandType::cmd_vkCmdDrawIndirect, map.size() - 1, 0, 0
     );
 }
 template<>
@@ -858,8 +874,9 @@ inline void AppendCommand(VkCommandBuffer buffer, VulkanSpy* spy, std::shared_pt
     auto& map = spy->CommandBuffers[buffer]->mBufferCommands.mvkCmdDrawIndexedIndirect;
     map[map.size()] = args;
     auto& references = spy->CommandBuffers[buffer]->mCommandReferences;
-    references[references.size()] = CommandReference(
-        buffer, references.size(), CommandType::cmd_vkCmdDrawIndexedIndirect, map.size() - 1, 0, 0
+    const uint32_t reference_idx = references.size();
+    references[reference_idx] = CommandReference(
+        buffer, reference_idx, CommandType::cmd_vkCmdDrawIndexedIndirect, map.size() - 1, 0, 0
     );
 }
 template<>
@@ -867,8 +884,9 @@ inline void AppendCommand(VkCommandBuffer buffer, VulkanSpy* spy, std::shared_pt
     auto& map = spy->CommandBuffers[buffer]->mBufferCommands.mvkCmdDispatch;
     map[map.size()] = args;
     auto& references = spy->CommandBuffers[buffer]->mCommandReferences;
-    references[references.size()] = CommandReference(
-        buffer, references.size(), CommandType::cmd_vkCmdDispatch, map.size() - 1, 0, 0
+    const uint32_t reference_idx = references.size();
+    references[reference_idx] = CommandReference(
+        buffer, reference_idx, CommandType::cmd_vkCmdDispatch, map.size() - 1, 0, 0
     );
 }
 template<>
@@ -876,8 +894,9 @@ inline void AppendCommand(VkCommandBuffer buffer, VulkanSpy* spy, std::shared_pt
     auto& map = spy->CommandBuffers[buffer]->mBufferCommands.mvkCmdDispatchIndirect;
     map[map.size()] = args;
     auto& references = spy->CommandBuffers[buffer]->mCommandReferences;
-    references[references.size()] = CommandReference(
-        buffer, references.size(), CommandType::cmd_vkCmdDispatchIndirect, map.size() - 1, 0, 0
+    const uint32_t reference_idx = references.size();
+    references[reference_idx] = CommandReference(
+        buffer, reference_idx, CommandType::cmd_vkCmdDispatchIndirect, map.size() - 1, 0, 0
     );
 }
 template<>
@@ -885,8 +904,9 @@ inline void AppendCommand(VkCommandBuffer buffer, VulkanSpy* spy, std::shared_pt
     auto& map = spy->CommandBuffers[buffer]->mBufferCommands.mvkCmdCopyBuffer;
     map[map.size()] = args;
     auto& references = spy->CommandBuffers[buffer]->mCommandReferences;
-    references[references.size()] = CommandReference(
-        buffer, references.size(), CommandType::cmd_vkCmdCopyBuffer, map.size() - 1, 0, 0
+    const uint32_t reference_idx = references.size();
+    references[reference_idx] = CommandReference(
+        buffer, reference_idx, CommandType::cmd_vkCmdCopyBuffer, map.size() - 1, 0, 0
     );
 }
 template<>
@@ -894,8 +914,9 @@ inline void AppendCommand(VkCommandBuffer buffer, VulkanSpy* spy, std::shared_pt
     auto& map = spy->CommandBuffers[buffer]->mBufferCommands.mvkCmdCopyImage;
     map[map.size()] = args;
     auto& references = spy->CommandBuffers[buffer]->mCommandReferences;
-    references[references.size()] = CommandReference(
-        buffer, references.size(), CommandType::cmd_vkCmdCopyImage, map.size() - 1, 0, 0
+    const uint32_t reference_idx = references.size();
+    references[reference_idx] = CommandReference(
+        buffer, reference_idx, CommandType::cmd_vkCmdCopyImage, map.size() - 1, 0, 0
     );
 }
 template<>
@@ -903,8 +924,9 @@ inline void AppendCommand(VkCommandBuffer buffer, VulkanSpy* spy, std::shared_pt
     auto& map = spy->CommandBuffers[buffer]->mBufferCommands.mvkCmdBlitImage;
     map[map.size()] = args;
     auto& references = spy->CommandBuffers[buffer]->mCommandReferences;
-    references[references.size()] = CommandReference(
-        buffer, references.size(), CommandType::cmd_vkCmdBlitImage, map.size() - 1, 0, 0
+    const uint32_t reference_idx = references.size();
+    references[reference_idx] = CommandReference(
+        buffer, reference_idx, CommandType::cmd_vkCmdBlitImage, map.size() - 1, 0, 0
     );
 }
 template<>
@@ -912,8 +934,9 @@ inline void AppendCommand(VkCommandBuffer buffer, VulkanSpy* spy, std::shared_pt
     auto& map = spy->CommandBuffers[buffer]->mBufferCommands.mvkCmdCopyBufferToImage;
     map[map.size()] = args;
     auto& references = spy->CommandBuffers[buffer]->mCommandReferences;
-    references[references.size()] = CommandReference(
-        buffer, references.size(), CommandType::cmd_vkCmdCopyBufferToImage, map.size() - 1, 0, 0
+    const uint32_t reference_idx = references.size();
+    references[reference_idx] = CommandReference(
+        buffer, reference_idx, CommandType::cmd_vkCmdCopyBufferToImage, map.size() - 1, 0, 0
     );
 }
 template<>
@@ -921,8 +944,9 @@ inline void AppendCommand(VkCommandBuffer buffer, VulkanSpy* spy, std::shared_pt
     auto& map = spy->CommandBuffers[buffer]->mBufferCommands.mvkCmdCopyImageToBuffer;
     map[map.size()] = args;
     auto& references = spy->CommandBuffers[buffer]->mCommandReferences;
-    references[references.size()] = CommandReference(
-        buffer, references.size(), CommandType::cmd_vkCmdCopyImageToBuffer, map.size() - 1, 0, 0
+    const uint32_t reference_idx = references.size();
+    references[reference_idx] = CommandReference(
+        buffer, reference_idx, CommandType::cmd_vkCmdCopyImageToBuffer, map.size() - 1, 0, 0
     );
 }
 template<>
@@ -930,8 +954,9 @@ inline void AppendCommand(VkCommandBuffer buffer, VulkanSpy* spy, std::shared_pt
     auto& map = spy->CommandBuffers[buffer]->mBufferCommands.mvkCmdUpdateBuffer;
     map[map.size()] = args;
     auto& references = spy->CommandBuffers[buffer]->mCommandReferences;
-    references[references.size()] = CommandReference(
-        buffer, references.size(), CommandType::cmd_vkCmdUpdateBuffer, map.size() - 1, 0, 0
+    const uint32_t reference_idx = references.size();
+    references[reference_idx] = CommandReference(
+        buffer, reference_idx, CommandType::cmd_vkCmdUpdateBuffer, map.size() - 1, 0, 0
     );
 }
 template<>
@@ -939,8 +964,9 @@ inline void AppendCommand(VkCommandBuffer buffer, VulkanSpy* spy, std::shared_pt
     auto& map = spy->CommandBuffers[buffer]->mBufferCommands.mvkCmdFillBuffer;
     map[map.size()] = args;
     auto& references = spy->CommandBuffers[buffer]->mCommandReferences;
-    references[references.size()] = CommandReference(
-        buffer, references.size(), CommandType::cmd_vkCmdFillBuffer, map.size() - 1, 0, 0
+    const uint32_t reference_idx = references.size();
+    references[reference_idx] = CommandReference(
+        buffer, reference_idx, CommandType::cmd_vkCmdFillBuffer, map.size() - 1, 0, 0
     );
 }
 template<>
@@ -948,8 +974,9 @@ inline void AppendCommand(VkCommandBuffer buffer, VulkanSpy* spy, std::shared_pt
     auto& map = spy->CommandBuffers[buffer]->mBufferCommands.mvkCmdClearColorImage;
     map[map.size()] = args;
     auto& references = spy->CommandBuffers[buffer]->mCommandReferences;
-    references[references.size()] = CommandReference(
-        buffer, references.size(), CommandType::cmd_vkCmdClearColorImage, map.size() - 1, 0, 0
+    const uint32_t reference_idx = references.size();
+    references[reference_idx] = CommandReference(
+        buffer, reference_idx, CommandType::cmd_vkCmdClearColorImage, map.size() - 1, 0, 0
     );
 }
 template<>
@@ -957,8 +984,9 @@ inline void AppendCommand(VkCommandBuffer buffer, VulkanSpy* spy, std::shared_pt
     auto& map = spy->CommandBuffers[buffer]->mBufferCommands.mvkCmdClearDepthStencilImage;
     map[map.size()] = args;
     auto& references = spy->CommandBuffers[buffer]->mCommandReferences;
-    references[references.size()] = CommandReference(
-        buffer, references.size(), CommandType::cmd_vkCmdClearDepthStencilImage, map.size() - 1, 0, 0
+    const uint32_t reference_idx = references.size();
+    references[reference_idx] = CommandReference(
+        buffer, reference_idx, CommandType::cmd_vkCmdClearDepthStencilImage, map.size() - 1, 0, 0
     );
 }
 template<>
@@ -966,8 +994,9 @@ inline void AppendCommand(VkCommandBuffer buffer, VulkanSpy* spy, std::shared_pt
     auto& map = spy->CommandBuffers[buffer]->mBufferCommands.mvkCmdClearAttachments;
     map[map.size()] = args;
     auto& references = spy->CommandBuffers[buffer]->mCommandReferences;
-    references[references.size()] = CommandReference(
-        buffer, references.size(), CommandType::cmd_vkCmdClearAttachments, map.size() - 1, 0, 0
+    const uint32_t reference_idx = references.size();
+    references[reference_idx] = CommandReference(
+        buffer, reference_idx, CommandType::cmd_vkCmdClearAttachments, map.size() - 1, 0, 0
     );
 }
 template<>
@@ -975,8 +1004,9 @@ inline void AppendCommand(VkCommandBuffer buffer, VulkanSpy* spy, std::shared_pt
     auto& map = spy->CommandBuffers[buffer]->mBufferCommands.mvkCmdResolveImage;
     map[map.size()] = args;
     auto& references = spy->CommandBuffers[buffer]->mCommandReferences;
-    references[references.size()] = CommandReference(
-        buffer, references.size(), CommandType::cmd_vkCmdResolveImage, map.size() - 1, 0, 0
+    const uint32_t reference_idx = references.size();
+    references[reference_idx] = CommandReference(
+        buffer, reference_idx, CommandType::cmd_vkCmdResolveImage, map.size() - 1, 0, 0
     );
 }
 template<>
@@ -984,8 +1014,9 @@ inline void AppendCommand(VkCommandBuffer buffer, VulkanSpy* spy, std::shared_pt
     auto& map = spy->CommandBuffers[buffer]->mBufferCommands.mvkCmdSetEvent;
     map[map.size()] = args;
     auto& references = spy->CommandBuffers[buffer]->mCommandReferences;
-    references[references.size()] = CommandReference(
-        buffer, references.size(), CommandType::cmd_vkCmdSetEvent, map.size() - 1, 0, 0
+    const uint32_t reference_idx = references.size();
+    references[reference_idx] = CommandReference(
+        buffer, reference_idx, CommandType::cmd_vkCmdSetEvent, map.size() - 1, 0, 0
     );
 }
 template<>
@@ -993,8 +1024,9 @@ inline void AppendCommand(VkCommandBuffer buffer, VulkanSpy* spy, std::shared_pt
     auto& map = spy->CommandBuffers[buffer]->mBufferCommands.mvkCmdResetEvent;
     map[map.size()] = args;
     auto& references = spy->CommandBuffers[buffer]->mCommandReferences;
-    references[references.size()] = CommandReference(
-        buffer, references.size(), CommandType::cmd_vkCmdResetEvent, map.size() - 1, 0, 0
+    const uint32_t reference_idx = references.size();
+    references[reference_idx] = CommandReference(
+        buffer, reference_idx, CommandType::cmd_vkCmdResetEvent, map.size() - 1, 0, 0
     );
 }
 template<>
@@ -1002,8 +1034,9 @@ inline void AppendCommand(VkCommandBuffer buffer, VulkanSpy* spy, std::shared_pt
     auto& map = spy->CommandBuffers[buffer]->mBufferCommands.mvkCmdWaitEvents;
     map[map.size()] = args;
     auto& references = spy->CommandBuffers[buffer]->mCommandReferences;
-    references[references.size()] = CommandReference(
-        buffer, references.size(), CommandType::cmd_vkCmdWaitEvents, map.size() - 1, 0, 0
+    const uint32_t reference_idx = references.size();
+    references[reference_idx] = CommandReference(
+        buffer, reference_idx, CommandType::cmd_vkCmdWaitEvents, map.size() - 1, 0, 0
     );
 }
 template<>
@@ -1011,8 +1044,9 @@ inline void AppendCommand(VkCommandBuffer buffer, VulkanSpy* spy, std::shared_pt
     auto& map = spy->CommandBuffers[buffer]->mBufferCommands.mvkCmdPipelineBarrier;
     map[map.size()] = args;
     auto& references = spy->CommandBuffers[buffer]->mCommandReferences;
-    references[references.size()] = CommandReference(
-        buffer, references.size(), CommandType::cmd_vkCmdPipelineBarrier, map.size() - 1, 0, 0
+    const uint32_t reference_idx = references.size();
+    references[reference_idx] = CommandReference(
+        buffer, reference_idx, CommandType::cmd_vkCmdPipelineBarrier, map.size() - 1, 0, 0
     );
 }
 template<>
@@ -1020,8 +1054,9 @@ inline void AppendCommand(VkCommandBuffer buffer, VulkanSpy* spy, std::shared_pt
     auto& map = spy->CommandBuffers[buffer]->mBufferCommands.mvkCmdBeginQuery;
     map[map.size()] = args;
     auto& references = spy->CommandBuffers[buffer]->mCommandReferences;
-    references[references.size()] = CommandReference(
-        buffer, references.size(), CommandType::cmd_vkCmdBeginQuery, map.size() - 1, 0, 0
+    const uint32_t reference_idx = references.size();
+    references[reference_idx] = CommandReference(
+        buffer, reference_idx, CommandType::cmd_vkCmdBeginQuery, map.size() - 1, 0, 0
     );
 }
 template<>
@@ -1029,8 +1064,9 @@ inline void AppendCommand(VkCommandBuffer buffer, VulkanSpy* spy, std::shared_pt
     auto& map = spy->CommandBuffers[buffer]->mBufferCommands.mvkCmdEndQuery;
     map[map.size()] = args;
     auto& references = spy->CommandBuffers[buffer]->mCommandReferences;
-    references[references.size()] = CommandReference(
-        buffer, references.size(), CommandType::cmd_vkCmdEndQuery, map.size() - 1, 0, 0
+    const uint32_t reference_idx = references.size();
+    references[reference_idx] = CommandReference(
+        buffer, reference_idx, CommandType::cmd_vkCmdEndQuery, map.size() - 1, 0, 0
     );
 }
 template<>
@@ -1038,8 +1074,9 @@ inline void AppendCommand(VkCommandBuffer buffer, VulkanSpy* spy, std::shared_pt
     auto& map = spy->CommandBuffers[buffer]->mBufferCommands.mvkCmdResetQueryPool;
     map[map.size()] = args;
     auto& references = spy->CommandBuffers[buffer]->mCommandReferences;
-    references[references.size()] = CommandReference(
-        buffer, references.size(), CommandType::cmd_vkCmdResetQueryPool, map.size() - 1, 0, 0
+    const uint32_t reference_idx = references.size();
+    references[reference_idx] = CommandReference(
+        buffer, reference_idx, CommandType::cmd_vkCmdResetQueryPool, map.size() - 1, 0, 0
     );
 }
 template<>
@@ -1047,8 +1084,9 @@ inline void AppendCommand(VkCommandBuffer buffer, VulkanSpy* spy, std::shared_pt
     auto& map = spy->CommandBuffers[buffer]->mBufferCommands.mvkCmdWriteTimestamp;
     map[map.size()] = args;
     auto& references = spy->CommandBuffers[buffer]->mCommandReferences;
-    references[references.size()] = CommandReference(
-        buffer, references.size(), CommandType::cmd_vkCmdWriteTimestamp, map.size() - 1, 0, 0
+    const uint32_t reference_idx = references.size();
+    references[reference_idx] = CommandReference(
+        buffer, reference_idx, CommandType::cmd_vkCmdWriteTimestamp, map.size() - 1, 0, 0
     );
 }
 template<>
@@ -1056,8 +1094,9 @@ inline void AppendCommand(VkCommandBuffer buffer, VulkanSpy* spy, std::shared_pt
     auto& map = spy->CommandBuffers[buffer]->mBufferCommands.mvkCmdCopyQueryPoolResults;
     map[map.size()] = args;
     auto& references = spy->CommandBuffers[buffer]->mCommandReferences;
-    references[references.size()] = CommandReference(
-        buffer, references.size(), CommandType::cmd_vkCmdCopyQueryPoolResults, map.size() - 1, 0, 0
+    const uint32_t reference_idx = references.size();
+    references[reference_idx] = CommandReference(
+        buffer, reference_idx, CommandType::cmd_vkCmdCopyQueryPoolResults, map.size() - 1, 0, 0
     );
 }
 template<>
@@ -1065,8 +1104,9 @@ inline void AppendCommand(VkCommandBuffer buffer, VulkanSpy* spy, std::shared_pt
     auto& map = spy->CommandBuffers[buffer]->mBufferCommands.mvkCmdPushConstants;
     map[map.size()] = args;
     auto& references = spy->CommandBuffers[buffer]->mCommandReferences;
-    references[references.size()] = CommandReference(
-        buffer, references.size(), CommandType::cmd_vkCmdPushConstants, map.size() - 1, 0, 0
+    const uint32_t reference_idx = references.size();
+    references[reference_idx] = CommandReference(
+        buffer, reference_idx, CommandType::cmd_vkCmdPushConstants, map.size() - 1, 0, 0
     );
 }
 template<>
@@ -1074,8 +1114,9 @@ inline void AppendCommand(VkCommandBuffer buffer, VulkanSpy* spy, std::shared_pt
     auto& map = spy->CommandBuffers[buffer]->mBufferCommands.mvkCmdBeginRenderPass;
     map[map.size()] = args;
     auto& references = spy->CommandBuffers[buffer]->mCommandReferences;
-    references[references.size()] = CommandReference(
-        buffer, references.size(), CommandType::cmd_vkCmdBeginRenderPass, map.size() - 1, 0, 0
+    const uint32_t reference_idx = references.size();
+    references[reference_idx] = CommandReference(
+        buffer, reference_idx, CommandType::cmd_vkCmdBeginRenderPass, map.size() - 1, 0, 0
     );
 }
 template<>
@@ -1083,8 +1124,9 @@ inline void AppendCommand(VkCommandBuffer buffer, VulkanSpy* spy, std::shared_pt
     auto& map = spy->CommandBuffers[buffer]->mBufferCommands.mvkCmdNextSubpass;
     map[map.size()] = args;
     auto& references = spy->CommandBuffers[buffer]->mCommandReferences;
-    references[references.size()] = CommandReference(
-        buffer, references.size(), CommandType::cmd_vkCmdNextSubpass, map.size() - 1, 0, 0
+    const uint32_t reference_idx = references.size();
+    references[reference_idx] = CommandReference(
+        buffer, reference_idx, CommandType::cmd_vkCmdNextSubpass, map.size() - 1, 0, 0
     );
 }
 template<>
@@ -1092,8 +1134,9 @@ inline void AppendCommand(VkCommandBuffer buffer, VulkanSpy* spy, std::shared_pt
     auto& map = spy->CommandBuffers[buffer]->mBufferCommands.mvkCmdEndRenderPass;
     map[map.size()] = args;
     auto& references = spy->CommandBuffers[buffer]->mCommandReferences;
-    references[references.size()] = CommandReference(
-        buffer, references.size(), CommandType::cmd_vkCmdEndRenderPass, map.size() - 1, 0, 0
+    const uint32_t reference_idx = references.size();
+    references[reference_idx] = CommandReference(
+        buffer, reference_idx, CommandType::cmd_vkCmdEndRenderPass, map.size() - 1, 0, 0
     );
 }
 template<>
@@ -1101,8 +1144,9 @@ inline void AppendCommand(VkCommandBuffer buffer, VulkanSpy* spy, std::shared_pt
     auto& map = spy->CommandBuffers[buffer]->mBufferCommands.mvkCmdExecuteCommands;
     map[map.size()] = args;
     auto& references = spy->CommandBuffers[buffer]->mCommandReferences;
-    references[references.size()] = CommandReference(
-        buffer, references.size(), CommandType::cmd_vkCmdExecuteCommands, map.size() - 1, 0, 0
+    const uint32_t reference_idx = references.size();
+    references[reference_idx] = CommandReference(
+        buffer, reference_idx, CommandType::cmd_vkCmdExecuteCommands, map.size() - 1, 0, 0
     );
 }
 template<>
@@ -1110,8 +1154,9 @@ inline void AppendCommand(VkCommandBuffer buffer, VulkanSpy* spy, std::shared_pt
     auto& map = spy->CommandBuffers[buffer]->mBufferCommands.mvkCmdDebugMarkerBeginEXT;
     map[map.size()] = args;
     auto& references = spy->CommandBuffers[buffer]->mCommandReferences;
-    references[references.size()] = CommandReference(
-        buffer, references.size(), CommandType::cmd_vkCmdDebugMarkerBeginEXT, map.size() - 1, 0, 0
+    const uint32_t reference_idx = references.size();
+    references[reference_idx] = CommandReference(
+        buffer, reference_idx, CommandType::cmd_vkCmdDebugMarkerBeginEXT, map.size() - 1, 0, 0
     );
 }
 template<>
@@ -1119,8 +1164,9 @@ inline void AppendCommand(VkCommandBuffer buffer, VulkanSpy* spy, std::shared_pt
     auto& map = spy->CommandBuffers[buffer]->mBufferCommands.mvkCmdDebugMarkerEndEXT;
     map[map.size()] = args;
     auto& references = spy->CommandBuffers[buffer]->mCommandReferences;
-    references[references.size()] = CommandReference(
-        buffer, references.size(), CommandType::cmd_vkCmdDebugMarkerEndEXT, map.size() - 1, 0, 0
+    const uint32_t reference_idx = references.size();
+    references[reference_idx] = CommandReference(
+        buffer, reference_idx, CommandType::cmd_vkCmdDebugMarkerEndEXT, map.size() - 1, 0, 0
     );
 }
 template<>
@@ -1128,8 +1174,9 @@ inline void AppendCommand(VkCommandBuffer buffer, VulkanSpy* spy, std::shared_pt
     auto& map = spy->CommandBuffers[buffer]->mBufferCommands.mvkCmdDebugMarkerInsertEXT;
     map[map.size()] = args;
     auto& references = spy->CommandBuffers[buffer]->mCommandReferences;
-    references[references.size()] = CommandReference(
-        buffer, references.size(), CommandType::cmd_vkCmdDebugMarkerInsertEXT, map.size() - 1, 0, 0
+    const uint32_t reference_idx = references.size();
+    references[reference_idx] = CommandReference(
+        buffer, reference_idx, CommandType::cmd_vkCmdDebugMarkerInsertEXT, map.size() - 1, 0, 0
     );
 }
 //////////////// Command Buffer Insertion


### PR DESCRIPTION
We were incorrectly relying on the order of evaluation of
left-hand and right-hand side of assignments. This meant
that values were not correct of evaluating LHS first.