### PR TITLE
Fix the physical device enumeration order problem

### DIFF
--- a/gapii/cc/vulkan_mid_execution.cpp
+++ b/gapii/cc/vulkan_mid_execution.cpp
@@ -364,17 +364,17 @@ void VulkanSpy::EnumerateVulkanResources(CallObserver* observer) {
     for (auto& instance_devices : devices) {
       // Enumerate the physical devices for one instance
       uint32_t count = instance_devices.second.size();
-      std::vector<VkPhysicalDeviceProperties> props_in_enumerated_order;
-      props_in_enumerated_order.reserve(count);
+      // The physical device properties must be in the same order as the
+      // physical devices
+      std::vector<VkPhysicalDeviceProperties> props_in_order;
+      props_in_order.reserve(count);
       for (size_t i = 0; i < count; ++i) {
-        VkPhysicalDevice phy_dev =
-            Instances[instance_devices.first]->mEnumeratedPhysicalDevices[i];
-        props_in_enumerated_order.push_back(
-            PhysicalDevices[phy_dev]->mPhysicalDeviceProperties);
+        props_in_order.push_back(PhysicalDevices[instance_devices.second[i]]
+                                     ->mPhysicalDeviceProperties);
       }
       RecreatePhysicalDevices(observer, instance_devices.first, &count,
                               instance_devices.second.data(),
-                              props_in_enumerated_order.data());
+                              props_in_order.data());
     }
 
     for (auto& physical_device : PhysicalDevices) {

--- a/gapis/api/vulkan/vulkan.api
+++ b/gapis/api/vulkan/vulkan.api
@@ -2519,12 +2519,6 @@ cmd void prefetchPhysicalDeviceProperties(
     VkPhysicalDevice physicalDevice,
     VkPhysicalDeviceProperties* pProperties) {
   pProperties[0] = ?
-  numEnumerated := len(Instances[instance].EnumeratedPhysicalDevices)
-  switch (PhysicalDevices[physicalDevice] == null) {
-    case true:
-      // First time see the physical device, save the order.
-      Instances[instance].EnumeratedPhysicalDevices[as!u32(numEnumerated)] = physicalDevice
-  }
   object := switch (PhysicalDevices[physicalDevice] == null) {
     case true:
       new!PhysicalDeviceObject()
@@ -8945,7 +8939,6 @@ sub void clearLastDrawInfoDrawCommandParameters() {
   @unused map!(u32, string) EnabledLayers
   @unused VkInstance        VulkanHandle
   @unused ref!VulkanDebugMarkerInfo     DebugInfo
-  @hidden @unused map!(u32, VkPhysicalDevice) EnumeratedPhysicalDevices
 }
 
 @extension("VK_KHR_xlib_surface") define VK_KHR_XLIB_SURFACE_SPEC_VERSION   6


### PR DESCRIPTION
No need to cache the enumeration order of the trace in the state block.
But must make sure the content in the physical devices and the
Vender|DeviceID array matches with each other.

Details in the discussion of https://github.com/google/gapid/pull/1320