### PR TITLE
Fix indices for subcommand in Vulkan when resolving command groups

### DIFF
--- a/gapis/resolve/command_tree.go
+++ b/gapis/resolve/command_tree.go
@@ -118,8 +118,6 @@ func CommandTreeNode(ctx context.Context, c *path.CommandTreeNode) (*service.Com
 		commandEnd := append([]uint64{}, item.Id...)
 		if len(item.Id) > 1 {
 			g = fmt.Sprintf("%v", item.Id)
-			commandStart = append(commandStart, uint64(0))
-			commandEnd = append(commandEnd, uint64(item.SubGroup.Count()-1))
 			count = uint64(item.SubGroup.Count())
 		}
 		return &service.CommandTreeNode{

--- a/gapis/resolve/command_tree.go
+++ b/gapis/resolve/command_tree.go
@@ -114,15 +114,13 @@ func CommandTreeNode(ctx context.Context, c *path.CommandTreeNode) (*service.Com
 	case api.SubCmdRoot:
 		count := uint64(1)
 		g := ""
-		commandStart := append([]uint64{}, item.Id...)
-		commandEnd := append([]uint64{}, item.Id...)
 		if len(item.Id) > 1 {
 			g = fmt.Sprintf("%v", item.Id)
 			count = uint64(item.SubGroup.Count())
 		}
 		return &service.CommandTreeNode{
 			NumChildren: item.SubGroup.Count(),
-			Commands:    cmdTree.path.Capture.SubCommandRange(commandStart, commandEnd),
+			Commands:    cmdTree.path.Capture.SubCommandRange(item.Id, item.Id),
 			Group:       g,
 			NumCommands: count,
 		}, nil


### PR DESCRIPTION
Should fix #1214

Turns out we just need to remove two historical lines of code