### PR TITLE
Fix side by side video replaying wrong command.

### DIFF
--- a/cmd/gapit/sxs_video.go
+++ b/cmd/gapit/sxs_video.go
@@ -79,7 +79,7 @@ func getVideoFrames(
 				fboIndex:     fmt.Sprint(e.Command.Indices),
 				frameIndex:   frameIndex,
 				numDrawCalls: numDrawCalls,
-				command:      e.Command.Capture.Command(e.Command.Indices[0]),
+				command:      e.Command.Capture.Command(e.Command.Indices[0] - 1), // -1 to skip the observation itself.
 			})
 		case service.EventKind_DrawCall:
 			numDrawCalls++


### PR DESCRIPTION
The sxs video replays were specifying the incorrect command to capture
for replay and thus were retrieving an undefined replay frame. This is
effectively a revert from a previous change. The reasoning is that the
observation itself will show up as a command index and to get the
correct end of frame command we must subtract 1 in order to skip the
observation.

fixes https://github.com/google/gapid/issues/1243