### PR TITLE
Fixes false positives in sxs video for empty frames.

### DIFF
--- a/cmd/gapit/sxs_video.go
+++ b/cmd/gapit/sxs_video.go
@@ -267,10 +267,7 @@ func (verb *videoVerb) sxsVideoSource(
 
 		const threshold = 0.01
 		for _, v := range videoFrames {
-			// TODO: We need more sophisticated way to detect undefined framebuffers.
-			//       However, that is tricky without running the GLES mutator here.
-			undefined := v.frameIndex == 0 || v.numDrawCalls == 0
-			if v.squareError > threshold && !undefined {
+			if v.squareError > threshold {
 				return fmt.Errorf("FramebufferObservation did not match replayed framebuffer. Difference: %v%%", v.squareError*100)
 			}
 		}


### PR DESCRIPTION
If a frame was empty it would ignore the difference it had with the
frame buffer observation and not report an error in the side by side
video generator. This makes a bunch of replays on robot look green when
they are anything but. To fix this I just removed the check for
undefined video frames before the error report, I'm not even sure why
undefined frames were considered acceptable in the first place.