### PR TITLE
Increased the timeout for jdwp commands.

### DIFF
--- a/core/java/jdwp/jdwp.go
+++ b/core/java/jdwp/jdwp.go
@@ -160,7 +160,7 @@ func (c *Connection) get(cmdSet cmdSet, cmd cmdID, req interface{}, out interfac
 			panic(fmt.Errorf("Only %d/%d bytes read from reply packet", offset, len(reply.data)))
 		}
 		return nil
-	case <-time.After(time.Second * 30):
+	case <-time.After(time.Second * 120):
 		return fmt.Errorf("timeout")
 	}
 }


### PR DESCRIPTION
Since we load the interceptor and gapii inside a jdwp command,
they can take a long time, especially in debug where we log
a lot of things. Increase the timer to make sure we don't disconnect
early.