### PR TITLE
Protobuf: Use 'sint' for most fields.

### DIFF
--- a/gapii/cc/spy.cpp
+++ b/gapii/cc/spy.cpp
@@ -40,7 +40,7 @@
 
 // CurrentCaptureVersion is incremented on breaking changes to the capture format.
 // NB: Also update equally named field in capture.go
-static const int CurrentCaptureVersion = 0;
+static const int CurrentCaptureVersion = 1;
 
 #if TARGET_OS == GAPID_OS_WINDOWS
 #include "windows/wgl.h"

--- a/gapis/api/templates/api.proto.tmpl
+++ b/gapis/api/templates/api.proto.tmpl
@@ -47,12 +47,15 @@
     ¶
     // {{$name}} is the structure for serializing the parameters to the api command {{$.Name}}¶
     message {{$name}} {»¶
-      uint64 thread = {{Inc "ProtoID"}};¶
+      sint64 thread = {{Inc "ProtoID"}};¶
+      {{/* Reserve proto IDs up to 7 for future use */}}
+      {{Global "ProtoID" 7}}
       {{range $p := $.CallParameters}}
         {{Template "Proto.Entry" "Param" $p "Type" (TypeOf $p)}}
       {{end}}
     «}¶
 ¶
+    {{Global "ProtoID" 0}}
     {{if not (IsVoid $.Return.Type)}}
       // {{$name}}Call is the structure for serializing the call of the api command {{$.Name}}¶
       message {{$name}}Call {»¶
@@ -86,24 +89,24 @@
 -------------------------------------------------------------------------------
 */}}
 {{define "Proto.Type"}}
-  {{if IsBool               $}}bool
+  {{if IsBool               $}}sint32
   {{else if IsInt           $}}sint64
-  {{else if IsUint          $}}uint64
-  {{else if IsSize          $}}uint64
-  {{else if IsChar          $}}int32
-  {{else if IsU8            $}}uint32
+  {{else if IsUint          $}}sint64
+  {{else if IsSize          $}}sint64
+  {{else if IsChar          $}}sint32
+  {{else if IsU8            $}}sint32
   {{else if IsS8            $}}sint32
-  {{else if IsU16           $}}uint32
+  {{else if IsU16           $}}sint32
   {{else if IsS16           $}}sint32
   {{else if IsF32           $}}float
-  {{else if IsU32           $}}uint32
+  {{else if IsU32           $}}sint32
   {{else if IsS32           $}}sint32
   {{else if IsF64           $}}double
-  {{else if IsU64           $}}uint64
-  {{else if IsS64           $}}int64
+  {{else if IsU64           $}}sint64
+  {{else if IsS64           $}}sint64
   {{else if IsString        $}}string
-  {{else if IsEnum          $}}uint32
-  {{else if IsPointer       $}}memory_pb.Pointer
+  {{else if IsEnum          $}}sint32
+  {{else if IsPointer       $}}sint64
   {{else if IsSlice         $}}memory_pb.Slice
   {{else if IsClass         $}}{{$.Name}}
   {{else if IsPseudonym     $}}{{Template "Proto.Type" $.To}}

--- a/gapis/api/templates/cpp_common.tmpl
+++ b/gapis/api/templates/cpp_common.tmpl
@@ -1128,7 +1128,7 @@
   {{$setter := $.Name | Strings | Lower}}
   {{$ty := $.Type | TypeOf | Underlying}}
   {{if      IsClass       $ty}}{{$.Prefix}}{{$.Name}}.toProto({{$.Proto}}mutable_{{$setter}}());
-  {{else if IsPointer     $ty}}::gapii::toProtoPointer({{$.Proto}}mutable_{{$setter}}(), {{$.Prefix}}{{$.Name}});
+  {{else if IsPointer     $ty}}{{$.Proto}}set_{{$setter}}(reinterpret_cast<uint64_t>({{$.Prefix}}{{$.Name}}));
   {{else if IsSlice       $ty}}::gapii::toProtoSlice({{$.Proto}}mutable_{{$setter}}(), {{$.Prefix}}{{$.Name}});
   {{else if IsStaticArray $ty}}::gapii::toProto({{$.Proto}}mutable_{{$setter}}(), core::StaticArray<{{Macro "C++.Type" $ty.ValueType}}, {{$ty.Size}}>({{$.Prefix}}{{$.Name}}));
   {{else if IsMap         $ty}}::gapii::toProto({{$.Proto}}mutable_{{$setter}}(), {{$.Prefix}}{{$.Name}});

--- a/gapis/api/templates/go_convert_common.tmpl
+++ b/gapis/api/templates/go_convert_common.tmpl
@@ -29,7 +29,7 @@
   ¶
   // ToProto returns the primary storage proto of the {{$name}} command.¶
   func (ϟa *{{$name}}) ToProto() *{{$p}} {»¶
-    to := &{{$p}}{Thread: ϟa.Thread()}¶
+    to := &{{$p}}{Thread: int64(ϟa.Thread())}¶
     {{range $v := $.CallParameters}}
       {{Template "Convert.To" "Field" $v "Outer" $proto}}
     {{end}}
@@ -38,7 +38,7 @@
   ¶
   // {{$name}}From builds a {{$name}} from the storage form.¶
   func {{$name}}From(from *{{$p}}) *{{$name}} {»¶
-    ϟa := &{{$name}}{caller: api.CmdNoID, thread: from.GetThread()}¶
+    ϟa := &{{$name}}{caller: api.CmdNoID, thread: uint64(from.GetThread())}¶
     {{range $v := $.CallParameters}}
       {{Template "Convert.From" "Field" $v "Outer" $proto}}
     {{end}}
@@ -122,6 +122,9 @@
         Value: {{Template "Convert.ToProto" "Type" $type.ValueType "Value" "ϟv"}}
       })¶
     «}¶
