### PR TITLE
Override the OSX scrollbar behavior for the image panel.

### DIFF
--- a/gapic/src/main/com/google/gapid/widgets/ImagePanel.java
+++ b/gapic/src/main/com/google/gapid/widgets/ImagePanel.java
@@ -25,6 +25,7 @@ import static com.google.gapid.widgets.Widgets.createSeparator;
 import static com.google.gapid.widgets.Widgets.createToggleToolItem;
 import static com.google.gapid.widgets.Widgets.createToolItem;
 import static com.google.gapid.widgets.Widgets.withSpans;
+import static org.eclipse.swt.widgets.SwtUtil.disableAutoHideScrollbars;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -440,6 +441,7 @@ public class ImagePanel extends Composite {
         boolean naturallyFlipped) {
       super(parent, SWT.BORDER | SWT.V_SCROLL | SWT.H_SCROLL | SWT.NO_BACKGROUND);
       setLayout(new FillLayout(SWT.VERTICAL));
+      disableAutoHideScrollbars(this);
 
       this.showAlphaWarning = showAlphaWarning;
       this.naturallyFlipped = naturallyFlipped;

--- a/gapic/src/platform/linux/org/eclipse/swt/widgets/SwtUtil.java
+++ b/gapic/src/platform/linux/org/eclipse/swt/widgets/SwtUtil.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.swt.widgets;
+
+public class SwtUtil {
+  private SwtUtil() {
+  }
+
+  public static void disableAutoHideScrollbars(@SuppressWarnings("unused") Scrollable widget) {
+    // Do nothing.
+  }
+}

--- a/gapic/src/platform/osx/org/eclipse/swt/widgets/SwtUtil.java
+++ b/gapic/src/platform/osx/org/eclipse/swt/widgets/SwtUtil.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.swt.widgets;
+
+import org.eclipse.swt.internal.cocoa.OS;
+
+public class SwtUtil {
+  private SwtUtil() {
+  }
+
+  public static void disableAutoHideScrollbars(Scrollable widget) {
+    if (OS.VERSION >= 0x1070) {
+      OS.objc_msgSend(widget.scrollView.id,
+          OS.sel_registerName("setScrollerStyle:"), 0 /* NSScrollerStyleLegacy */);
+      widget.scrollView.setAutohidesScrollers(false);
+    }
+  }
+}

--- a/gapic/src/platform/windows/org/eclipse/swt/widgets/SwtUtil.java
+++ b/gapic/src/platform/windows/org/eclipse/swt/widgets/SwtUtil.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.swt.widgets;
+
+public class SwtUtil {
+  private SwtUtil() {
+  }
+
+  public static void disableAutoHideScrollbars(@SuppressWarnings("unused") Scrollable widget) {
+    // Do nothing.
+  }
+}


### PR DESCRIPTION
Forces the use of the "always visible" style of the scrollbars on the image panel, instead of the possible overlay style, which would hide portions of the image.

Introduces a platform specific `SwtUtil` class inside the the SWT package, so it can easily access protected fields, which can be (sparingly) used to customize platform specific behavior.

Fixes #1141