### PR TITLE
Fix for multiple devices in one system.

### DIFF
--- a/gapii/cc/vulkan_mid_execution.cpp
+++ b/gapii/cc/vulkan_mid_execution.cpp
@@ -18,6 +18,7 @@
 #include <map>
 #include <vector>
 #include <unordered_set>
+#include "gapii/cc/vulkan_exports.h"
 #include "gapii/cc/vulkan_spy.h"
 
 #ifdef _WIN32
@@ -364,7 +365,14 @@ void VulkanSpy::EnumerateVulkanResources(CallObserver* observer) {
       uint32_t count = instance_devices.second.size();
       RecreatePhysicalDevices(observer, instance_devices.first, &count,
                               instance_devices.second.data());
+      for (size_t i = 0; i < count; ++i) {
+        VkPhysicalDeviceProperties props;
+        mImports.mVkInstanceFunctions[instance_devices.first]
+          .vkGetPhysicalDeviceProperties(instance_devices.second[i], &props);
+        vkGetPhysicalDeviceProperties(observer, instance_devices.second[i], &props);
+      }
     }
+
     for (auto& physical_device : PhysicalDevices) {
       uint32_t queueFamilyPropertyCount = 0;
       std::vector<VkQueueFamilyProperties> queueFamilyProperties;

--- a/gapir/cc/context.cpp
+++ b/gapir/cc/context.cpp
@@ -399,6 +399,20 @@ void Context::registerCallbacks(Interpreter* interpreter) {
                 return false;
             }
         });
+    interpreter->registerBuiltin(
+        Vulkan::INDEX,
+        Builtins::ReplayEnumeratePhysicalDevices,
+        [this, interpreter](uint32_t label, Stack* stack, bool push_return) {
+            GAPID_DEBUG("[%u]replayEnumeratePhysicalDevices()", label);
+            if (mVulkanRenderer != nullptr) {
+                auto* api = mVulkanRenderer->getApi<Vulkan>();
+                return api->replayEnumeratePhysicalDevices(stack, push_return);
+            } else {
+                GAPID_WARNING("[%u]replayEnumeratePhysicalDevices called without a "
+                              "bound Vulkan renderer", label);
+                return false;
+            }
+        });
 
     interpreter->registerBuiltin(Vulkan::INDEX, Builtins::ReplayGetFenceStatus,
                                  [this, interpreter](uint32_t label, Stack* stack, bool push_return) {

--- a/gapir/cc/vulkan_gfx_api.inl
+++ b/gapir/cc/vulkan_gfx_api.inl
@@ -99,3 +99,8 @@ bool replayGetEventStatus(Stack* stack, bool pushReturn);
 // Builtin function for getting image memory requirement and allocating
 // corresponding memory for a image on the replay side.
 bool replayAllocateImageMemory(Stack* stack, bool pushReturn);
+
+// Builtin function for recreating physical devices. The reason we have
+// to customize this is that the device can choose to return the
+// physical devices in any order.
+bool replayEnumeratePhysicalDevices(Stack* stack, bool pushReturn);

--- a/gapis/api/templates/vulkan_gfx_api_extras.tmpl
+++ b/gapis/api/templates/vulkan_gfx_api_extras.tmpl
@@ -404,6 +404,71 @@ bool Vulkan::replayGetEventStatus(Stack* stack, bool pushReturn) {
     }
 }
 ¶
+bool Vulkan::replayEnumeratePhysicalDevices(Stack* stack, bool pushReturn) {
+    auto physicalDeviceIDs = stack->pop<uint64_t*>();
+    auto physicalDevices = stack->pop<VkPhysicalDevice*>();
+    auto physicalDeviceCount = stack->pop<uint32_t*>();
+    auto instance = static_cast<size_val>(stack->pop<size_val>());
+    if (stack->isValid()) {
+        GAPID_DEBUG("replayEnumeratePhysicalDevices");
+        if (mVkInstanceFunctionStubs.find(instance) != mVkInstanceFunctionStubs.end() &&
+        mVkInstanceFunctionStubs[instance].vkEnumeratePhysicalDevices) {
+            auto enumerate = mVkInstanceFunctionStubs[instance].vkEnumeratePhysicalDevices;
+            auto props = mVkInstanceFunctionStubs[instance].vkGetPhysicalDeviceProperties;
+            std::vector<VkPhysicalDevice> devices;
+            std::vector<VkPhysicalDeviceProperties> properties;
+            uint32_t count = 0;
+            enumerate(instance, &count, nullptr);
+            devices.resize(count);
+            properties.resize(count);
+            auto return_value = enumerate(instance, &count, devices.data());
+            for (size_t i = 0; i < count; ++i) {
+              props(devices[i], &properties[i]);
+            }
+            GAPID_DEBUG("Returned: %u", return_value);
+            if (count < *physicalDeviceCount) {
+              GAPID_WARNING("Fewer physical devices than in trace, replay may not work correctly");
+            } else if (count > *physicalDeviceCount) {
+              GAPID_WARNING("More physical devices than in trace");
+            }
+            if (count == 0) {
+              GAPID_ERROR("No physical devices on replay device");
+            }
+
+            for (size_t i = 0; i < *physicalDeviceCount; ++i) {
+              auto device_id = physicalDeviceIDs[i];
+              size_t j = 0;
+              for (; j < count; ++j) {
+                uint64_t new_device_id = static_cast<uint64_t>(properties[j].vendorID) << 32 |
+                    static_cast<uint64_t>(properties[j].deviceID);
+                if (device_id == new_device_id) {
+                  break;
+                }
+              }
+              if (j == count) {
+                GAPID_WARNING("Could not find device with deviceID %d, and vendorID %d", (device_id >> 32) & 0xFFFFFFFF, 
+                    device_id & 0xFFFFFFFF);
+                j = count - 1;
+              }
+              if (j != i) {
+                GAPID_WARNING("Remapping physical device on replay: %d -> %d", j, i);
+              }
+              physicalDevices[i] = devices[j];
+            }
+            
+            if (pushReturn) {
+                stack->push<VkResult>(return_value);
+            }
+        } else {
+            GAPID_WARNING("Attempted to call unsupported function replayEnumeratePhysicalDevices");
+        }
+        return true;
+    } else {
+        GAPID_WARNING("Error during calling function replayEnumeratePhysicalDevices");
+        return false;
+    }
+}
+¶
   »}  // namespace gapir
 ¶
 {{end}}

