### PR TITLE
Fixed replay of partial command-buffers that contain pushconstants.

### DIFF
--- a/gapis/api/vulkan/command_buffer_rebuilder.go
+++ b/gapis/api/vulkan/command_buffer_rebuilder.go
@@ -632,7 +632,8 @@ func rebuildVkCmdPushConstants(
 	s *api.GlobalState,
 	d *VkCmdPushConstantsArgs) (func(), api.Cmd) {
 
-	data := s.AllocDataOrPanic(ctx, d.Data)
+	dat := d.Data.MustRead(ctx, nil, s, nil)
+	data := s.AllocDataOrPanic(ctx, dat)
 
 	return func() {
 			data.Free()
@@ -840,7 +841,9 @@ func rebuildVkCmdUpdateBuffer(
 	commandBuffer VkCommandBuffer,
 	s *api.GlobalState,
 	d *VkCmdUpdateBufferArgs) (func(), api.Cmd) {
-	data := s.AllocDataOrPanic(ctx, d.Data)
+
+	dat := d.Data.MustRead(ctx, nil, s, nil)
+	data := s.AllocDataOrPanic(ctx, dat)
 
 	return func() {
 			data.Free()

--- a/gapis/api/vulkan/vulkan.api
+++ b/gapis/api/vulkan/vulkan.api
@@ -7209,9 +7209,8 @@ cmd void vkCmdPushConstants(
     u32                offset,
     u32                size,
     const void*        pValues) {
-  data := clone(as!u8*(pValues)[0:size])
   args := new!vkCmdPushConstantsArgs(
-    layout,           stageFlags, offset, size, data
+    layout,           stageFlags, offset, size, clone(as!u8*(pValues)[0:size])
   )
 
   addCmd(commandBuffer, args, dovkCmdPushConstants)


### PR DESCRIPTION
We were getting the data for the U8s, which was not correct.
Instead read the data out into a []uint8, and then upload
that in the recreated command. This has the desired effect
of pushing the right data into the push constants.

This also fixes the same problem with VkCmdUpdateBuffer.