### PR TITLE
gapic: Band-aids for widget dispose errors and null states.

### DIFF
--- a/gapic/src/main/com/google/gapid/util/Trees.java
+++ b/gapic/src/main/com/google/gapid/util/Trees.java
@@ -58,6 +58,9 @@ public class Trees {
    * @return whether the bottom has been reached.
    */
   private static boolean getVisibleItems(TreeItem item, int treeBottom, Set<TreeItem> visible) {
+    if (item.isDisposed()) {
+      return false;
+    }
     visible.add(item);
     if (bottom(item.getBounds()) > treeBottom) {
       return true;
@@ -78,6 +81,9 @@ public class Trees {
    * @return the next parent or {@code null} if the bottom has been reached.
    */
   private static TreeItem getVisibleSiblings(TreeItem item, int treeBottom, Set<TreeItem> visible) {
+    if (item.isDisposed()) {
+      return null;
+    }
     TreeItem parent = item.getParentItem();
     TreeItem[] siblings = (parent == null) ? item.getParent().getItems() : parent.getItems();
     int idx = 0;

--- a/gapic/src/main/com/google/gapid/views/StateView.java
+++ b/gapic/src/main/com/google/gapid/views/StateView.java
@@ -227,6 +227,9 @@ public class StateView extends Composite
 
   private void updateSelectionState() {
     ApiState.Node root = models.state.getData();
+    if (root == null) {
+      return;
+    }
     selectionHandler.updateSelectionFromModel(
         () -> Futures.transformAsync(models.state.getResolvedSelectedPath(),
             nodePath -> getTreePath(root, nodePath)).get(),

--- a/gapic/src/main/com/google/gapid/widgets/LinkifiedTree.java
+++ b/gapic/src/main/com/google/gapid/widgets/LinkifiedTree.java
@@ -189,7 +189,7 @@ public abstract class LinkifiedTree<T, F> extends Composite {
 
   public Point getScrollPos() {
     TreeItem topItem = viewer.getTree().getTopItem();
-    return (topItem == null) ? null : GeoUtils.center(topItem.getBounds());
+    return (topItem == null || topItem.isDisposed()) ? null : GeoUtils.center(topItem.getBounds());
   }
 
   public void scrollTo(Point pos) {
@@ -286,8 +286,10 @@ public abstract class LinkifiedTree<T, F> extends Composite {
     public void onShow(TreeItem item) {
       T element = getElement(item);
       contentProvider.load(element, () -> {
-        update(item);
-        refresher.refresh();
+        if (!item.isDisposed()) {
+          update(item);
+          refresher.refresh();
+        }
       });
     }
 


### PR DESCRIPTION
Not sure if this is the right way to fix these issues, but there seem to be plenty of ways to cause these exceptions when going monkeying with GVR apps.