### PR TITLE
GAPID gfxtrace file associations

### DIFF
--- a/gapic/src/main/com/google/gapid/MainWindow.java
+++ b/gapic/src/main/com/google/gapid/MainWindow.java
@@ -184,7 +184,8 @@ public class MainWindow extends ApplicationWindow {
     if (OS.isMac) {
       MacApplication.init(shell.getDisplay(),
           () -> showAbout(shell, widgets().theme),
-          () -> showSettingsDialog(shell, models().settings));
+          () -> showSettingsDialog(shell, models().settings),
+          file -> models().capture.loadCapture(new File(file)));
     }
   }
 

--- a/gapic/src/main/com/google/gapid/util/MacApplication.java
+++ b/gapic/src/main/com/google/gapid/util/MacApplication.java
@@ -20,6 +20,8 @@ import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Menu;
 import org.eclipse.swt.widgets.MenuItem;
 
+import java.util.function.Consumer;
+
 /**
  * Special handling for OSX application menus.
  */
@@ -30,7 +32,8 @@ public class MacApplication {
   /**
    * Initializes the OSX application menus.
    */
-  public static void init(Display display, Runnable onAbout, Runnable onSettings) {
+  public static void init(
+      Display display, Runnable onAbout, Runnable onSettings, Consumer<String> onOpen) {
     Menu menu = display.getSystemMenu();
     if (menu == null) {
       return;
@@ -46,5 +49,7 @@ public class MacApplication {
           break;
       }
     }
+
+    display.addListener(SWT.OpenDocument, e -> onOpen.accept(e.text));
   }
 }

--- a/kokoro/linux/gapid-mime.xml
+++ b/kokoro/linux/gapid-mime.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mime-info xmlns="http://www.freedesktop.org/standards/shared-mime-info">
+   <mime-type type="application/x-gfxtrace">
+     <comment>Graphics API Trace</comment>
+     <glob pattern="*.gfxtrace"/>
+   </mime-type>
+</mime-info>

--- a/kokoro/linux/gapid.desktop
+++ b/kokoro/linux/gapid.desktop
@@ -7,3 +7,4 @@ Categories=Development;Debugger;Graphics;3DGraphics
 Icon=/opt/gapid/icon.png
 Exec=/opt/gapid/gapid %f
 Terminal=false
+MimeType=application/x-gfxtrace

--- a/kokoro/linux/package.sh
+++ b/kokoro/linux/package.sh
@@ -38,12 +38,13 @@ VERSION=$(awk -F= 'BEGIN {major=0; minor=0; micro=0}
                   END {print major"."minor"."micro}' ../pkg/build.properties)
 
 # Combine package contents.
-mkdir -p gapid/DEBIAN gapid/opt/gapid gapid/usr/share/applications gapid/usr/share/menu
+mkdir -p gapid/DEBIAN gapid/opt/gapid gapid/usr/share/applications gapid/usr/share/menu gapid/usr/share/mime/packages
 cp -r ../pkg/* gapid/opt/gapid
 cp -r ../current/java/gapic-linux.jar gapid/opt/gapid/lib/gapic.jar
 cp "$SRC/../../gapic/res/icons/logo@2x.png" gapid/opt/gapid/icon.png
 cp "$SRC/gapid.desktop" gapid/usr/share/applications/google-gapid.desktop
 cp "$SRC/gapid.menu" gapid/usr/share/menu/google-gapid.menu
+cp "$SRC/gapid-mime.xml" gapid/usr/share/mime/packages/gapid.xml
 
 # Create the dpkg config file.
 cat > gapid/DEBIAN/control <<EOF

--- a/kokoro/macos/Info.plist
+++ b/kokoro/macos/Info.plist
@@ -22,5 +22,22 @@
   <string>Copyright © 2017 Google Inc.</string>
   <key>LSApplicationCategoryType</key>
   <string>public.app-category.developer-tools</string>
+  <key>CFBundleDocumentTypes</key>
+  <array>
+   <dict>
+    <key>CFBundleTypeExtensions</key>
+    <array>
+     <string>gfxtrace</string>
+    </array>
+    <key>CFBundleTypeIconFile</key>
+    <string>GAPID.icns</string>
+    <key>CFBundleTypeName</key>
+    <string>Graphics API Trace</string>
+    <key>CFBundleTypeRole</key>
+    <string>Editor</string>
+    <key>LSHandlerRank</key>
+    <string>Owner</string>
+   </dict>
+  </array>
  </dict>
 </plist>

--- a/kokoro/windows/gapid.wxs
+++ b/kokoro/windows/gapid.wxs
@@ -55,9 +55,33 @@
 
     <Icon Id="gapid.ico" SourceFile="gapid.ico" />
 
+    <DirectoryRef Id="GAPID">
+      <Component Id="FileAssociation" Guid="*">
+        <RegistryValue Root="HKLM" Key="Software\Classes\GAPID.Trace" Value="Graphics API Trace" Type="string" />
+        <RegistryValue Root="HKLM" Key="Software\Classes\GAPID.Trace" Name="AppUserModelId" Value="GAPID" Type="string" />
+        <RegistryValue Root="HKLM" Key="Software\Classes\GAPID.Trace\Application" Name="AppUserModelId" Value="GAPID" Type="string" />
+        <RegistryValue Root="HKLM" Key="Software\Classes\GAPID.Trace\Application" Name="ApplicationIcon" Value="[!gapid.ico]" Type="string" />
+        <RegistryValue Root="HKLM" Key="Software\Classes\GAPID.Trace\Application" Name="ApplicationName" Value="Graphics API Debugger" Type="string" />
+        <RegistryValue Root="HKLM" Key="Software\Classes\GAPID.Trace\Application" Name="ApplicationDescription" Value="Inspect Graphics Traces" Type="string" />
+        <RegistryValue Root="HKLM" Key="Software\Classes\GAPID.Trace\Application" Name="ApplicationCompany" Value="Google, Inc" Type="string" />
+        <RegistryValue Root="HKLM" Key="Software\Classes\GAPID.Trace\DefaultIcon" Value="[!gapid.ico]" Type="string" />
+        <RegistryValue Root="HKLM" Key="Software\Classes\GAPID.Trace\shell\open\command" Value="&quot;[!gapid.exe]&quot; &quot;%1&quot;" Type="string" />
+
+        <RegistryValue Root="HKLM" Key="Software\Microsoft\Windows\CurrentVersion\App Paths\gapid.exe" Value="[!gapid.exe]" Type="string" />
+        <RegistryValue Root="HKLM" Key="Software\Microsoft\Windows\CurrentVersion\App Paths\gapid.exe" Name="Path" Value="[GAPID]" Type="string" />
+
+        <RegistryValue Root="HKLM" Key="Software\Classes\Applications\gapid.exe\SupportedTypes" Name=".gfxtrace" Value="" Type="string" />
+        <RegistryValue Root="HKLM" Key="Software\Classes\Applications\gapid.exe\shell\open\command" Value="&quot;[!gapid.exe]&quot; &quot;%1&quot;" Type="string" />
+
+        <RegistryValue Root="HKLM" Key="Software\Classes\.gfxtrace" Value="GAPID.Trace" Type="string" />
+        <RegistryValue Root="HKLM" Key="Software\Classes\SystemFileAssociations\.gfxtrace\shell\edit\command" Value="&quot;[!gapid.exe]&quot; &quot;%1&quot;" Type="string" />
+      </Component>
+    </DirectoryRef>
+
     <Feature Id="GAPID"  Title="Graphics API Debugger" Level="1">
       <ComponentGroupRef Id="gapid" />
       <ComponentRef Id="ApplicationShortcut" />
+      <ComponentRef Id="FileAssociation" />
     </Feature>
 
     <Property Id="WIXUI_INSTALLDIR" Value="GAPID" />

--- a/kokoro/windows/package.bat
+++ b/kokoro/windows/package.bat
@@ -47,6 +47,7 @@ set /p VERSION=<version.txt
 REM Combine package contents.
 xcopy /e ..\pkg\* gapid\
 copy ..\current\java\gapic-windows.jar gapid\lib\gapic.jar
+copy "%~dp0\gapid.ico" gapid
 call "%~dp0\copy_jre.bat" "%cd%\gapid\jre"
 
 REM Package up the zip file.
@@ -54,7 +55,6 @@ zip -r gapid-%VERSION%-windows.zip gapid
 
 REM Create an MSI installer.
 copy "%~dp0\gapid.wxs" .
-copy "%~dp0\gapid.ico" .
 "%WIX%\heat.exe" dir gapid -ag -cg gapid -dr GAPID -template fragment -sreg -sfrag -srd -suid -o component.wxs
 "%WIX%\candle.exe" -dGAPIDVersion="%VERSION%" gapid.wxs component.wxs
 "%WIX%\light.exe" gapid.wixobj component.wixobj -b gapid -ext WixUIExtension -cultures:en-us -o gapid-%VERSION%-windows.msi


### PR DESCRIPTION
Associate .gfxtrace files with GAPID on all platforms:
- on Windows it is done via the registry, setup by the MSI installer
- on macOS, GAPIC now listens for the OS event to open the document, and the .app bundle registers GAPID as the owner of gfxtrace files
- on linux, .deb file now registers a mime type that is associated with GAPID in the .desktop file

Fixes #565 