### PR TITLE
deviceinfo: Do the device instance querying on a separate thread.

### DIFF
--- a/core/os/device/deviceinfo/cc/android/jni.cpp
+++ b/core/os/device/deviceinfo/cc/android/jni.cpp
@@ -21,7 +21,9 @@
 extern "C" {
 
 jbyteArray Java_com_google_android_gapid_DeviceInfoService_getDeviceInfo(JNIEnv* env) {
-    auto device_instance = get_device_instance(env);
+    JavaVM* vm = nullptr;
+    env->GetJavaVM(&vm);
+    auto device_instance = get_device_instance(vm);
     auto out = env->NewByteArray(device_instance.size);
     auto data = reinterpret_cast<jbyte*>(device_instance.data);
     env->SetByteArrayRegion(out, 0, device_instance.size, data);


### PR DESCRIPTION
The queries for GL information was corrupting the currently bound EGL context. Instead of jumping through hoops to store and restore the context, just do the query on a separate throw-away thread.

Also clean up the messy logic in `Spy::get()` which was unnecessarily complicated and can now be simplified due to the explicit installation of the interceptor.

Fixes some traces where contexts were corrupted when traced.