### PR TITLE
Show a warning if the image has an empty alpha channel.

### DIFF
--- a/gapic/src/main/com/google/gapid/image/Image.java
+++ b/gapic/src/main/com/google/gapid/image/Image.java
@@ -153,6 +153,16 @@ public interface Image {
       public float getMax() {
         return 1;
       }
+
+      @Override
+      public float getAlphaMin() {
+        return 1;
+      }
+
+      @Override
+      public float getAlphaMax() {
+        return 1;
+      }
     };
 
     /**
@@ -164,5 +174,15 @@ public interface Image {
      * @return the maximum value across all channels of the image data. Used for tone mapping.
      */
     public float getMax();
+
+    /**
+     * @return the minimum alpha value of the image data.
+     */
+    public float getAlphaMin();
+
+    /**
+     * @return the maximum alpha value of the image data.
+     */
+    public float getAlphaMax();
   }
 }

--- a/gapic/src/main/com/google/gapid/views/LogView.java
+++ b/gapic/src/main/com/google/gapid/views/LogView.java
@@ -217,25 +217,25 @@ public class LogView extends Composite implements Tab {
 
   private Color severityBackgroundColor(Log.Severity severity) {
     switch (severity) {
-      case Verbose: return theme.verboseBackground();
-      case Debug: return theme.debugBackground();
-      case Info: return theme.infoBackground();
-      case Warning: return theme.warningBackground();
-      case Error: return theme.errorBackground();
-      case Fatal: return theme.fatalBackground();
-      default: return theme.infoBackground();
+      case Verbose: return theme.logVerboseBackground();
+      case Debug: return theme.logDebugBackground();
+      case Info: return theme.logInfoBackground();
+      case Warning: return theme.logWarningBackground();
+      case Error: return theme.logErrorBackground();
+      case Fatal: return theme.logFatalBackground();
+      default: return theme.logInfoBackground();
     }
   }
 
   private Color severityForegroundColor(Log.Severity severity) {
     switch (severity) {
-      case Verbose: return theme.verboseForeground();
-      case Debug: return theme.debugForeground();
-      case Info: return theme.infoForeground();
-      case Warning: return theme.warningForeground();
-      case Error: return theme.errorForeground();
-      case Fatal: return theme.fatalForeground();
-      default: return theme.infoForeground();
+      case Verbose: return theme.logVerboseForeground();
+      case Debug: return theme.logDebugForeground();
+      case Info: return theme.logInfoForeground();
+      case Warning: return theme.logWarningForeground();
+      case Error: return theme.logErrorForeground();
+      case Fatal: return theme.logFatalForeground();
+      default: return theme.logInfoForeground();
     }
   }
 

--- a/gapic/src/main/com/google/gapid/widgets/Theme.java
+++ b/gapic/src/main/com/google/gapid/widgets/Theme.java
@@ -103,31 +103,37 @@ public interface Theme {
   @Icon("android/zoom_out.png") public Image zoomOut();
   @Icon("android/android.png") public Image androidLogo();
 
+  // Shader source highlight colors.
   @RGB(argb = 0xff808080) public Color commentColor();
   @RGB(argb = 0xff7f0055) public Color keywordColor();
   @RGB(argb = 0xff000080) public Color identifierColor();
   @RGB(argb = 0xff0000ff) public Color numericConstantColor();
   @RGB(argb = 0xff808000) public Color preprocessorColor();
+
+  // Memory highlighting (background) colors.
   @RGB(argb = 0xffdcfadc) public Color memoryReadHighlight();
   @RGB(argb = 0xfffadcdc) public Color memoryWriteHighlight();
   @RGB(argb = 0xffdcdcfa) public Color memorySelectionHighlight();
+
+  // About dialog text colors
   @RGB(argb = 0xff282828) public Color aboutBackground();
   @RGB(argb = 0xffc8c8c8) public Color aboutForeground();
 
-  @RGB(argb = 0xffcecece) public Color verboseBackground();
-  @RGB(argb = 0xffe5e5e5) public Color debugBackground();
-  @RGB(argb = 0xfff2f2f2) public Color infoBackground();
-  @RGB(argb = 0xfffffa82) public Color warningBackground();
-  @RGB(argb = 0xffff8484) public Color errorBackground();
-  @RGB(argb = 0xffcd83ff) public Color fatalBackground();
+  // Logging view colors by log level.
+  @RGB(argb = 0xbb000000) public Color logVerboseForeground();
+  @RGB(argb = 0xffcecece) public Color logVerboseBackground();
+  @RGB(argb = 0xdd000000) public Color logDebugForeground();
+  @RGB(argb = 0xffe5e5e5) public Color logDebugBackground();
+  @RGB(argb = 0xff000000) public Color logInfoForeground();
+  @RGB(argb = 0xfff2f2f2) public Color logInfoBackground();
+  @RGB(argb = 0xff4c4a00) public Color logWarningForeground();
+  @RGB(argb = 0xfffffa82) public Color logWarningBackground();
+  @RGB(argb = 0xff4c0100) public Color logErrorForeground();
+  @RGB(argb = 0xffff8484) public Color logErrorBackground();
+  @RGB(argb = 0xff1b004c) public Color logFatalForeground();
+  @RGB(argb = 0xffcd83ff) public Color logFatalBackground();
 
-  @RGB(argb = 0xbb000000) public Color verboseForeground();
-  @RGB(argb = 0xdd000000) public Color debugForeground();
-  @RGB(argb = 0xff000000) public Color infoForeground();
-  @RGB(argb = 0xff4c4a00) public Color warningForeground();
-  @RGB(argb = 0xff4c0100) public Color errorForeground();
-  @RGB(argb = 0xff1b004c) public Color fatalForeground();
-
+  // Image panel colors.
   @RGB(argb = 0xffc0c0c0) public Color imageCheckerDark();
   @RGB(argb = 0xffffffff) public Color imageCheckerLight();
   @RGB(argb = 0xff000000) public Color imageCursorDark();

--- a/gapic/src/main/com/google/gapid/widgets/Theme.java
+++ b/gapic/src/main/com/google/gapid/widgets/Theme.java
@@ -138,6 +138,7 @@ public interface Theme {
   @RGB(argb = 0xffffffff) public Color imageCheckerLight();
   @RGB(argb = 0xff000000) public Color imageCursorDark();
   @RGB(argb = 0xffffffff) public Color imageCursorLight();
+  @RGB(argb = 0xffff9900) public Color imageWarning();
 
   @TextStyle(foreground = 0xa9a9a9) public Styler structureStyler();
   @TextStyle(foreground = 0x0000ee) public Styler identifierStyler();


### PR DESCRIPTION
If the image has an alpha channel, where all values are below a threshold, a warning and option to disable the alpha channel are shown. If the alpha channel is disabled through this option and later an image with an alpha channel is selected, a warning and option to re-enable the alpha channel are shown.

Fixes #723 