+  {{else if IsBool $truetype}}
+    {{$value := printf "ϟa.%s" $name}}
+    if {{$value}} { to.{{$proto}} = 1 }¶
   {{else}}
     {{$value := printf "ϟa.%s" $name}}
     to.{{$proto}} = {{Template "Convert.ToProto" "Type" $type "Value" $value}}¶
@@ -151,6 +154,9 @@
       ϟv := {{Template "Convert.FromProto" "Type" $truetype.ValueType "Value" "ϟe.Value"}}¶
       ϟa.{{$name}}[ϟk] = ϟv¶
     «}¶
+  {{else if IsBool $truetype}}
+    {{$value := printf "from.%s" $proto}}
+    ϟa.{{$name}} = ({{$value}} != 0)¶
   {{else}}
     {{$value := printf "from.%s" $proto}}
     ϟa.{{$name}} = {{Template "Convert.FromProto" "Type" $type "Value" $value}}¶
@@ -197,24 +203,24 @@
 -------------------------------------------------------------------------------
 */}}
 {{define "Convert.StorageType"}}
-  {{if IsBool               $}}bool
+  {{if IsBool               $}}int32
   {{else if IsInt           $}}int64
-  {{else if IsUint          $}}uint64
-  {{else if IsSize          $}}uint64
+  {{else if IsUint          $}}int64
+  {{else if IsSize          $}}int64
   {{else if IsChar          $}}int32
-  {{else if IsU8            $}}uint32
+  {{else if IsU8            $}}int32
   {{else if IsS8            $}}int32
-  {{else if IsU16           $}}uint32
+  {{else if IsU16           $}}int32
   {{else if IsS16           $}}int32
   {{else if IsF32           $}}float32
-  {{else if IsU32           $}}uint32
+  {{else if IsU32           $}}int32
   {{else if IsS32           $}}int32
   {{else if IsF64           $}}float64
-  {{else if IsU64           $}}uint64
+  {{else if IsU64           $}}int64
   {{else if IsS64           $}}int64
   {{else if IsString        $}}string
-  {{else if IsEnum          $}}uint32
-  {{else if IsPointer       $}}memory_pb.Pointer
+  {{else if IsEnum          $}}int32
+  {{else if IsPointer       $}}int64
   {{else if IsSlice         $}}memory_pb.Slice
   {{else if IsPseudonym     $}}{{Template "Convert.StorageType" $.To}}
   {{else if IsClass         $}}*{{Global "Store"}}.{{$.Name | ProtoGoName}}
@@ -233,7 +239,7 @@
     {{$target := Macro "Convert.StorageType" $.Type}}
     {{$truetype := Underlying $.Type}}
     {{if IsClass $truetype}}{{$.Value}}.ToProto()
-    {{else if IsPointer $truetype}}&{{$target}}{Address: {{$.Value}}.addr, Pool: uint32({{$.Value}}.pool)}
+    {{else if IsPointer $truetype}}{{$target}}({{$.Value}}.addr)
     {{else if IsSlice $truetype}}&{{$target}}{»¶
       Root: {{$.Value}}.root,¶
       Base: {{$.Value}}.base,¶
@@ -256,7 +262,7 @@
     {{$target := Macro "Convert.LiveType" $.Type}}
     {{$truetype := Underlying $.Type}}
     {{if IsClass $truetype}}{{Template "Go.Type" $.Type}}From({{$.Value}})
-    {{else if IsPointer $truetype}}{{$target}}{addr: {{$.Value}}.Address, pool: memory.PoolID({{$.Value}}.Pool)}
+    {{else if IsPointer $truetype}}{{$target}}{addr: uint64({{$.Value}}), pool: memory.ApplicationPool}
     {{else if IsSlice $truetype}}{{$target}}{»¶
       root:  {{$.Value}}.Root,¶
       base:  {{$.Value}}.Base,¶

--- a/gapis/capture/capture.go
+++ b/gapis/capture/capture.go
@@ -46,7 +46,7 @@ var (
 const (
 	// CurrentCaptureVersion is incremented on breaking changes to the capture format.
 	// NB: Also update equally named field in spy.cpp
-	CurrentCaptureVersion int32 = 0
+	CurrentCaptureVersion int32 = 1
 )
 
 type ErrUnsupportedVersion struct{ Version int32 }


### PR DESCRIPTION
This will avoid breaking compatibility in the future
if we change, say GLint to GLuint, somewhere.

'sint' can represent all values including unsigned.
For example, 0xFFFFFFFF can be compactly stored by
by cast to int32 (-1) which is stored in one byte.

All command arguments are in the app pool by definition.
Remove the pool ID as it is redundant and just takes space.

Renumber keys in commands.