### PR TITLE
Fix the incorrect renderpass grouping when secondary commandbuffers involved

### DIFF
--- a/gapis/api/subcmd_idx_trie_test.go
+++ b/gapis/api/subcmd_idx_trie_test.go
@@ -15,6 +15,7 @@
 package api
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/google/gapid/core/assert"
@@ -79,4 +80,49 @@ func TestSubCmdIdxTrie(t *testing.T) {
 	expectNonValue(SubCmdIdx{100, 99, 98})
 	expectNonValue(SubCmdIdx{100, 99})
 	expectNonValue(SubCmdIdx{100})
+}
+
+func TestSubCmdIdxTriePostOrderSortedKeys(t *testing.T) {
+	expectKeys := func(trie *SubCmdIdxTrie, expectedKeys []SubCmdIdx) {
+		keys := trie.PostOrderSortedKeys()
+		assert.To(t).For("Expected returned keys: %v", expectedKeys).That(
+			reflect.DeepEqual(keys, expectedKeys)).Equals(true)
+	}
+
+	trie := &SubCmdIdxTrie{}
+	expectKeys(trie, []SubCmdIdx{})
+
+	trie.SetValue(SubCmdIdx{}, 100)
+	expectKeys(trie, []SubCmdIdx{
+		SubCmdIdx{},
+	})
+
+	trie.SetValue(SubCmdIdx{1}, 101)
+	trie.SetValue(SubCmdIdx{1, 2, 3, 4, 5, 6}, 102)
+	trie.SetValue(SubCmdIdx{100, 99, 98, 97}, 103)
+	expectKeys(trie, []SubCmdIdx{
+		SubCmdIdx{1, 2, 3, 4, 5, 6},
+		SubCmdIdx{1},
+		SubCmdIdx{100, 99, 98, 97},
+		SubCmdIdx{},
+	})
+
+	trie.RemoveValue(SubCmdIdx{})
+	trie.RemoveValue(SubCmdIdx{1})
+	trie.RemoveValue(SubCmdIdx{1, 2, 3, 4, 5, 6})
+	trie.RemoveValue(SubCmdIdx{100, 99, 98, 97})
+	expectKeys(trie, []SubCmdIdx{})
+
+	trie.SetValue(SubCmdIdx{0, 1, 2}, true)
+	trie.SetValue(SubCmdIdx{0, 2}, true)
+	trie.SetValue(SubCmdIdx{1}, true)
+	trie.SetValue(SubCmdIdx{1, 2, 3}, true)
+	trie.SetValue(SubCmdIdx{0, 1}, true)
+	expectKeys(trie, []SubCmdIdx{
+		SubCmdIdx{0, 1, 2},
+		SubCmdIdx{0, 1},
+		SubCmdIdx{0, 2},
+		SubCmdIdx{1, 2, 3},
+		SubCmdIdx{1},
+	})
 }

--- a/gapis/resolve/command_tree.go
+++ b/gapis/resolve/command_tree.go
@@ -300,8 +300,9 @@ func (r *CommandTreeResolvable) Resolve(ctx context.Context) (interface{}, error
 				// subcommand marker groups are added before subcommands. And groups with
 				// shorter indices are added before groups with longer indices.
 				// SubCmdRoot will be created when necessary.
-				if snc.SubCommandMarkerGroups.Value(append([]uint64{uint64(id)}, x[0:len(x)-1]...)) != nil {
-					markers := snc.SubCommandMarkerGroups.Value(append([]uint64{uint64(id)}, x[0:len(x)-1]...)).([]*api.CmdIDGroup)
+				parentIdx := append([]uint64{uint64(id)}, x[0:len(x)-1]...)
+				if snc.SubCommandMarkerGroups.Value(parentIdx) != nil {
+					markers := snc.SubCommandMarkerGroups.Value(parentIdx).([]*api.CmdIDGroup)
 					r.AddSubCmdMarkerGroups(x[0:len(x)-1], markers)
 				}
 				r.Insert(append([]uint64{}, x...))


### PR DESCRIPTION
Add PostOrderSortedKeys() to `SubCmdIdxTrie`, to dump the keys stored in the trie.