### PR TITLE
SPIRV-Cross workarounds for early_fragment_tests

### DIFF
--- a/gapis/api/gles/compat.go
+++ b/gapis/api/gles/compat.go
@@ -455,8 +455,9 @@ func compat(ctx context.Context, device *device.Instance) (transform.Transformer
 					log.W(ctx, "%v compat: %v", cmd, err)
 				}
 				opts := shadertools.Options{
-					ShaderType: st,
-					Relaxed:    true, // find_issues will still report bad GLSL.
+					ShaderType:         st,
+					Relaxed:            true, // find_issues will still report bad GLSL.
+					StripOptimizations: true,
 				}
 
 				// Trim any prefix whitespace / newlines.

--- a/gapis/shadertools/CMakeFiles.cmake
+++ b/gapis/shadertools/CMakeFiles.cmake
@@ -19,6 +19,7 @@
 
 set(files
     shadertools.go
+    shadertools_test.go
 )
 set(dirs
     cc

--- a/gapis/shadertools/cc/libmanager.cpp
+++ b/gapis/shadertools/cc/libmanager.cpp
@@ -233,7 +233,7 @@ code_with_debug_info_t* convertGlsl(const char* input, size_t length, const opti
     strcpy(result->disassembly_string, tmp.c_str());
   }
 
-  std::string source = spirv2glsl(std::move(spirv_new));
+  std::string source = spirv2glsl(std::move(spirv_new), options->strip_optimizations);
 
   result->source_code = new char[source.length() + 1];
   strcpy(result->source_code, source.c_str());

--- a/gapis/shadertools/cc/libmanager.h
+++ b/gapis/shadertools/cc/libmanager.h
@@ -69,6 +69,7 @@ typedef struct options_t {
   bool check_after_changes;
   bool disassemble;
   bool relaxed;
+  bool strip_optimizations;
 } options_t;
 
 typedef struct spirv_binary_t {

--- a/gapis/shadertools/cc/spirv2glsl.cpp
+++ b/gapis/shadertools/cc/spirv2glsl.cpp
@@ -21,7 +21,7 @@
 // so it is important we never include both at the same time.
 #include "third_party/SPIRV-Cross/spirv_glsl.hpp"
 
-std::string spirv2glsl(std::vector<uint32_t> spirv) {
+std::string spirv2glsl(std::vector<uint32_t> spirv, bool strip_optimizations) {
   spirv_cross::CompilerGLSL glsl(std::move(spirv));
   spirv_cross::CompilerGLSL::Options cross_options;
   cross_options.version = 330;
@@ -29,5 +29,8 @@ std::string spirv2glsl(std::vector<uint32_t> spirv) {
   cross_options.force_temporary = false;
   cross_options.vertex.fixup_clipspace = false;
   glsl.set_options(cross_options);
+  if (strip_optimizations) {
+    glsl.unset_execution_mode(spv::ExecutionModeEarlyFragmentTests);
+  }
   return glsl.compile();
 }

--- a/gapis/shadertools/cc/spirv2glsl.h
+++ b/gapis/shadertools/cc/spirv2glsl.h
@@ -17,4 +17,4 @@
 #include <string>
 #include <vector>
 
-std::string spirv2glsl(std::vector<uint32_t> spirv);
+std::string spirv2glsl(std::vector<uint32_t> spirv, bool strip_optimizations);

--- a/gapis/shadertools/shadertools_test.go
+++ b/gapis/shadertools/shadertools_test.go
@@ -1,0 +1,89 @@
+// Copyright (C) 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package shadertools_test
+
+import (
+	"testing"
+
+	"github.com/google/gapid/core/assert"
+	"github.com/google/gapid/core/log"
+	"github.com/google/gapid/gapis/shadertools"
+)
+
+func TestConvertGlsl(t *testing.T) {
+	for _, test := range []struct {
+		desc     string
+		opts     shadertools.Options
+		src      string
+		expected string
+	}{
+		{
+			"Test shadertools propagates early_fragment_tests",
+			shadertools.Options{
+				ShaderType:        shadertools.TypeFragment,
+				CheckAfterChanges: true,
+			},
+			`#version 310 es
+layout(early_fragment_tests) in;
+out highp vec4 color;
+void main() { color = vec4(1., 1., 1., 1.); }`,
+			`#version 330
+#ifdef GL_ARB_shading_language_420pack
+#extension GL_ARB_shading_language_420pack : require
+#endif
+#extension GL_ARB_shader_image_load_store : require
+layout(early_fragment_tests) in;
+
+out vec4 color;
+
+void main()
+{
+    color = vec4(1.0);
+}
+
+`}, {
+			"Test shadertools strips early_fragment_tests",
+			shadertools.Options{
+				ShaderType:         shadertools.TypeFragment,
+				CheckAfterChanges:  true,
+				StripOptimizations: true,
+			},
+			`#version 310 es
+layout(early_fragment_tests) in;
+out highp vec4 color;
+void main() { color = vec4(1., 1., 1., 1.); }`,
+			`#version 330
+#ifdef GL_ARB_shading_language_420pack
+#extension GL_ARB_shading_language_420pack : require
+#endif
+
+out vec4 color;
+
+void main()
+{
+    color = vec4(1.0);
+}
+
+`},
+	} {
+		t.Run(test.desc, func(t *testing.T) {
+			ctx := log.Testing(t)
+			out, err := shadertools.ConvertGlsl(test.src, &test.opts)
+			if assert.For(ctx, "err").ThatError(err).Succeeded() {
+				assert.For(ctx, "src").ThatString(out.SourceCode).Equals(test.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This isn't supported on macOS, either as core OpenGL (too recent a profile), or as an extension.

Use SPIRV-Cross to remove these optimizations for compat.