### PR TITLE
cmd/gapit trace: Add additional debugging.

### DIFF
--- a/cmd/gapit/flags.go
+++ b/cmd/gapit/flags.go
@@ -97,9 +97,9 @@ type (
 	InfoFlags struct {
 	}
 	ReportFlags struct {
-		Gapis     GapisFlags
-		Gapir     GapirFlags
-		Out       string `help:"output report path"`
+		Gapis GapisFlags
+		Gapir GapirFlags
+		Out   string `help:"output report path"`
 		CommandFilterFlags
 	}
 	VideoFlags struct {
@@ -174,6 +174,7 @@ type (
 			Activity string `help:"the full activity name"`
 			Action   string `help:"the full action name"`
 			Attach   bool   `help:"attach to running instance of the specified package"`
+			Logcat   bool   `help:"print the output of logcat while tracing"`
 		}
 		APK     file.Path `help:"the path to an apk to install"`
 		Observe struct {

--- a/core/os/android/device.go
+++ b/core/os/android/device.go
@@ -94,6 +94,7 @@ func (m LogcatMessage) Log(ctx context.Context) {
 	// Override the timestamping function to replicate the logcat timestamp
 	ctx = log.PutClock(ctx, log.FixedClock(m.Timestamp))
 	ctx = log.PutTag(ctx, m.Tag)
+	ctx = log.PutProcess(ctx, "logcat")
 	ctx = log.V{
 		"pid": m.ProcessID,
 		"tid": m.ThreadID,

--- a/gapii/client/jdwp_loader.go
+++ b/gapii/client/jdwp_loader.go
@@ -160,6 +160,7 @@ func (p *Process) loadAndConnectViaJDWP(
 		}
 		if conn, err = jdwp.Open(ctx, sock); err != nil {
 			sock.Close()
+			log.I(ctx, "Failed to connect to the application: %v. Retrying...", err)
 			return false, err
 		}
 		return true, nil


### PR DESCRIPTION
Add flag to print device logcat.
Print message if JDWP fails to connect.

These changes are to try to identify the cause of #1116.