### PR TITLE
Only destroy the command pool, do not destroy each command buffer.

### DIFF
--- a/core/vulkan/vk_virtual_swapchain/cc/virtual_swapchain.cpp
+++ b/core/vulkan/vk_virtual_swapchain/cc/virtual_swapchain.cpp
@@ -285,8 +285,6 @@ void VirtualSwapchain::Destroy(const VkAllocationCallbacks *pAllocator) {
                              pAllocator);
     functions_->vkDestroyBuffer(device_, image_data_[i].buffer_, pAllocator);
     functions_->vkDestroyFence(device_, image_data_[i].fence_, pAllocator);
-    functions_->vkFreeCommandBuffers(device_, command_pool_, 1,
-                                     &image_data_[i].command_buffer_);
   }
 
   functions_->vkDestroyCommandPool(device_, command_pool_, pAllocator);


### PR DESCRIPTION
We do not need to destroy every command-buffer just before
we destroy the entire command-pool for the virtual swapchain.