### PR TITLE
GLES: Add support for reading depth-stencil buffers

### DIFF
--- a/core/image/astc.go
+++ b/core/image/astc.go
@@ -39,6 +39,6 @@ func (f *FmtASTC) check(data []byte, w, h, d int) error {
 	}
 	return nil
 }
-func (*FmtASTC) channels() []stream.Channel {
-	return []stream.Channel{stream.Channel_Red, stream.Channel_Green, stream.Channel_Blue, stream.Channel_Alpha}
+func (*FmtASTC) channels() stream.Channels {
+	return stream.Channels{stream.Channel_Red, stream.Channel_Green, stream.Channel_Blue, stream.Channel_Alpha}
 }

--- a/core/image/atc.go
+++ b/core/image/atc.go
@@ -53,8 +53,8 @@ func (*FmtATC_RGB_AMD) size(w, h, d int) int {
 func (f *FmtATC_RGB_AMD) check(data []byte, w, h, d int) error {
 	return checkSize(data, f, w, h, d)
 }
-func (*FmtATC_RGB_AMD) channels() []stream.Channel {
-	return []stream.Channel{stream.Channel_Red, stream.Channel_Green, stream.Channel_Blue}
+func (*FmtATC_RGB_AMD) channels() stream.Channels {
+	return stream.Channels{stream.Channel_Red, stream.Channel_Green, stream.Channel_Blue}
 }
 
 func (f *FmtATC_RGBA_EXPLICIT_ALPHA_AMD) key() interface{} {
@@ -66,8 +66,8 @@ func (*FmtATC_RGBA_EXPLICIT_ALPHA_AMD) size(w, h, d int) int {
 func (f *FmtATC_RGBA_EXPLICIT_ALPHA_AMD) check(data []byte, w, h, d int) error {
 	return checkSize(data, f, w, h, d)
 }
-func (*FmtATC_RGBA_EXPLICIT_ALPHA_AMD) channels() []stream.Channel {
-	return []stream.Channel{stream.Channel_Red, stream.Channel_Green, stream.Channel_Blue, stream.Channel_Alpha}
+func (*FmtATC_RGBA_EXPLICIT_ALPHA_AMD) channels() stream.Channels {
+	return stream.Channels{stream.Channel_Red, stream.Channel_Green, stream.Channel_Blue, stream.Channel_Alpha}
 }
 
 func (f *FmtATC_RGBA_INTERPOLATED_ALPHA_AMD) key() interface{} {
@@ -79,8 +79,8 @@ func (*FmtATC_RGBA_INTERPOLATED_ALPHA_AMD) size(w, h, d int) int {
 func (f *FmtATC_RGBA_INTERPOLATED_ALPHA_AMD) check(data []byte, w, h, d int) error {
 	return checkSize(data, f, w, h, d)
 }
-func (*FmtATC_RGBA_INTERPOLATED_ALPHA_AMD) channels() []stream.Channel {
-	return []stream.Channel{stream.Channel_Red, stream.Channel_Green, stream.Channel_Blue, stream.Channel_Alpha}
+func (*FmtATC_RGBA_INTERPOLATED_ALPHA_AMD) channels() stream.Channels {
+	return stream.Channels{stream.Channel_Red, stream.Channel_Green, stream.Channel_Blue, stream.Channel_Alpha}
 }
 
 func init() {

--- a/core/image/etc1.go
+++ b/core/image/etc1.go
@@ -38,8 +38,8 @@ func (*FmtETC1_RGB_U8_NORM) size(w, h, d int) int {
 func (f *FmtETC1_RGB_U8_NORM) check(data []byte, w, h, d int) error {
 	return checkSize(data, f, w, h, d)
 }
-func (*FmtETC1_RGB_U8_NORM) channels() []stream.Channel {
-	return []stream.Channel{stream.Channel_Red, stream.Channel_Green, stream.Channel_Blue}
+func (*FmtETC1_RGB_U8_NORM) channels() stream.Channels {
+	return stream.Channels{stream.Channel_Red, stream.Channel_Green, stream.Channel_Blue}
 }
 
 func init() {

--- a/core/image/etc2.go
+++ b/core/image/etc2.go
@@ -58,8 +58,8 @@ func (*FmtETC2_RGB_U8_NORM) size(w, h, d int) int {
 func (f *FmtETC2_RGB_U8_NORM) check(data []byte, w, h, d int) error {
 	return checkSize(data, f, w, h, d)
 }
-func (*FmtETC2_RGB_U8_NORM) channels() []stream.Channel {
-	return []stream.Channel{stream.Channel_Red, stream.Channel_Green, stream.Channel_Blue}
+func (*FmtETC2_RGB_U8_NORM) channels() stream.Channels {
+	return stream.Channels{stream.Channel_Red, stream.Channel_Green, stream.Channel_Blue}
 }
 
 // NewETC2_RGBA_U8_NORM returns a format representing the
@@ -83,8 +83,8 @@ func (*FmtETC2_RGBA_U8_NORM) size(w, h, d int) int {
 func (f *FmtETC2_RGBA_U8_NORM) check(data []byte, w, h, d int) error {
 	return checkSize(data, f, w, h, d)
 }
-func (*FmtETC2_RGBA_U8_NORM) channels() []stream.Channel {
-	return []stream.Channel{stream.Channel_Red, stream.Channel_Green, stream.Channel_Blue, stream.Channel_Alpha}
+func (*FmtETC2_RGBA_U8_NORM) channels() stream.Channels {
+	return stream.Channels{stream.Channel_Red, stream.Channel_Green, stream.Channel_Blue, stream.Channel_Alpha}
 }
 
 // NewETC2_RGBA_U8U8U8U1_NORM returns a format representing the
@@ -108,8 +108,8 @@ func (*FmtETC2_RGBA_U8U8U8U1_NORM) size(w, h, d int) int {
 func (f *FmtETC2_RGBA_U8U8U8U1_NORM) check(data []byte, w, h, d int) error {
 	return checkSize(data, f, w, h, d)
 }
-func (*FmtETC2_RGBA_U8U8U8U1_NORM) channels() []stream.Channel {
-	return []stream.Channel{stream.Channel_Red, stream.Channel_Green, stream.Channel_Blue, stream.Channel_Alpha}
+func (*FmtETC2_RGBA_U8U8U8U1_NORM) channels() stream.Channels {
+	return stream.Channels{stream.Channel_Red, stream.Channel_Green, stream.Channel_Blue, stream.Channel_Alpha}
 }
 
 // NewETC2_R_U11_NORM returns a format representing the COMPRESSED_R11_EAC
@@ -127,8 +127,8 @@ func (*FmtETC2_R_U11_NORM) size(w, h, d int) int {
 func (f *FmtETC2_R_U11_NORM) check(data []byte, w, h, d int) error {
 	return checkSize(data, f, w, h, d)
 }
-func (*FmtETC2_R_U11_NORM) channels() []stream.Channel {
-	return []stream.Channel{stream.Channel_Red}
+func (*FmtETC2_R_U11_NORM) channels() stream.Channels {
+	return stream.Channels{stream.Channel_Red}
 }
 
 // NewETC2_RG_U11_NORM returns a format representing the COMPRESSED_RG11_EAC
@@ -146,8 +146,8 @@ func (*FmtETC2_RG_U11_NORM) size(w, h, d int) int {
 func (f *FmtETC2_RG_U11_NORM) check(data []byte, w, h, d int) error {
 	return checkSize(data, f, w, h, d)
 }
-func (*FmtETC2_RG_U11_NORM) channels() []stream.Channel {
-	return []stream.Channel{stream.Channel_Red, stream.Channel_Green}
+func (*FmtETC2_RG_U11_NORM) channels() stream.Channels {
+	return stream.Channels{stream.Channel_Red, stream.Channel_Green}
 }
 
 // NewETC2_R_S11_NORM returns a format representing the
@@ -165,8 +165,8 @@ func (*FmtETC2_R_S11_NORM) size(w, h, d int) int {
 func (f *FmtETC2_R_S11_NORM) check(data []byte, w, h, d int) error {
 	return checkSize(data, f, w, h, d)
 }
-func (*FmtETC2_R_S11_NORM) channels() []stream.Channel {
-	return []stream.Channel{stream.Channel_Red}
+func (*FmtETC2_R_S11_NORM) channels() stream.Channels {
+	return stream.Channels{stream.Channel_Red}
 }
 
 // NewETC2_RG_S11_NORM returns a format representing the COMPRESSED_RG11_EAC
@@ -184,8 +184,8 @@ func (*FmtETC2_RG_S11_NORM) size(w, h, d int) int {
 func (f *FmtETC2_RG_S11_NORM) check(data []byte, w, h, d int) error {
 	return checkSize(data, f, w, h, d)
 }
-func (*FmtETC2_RG_S11_NORM) channels() []stream.Channel {
-	return []stream.Channel{stream.Channel_Red, stream.Channel_Green}
+func (*FmtETC2_RG_S11_NORM) channels() stream.Channels {
+	return stream.Channels{stream.Channel_Red, stream.Channel_Green}
 }
 
 func init() {

--- a/core/image/format.go
+++ b/core/image/format.go
@@ -46,7 +46,7 @@ type format interface {
 
 	// Channels returns the list of channels described by this format.
 	// If the channels vary based on the image data, then channels returns nil.
-	channels() []stream.Channel
+	channels() stream.Channels
 }
 
 // Interface compliance check.
@@ -96,7 +96,7 @@ func (f *Format) Key() interface{} {
 
 // Channels returns the list of channels described by this format.
 // If the channels vary based on the image data, then Channels returns nil.
-func (f *Format) Channels() []stream.Channel {
+func (f *Format) Channels() stream.Channels {
 	return f.format().channels()
 }
 

--- a/core/image/png.go
+++ b/core/image/png.go
@@ -53,7 +53,7 @@ func (*FmtPNG) check(data []byte, w, h, d int) error { return nil }
 func (*FmtPNG) resize(data []byte, srcW, srcH, dstW, dstH int) ([]byte, error) {
 	return nil, ErrResizeUnsupported
 }
-func (*FmtPNG) channels() []stream.Channel {
+func (*FmtPNG) channels() stream.Channels {
 	return nil
 }
 func init() {

--- a/core/image/s3_dxt1_rgb.go
+++ b/core/image/s3_dxt1_rgb.go
@@ -38,6 +38,6 @@ func (*FmtS3_DXT1_RGB) size(w, h, d int) int {
 func (f *FmtS3_DXT1_RGB) check(data []byte, w, h, d int) error {
 	return checkSize(data, f, w, h, d)
 }
-func (*FmtS3_DXT1_RGB) channels() []stream.Channel {
-	return []stream.Channel{stream.Channel_Red, stream.Channel_Green, stream.Channel_Blue}
+func (*FmtS3_DXT1_RGB) channels() stream.Channels {
+	return stream.Channels{stream.Channel_Red, stream.Channel_Green, stream.Channel_Blue}
 }

--- a/core/image/s3_dxt1_rgba.go
+++ b/core/image/s3_dxt1_rgba.go
@@ -38,6 +38,6 @@ func (*FmtS3_DXT1_RGBA) size(w, h, d int) int {
 func (f *FmtS3_DXT1_RGBA) check(data []byte, w, h, d int) error {
 	return checkSize(data, f, w, h, d)
 }
-func (*FmtS3_DXT1_RGBA) channels() []stream.Channel {
-	return []stream.Channel{stream.Channel_Red, stream.Channel_Green, stream.Channel_Blue, stream.Channel_Alpha}
+func (*FmtS3_DXT1_RGBA) channels() stream.Channels {
+	return stream.Channels{stream.Channel_Red, stream.Channel_Green, stream.Channel_Blue, stream.Channel_Alpha}
 }

--- a/core/image/s3_dxt3_rgba.go
+++ b/core/image/s3_dxt3_rgba.go
@@ -36,6 +36,6 @@ func (*FmtS3_DXT3_RGBA) size(w, h, d int) int {
 func (f *FmtS3_DXT3_RGBA) check(data []byte, w, h, d int) error {
 	return checkSize(data, f, w, h, d)
 }
-func (*FmtS3_DXT3_RGBA) channels() []stream.Channel {
-	return []stream.Channel{stream.Channel_Red, stream.Channel_Green, stream.Channel_Blue, stream.Channel_Alpha}
+func (*FmtS3_DXT3_RGBA) channels() stream.Channels {
+	return stream.Channels{stream.Channel_Red, stream.Channel_Green, stream.Channel_Blue, stream.Channel_Alpha}
 }

--- a/core/image/s3_dxt5_rgba.go
+++ b/core/image/s3_dxt5_rgba.go
@@ -36,6 +36,6 @@ func (*FmtS3_DXT5_RGBA) size(w, h, d int) int {
 func (f *FmtS3_DXT5_RGBA) check(data []byte, w, h, d int) error {
 	return checkSize(data, f, w, h, d)
 }
-func (*FmtS3_DXT5_RGBA) channels() []stream.Channel {
-	return []stream.Channel{stream.Channel_Red, stream.Channel_Green, stream.Channel_Blue, stream.Channel_Alpha}
+func (*FmtS3_DXT5_RGBA) channels() stream.Channels {
+	return stream.Channels{stream.Channel_Red, stream.Channel_Green, stream.Channel_Blue, stream.Channel_Alpha}
 }

--- a/core/image/uncompressed.go
+++ b/core/image/uncompressed.go
@@ -56,8 +56,8 @@ func (f *FmtUncompressed) size(w, h, d int) int {
 func (f *FmtUncompressed) check(data []byte, w, h, d int) error {
 	return checkSize(data, f, w, h, d)
 }
-func (f *FmtUncompressed) channels() []stream.Channel {
-	out := make([]stream.Channel, len(f.Format.Components))
+func (f *FmtUncompressed) channels() stream.Channels {
+	out := make(stream.Channels, len(f.Format.Components))
 	for i, c := range f.Format.Components {
 		out[i] = c.Channel
 	}

--- a/core/stream/channel.go
+++ b/core/stream/channel.go
@@ -63,7 +63,7 @@ func (c Channel) Format(w fmt.State, r rune) {
 }
 
 // ColorChannels is the list of channels considered colors.
-var ColorChannels = []Channel{
+var ColorChannels = Channels{
 	Channel_Red,
 	Channel_Green,
 	Channel_Blue,
@@ -75,12 +75,17 @@ var ColorChannels = []Channel{
 }
 
 // DepthChannels is the list of channels considered depth.
-var DepthChannels = []Channel{
+var DepthChannels = Channels{
 	Channel_Depth,
 }
 
+// StencilChannels is the list of channels considered stencil.
+var StencilChannels = Channels{
+	Channel_Stencil,
+}
+
 // VectorChannels is the list of channels considered vectors.
-var VectorChannels = []Channel{
+var VectorChannels = Channels{
 	Channel_X,
 	Channel_Y,
 	Channel_Z,
@@ -109,11 +114,79 @@ func (c Channel) IsDepth() bool {
 	return false
 }
 
+// IsStencil returns true if the channel is considered a stencil channel.
+// See StencilChannels for the list of channels considered stencil.
+func (c Channel) IsStencil() bool {
+	for _, t := range StencilChannels {
+		if t == c {
+			return true
+		}
+	}
+	return false
+}
+
 // IsVector returns true if the channel is considered a vector channel.
 // See VectorChannels for the list of channels considered vector.
 func (c Channel) IsVector() bool {
 	for _, t := range VectorChannels {
 		if t == c {
+			return true
+		}
+	}
+	return false
+}
+
+// Channels is a list of channels.
+type Channels []Channel
+
+// Contains returns true if l contains c.
+func (l Channels) Contains(c Channel) bool {
+	for _, t := range l {
+		if t == c {
+			return true
+		}
+	}
+	return false
+}
+
+// ContainsColor returns true if l contains a color channel.
+// See ColorChannels for channels considered colors.
+func (l Channels) ContainsColor() bool {
+	for _, t := range l {
+		if t.IsColor() {
+			return true
+		}
+	}
+	return false
+}
+
+// ContainsDepth returns true if l contains a depth channel.
+// See DepthChannels for channels considered depth.
+func (l Channels) ContainsDepth() bool {
+	for _, t := range l {
+		if t.IsDepth() {
+			return true
+		}
+	}
+	return false
+}
+
+// ContainsStencil returns true if l contains a stencil channel.
+// See StencilChannels for channels considered stencil.
+func (l Channels) ContainsStencil() bool {
+	for _, t := range l {
+		if t.IsStencil() {
+			return true
+		}
+	}
+	return false
+}
+
+// ContainsVector returns true if l contains a vector channel.
+// See VectorChannels for channels considered vectors.
+func (l Channels) ContainsVector() bool {
+	for _, t := range l {
+		if t.IsVector() {
 			return true
 		}
 	}

--- a/core/stream/format.go
+++ b/core/stream/format.go
@@ -131,34 +131,24 @@ func (f *Format) Component(c ...Channel) (*Component, error) {
 	}
 }
 
-// HasComponent returns true if the Format contains a component with the channel
-// c.
-func (f *Format) HasComponent(c Channel) bool {
+// Channels returns all the unique channels used by the format.
+func (f *Format) Channels() Channels {
+	seen := map[Channel]struct{}{}
+	out := make(Channels, 0, len(f.Components))
 	for _, t := range f.Components {
-		if t.Channel == c {
-			return true
+		if _, ok := seen[t.Channel]; !ok {
+			out = append(out, t.Channel)
+			seen[t.Channel] = struct{}{}
 		}
 	}
-	return false
+	return out
 }
 
-// HasColorComponent returns true if the format contains a color component.
-// See ColorChannels for channels considered colors.
-func (f *Format) HasColorComponent() bool {
-	for _, t := range f.Components {
-		if t.Channel.IsColor() {
-			return true
-		}
-	}
-	return false
-}
-
-// GetSingleColorComponent returns a component if the format contains a single
-// color component, otherwise nil. See ColorChannels for channels considered colors.
-func (f *Format) GetSingleColorComponent() *Component {
+// GetSingleComponent returns the single component that matches the predicate p.
+func (f *Format) GetSingleComponent(p func(*Component) bool) *Component {
 	var c *Component
 	for _, t := range f.Components {
-		if t.Channel.IsColor() {
+		if p(t) {
 			if c != nil {
 				return nil
 			}
@@ -166,28 +156,6 @@ func (f *Format) GetSingleColorComponent() *Component {
 		}
 	}
 	return c
-}
-
-// HasDepthComponent returns true if the format contains a depth component.
-// See DepthChannels for channels considered depth.
-func (f *Format) HasDepthComponent() bool {
-	for _, t := range f.Components {
-		if t.Channel.IsDepth() {
-			return true
-		}
-	}
-	return false
-}
-
-// HasVectorComponent returns true if the format contains a vector component.
-// See VectorChannels for channels considered vectors.
-func (f *Format) HasVectorComponent() bool {
-	for _, t := range f.Components {
-		if t.Channel.IsVector() {
-			return true
-		}
-	}
-	return false
 }
 
 // BitOffsets returns the bit-offsets for the components of the format.

--- a/core/stream/shared_exp.go
+++ b/core/stream/shared_exp.go
@@ -39,7 +39,7 @@ func convertSharedExponent(dst, src *Format, data []byte) ([]byte, error) {
 		},
 	}
 	for _, c := range dst.Components {
-		if c.Channel != Channel_SharedExponent && src.HasComponent(c.Channel) {
+		if c.Channel != Channel_SharedExponent && src.Channels().Contains(c.Channel) {
 			format.Components = append(format.Components, &Component{
 				Channel:  c.Channel,
 				DataType: &F32,

--- a/gapis/api/gles/draw_call_mesh.go
+++ b/gapis/api/gles/draw_call_mesh.go
@@ -254,7 +254,7 @@ func translateVertexFormat(vaa *VertexAttributeArray) (*stream.Format, error) {
 		Components: make([]*stream.Component, vaa.Size),
 	}
 
-	xyzw := []stream.Channel{
+	xyzw := stream.Channels{
 		stream.Channel_X,
 		stream.Channel_Y,
 		stream.Channel_Z,

--- a/gapis/api/gles/image.go
+++ b/gapis/api/gles/image.go
@@ -96,7 +96,7 @@ func getUncompressedStreamFormat(unsizedFormat, ty GLenum) (format *stream.Forma
 		return nil, fmt.Errorf("Unknown unsized format: %v", unsizedFormat)
 	}
 	glChannels := []GLenum{info.Channel0, info.Channel1, info.Channel2, info.Channel3}
-	channels := make([]stream.Channel, info.Count)
+	channels := make(stream.Channels, info.Count)
 	for i := range channels {
 		channel, ok := glChannelToStreamChannel[glChannels[i]]
 		if !ok {
@@ -195,7 +195,7 @@ func getUncompressedStreamFormat(unsizedFormat, ty GLenum) (format *stream.Forma
 		addComponent(1, &stream.U8)
 		addComponent(-1, &stream.U24)
 	default:
-		return nil, fmt.Errorf("Unsupported data type: ", ty)
+		return nil, fmt.Errorf("Unsupported data type: %v", ty)
 	}
 	return format, nil
 }

--- a/gapis/api/gles/state.go
+++ b/gapis/api/gles/state.go
@@ -47,28 +47,23 @@ func attachmentToEnum(a api.FramebufferAttachment) (GLenum, error) {
 	}
 }
 
-func (f *Framebuffer) getAttachment(a api.FramebufferAttachment) (FramebufferAttachment, error) {
+func (f *Framebuffer) getAttachment(a GLenum) (FramebufferAttachment, error) {
 	switch a {
-	case api.FramebufferAttachment_Color0:
-		return f.ColorAttachments.Get(0), nil
-	case api.FramebufferAttachment_Color1:
-		return f.ColorAttachments.Get(1), nil
-	case api.FramebufferAttachment_Color2:
-		return f.ColorAttachments.Get(2), nil
-	case api.FramebufferAttachment_Color3:
-		return f.ColorAttachments.Get(3), nil
-	case api.FramebufferAttachment_Depth:
+	case GLenum_GL_DEPTH_ATTACHMENT, GLenum_GL_DEPTH_STENCIL_ATTACHMENT:
 		return f.DepthAttachment, nil
-	case api.FramebufferAttachment_Stencil:
+	case GLenum_GL_STENCIL_ATTACHMENT:
 		return f.StencilAttachment, nil
 	default:
-		return FramebufferAttachment{}, fmt.Errorf("Framebuffer attachment %v unsupported by gles", a)
+		if a >= GLenum_GL_COLOR_ATTACHMENT0 && a < GLenum_GL_COLOR_ATTACHMENT0+64 {
+			return f.ColorAttachments.Get(GLint(a - GLenum_GL_COLOR_ATTACHMENT0)), nil
+		}
+		return FramebufferAttachment{}, fmt.Errorf("Unhandled attachment: %v", a)
 	}
 }
 
 // TODO: When gfx api macros produce functions instead of inlining, move this logic
 // to the gles.api file.
-func (s *State) getFramebufferAttachmentInfo(thread uint64, fb FramebufferId, att api.FramebufferAttachment) (fbai, error) {
+func (s *State) getFramebufferAttachmentInfo(thread uint64, fb FramebufferId, att GLenum) (fbai, error) {
 	c := s.GetContext(thread)
 	if c == nil {
 		return fbai{}, fmt.Errorf("No context bound")

--- a/gapis/replay/replay.go
+++ b/gapis/replay/replay.go
@@ -64,6 +64,17 @@ type Request interface{}
 // One of val and err must be nil.
 type Result func(val interface{}, err error)
 
+// Do calls f and passes the return value-error pair to Result.
+func (r Result) Do(f func() (val interface{}, err error)) error {
+	val, err := f()
+	if err != nil {
+		r(nil, err)
+		return err
+	}
+	r(val, nil)
+	return nil
+}
+
 // RequestAndResult is a pair of Request and Result.
 type RequestAndResult struct {
 	Request Request


### PR DESCRIPTION
Attempting to read depth from a `GL_DEPTH_STENCIL` buffer was broken.

The client does not have support for requesting or displaying stencil buffers yet, but this also implements the functionality in the server.