### PR TITLE
 Handle the case when Semaphores block

### DIFF
--- a/gapis/api/vulkan/custom_replay.go
+++ b/gapis/api/vulkan/custom_replay.go
@@ -755,6 +755,12 @@ func (a *VkAcquireNextImageKHR) Mutate(ctx context.Context, id api.CmdID, s *api
 	}
 	a.PImageIndex.Slice(uint64(0), uint64(1), l).Index(uint64(0), l).Write(ctx, a.PImageIndex.Slice(uint64(0), uint64(1), l).Index(uint64(0), l).MustRead(ctx, a, s, nil), a, s, b)
 	_ = a.Result
+	if a.Semaphore != VkSemaphore(0) {
+		GetState(s).Semaphores.Get(a.Semaphore).Signaled = true
+	}
+	if a.Fence != VkFence(0) {
+		GetState(s).Fences.Get(a.Fence).Signaled = true
+	}
 	return nil
 }
 

--- a/gapis/api/vulkan/vulkan.api
+++ b/gapis/api/vulkan/vulkan.api
@@ -8915,6 +8915,7 @@ sub void clearLastDrawInfoDrawCommandParameters() {
   @unused u32                    Index
   @unused VkQueue                VulkanHandle
   map!(VkEvent, ref!EventObject) PendingEvents
+  map!(VkSemaphore, ref!SemaphoreObject) PendingSemaphores
   @unused ref!VulkanDebugMarkerInfo DebugInfo
   map!(u32, CommandReference) PendingCommands
 }
@@ -9390,6 +9391,7 @@ enum SemaphoreUpdate {
   @unused VkQueue     LastQueue
   @unused bool        Signaled
   @unused ref!VulkanDebugMarkerInfo DebugInfo
+  @unused VkQueue WaitingQueue
 }
 
 @internal class EventObject {


### PR DESCRIPTION
Semaphores may block queue execution when VkEvent is used. See #1293 for
example. This CL should fix #1293 