### PR TITLE
core/fault/stacktrace: Implement compression.

### DIFF
--- a/core/data/binary/bitstream.go
+++ b/core/data/binary/bitstream.go
@@ -45,10 +45,19 @@ func (s *BitStream) WriteBit(bit uint64) {
 	s.WritePos++
 }
 
+// CanRead returns true if there's enough data to call Read(count).
+func (s *BitStream) CanRead(count uint32) bool {
+	return int(s.ReadPos+count) <= len(s.Data)*8
+}
+
 // Read reads the specified number of bits from the BitStream, increamenting the ReadPos by the
 // specified number of bits and returning the bits packed into a uint64. The bits are packed into
 // the uint64 from LSB to MSB.
 func (s *BitStream) Read(count uint32) uint64 {
+	if count == 0 {
+		return 0
+	}
+
 	byteIdx := s.ReadPos / 8
 	bitIdx := s.ReadPos & 7
 

--- a/core/fault/stacktrace/CMakeFiles.cmake
+++ b/core/fault/stacktrace/CMakeFiles.cmake
@@ -18,12 +18,13 @@
 # build and the file will be recreated, check in the new version.
 
 set(files
-    auto.go
     doc.go
     filter.go
+    pack.go
+    pack_test.go
     stacktrace.go
     stacktrace_test.go
 )
 set(dirs
-    
+
 )

--- a/core/fault/stacktrace/filter.go
+++ b/core/fault/stacktrace/filter.go
@@ -16,7 +16,7 @@ package stacktrace
 
 type (
 	// Source is the signature for something that returns a stacktrace.
-	Source func() []Entry
+	Source func() Callstack
 
 	// Matcher is a predicate for stack entries.
 	Matcher func(Entry) bool
@@ -39,10 +39,10 @@ func MatchFunction(fun string) Matcher {
 // TrimBottom trims stack entries from the bottom of the trace.
 // It trims from the first matching entry down to the end of the trace.
 func TrimBottom(match Matcher, source Source) Source {
-	return func() []Entry {
+	return func() Callstack {
 		stack := source()
 		for i := len(stack) - 2; i >= 0; i-- {
-			if match(stack[i]) {
+			if match(stack.Get(i)) {
 				return stack[i+1:]
 			}
 		}
@@ -53,10 +53,10 @@ func TrimBottom(match Matcher, source Source) Source {
 // TrimTop trims stack entries from the top of the trace.
 // It trims from the last matching entry up to the start of the trace.
 func TrimTop(match Matcher, source Source) Source {
-	return func() []Entry {
+	return func() Callstack {
 		stack := source()
-		for i, s := range stack[:len(stack)-1] {
-			if match(s) {
+		for i := range stack[:len(stack)-1] {
+			if match(stack.Get(i)) {
 				return stack[:i]
 			}
 		}

--- a/core/fault/stacktrace/pack.go
+++ b/core/fault/stacktrace/pack.go
@@ -1,0 +1,366 @@
+// Copyright (C) 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stacktrace
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/google/gapid/core/data/binary"
+)
+
+// Tweakables
+const (
+	bitChunkMinSize   = 2
+	bitChunkIncrement = 1
+
+	debug = false
+)
+
+func printVLE(v uint64) {
+	fmt.Printf("[")
+	writeVLE(v, bitPrinter{})
+	fmt.Printf("]")
+}
+
+type bitPrinter struct{}
+
+func (bitPrinter) Write(v uint64, c uint32) {
+	for ; c > 0; c-- {
+		fmt.Printf("%v", v&1)
+		v >>= 1
+	}
+}
+func (bitPrinter) WriteBit(v uint64) {
+	if v == 0 {
+		fmt.Print("⁰")
+	} else {
+		fmt.Print("¹")
+	}
+}
+
+type bitwriter interface {
+	Write(bits uint64, count uint32)
+	WriteBit(bit uint64)
+}
+
+func writeVLE(i uint64, w bitwriter) {
+	chunkSize := uint32(bitChunkMinSize)
+	for i != 0 {
+		w.WriteBit(0)
+		w.Write(uint64(i), chunkSize)
+		i >>= chunkSize
+		chunkSize += bitChunkIncrement
+	}
+	w.WriteBit(1)
+}
+
+func readVLE(bs *binary.BitStream) (uint64, bool) {
+	chunkSize := uint32(bitChunkMinSize)
+	i, s := uint64(0), uint32(0)
+	for {
+		if !bs.CanRead(1) {
+			return 0, false
+		}
+		if bs.ReadBit() == 1 {
+			break
+		}
+		if !bs.CanRead(chunkSize) {
+			return 0, false
+		}
+		i |= bs.Read(chunkSize) << s
+		s += chunkSize
+		chunkSize += bitChunkIncrement
+	}
+	return uint64(i), true
+}
+
+type compressor interface {
+	compress([]uint64) []uint64
+	decompress([]uint64) []uint64
+}
+
+type noCompressor struct{}
+
+func (p noCompressor) compress(c []uint64) []uint64 {
+	return c
+}
+
+func (p noCompressor) decompress(c []uint64) []uint64 {
+	return c
+}
+
+type baseCompressor struct{}
+
+func (p baseCompressor) compress(c []uint64) []uint64 {
+	base := ^(uint64)(0)
+	for _, v := range c {
+		if v < base {
+			base = v
+		}
+	}
+	out := make([]uint64, len(c)+1)
+	out[0] = base
+	for i, v := range c {
+		out[i+1] = v - base
+	}
+	return out
+}
+
+func (p baseCompressor) decompress(c []uint64) []uint64 {
+	if len(c) < 2 {
+		return c
+	}
+	out := make([]uint64, len(c)-1)
+	base := c[0]
+	for i, pc := range c[1:] {
+		out[i] = pc + base
+	}
+	return out
+}
+
+type xorCompressor struct{}
+
+func (p xorCompressor) compress(c []uint64) []uint64 {
+	var prev uint64
+	out := make([]uint64, len(c))
+	for i, v := range c {
+		out[i], prev = v^prev, v
+	}
+	return out
+}
+
+func (p xorCompressor) decompress(c []uint64) []uint64 {
+	var prev uint64
+	out := make([]uint64, len(c))
+	for i, val := range c {
+		v := val ^ prev
+		out[i], prev = v, v
+	}
+	return out
+}
+
+type backRefCompressor struct {
+	pack   func(ref, val uint64) uint64
+	unpack func(ref, packed uint64) uint64
+}
+
+func packXor(ref, val uint64) uint64      { return ref ^ val }
+func unpackXor(ref, packed uint64) uint64 { return ref ^ packed }
+
+func packDiff(ref, val uint64) uint64 {
+	if ref > val {
+		return (ref - val) << 1
+	}
+	return (val-ref)<<1 | 1
+}
+func unpackDiff(ref, val uint64) uint64 {
+	sign, val := val&1, val>>1
+	if sign == 0 {
+		return ref + val
+	}
+	return ref - val
+}
+
+func (p backRefCompressor) compress(c []uint64) []uint64 {
+	out := make([]uint64, 0, len(c))
+
+	size := func(val uint64) uint32 {
+		bs := binary.BitStream{}
+		writeVLE(val, &bs)
+		return bs.WritePos
+	}
+
+	for i, v := range c {
+		bestValue := v
+		bestIndex := 0
+		bestScore := size(uint64(bestIndex)) + size(bestValue)
+		for j := 0; j < i; j++ {
+			idx := i - j
+			val := p.pack(v, c[j])
+			if score := size(val) + size(uint64(idx)); score < bestScore {
+				bestValue, bestIndex, bestScore = val, idx, score
+			}
+		}
+
+		out = append(out, uint64(bestIndex), bestValue)
+
+		if debug {
+			printVLE(v)
+			fmt.Printf("(%d) -- <%v> ", size(v), bestIndex)
+			printVLE(uint64(bestIndex))
+			fmt.Printf(", ")
+			printVLE(bestValue)
+			fmt.Printf("(%d) ", bestScore)
+			fmt.Printf("\n")
+		}
+	}
+	return out
+}
+
+func (p backRefCompressor) decompress(c []uint64) []uint64 {
+	out := make([]uint64, 0, len(c)/2)
+	for len(c) >= 2 {
+		idx, val := int(c[0]), c[1]
+		if idx == 0 {
+			out = append(out, val)
+		} else {
+			ref := out[len(out)-idx]
+			out = append(out, p.unpack(ref, val))
+		}
+		c = c[2:]
+	}
+	return out
+}
+
+type dictionaryCompressor struct{}
+
+func (p dictionaryCompressor) compress(c []uint64) []uint64 {
+	unique := map[uint64]struct{}{}
+	for _, v := range c {
+		unique[v] = struct{}{}
+	}
+
+	sorted := make([]uint64, 0, len(unique))
+	for v := range unique {
+		sorted = append(sorted, v)
+	}
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i] < sorted[j] })
+
+	indices := map[uint64]uint64{}
+	for i, v := range sorted {
+		indices[v] = uint64(i)
+	}
+
+	out := make([]uint64, 0, len(c)*2)
+
+	// Delta
+	prev := uint64(0)
+	for _, v := range sorted {
+		delta := v - prev
+		out, prev = append(out, delta), v
+	}
+
+	// Delimiter
+	out = append(out, 0)
+
+	// Values
+	for _, v := range c {
+		idx := indices[v]
+		out = append(out, uint64(idx))
+	}
+
+	return out
+}
+
+func (p dictionaryCompressor) decompress(c []uint64) []uint64 {
+	table, prev := make([]uint64, 0, len(c)), uint64(0)
+	for i, delta := range c {
+		if delta == 0 {
+			c = c[i+1:]
+			break
+		}
+		val := prev + delta
+		table, prev = append(table, val), val
+	}
+
+	out := make([]uint64, len(c))
+	for i, v := range c {
+		out[i] = table[v]
+	}
+	return out
+}
+
+type compressorList []compressor
+
+func (l compressorList) compress(c []uint64) []uint64 {
+	for _, p := range l {
+		c = p.compress(c)
+	}
+	return c
+}
+
+func (l compressorList) decompress(c []uint64) []uint64 {
+	for i := len(l) - 1; i >= 0; i-- {
+		p := l[i]
+		c = p.decompress(c)
+	}
+	return c
+}
+
+const compressorIdxBits = 2
+
+var compressors = [1 << compressorIdxBits]compressor{
+	/* 0 */ dictionaryCompressor{},
+	/* 1 */ xorCompressor{},
+	/* 2 */ compressorList{baseCompressor{}, backRefCompressor{packXor, unpackXor}},
+	/* 3 */ compressorList{baseCompressor{}, backRefCompressor{packDiff, unpackDiff}},
+}
+
+// Pack compresses the callstack down to a minimal compressed form.
+func (c Callstack) Pack() []byte {
+	var smallest []byte
+	for i, p := range compressors {
+		bs := binary.BitStream{}
+		bs.Write(uint64(i), compressorIdxBits)
+		c.packWith(p, &bs)
+		if smallest == nil || len(bs.Data) < len(smallest) {
+			smallest = bs.Data
+		}
+	}
+	return smallest
+}
+
+func (c Callstack) packWith(p compressor, bs *binary.BitStream) {
+	compressed := p.compress(c.toU64s())
+	for _, pc := range compressed {
+		writeVLE(pc, bs)
+	}
+}
+
+// Unpack decompresses the callstack from the minimal compressed form.
+func Unpack(data []byte) Callstack {
+	bs := binary.BitStream{Data: data}
+	idx := bs.Read(compressorIdxBits)
+	p := compressors[idx]
+	return unpackWith(p, &bs)
+}
+
+func unpackWith(p compressor, bs *binary.BitStream) Callstack {
+	vals := []uint64{}
+	for {
+		v, ok := readVLE(bs)
+		if !ok {
+			return toCallstack(p.decompress(vals))
+		}
+		vals = append(vals, v)
+	}
+}
+
+func (c Callstack) toU64s() []uint64 {
+	out := make([]uint64, len(c))
+	for i := range c {
+		out[i] = uint64(c[i])
+	}
+	return out
+}
+
+func toCallstack(v []uint64) Callstack {
+	out := make(Callstack, len(v))
+	for i := range v {
+		out[i] = uintptr(v[i])
+	}
+	return out
+}

--- a/core/fault/stacktrace/pack_test.go
+++ b/core/fault/stacktrace/pack_test.go
@@ -1,0 +1,149 @@
+// Copyright (C) 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stacktrace
+
+import (
+	"bytes"
+	"compress/flate"
+	"compress/gzip"
+	"compress/lzw"
+	"compress/zlib"
+	"fmt"
+	"testing"
+
+	"github.com/google/gapid/core/assert"
+	"github.com/google/gapid/core/data/binary"
+	"github.com/google/gapid/core/data/endian"
+	"github.com/google/gapid/core/log"
+	"github.com/google/gapid/core/os/device"
+)
+
+var callstack = Callstack{
+	0x400b281,
+	0x4737568,
+	0x4a62224,
+	0x4c4d740,
+	0x4c5a2c7,
+	0x45760d5,
+	0x4576ea1,
+	0x45761b3,
+	0x4576d91,
+	0x45756f0,
+	0x45761b3,
+	0x4576d91,
+	0x4cd89dc,
+	0x45760d5,
+	0x4576ea1,
+	0x45761b3,
+	0x4576d91,
+	0x4576266,
+	0x45146b5,
+	0x45740a1,
+	0x4575b4c,
+	0x4c4028c,
+	0x4da8d8b,
+	0x457a4cc,
+	0x4462d2b,
+	0x4578293,
+	0x457767b,
+	0x457af13,
+	0x456ed48,
+	0x456e1c9,
+	0x405aa61,
+}
+var raw []byte
+
+func init() {
+	buf := bytes.Buffer{}
+	w := endian.Writer(&buf, device.LittleEndian)
+	for _, pc := range callstack {
+		w.Uint64(uint64(pc))
+	}
+	raw = buf.Bytes()
+}
+
+func TestPackUnpack(t *testing.T) {
+	ctx := log.Testing(t)
+	data := callstack.Pack()
+	got := Unpack(data)
+	assert.For(ctx, "callstack").ThatSlice(got).Equals(callstack)
+	fmt.Printf("Packed from %v to %d bytes\n", len(raw), len(data))
+}
+
+func TestCompressDecompress(t *testing.T) {
+	ctx := log.Testing(t)
+	for _, c := range compressors {
+		values := callstack.toU64s()
+		compressed := c.compress(values)
+		decompressed := c.decompress(compressed)
+		assert.For(ctx, "%T%v", c, c).ThatSlice(decompressed).Equals(values)
+	}
+}
+
+func TestCompressorPackUnpack(t *testing.T) {
+	ctx := log.Testing(t)
+	printCompressionRatio("raw", raw)
+	for i, c := range compressors {
+		bs := binary.BitStream{}
+		callstack.packWith(c, &bs)
+		unpacked := unpackWith(c, &bs)
+		assert.For(ctx, "%T%v", c, c).ThatSlice(unpacked).Equals(callstack)
+		printCompressionRatio(fmt.Sprint("  ", i), bs.Data)
+	}
+}
+
+func printCompressionRatio(method string, data []byte) {
+	fmt.Printf("%s: %.2f:1 %3.d bytes (flate: %v, gzip: %v, lzw: %v, zlib: %v)\n",
+		method,
+		float32(len(raw))/float32(len(data)),
+		len(data),
+		len(compressFlate(data)),
+		len(compressGzip(data)),
+		len(compressLZW(data)),
+		len(compressZlib(data)),
+	)
+}
+
+func compressFlate(data []byte) []byte {
+	buf := bytes.Buffer{}
+	w, _ := flate.NewWriter(&buf, flate.BestCompression)
+	w.Write(data)
+	w.Close()
+	return buf.Bytes()
+}
+
+func compressGzip(data []byte) []byte {
+	buf := bytes.Buffer{}
+	w, _ := gzip.NewWriterLevel(&buf, gzip.BestCompression)
+	w.Write(data)
+	w.Close()
+	return buf.Bytes()
+}
+
+func compressLZW(data []byte) []byte {
+	buf := bytes.Buffer{}
+	w := lzw.NewWriter(&buf, lzw.LSB, 8)
+	w.Write(data)
+	w.Close()
+	return buf.Bytes()
+}
+
+func compressZlib(data []byte) []byte {
+	buf := bytes.Buffer{}
+	w, _ := zlib.NewWriterLevel(&buf, zlib.BestCompression)
+	w.Write(data)
+	w.Close()
+	return buf.Bytes()
+}

--- a/core/fault/stacktrace/stacktrace_test.go
+++ b/core/fault/stacktrace/stacktrace_test.go
@@ -31,8 +31,8 @@ import (
 // be very careful re-ordering the top of this file, the stack trace captures line numbers
 //!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
-func invokeNestedCapture() []stacktrace.Entry { return nestedCapture() }
-func nestedCapture() []stacktrace.Entry       { return stacktrace.Capture() }
+func invokeNestedCapture() stacktrace.Callstack { return nestedCapture() }
+func nestedCapture() stacktrace.Callstack       { return stacktrace.Capture() }
 func init() {
 	for i := range traces {
 		traces[i].cap = traces[i].fun()
@@ -45,15 +45,15 @@ func init() {
 
 type traceEntry struct {
 	fun      stacktrace.Source
-	cap      []stacktrace.Entry
+	cap      stacktrace.Callstack
 	expect   []string
 	brief    string
 	normal   string
 	detailed string
 }
 
-func (e traceEntry) RawCapture() []stacktrace.Entry { return e.cap }
-func (e traceEntry) FilteredCapture() []stacktrace.Entry {
+func (e traceEntry) RawCapture() stacktrace.Callstack { return e.cap }
+func (e traceEntry) FilteredCapture() stacktrace.Callstack {
 	return stacktrace.TrimTop(top, stacktrace.TrimBottom(bottom, e.RawCapture))()
 }
 
@@ -106,7 +106,8 @@ func TestCapture(t *testing.T) {
 		cap := test.FilteredCapture()
 		assert.For("stack length").ThatSlice(cap).IsLength(len(test.expect))
 		for i, expect := range test.expect {
-			assert.For("stack entry %d", i).That(cap[i].String()).Equals(expect)
+			got := cap.Get(i).String()
+			assert.For("stack entry %d", i).That(got).Equals(expect)
 		}
 	}
 }


### PR DESCRIPTION
The goal here is to get a stacktrace down to something under a 150 bytes so it could be reported in a Google Analytics exception message.

I've implemented a bunch of different compression methods, compared these to flate, gzip, lzw and zlib. All of the custom compressors out-compress the standard compressors.

As compression payloads are small, and time isn't that important, the algorithm tries to compress with 8 different compressors - and encodes the compression type as the first 3 bits of the data.

Currently unused, but hopefully will be soon.