### PR TITLE
Fix an index out of bounds exception if the tree is empty.

### DIFF
--- a/gapic/src/main/com/google/gapid/widgets/LinkifiedTree.java
+++ b/gapic/src/main/com/google/gapid/widgets/LinkifiedTree.java
@@ -146,7 +146,7 @@ public abstract class LinkifiedTree<T, F> extends Composite {
 
   public void setInput(T root) {
     viewer.setInput(root);
-    if (root != null) {
+    if (root != null && viewer.getTree().getItemCount() > 0) {
       viewer.getTree().setSelection(viewer.getTree().getItem(0));
       viewer.getTree().showSelection();
     }


### PR DESCRIPTION
Fixes #1154