### PR TITLE
Revert unused `gapit report histogram` flag.

### DIFF
--- a/cmd/gapit/flags.go
+++ b/cmd/gapit/flags.go
@@ -100,7 +100,6 @@ type (
 		Gapis     GapisFlags
 		Gapir     GapirFlags
 		Out       string `help:"output report path"`
-		Histogram bool   `help:"output observed vs replayed difference histogram"`
 		CommandFilterFlags
 	}
 	VideoFlags struct {

--- a/cmd/gapit/report.go
+++ b/cmd/gapit/report.go
@@ -15,7 +15,6 @@
 package main
 
 import (
-	"bytes"
 	"context"
 	"flag"
 	"fmt"
@@ -26,7 +25,6 @@ import (
 	"github.com/google/gapid/core/app"
 	"github.com/google/gapid/core/log"
 	"github.com/google/gapid/gapis/service"
-	"github.com/google/gapid/gapis/service/path"
 	"github.com/google/gapid/gapis/stringtable"
 )
 
@@ -122,39 +120,6 @@ func (verb *reportVerb) Run(ctx context.Context, flags flag.FlagSet) error {
 		}
 		msg := report.Msg(e.Message).Text(stringTable)
 		fmt.Fprintln(reportWriter, fmt.Sprintf("[%s] %s%s", e.Severity.String(), where, msg))
-	}
-
-	if verb.Histogram {
-		events, err := getEvents(ctx, client, &path.Events{
-			Capture:                 capturePath,
-			DrawCalls:               true,
-			LastInFrame:             true,
-			FramebufferObservations: true,
-		})
-		if err != nil {
-			return log.Err(ctx, err, "Failed to get events for replay diff histogram")
-		}
-
-		// The maximum width and height need to match the values in spy.cpp
-		// in order to properly compare observed and rendered framebuffers.
-		maxWidth := 1920
-		maxHeight := 1280
-		videoFrames, _, _, err := getVideoFrames(ctx, client, device, events, maxWidth, maxHeight)
-		if err != nil {
-			return log.Err(ctx, err, "Failed to get video frames for replay diff histogram")
-		}
-
-		for i, f := range videoFrames {
-			var histBuf bytes.Buffer
-			for bin := 0; bin < bins; bin++ {
-				histBuf.WriteString(fmt.Sprintf(", [%d,(%d,%d,%d,%d)]", bin,
-					f.histogramData[bin][0],
-					f.histogramData[bin][1],
-					f.histogramData[bin][2],
-					f.histogramData[bin][3]))
-			}
-			fmt.Fprintln(reportWriter, fmt.Sprintf("[Histogram] frame #%d%s", i, histBuf.String()))
-		}
 	}
 
 	if len(report.Items) == 0 {

--- a/cmd/gapit/sxs_video.go
+++ b/cmd/gapit/sxs_video.go
@@ -50,92 +50,6 @@ type videoFrame struct {
 	squareError   float64
 }
 
-func getVideoFrames(
-	ctx context.Context,
-	client service.Service,
-	device *path.Device,
-	events []*service.Event,
-	maxWidth, maxHeight int) ([]*videoFrame, int, int, error) {
-	// Find maximum frame width / height of all frames, and get all observation
-	// command indices.
-	videoFrames := []*videoFrame{}
-	w, h := 0, 0
-	frameIndex, numDrawCalls := 0, 0
-	var lastFrameEvent *path.Command
-	for _, e := range events {
-		switch e.Kind {
-		case service.EventKind_FramebufferObservation:
-			// We assume FBO events come after other events on a command.
-			if lastFrameEvent == nil {
-				log.W(ctx, "Got framebuffer observation but nothing wrote to the frame")
-				continue
-			}
-			fbo, err := getFBO(ctx, client, e.Command)
-			if err != nil {
-				return nil, 0, 0, err
-			}
-			if int(fbo.Width) > w {
-				w = int(fbo.Width)
-			}
-			if int(fbo.Height) > h {
-				h = int(fbo.Height)
-			}
-			videoFrames = append(videoFrames, &videoFrame{
-				fbo:          fbo,
-				fboIndex:     fmt.Sprint(e.Command.Indices),
-				frameIndex:   frameIndex,
-				numDrawCalls: numDrawCalls,
-				command:      lastFrameEvent,
-			})
-		case service.EventKind_Clear:
-			lastFrameEvent = e.Command
-		case service.EventKind_DrawCall:
-			lastFrameEvent = e.Command
-			numDrawCalls++
-		case service.EventKind_LastInFrame:
-			lastFrameEvent = e.Command
-			frameIndex++
-			numDrawCalls = 0
-		}
-	}
-
-	// Get all the observed and rendered frames, and compare them.
-	start := time.Now()
-	w, h = uniformScale(w, h, maxWidth/2, maxHeight/2)
-	var wg sync.WaitGroup
-	for _, v := range videoFrames {
-		v := v
-		wg.Add(1)
-		crash.Go(func() {
-			v.observed = &image.NRGBA{
-				Pix:    v.fbo.Bytes,
-				Stride: int(v.fbo.Width) * 4,
-				Rect:   image.Rect(0, 0, int(v.fbo.Width), int(v.fbo.Height)),
-			}
-			if frame, err := getFrame(ctx, maxWidth, maxHeight, v.command, device, client); err == nil {
-				v.rendered = frame
-			} else {
-				v.renderError = err
-			}
-			v.observed = flipImg(downsample(v.observed, w, h))
-			v.rendered = flipImg(downsample(v.rendered, w, h))
-			if v.observed != nil && v.rendered != nil {
-				v.difference, v.squareError = getDifference(v.observed, v.rendered, &v.histogramData)
-			}
-			wg.Done()
-		})
-	}
-	wg.Wait()
-	log.D(ctx, "Frames rendered in %v", time.Since(start))
-	for _, v := range videoFrames {
-		if v.renderError != nil {
-			return nil, 0, 0, v.renderError
-		}
-	}
-
-	return videoFrames, w, h, nil
-}
-
 // getFBO fetches the framebuffer observation of the command.
 func getFBO(ctx context.Context, client service.Service, a *path.Command) (*img.Data, error) {
 	obj, err := client.Get(ctx, a.FramebufferObservation().Path())
@@ -181,9 +95,81 @@ func (verb *videoVerb) sxsVideoSource(
 		return nil, log.Err(ctx, err, "Couldn't get events")
 	}
 
-	videoFrames, w, h, err := getVideoFrames(ctx, client, device, events, verb.Max.Width, verb.Max.Height)
-	if err != nil {
-		return nil, err
+	// Find maximum frame width / height of all frames, and get all observation
+	// command indices.
+	videoFrames := []*videoFrame{}
+	w, h := 0, 0
+	frameIndex, numDrawCalls := 0, 0
+	var lastFrameEvent *path.Command
+	for _, e := range events {
+		switch e.Kind {
+		case service.EventKind_FramebufferObservation:
+			// We assume FBO events come after other events on a command.
+			if lastFrameEvent == nil {
+				log.W(ctx, "Got framebuffer observation but nothing wrote to the frame")
+				continue
+			}
+			fbo, err := getFBO(ctx, client, e.Command)
+			if err != nil {
+				return nil, err
+			}
+			if int(fbo.Width) > w {
+				w = int(fbo.Width)
+			}
+			if int(fbo.Height) > h {
+				h = int(fbo.Height)
+			}
+			videoFrames = append(videoFrames, &videoFrame{
+				fbo:          fbo,
+				fboIndex:     fmt.Sprint(e.Command.Indices),
+				frameIndex:   frameIndex,
+				numDrawCalls: numDrawCalls,
+				command:      lastFrameEvent,
+			})
+		case service.EventKind_Clear:
+			lastFrameEvent = e.Command
+		case service.EventKind_DrawCall:
+			lastFrameEvent = e.Command
+			numDrawCalls++
+		case service.EventKind_LastInFrame:
+			lastFrameEvent = e.Command
+			frameIndex++
+			numDrawCalls = 0
+		}
+	}
+
+	// Get all the observed and rendered frames, and compare them.
+	start := time.Now()
+	w, h = uniformScale(w, h, verb.Max.Width/2, verb.Max.Height/2)
+	var wg sync.WaitGroup
+	for _, v := range videoFrames {
+		v := v
+		wg.Add(1)
+		crash.Go(func() {
+			v.observed = &image.NRGBA{
+				Pix:    v.fbo.Bytes,
+				Stride: int(v.fbo.Width) * 4,
+				Rect:   image.Rect(0, 0, int(v.fbo.Width), int(v.fbo.Height)),
+			}
+			if frame, err := getFrame(ctx, verb.Max.Width, verb.Max.Height, v.command, device, client); err == nil {
+				v.rendered = frame
+			} else {
+				v.renderError = err
+			}
+			v.observed = flipImg(downsample(v.observed, w, h))
+			v.rendered = flipImg(downsample(v.rendered, w, h))
+			if v.observed != nil && v.rendered != nil {
+				v.difference, v.squareError = getDifference(v.observed, v.rendered, &v.histogramData)
+			}
+			wg.Done()
+		})
+	}
+	wg.Wait()
+	log.D(ctx, "Frames rendered in %v", time.Since(start))
+	for _, v := range videoFrames {
+		if v.renderError != nil {
+			return nil, v.renderError
+		}
 	}
 
 	// Produce the histogram image


### PR DESCRIPTION
This also cleans up some of the code surrounding that change.