### PR TITLE
Workaround for apparent JFace bug with selection preserving

### DIFF
--- a/gapic/src/main/com/google/gapid/widgets/LinkifiedTree.java
+++ b/gapic/src/main/com/google/gapid/widgets/LinkifiedTree.java
@@ -145,6 +145,10 @@ public abstract class LinkifiedTree<T, F> extends Composite {
   }
 
   public void setInput(T root) {
+    // Clear the selection, since we handle maintaining the selection ourselves and so
+    // don't want JFace's selection preserving, as it appears to be broken on input
+    // change (see https://github.com/google/gapid/issues/1264)
+    setSelection(null);
     viewer.setInput(root);
     if (root != null && viewer.getTree().getItemCount() > 0) {
       viewer.getTree().setSelection(viewer.getTree().getItem(0));


### PR DESCRIPTION
The stack trace from #1264 indicates that there is a bug in JFace's selection preserving when changing the viewer's input. The way our viewers are setup, only the root node is in the loaded state when the viewer's input is changed. JFace, however seems to query children of a yet unloaded node, which causes the failed precondition.

This changes clears the selection just before changing the input, which will cause the selection preservation to be skipped. This will not only work around this issue, but also improve performance, since right after setting the input we also fix the selection anyways.

Fixes #1264