### PR TITLE
Hide the InRenderPass bool from UI

### DIFF
--- a/gapis/api/vulkan/vulkan.api
+++ b/gapis/api/vulkan/vulkan.api
@@ -8763,7 +8763,7 @@ ref!ComputePipelineObject CurrentComputePipeline
   // The render pass in which this draw takes place
   ref!RenderPassObject RenderPass
   // Whether or not we are in an unclosed render pass
-  bool InRenderPass
+  @hidden bool InRenderPass
 }
 
 map!(VkQueue, ref!DrawInfo) LastDrawInfos


### PR DESCRIPTION
This `InRenderPass` bool is only used in the early terminator of Vulkan side. And it shows incorrect value in the UI.

E.g.: If the user click on a sub command in a renderpass, like vkCmdDraw. The `InRenderPass` value in the state view will be `false`, which is not correct from the users' point of view. The value `false` is set by the extra commands we added after the vkCmdDraw to make sure the instructions sent to the replay device are valid.