### PR TITLE
Add entity previews to object view.

### DIFF
--- a/test/robot/web/client/client.go
+++ b/test/robot/web/client/client.go
@@ -319,6 +319,31 @@ func robotEntityLink(path string, s interface{}) interface{} {
 	return a
 }
 
+func robotTextPreview(path string, s interface{}) interface{} {
+	id := s.(string)
+
+	div := dom.NewDiv()
+	div.Element.Style.MaxWidth = 600
+	div.Element.Style.MaxHeight = 420
+	div.Element.Style.Overflow = "auto"
+	go func() {
+		full_text, err := queryRestEndpoint(fmt.Sprintf("/entities/%s", id))
+		if err != nil {
+			panic(err)
+		}
+
+		div.Append(string(full_text))
+	}()
+	return div
+}
+
+func robotVideoView(path string, s interface{}) interface{} {
+	id := s.(string)
+	v := dom.NewVideo(600, 420, fmt.Sprintf("/entities/%s", id), "mp4")
+	v.Append("Your browser does not support embedded video tags")
+	return v
+}
+
 func setupGrid(tasks []*task) *page {
 	const (
 		optAuto  = "!!auto"
@@ -353,7 +378,8 @@ func setupGrid(tasks []*task) *page {
 		},
 	).Add("/1/input/((gapi[irst])|gapid_apk|trace|subject|interceptor|vulkanLayer)", robotEntityLink).
 		Add("/1/input/layout", objView.Expandable).
-		Add("/1/output/", robotEntityLink).
+		Add("/1/output/(log|report)", robotTextPreview).
+		Add("/1/output/video", robotVideoView).
 		Add("/0/", objView.Expandable)
 
 	filters := map[*dimension]*dom.Select{}
@@ -423,6 +449,9 @@ func setupGrid(tasks []*task) *page {
 
 	body := dom.Doc().Body()
 	body.Style.BackgroundColor = dom.RGB(0.98, 0.98, 0.98)
+	objView.Div.Element.Style.Position = "sticky"
+	objView.Div.Element.Style.Top = "0"
+	objView.Div.Element.Style.Float = "right"
 	body.Append(objView)
 	body.Append(div)
 

--- a/test/robot/web/client/dom/video.go
+++ b/test/robot/web/client/dom/video.go
@@ -1,0 +1,64 @@
+// Copyright (C) 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dom
+
+import (
+	"path/filepath"
+)
+
+type Source struct {
+	*Element
+	Src string `js:"src"`
+	Typ string `js:"type"`
+}
+
+// Video represents an HTML <video> element
+type Video struct {
+	*Element
+
+	Autoplay bool `js:"autoplay"`
+	Controls bool `js:"controls"`
+}
+
+func isSupportedSourceType(typ string) bool {
+	return map[string]bool{"mp4": true, "webm": true, "ogg": true}[typ]
+}
+
+func (v *Video) Resize(width, height int) {
+	drp := Win.DevicePixelRatio
+	style := v.Style
+	v.Width, v.Height = int(float64(width)*drp), int(float64(height)*drp)
+	style.Width, style.Height = width, height
+}
+
+func (s *Source) SetSource(source, typ string) {
+	s.Src = source
+	if isSupportedSourceType(typ) {
+		s.Typ = "video/" + typ
+	} else if isSupportedSourceType(filepath.Ext(source)) {
+		s.Typ = "video/" + filepath.Ext(source)
+	}
+}
+
+func NewVideo(width, height int, source, typ string) *Video {
+	v := &Video{Element: newEl("video")}
+	v.Autoplay = true
+	v.Controls = true
+	s := &Source{Element: newEl("source")}
+	s.SetSource(source, typ)
+	v.Append(s)
+	v.Resize(width, height)
+	return v
+}


### PR DESCRIPTION
In order to preview entities without needing to leave the grid this
change adds a video dom element and modifies the object view to create
previews of logs, reports, and videos in the grid view. Because this
makes the object view larger in size it also made sense to move it to
the right side of the screen and position it absolutely (so you don't
need to scroll to the top of the screen either).