### PR TITLE
Continue footprint building even if an error occur in another API command

### DIFF
--- a/gapis/api/vulkan/footprint_builder.go
+++ b/gapis/api/vulkan/footprint_builder.go
@@ -1279,7 +1279,8 @@ func (vb *FootprintBuilder) BuildFootprint(ctx context.Context,
 
 	// Mutate
 	if err := cmd.Mutate(ctx, id, s, nil); err != nil {
-		log.E(ctx, "Command %v %v: %v", id, cmd, err)
+		// Continue the footprint building without emitting errors here. It is the
+		// following mutate() calls' responsibility to catch the error.
 		return
 	}
 

--- a/gapis/resolve/dependencygraph/footprint.go
+++ b/gapis/resolve/dependencygraph/footprint.go
@@ -229,8 +229,11 @@ func (r *FootprintResolvable) Resolve(ctx context.Context) (interface{}, error) 
 				// side effect of the this command.
 				if err := cmd.Mutate(ctx, id, s, nil); err != nil {
 					bh.Aborted = true
+					// Continue the footprint building even if errors are found. It is
+					// following mutate calls, which are to build the replay
+					// instructions, that are responsible to catch the error.
 					// TODO: This error should be moved to report view.
-					return fmt.Errorf("Command %v %v: %v", id, cmd, err)
+					log.E(ctx, "Command %v %v: %v", id, cmd, err)
 				}
 				ft.AddBehavior(ctx, bh)
 				return nil

--- a/gapis/resolve/dependencygraph/footprint.go
+++ b/gapis/resolve/dependencygraph/footprint.go
@@ -161,7 +161,7 @@ func (f *Footprint) BehaviorIndex(ctx context.Context,
 		if u, ok := v.(uint64); ok {
 			return u
 		}
-		log.E(ctx, "Invalid behavior index: %v is not a uint64", v)
+		log.E(ctx, "Invalid behavior index: %v is not a uint64. Request command index: %v", v, fci)
 		return uint64(0)
 	}
 	log.E(ctx, "Cannot get behavior index for command indexed with: %v", fci)
@@ -233,7 +233,6 @@ func (r *FootprintResolvable) Resolve(ctx context.Context) (interface{}, error) 
 					// following mutate calls, which are to build the replay
 					// instructions, that are responsible to catch the error.
 					// TODO: This error should be moved to report view.
-					log.E(ctx, "Command %v %v: %v", id, cmd, err)
 				}
 				ft.AddBehavior(ctx, bh)
 				return nil


### PR DESCRIPTION
Fix #1255 

Turns out that the first command in desktop vulkanBloom trace is `glXMakeContextCurrent`, whose `mutate()` returns with error: `aborted(No context bound)`. Because of this error, the whole footprint was not built then gapis crashes when accessing the footprint.

@ben-clayton I'm wondering what is the most correct way to handle such cases. We definitely don't want to crash the server if we have a bad trace file. So is it right to turn off the whole DCE if an error occurs during footprint building or DCE backpropagation?