### PR TITLE
Fix trace failures not uploading logs.

### DIFF
--- a/test/robot/replay/client.go
+++ b/test/robot/replay/client.go
@@ -63,6 +63,8 @@ func (c *client) replay(ctx context.Context, t *Task) error {
 	return c.manager.Update(ctx, t.Action, status, output)
 }
 
+// doReplay extracts input files and runs `gapit video` on them, capturing the output. The output object will
+// be partially filled in the event of an upload error from store in order to allow examination of the logs.
 func doReplay(ctx context.Context, action string, in *Input, store *stash.Client, tempDir file.Path) (*Output, error) {
 	tracefile := tempDir.Join(action + ".gfxtrace")
 	videofile := tempDir.Join(action + "_replay.mp4")

--- a/test/robot/report/client.go
+++ b/test/robot/report/client.go
@@ -63,6 +63,8 @@ func (c *client) report(ctx context.Context, t *Task) error {
 	return c.manager.Update(ctx, t.Action, status, output)
 }
 
+// doReport extracts input files and runs `gapit report` on them, capturing the output. The output object will
+// be partially filled in the event of an upload error from store in order to allow examination of the logs.
 func doReport(ctx context.Context, action string, in *Input, store *stash.Client, tempDir file.Path) (*Output, error) {
 	tracefile := tempDir.Join(action + ".gfxtrace")
 	reportfile := tempDir.Join(action + "_report.txt")

--- a/test/robot/trace/client.go
+++ b/test/robot/trace/client.go
@@ -144,6 +144,8 @@ func (r *runner) trace(ctx context.Context, t *Task) error {
 	return r.manager.Update(ctx, t.Action, status, output)
 }
 
+// doTrace extracts input files and runs `gapit trace` on them, capturing the output. The output object will
+// be partially filled in the event of an upload error from store in order to allow examination of the logs.
 func doTrace(ctx context.Context, action string, in *Input, store *stash.Client, d bind.Device, tempDir file.Path) (*Output, error) {
 	subject := tempDir.Join(action + ".apk")
 	tracefile := tempDir.Join(action + ".gfxtrace")

--- a/test/robot/trace/client.go
+++ b/test/robot/trace/client.go
@@ -207,12 +207,12 @@ func doTrace(ctx context.Context, action string, in *Input, store *stash.Client,
 	log.I(ctx, output)
 	logID, err := store.UploadString(ctx, stash.Upload{Name: []string{"trace.log"}, Type: []string{"text/plain"}}, output)
 	if err != nil {
-		return nil, err
+		return outputObj, err
 	}
 	outputObj.Log = logID
 	traceID, err := store.UploadFile(ctx, tracefile)
 	if err != nil {
-		return nil, err
+		return outputObj, err
 	}
 	outputObj.Trace = traceID
 	return outputObj, nil


### PR DESCRIPTION
Despite this being against golangs ideomatic style to returning errors
only with nil objects, the clients return "valid" output objects during
an error, this is to communicate logs and error strings that otherwise
could not get uploaded. A fix changed this behavior in the trace client,
and it has not uploaded any logs since.

This fix reverts that change since the function is unexported, and the
alternative would be to populate an output parameter, which also goes
against golang style.