--- a/gapis/api/vulkan/synthetic.api
+++ b/gapis/api/vulkan/synthetic.api
@@ -116,3 +116,23 @@ cmd VkResult replayAllocateImageMemory(VkDevice device, VkPhysicalDeviceMemoryPr
   pMemory[0] = handle
   return ?
 }
+
+@synthetic
+cmd VkResult replayEnumeratePhysicalDevices(
+    VkInstance instance,
+    u32*              pPhysicalDeviceCount,
+    VkPhysicalDevice* pPhysicalDevices,
+    // This is an array of expected vendorID/deviceID (32-bits/32-bits)
+    u64*              pPhysicalDeviceIDs) {
+  count := pPhysicalDeviceCount[0]
+  read(pPhysicalDeviceIDs[0:count])
+  devices := pPhysicalDevices[0:count]
+  for i in (0 .. count) {
+    device := ?
+    PhysicalDevices[device] = new!PhysicalDeviceObject(Instance: instance,Index:  i,
+      VulkanHandle:              device)
+    devices[i] = device
+  }
+
+  return ?
+}

--- a/gapis/api/vulkan/templates/vk_spy_helpers.cpp.tmpl
+++ b/gapis/api/vulkan/templates/vk_spy_helpers.cpp.tmpl
@@ -571,6 +571,21 @@ uint32_t VulkanSpy::SpyOverride_vkAllocateMemory(VkDevice device, VkMemoryAlloca
     return r;
 }
 
+uint32_t VulkanSpy::SpyOverride_vkEnumeratePhysicalDevices(
+VkInstance instance, uint32_t* pPhysicalDeviceCount,
+VkPhysicalDevice* pPhysicalDevices) {
+    uint32_t fill_count = pPhysicalDevices? *pPhysicalDeviceCount : 0;
+    uint32_t r = mImports.mVkInstanceFunctions[instance].vkEnumeratePhysicalDevices(instance, pPhysicalDeviceCount, pPhysicalDevices);
+    if (fill_count > *pPhysicalDeviceCount) {
+        fill_count = *pPhysicalDeviceCount;
+    }
+    for (size_t i = 0; i < fill_count; ++i) {
+        VkPhysicalDeviceProperties properties;
+        gapii::vkGetPhysicalDeviceProperties(pPhysicalDevices[i], &properties);
+    }
+    return r;
+}
+
 uint32_t VulkanSpy::numberOfPNext(CallObserver* observer, void* pNext) {
   uint32_t counter = 0;
   while (pNext) {

--- a/gapis/api/vulkan/vulkan.api
+++ b/gapis/api/vulkan/vulkan.api
@@ -2511,6 +2511,7 @@ cmd void RecreatePhysicalDeviceProperties(
 
 @threadSafety("system")
 @indirect("VkInstance")
+@override
 cmd VkResult vkEnumeratePhysicalDevices(
     VkInstance        instance,
     u32*              pPhysicalDeviceCount,


### PR DESCRIPTION
Some systems, especially laptops, may have multiple adapters that
both support Vulkan. Furthermore, some drivers returns these
adapters in an effectively random order, or at least not
guaranteed to be the same between the tracing program, and
gapir. This remaps the physical devices on replay, so that
commands that were directed to a specific physical device are
directed to the same physical device if possible.