### PR TITLE
gles.moveClientVBsToVAs: Write VAP cmds on draw thread.

### DIFF
--- a/gapis/api/gles/compat_client.go
+++ b/gapis/api/gles/compat_client.go
@@ -227,12 +227,13 @@ func moveClientVBsToVAs(
 	for _, l := range va.VertexAttributeArrays.KeysSorted() {
 		arr := va.VertexAttributeArrays[l]
 		if arr.Enabled == GLboolean_GL_TRUE {
-			if cmd, ok := clientVAs[arr]; ok {
-				cmd := *cmd // Copy
-				i := interval.IndexOf(&rngs, cmd.Data.addr)
+			if glVAP, ok := clientVAs[arr]; ok {
+				glVAP := *glVAP // Copy
+				i := interval.IndexOf(&rngs, glVAP.Data.addr)
 				t.GlBindBuffer_ArrayBuffer(ctx, ids[i])
-				cmd.Data = VertexPointer{cmd.Data.addr - rngs[i].First, memory.ApplicationPool} // Offset
-				out.MutateAndWrite(ctx, dID, &cmd)
+				glVAP.SetThread(cmd.Thread())
+				glVAP.Data = VertexPointer{glVAP.Data.addr - rngs[i].First, memory.ApplicationPool} // Offset
+				out.MutateAndWrite(ctx, dID, &glVAP)
 			}
 		}
 	}

--- a/gapis/api/gles/compat_client.go
+++ b/gapis/api/gles/compat_client.go
@@ -231,6 +231,9 @@ func moveClientVBsToVAs(
 				glVAP := *glVAP // Copy
 				i := interval.IndexOf(&rngs, glVAP.Data.addr)
 				t.GlBindBuffer_ArrayBuffer(ctx, ids[i])
+				// The glVertexAttribPointer call may have come from a different thread
+				// and there's no guarantees that the thread still has the context bound.
+				// Use the draw call's thread instead.
 				glVAP.SetThread(cmd.Thread())
 				glVAP.Data = VertexPointer{glVAP.Data.addr - rngs[i].First, memory.ApplicationPool} // Offset
 				out.MutateAndWrite(ctx, dID, &glVAP)


### PR DESCRIPTION
The calls to `glVertexAttribPointer` may have come from a thread that has since unbound the context. Just use the thread that is making the draw call.

Issue: #1205