### PR TITLE
Flush the encoder before we close the connection.

### DIFF
--- a/core/cc/string_writer.h
+++ b/core/cc/string_writer.h
@@ -34,6 +34,9 @@ public:
     // as a memory optimization.
     virtual bool write(std::string& data) = 0;
 
+    // flush flushes out all of the pending in the steam
+    virtual void flush() = 0;
+
 protected:
     virtual ~StringWriter() {}
 };

--- a/gapii/cc/chunk_writer.cpp
+++ b/gapii/cc/chunk_writer.cpp
@@ -34,9 +34,9 @@ public:
     ~ChunkWriterImpl();
 
     virtual bool write(std::string& s) override;
+    virtual void flush() override;
 
 private:
-    void flush();
 
     std::string mBuffer;
 

--- a/gapii/cc/pack_encoder.cpp
+++ b/gapii/cc/pack_encoder.cpp
@@ -54,6 +54,7 @@ public:
 
     virtual void object(const Message* msg) override;
     virtual SPtr group(const Message* msg) override;
+    virtual void flush() override;
 
 private:
     struct TypeIDCache {
@@ -116,6 +117,10 @@ PackEncoderImpl::~PackEncoderImpl() {
         writeGroupID(buffer);
         flushBuffer(buffer);
     }
+}
+
+void PackEncoderImpl::flush() {
+    mShared->writer->flush();
 }
 
 void PackEncoderImpl::object(const Message* msg) {
@@ -242,6 +247,7 @@ public:
     virtual SPtr group(const ::google::protobuf::Message* msg) override {
         return instance;
     }
+    virtual void flush() override{}
 };
 
 gapii::PackEncoder::SPtr PackEncoderNoop::instance = gapii::PackEncoder::SPtr(new PackEncoderNoop);

--- a/gapii/cc/pack_encoder.h
+++ b/gapii/cc/pack_encoder.h
@@ -49,6 +49,9 @@ public:
     // objects and groups.
     virtual SPtr group(const ::google::protobuf::Message* msg) = 0;
 
+    // flush flushes out all of the pending in the encoder
+    virtual void flush() = 0;
+
     // create returns a PackEncoder::SPtr that writes to output.
     static SPtr create(std::shared_ptr<core::StreamWriter> output);
 

--- a/gapii/cc/spy.cpp
+++ b/gapii/cc/spy.cpp
@@ -466,6 +466,7 @@ void Spy::onPostStartOfFrame() {
     if (!is_suspended() && mCaptureFrames >= 1) {
         mCaptureFrames -= 1;
         if (mCaptureFrames == 0) {
+            mEncoder->flush();
             mConnection->close();
             set_suspended(true);
         }
@@ -503,6 +504,7 @@ void Spy::onPostEndOfFrame() {
     if (!is_suspended() && mCaptureFrames >= 1) {
         mCaptureFrames -= 1;
         if (mCaptureFrames == 0) {
+            mEncoder->flush();
             mConnection->close();
             set_suspended(true);
         }


### PR DESCRIPTION
This allows us to capture every command in the frame, and not drop the
last few if we had set a number of frames to capture.