### PR TITLE
Add stale unknown state to grid.

### DIFF
--- a/test/robot/web/client/data.go
+++ b/test/robot/web/client/data.go
@@ -76,7 +76,7 @@ var (
 		enumSrc: func() enum {
 			result := enum{}
 			devices := itemGetter("{{.id}}", machineDisplayTemplate, template.FuncMap{})(queryArray("/devices/"))
-			targets := itemGetter("{.target}", "{.target}", template.FuncMap{})(queryArray("/workers/"))
+			targets := itemGetter("{{.target}}", "{{.target}}", template.FuncMap{})(queryArray("/workers/"))
 			for _, d := range devices {
 				for _, t := range targets {
 					if d.Id() == t.Id() {
@@ -96,7 +96,7 @@ var (
 		enumSrc: func() enum {
 			result := enum{}
 			devices := itemGetter("{{.id}}", machineDisplayTemplate, template.FuncMap{})(queryArray("/devices/"))
-			hosts := itemGetter("{.host}", "{.host}", template.FuncMap{})(queryArray("/workers/"))
+			hosts := itemGetter("{{.host}}", "{{.host}}", template.FuncMap{})(queryArray("/workers/"))
 			for _, d := range devices {
 				for _, h := range hosts {
 					if d.Id() == h.Id() {
@@ -344,7 +344,7 @@ func newTask(entry map[string]interface{}, kind Item) *task {
 		}
 	} else {
 		t.status = grid.Stale
-		t.result = grid.Failed
+		t.result = grid.Unknown
 	}
 	return t
 }

--- a/test/robot/web/client/widgets/grid/data.go
+++ b/test/robot/web/client/widgets/grid/data.go
@@ -123,6 +123,7 @@ func (l TaskList) stats() taskStats {
 		numStaleFailed:            l.Count(taskStaleFailed),
 		numCurrentFailed:          l.Count(taskCurrentFailed),
 		numFailedWasSucceeded:     l.Count(taskFailedWasSucceeded),
+		numStaleUnknown:           l.Count(taskStaleUnknown),
 		numTasks:                  len(l),
 	}
 }
@@ -136,6 +137,7 @@ func taskStaleFailed(t Task) bool            { return t.Result == Failed && t.St
 func taskInProgressWasFailed(t Task) bool    { return t.Result == Failed && t.Status == InProgress }
 func taskFailedWasSucceeded(t Task) bool     { return t.Result == Failed && t.Status == Changed }
 func taskInProgressWasUnknown(t Task) bool   { return t.Result == Unknown && t.Status == InProgress }
+func taskStaleUnknown(t Task) bool           { return t.Result == Unknown && t.Status == Stale }
 
 type cell struct {
 	index           CellIndex
@@ -167,6 +169,7 @@ type taskStats struct {
 	numStaleFailed            int
 	numCurrentFailed          int
 	numFailedWasSucceeded     int
+	numStaleUnknown           int
 	numTasks                  int
 }
 

--- a/test/robot/web/client/widgets/grid/draw.go
+++ b/test/robot/web/client/widgets/grid/draw.go
@@ -298,6 +298,7 @@ func (g *Grid) drawCluster(ctx *dom.Context2D, c *cluster, r *dom.Rect) {
 		ctx.Restore()
 	}
 
+	drawSegment(g.Style.StaleUnknownForegroundColor, false, c.stats.numStaleUnknown)
 	drawSegment(g.Style.CurrentSucceededForegroundColor, false, c.stats.numCurrentSucceeded)
 	drawSegment(g.Style.StaleSucceededForegroundColor, true, c.stats.numInProgressWasSucceeded+c.stats.numInProgressWasUnknown)
 	drawSegment(g.Style.StaleSucceededForegroundColor, false, c.stats.numStaleSucceeded)

--- a/test/robot/web/client/widgets/grid/grid.go
+++ b/test/robot/web/client/widgets/grid/grid.go
@@ -69,6 +69,7 @@ func New() *Grid {
 		FixedForegroundColor:            dom.RGBA(0.18, 0.85, 0.20, 0.9),
 		UnknownBackgroundColor:          dom.RGBA(1.00, 1.00, 1.00, 1.0),
 		UnknownForegroundColor:          dom.RGBA(0.60, 0.60, 0.60, 0.9),
+		StaleUnknownForegroundColor:     dom.RGBA(0.60, 0.60, 0.60, 0.3),
 		SelectedBackgroundColor:         dom.RGB(0.89, 0.95, 0.97),
 		IconsFont:                       dom.NewFont(25, "Material Icons"),
 		Icons: Icons{

--- a/test/robot/web/client/widgets/grid/style.go
+++ b/test/robot/web/client/widgets/grid/style.go
@@ -46,6 +46,7 @@ type Style struct {
 	FixedForegroundColor            dom.Color // The foreground color used for tasks that last failed and now are succeeding.
 	UnknownBackgroundColor          dom.Color // The background color used for tasks that are in an unknown state.
 	UnknownForegroundColor          dom.Color // The foreground color used for tasks that are in an unknown state.
+	StaleUnknownForegroundColor     dom.Color // The foreground color used for tasks that are in an unknown state and are stale.
 	SelectedBackgroundColor         dom.Color // The background color used for cells and headers when selected.
 	IconsFont                       dom.Font  // The font to use for icon drawing.
 	Icons                           Icons     // The character table used for icon drawing.
@@ -65,8 +66,10 @@ func (s *Style) statsStyle(stats taskStats) (icon rune, backgroundColor, foregro
 		return s.Icons.Succeeded, s.StaleSucceededBackgroundColor, s.StaleSucceededForegroundColor
 	case stats.numCurrentSucceeded > 0:
 		return s.Icons.Succeeded, s.CurrentSucceededBackgroundColor, s.CurrentSucceededForegroundColor
-	case stats.numInProgressWasUnknown > 0:
+	case stats.numInProgressWasUnknown+stats.numStaleUnknown > 0:
 		return s.Icons.Unknown, s.UnknownBackgroundColor, s.UnknownForegroundColor
+	case stats.numStaleUnknown > 0:
+		return s.Icons.Unknown, s.UnknownBackgroundColor, s.StaleUnknownForegroundColor
 	default:
 		return s.Icons.Unknown, s.BackgroundColor, s.UnknownForegroundColor
 	}


### PR DESCRIPTION
Previously any task that was added to the grid, but yet to have started
would have no status associated and would get labeled as Stale/Failed.
This caused it to look similar to a failure case. Instead it is now
labeled as Stale/Unknown as it is not in progress yet, but it has been
scheduled thus the status is not yet known. It will show up in the grid
as grey instead of red.

This also fixes a bug where the template lookups for target and host
devices had missing braces, causing those templates to fail to match.