### PR TITLE
Hide the LastSubpass in Vulkan's state from UI

### DIFF
--- a/gapis/api/vulkan/vulkan.api
+++ b/gapis/api/vulkan/vulkan.api
@@ -8797,7 +8797,7 @@ ref!ComputePipelineObject CurrentComputePipeline
   // A mapping from the descriptor set bound numbers to descriptor set objects
   map!(u32, ref!DescriptorSetObject) DescriptorSets
   // The Last subpass number used in the draw
-  u32 LastSubpass
+  @hidden u32 LastSubpass
   // The graphics pipeline used for the draw
   ref!GraphicsPipelineObject GraphicsPipeline
   // The vertex buffers used for the draw. This is a map of binding number to


### PR DESCRIPTION
When a user clicks on a subcommand, LastSubpass will not show the
current subpass but the last subpass of the whole renderpass. This is
also because of the early terminator of Vulkan which appends extra
vkCmdNextSubpass.