### PR TITLE
service.proto: Add representation field to CommandTreeNode.

### DIFF
--- a/gapic/src/main/com/google/gapid/models/AtomStream.java
+++ b/gapic/src/main/com/google/gapid/models/AtomStream.java
@@ -402,7 +402,7 @@ public class AtomStream extends ModelBase.ForPath<AtomStream.Node, Void, AtomStr
     }
 
     public AtomIndex getIndex() {
-      return (data == null) ? null : AtomIndex.forNode(lastCommand(data.getCommands()),
+      return (data == null) ? null : AtomIndex.forNode(data.getRepresentation(),
           getPath(Path.CommandTreeNode.newBuilder()).build());
     }
 

--- a/gapis/api/gvr/extension.go
+++ b/gapis/api/gvr/extension.go
@@ -162,7 +162,7 @@ func (n noSubFrameEventGrouper) Build(end api.CmdID) []cmdgrouper.Group {
 	out := n.Grouper.Build(end)
 	for i := range out {
 		out[i].UserData = &resolve.CmdGroupData{
-			Thumbnail:          api.CmdNoID,
+			Representation:     api.CmdNoID,
 			NoFrameEventGroups: true,
 		}
 	}

--- a/gapis/resolve/thumbnail.go
+++ b/gapis/resolve/thumbnail.go
@@ -86,9 +86,7 @@ func CommandTreeNodeThumbnail(ctx context.Context, w, h uint32, f *image.Format,
 	case api.CmdIDGroup:
 		thumbnail := item.Range.Last()
 		if userData, ok := item.UserData.(*CmdGroupData); ok {
-			if userData.Thumbnail != api.CmdNoID {
-				thumbnail = userData.Thumbnail
-			}
+			thumbnail = userData.Representation
 		}
 		return CommandThumbnail(ctx, w, h, f, cmdTree.path.Capture.Command(uint64(thumbnail)))
 	case api.SubCmdIdx:

--- a/gapis/service/service.proto
+++ b/gapis/service/service.proto
@@ -630,14 +630,17 @@ message CommandTree {
 
 // CommandTreeNode is a node in a command tree hierarchy.
 message CommandTreeNode {
+  // The path to the command that best represents this group. For example the
+  // the last draw call in a frame.
+  path.Command representation = 1;
   // Number of child nodes.
-  uint64 num_children = 1;
+  uint64 num_children = 2;
   // Group name if this node represents a group of commands.
-  string group = 2;
+  string group = 3;
   // Path to the command range represented by this node.
-  path.Commands commands = 3;
+  path.Commands commands = 4;
   // Number of commands encapsulated by this group.
-  uint64 num_commands = 4;
+  uint64 num_commands = 5;
 }
 
 // ConstantSet is a collection on name-value pairs to be used as an enumeration


### PR DESCRIPTION
Use this for picking a command to show data for when selecting a group.

Fixes: #1134