### PR TITLE
Guarantee the framebuffer content of the last bound queue is not discarded by DCE

### DIFF
--- a/gapis/api/transform/dce.go
+++ b/gapis/api/transform/dce.go
@@ -182,9 +182,13 @@ func (t *DCE) backPropagate(ctx context.Context) (
 		if bh.Aborted {
 			continue
 		}
-		if t.requests.contains(fci) ||
-			t.requests.contains(api.SubCmdIdx{fci[0]}) ||
-			bh.Alive || machine.IsAlive(uint64(bi), t.footprint) {
+
+		if t.requests.contains(fci) || t.requests.contains(api.SubCmdIdx{fci[0]}) {
+			bh.Alive = true
+			machine.FramebufferRequest(uint64(bi), t.footprint)
+		}
+
+		if bh.Alive || machine.IsAlive(uint64(bi), t.footprint) {
 			alivedBehaviorIndices := machine.RecordBehaviorEffects(uint64(bi), t.footprint)
 			// TODO: Theoretically, we should re-back-propagation from the alive
 			// behaviors other than |bi|.

--- a/gapis/api/transform/dce_test.go
+++ b/gapis/api/transform/dce_test.go
@@ -66,6 +66,8 @@ func (m *dummyMachine) Clear() {
 	m.undefined = map[dummyDefUseVar]struct{}{}
 }
 
+func (m *dummyMachine) FramebufferRequest(uint64, *dependencygraph.Footprint) {}
+
 func TestDCE(t *testing.T) {
 	ctx := log.Testing(t)
 	ft := dependencygraph.NewEmptyFootprint(ctx)

--- a/gapis/resolve/dependencygraph/footprint.go
+++ b/gapis/resolve/dependencygraph/footprint.go
@@ -132,6 +132,10 @@ type BackPropagationMachine interface {
 	RecordBehaviorEffects(behaviorIndex uint64, ft *Footprint) []uint64
 	// Clear clears the internal state of the BackPropagationMachine.
 	Clear()
+	// FramebufferRequest marks the behavior indexed by the given index as where
+	// framebuffer will be requested, so a 'use' will be added for each image
+	// attachment.
+	FramebufferRequest(behaviorIndex uint64, ft *Footprint)
 }
 
 // dummyMachine does nothing but marks all the incoming Behaviors as alive.
@@ -143,7 +147,8 @@ func (m *dummyMachine) RecordBehaviorEffects(behaviorIndex uint64,
 	return []uint64{behaviorIndex}
 }
 
-func (m *dummyMachine) Clear() {}
+func (m *dummyMachine) Clear()                                {}
+func (m *dummyMachine) FramebufferRequest(uint64, *Footprint) {}
 
 // BehaviorIndex returns the index of the last Behavior in the Footprint
 // which belongs to the command or subcomand indexed by the given SubCmdIdx. In


### PR DESCRIPTION
Add a "Request()" function in the back propagation machine to differentiate normal alive commands, and request commands where the last bound framebuffer content will be requested.

Keep the last bound framebuffer content for each "behavior" of the normal commands (not subcommands) in the machine. Later when the user requests the command, the "Request()" function is called with the corresponding behavior index, we can mark a use of the last bound framebuffer content, so that all the commands that contributes to the content of the last bound framebuffer will be kept alive.