### PR TITLE
gapis/resolve: Fix commands vanishing on edit.

### DIFF
--- a/gapis/resolve/set.go
+++ b/gapis/resolve/set.go
@@ -137,6 +137,11 @@ func change(ctx context.Context, p path.Node, val interface{}) (path.Node, error
 		if len(cmd.Extras().All()) == 0 {
 			cmd.Extras().Add(oldCmd.Extras().All()...)
 		}
+
+		// Propagate caller (not exposed to client)
+		cmd.SetCaller(oldCmd.Caller())
+
+		// Replace the command
 		cmds[cmdIdx] = cmd
 
 		// Store the new command list


### PR DESCRIPTION
The caller private field was not being propagated, resulting the command being grouped under the 0'th command.

Fixes: #1265