### PR TITLE
Kill findOrZero.

### DIFF
--- a/gapii/cc/spy_base.h
+++ b/gapii/cc/spy_base.h
@@ -187,18 +187,6 @@ private:
     bool mIsRecordingState;
 };
 
-// finds a key in the map and returns the value. If no value is present
-// returns the zero for that type.
-template<typename Map>
-const typename Map::mapped_type& findOrZero(const Map& m, const typename Map::key_type& key) {
-  auto it = m.find(key);
-  if (it == m.end()) {
-    static auto zero = typename Map::mapped_type();
-    return zero;
-  }
-  return it->second;
-}
-
 template <class T>
 bool SpyBase::shouldObserve(const Slice<T>& slice) const {
     return mObserveApplicationPool && slice.isApplicationPool();

--- a/gapis/api/templates/cpp_common.tmpl
+++ b/gapis/api/templates/cpp_common.tmpl
@@ -586,7 +586,7 @@
   {{else if IsMember           $}}{{Template "C++.Dereference" $.Object}}{{Template "C++.Read" $.Field}}
   {{else if IsGlobal           $}}{{Template "C++.Global" $}}
   {{else if IsArrayIndex       $}}{{Template "C++.Read" $.Array}}[{{Template "C++.Read" $.Index}}]
-  {{else if IsMapIndex         $}}findOrZero({{Template "C++.Read" $.Map}}, {{Template "C++.Read" $.Index}})
+  {{else if IsMapIndex         $}}{{Template "C++.Read" $.Map}}[{{Template "C++.Read" $.Index}}]
   {{else if IsMapContains      $}}{{Template "C++.Read" $.Map}}.count({{Template "C++.Read" $.Key}}) > 0
   {{else if IsLength           $}}{{Template "C++.Type" $.Type}}(({{Template "C++.ReadLength" "Type" (TypeOf $.Object) "Value" $.Object}}))
   {{else if IsNull             $}}{{Template "C++.Null" $.Type}}


### PR DESCRIPTION
Just use the normal map indexing operator.
This mean indexing might modify the map.

This fixes a SharedMap bug which is caused by the fact that
findOrZero allocates one static global mapped type to return
in the cases where the key was not found. This ultimately
results in this global value being potentially shared.