### PR TITLE
Fixes various model loading timing issues when loading multiple captures.

### DIFF
--- a/gapic/src/main/com/google/gapid/models/AtomStream.java
+++ b/gapic/src/main/com/google/gapid/models/AtomStream.java
@@ -75,6 +75,7 @@ public class AtomStream extends ModelBase.ForPath<AtomStream.Node, Void, AtomStr
     if (!maintainState) {
       selection = null;
     }
+    reset();
   }
 
   @Override

--- a/gapic/src/main/com/google/gapid/models/Timeline.java
+++ b/gapic/src/main/com/google/gapid/models/Timeline.java
@@ -31,7 +31,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.logging.Logger;
 
-public class Timeline extends ModelBase.ForPath<List<Service.Event>, Void, Timeline.Listener>
+public class Timeline extends CaptureDependentModel<List<Service.Event>, Timeline.Listener>
     implements ApiContext.Listener {
   private static final Logger LOG = Logger.getLogger(Timeline.class.getName());
 
@@ -39,7 +39,7 @@ public class Timeline extends ModelBase.ForPath<List<Service.Event>, Void, Timel
   private final ApiContext context;
 
   public Timeline(Shell shell, Client client, Capture capture, ApiContext context) {
-    super(LOG, shell, client, Listener.class);
+    super(LOG, shell, client, Listener.class, capture);
     this.capture = capture;
     this.context = context;
 
@@ -53,7 +53,13 @@ public class Timeline extends ModelBase.ForPath<List<Service.Event>, Void, Timel
 
   @Override
   public void onContextSelected(FilteringContext ctx) {
-    load(events(capture.getData(), ctx), false);
+    load(getPath(capture.getData()), false);
+  }
+
+  @Override
+  protected Path.Any getPath(Path.Capture capturePath) {
+    FilteringContext ctx = context.isLoaded() ? context.getSelectedContext() : null;
+    return (ctx == null) ? null : events(capturePath, ctx);
   }
 
   @Override

--- a/gapic/src/main/com/google/gapid/views/ShaderView.java
+++ b/gapic/src/main/com/google/gapid/views/ShaderView.java
@@ -399,6 +399,7 @@ public class ShaderView extends Composite
 
     @Override
     public void onResourcesLoaded() {
+      lastUpdateContainedAllShaders = false;
       updateShaders();
     }
 
@@ -426,12 +427,16 @@ public class ShaderView extends Composite
                 }
                 newShaders.add(new Data(info));
               } else {
+                // This shader has not been created yet at this point in the trace, so we don't
+                // show it. Remember that we've skipped a shader and the UI list is incomplete.
                 skippedAnyShaders = true;
               }
             }
           }
         }
 
+        // If we previously had created the dropdown with all the shaders and didn't skip any
+        // this time, the dropdown does not need to change.
         if (!lastUpdateContainedAllShaders || skippedAnyShaders) {
           shaders = newShaders;
           lastUpdateContainedAllShaders = !skippedAnyShaders;


### PR DESCRIPTION
- Fixes the "hanging shader view" bug.
When selecting a command at a point in the trace where all shaders have been created, then opening/capturing another trace, will cause the shader view to stop updating itself, unless a command is selected in the (new) trace before all shaders were created.
- Fixes an issue with the filmstrip when opening multiple captures.
The timeline model did not reset itself when opening a new capture, but delayed the reset until the contexts were loaded. This caused the filmstrip to be in a bad state in the time between the new capture being loaded and the contexts of the new capture being loaded. At best this caused the old thumbnails to re-appear and at worst an error dialog, if the selection would be out of bounds in the new capture.
- Reset the atom tree model when a new capture is loaded.