### PR TITLE
gapit: Fixes for SxS videos.

### DIFF
--- a/gapii/cc/spy.cpp
+++ b/gapii/cc/spy.cpp
@@ -582,7 +582,7 @@ static bool downsamplePixels(const std::vector<uint8_t>& srcData, uint32_t srcW,
 }
 
 // observeFramebuffer captures the currently bound framebuffer, and writes
-// it to a FramebufferObservation atom.
+// it to a FramebufferObservation extra.
 void Spy::observeFramebuffer(CallObserver* observer, uint8_t api) {
     uint32_t w = 0;
     uint32_t h = 0;

--- a/gapis/resolve/events.go
+++ b/gapis/resolve/events.go
@@ -130,8 +130,15 @@ func Events(ctx context.Context, p *path.Events) (*service.Events, error) {
 				Command: p.Capture.Command(uint64(id)),
 			})
 		}
-
+		if p.AllCommands {
+			events = append(events, &service.Event{
+				Kind:    service.EventKind_AllCommands,
+				Command: p.Capture.Command(uint64(id)),
+			})
+		}
 		if p.FramebufferObservations {
+			// NOTE: gapit SxS video depends on FBO events coming after
+			// all other event types.
 			for _, e := range cmd.Extras().All() {
 				if _, ok := e.(*capture.FramebufferObservation); ok {
 					events = append(events, &service.Event{
@@ -140,13 +147,6 @@ func Events(ctx context.Context, p *path.Events) (*service.Events, error) {
 					})
 				}
 			}
-		}
-
-		if p.AllCommands {
-			events = append(events, &service.Event{
-				Kind:    service.EventKind_AllCommands,
-				Command: p.Capture.Command(uint64(id)),
-			})
 		}
 
 		for _, ep := range eps {


### PR DESCRIPTION
FramebufferObservations can happen on start of frames and end of frames.
Examples are: `eglSwapBuffers` and `gvr_frame_submit`.

For `gvr_frame_submit`, this was working correctly - when you request the frame for the framebuffer observation, you asked for the frame after the `gvr_frame_submit` command. The gvr library has some magic to correctly hand back the frame associated with the submit call, as the currently bound framebuffer could be anything.

For `eglSwapBuffers`, things were broken. Asking for the frame after a swap buffer correctly gives you back the undefined framebuffer pattern (as the contents is not preserved between swaps).

To fix, keep track of writes to the framebuffer. When you see an observation, compare this to the command that last wrote to the framebuffer.

Tested on GVR and GLES traces, both SxS and regular.

Fixes: #1243