### PR TITLE
Fix monitor/scheduler race condition.

### DIFF
--- a/test/robot/monitor/job.go
+++ b/test/robot/monitor/job.go
@@ -57,6 +57,12 @@ func (data *Data) FindDevice(id string) *Device {
 
 func (o *DataOwner) updateDevice(ctx context.Context, device *job.Device) error {
 	o.Write(func(data *Data) {
+		for i, e := range data.Devices.entries {
+			if device.Id == e.Id {
+				data.Devices.entries[i].Device = *device
+				return
+			}
+		}
 		data.Devices.entries = append(data.Devices.entries, &Device{Device: *device})
 	})
 	return nil

--- a/test/robot/monitor/replay.go
+++ b/test/robot/monitor/replay.go
@@ -38,7 +38,8 @@ func (r *Replays) All() []*Replay {
 
 func (o *DataOwner) updateReplay(ctx context.Context, action *replay.Action) error {
 	o.Write(func(data *Data) {
-		data.Replays.entries = append(data.Replays.entries, &Replay{Action: *action})
+		entry, _ := data.Replays.FindOrCreate(ctx, action)
+		entry.Action = *action
 	})
 	return nil
 }

--- a/test/robot/monitor/report.go
+++ b/test/robot/monitor/report.go
@@ -38,7 +38,8 @@ func (r *Reports) All() []*Report {
 
 func (o *DataOwner) updateReport(ctx context.Context, action *report.Action) error {
 	o.Write(func(data *Data) {
-		data.Reports.entries = append(data.Reports.entries, &Report{Action: *action})
+		entry, _ := data.Reports.FindOrCreate(ctx, action)
+		entry.Action = *action
 	})
 	return nil
 }

--- a/test/robot/monitor/subject.go
+++ b/test/robot/monitor/subject.go
@@ -37,6 +37,11 @@ func (s *Subjects) All() []*Subject {
 
 func (o *DataOwner) updateSubject(ctx context.Context, subj *subject.Subject) error {
 	o.Write(func(data *Data) {
+		for i, e := range data.Subjects.entries {
+			if subj.Id == e.Id {
+				data.Subjects.entries[i].Subject = *subj
+			}
+		}
 		data.Subjects.entries = append(data.Subjects.entries, &Subject{Subject: *subj})
 	})
 	return nil


### PR DESCRIPTION
There was a race condition that caused the scheduler to update robot
tasks with incomplete information. Managers would monitor for changes
inside a goroutine that would compete with the update logic of the data
owner. All initial data would be read in at once, but still in another
thread, which caused the scheduler to update without full knowledge of
entity state, this would cause extraneous tasks to get spawned every
time robot was restarted.

The fix is to initialize the owner's data with a non monitoring search
in the main thread before spawning goroutines to continue monitoring
updates. This ensures we have the complete initial information prior to
the first update. The other changes ensure that the monitoring updates
do not append extraneous entries.