### PR TITLE
Check if tree item is disposed in the load callback.

### DIFF
--- a/gapic/src/main/com/google/gapid/widgets/LinkifiedTree.java
+++ b/gapic/src/main/com/google/gapid/widgets/LinkifiedTree.java
@@ -286,8 +286,10 @@ public abstract class LinkifiedTree<T, F> extends Composite {
     public void onShow(TreeItem item) {
       T element = getElement(item);
       contentProvider.load(element, () -> {
-        update(item);
-        refresher.refresh();
+        if (!item.isDisposed()) {
+          update(item);
+          refresher.refresh();
+        }
       });
     }
 


### PR DESCRIPTION
If a tree node is being loaded, the tree is completely changed during the load, the item will have been disposed by the time the node has finished loading.

Fixes #1303