### PR TITLE
Hook the exception handler into the models and UI thread.

### DIFF
--- a/gapic/src/main/com/google/gapid/models/ApiContext.java
+++ b/gapic/src/main/com/google/gapid/models/ApiContext.java
@@ -25,6 +25,7 @@ import com.google.gapid.proto.service.Service;
 import com.google.gapid.proto.service.path.Path;
 import com.google.gapid.server.Client;
 import com.google.gapid.util.Events;
+import com.google.gapid.util.ExceptionHandler;
 
 import org.eclipse.swt.widgets.Shell;
 
@@ -41,8 +42,8 @@ public class ApiContext
 
   private FilteringContext selectedContext = null;
 
-  public ApiContext(Shell shell, Client client, Capture capture) {
-    super(LOG, shell, client, Listener.class, capture);
+  public ApiContext(Shell shell, ExceptionHandler handler, Client client, Capture capture) {
+    super(LOG, shell, handler, client, Listener.class, capture);
   }
 
   @Override

--- a/gapic/src/main/com/google/gapid/models/ApiState.java
+++ b/gapic/src/main/com/google/gapid/models/ApiState.java
@@ -35,6 +35,7 @@ import com.google.gapid.rpc.UiErrorCallback.ResultOrError;
 import com.google.gapid.server.Client;
 import com.google.gapid.server.Client.DataUnavailableException;
 import com.google.gapid.util.Events;
+import com.google.gapid.util.ExceptionHandler;
 import com.google.gapid.util.Loadable;
 import com.google.gapid.util.ObjectStore;
 import com.google.gapid.util.Paths;
@@ -55,9 +56,9 @@ public class ApiState
   private final ConstantSets constants;
   private final ObjectStore<Path.Any> selection = ObjectStore.create();
 
-  public ApiState(
-      Shell shell, Client client, Follower follower, AtomStream atoms, ApiContext contexts, ConstantSets constants) {
-    super(LOG, shell, client, Listener.class);
+  public ApiState(Shell shell, ExceptionHandler handler, Client client, Follower follower,
+      AtomStream atoms, ApiContext contexts, ConstantSets constants) {
+    super(LOG, shell, handler, client, Listener.class);
     this.constants = constants;
 
     atoms.addListener(new AtomStream.Listener() {

--- a/gapic/src/main/com/google/gapid/models/AtomStream.java
+++ b/gapic/src/main/com/google/gapid/models/AtomStream.java
@@ -35,6 +35,7 @@ import com.google.gapid.rpc.RpcException;
 import com.google.gapid.rpc.UiCallback;
 import com.google.gapid.server.Client;
 import com.google.gapid.util.Events;
+import com.google.gapid.util.ExceptionHandler;
 import com.google.gapid.util.Loadable;
 import com.google.gapid.util.Messages;
 import com.google.gapid.util.Paths;
@@ -59,9 +60,9 @@ public class AtomStream extends ModelBase.ForPath<AtomStream.Node, Void, AtomStr
   private final ConstantSets constants;
   private AtomIndex selection;
 
-  public AtomStream(
-      Shell shell, Client client, Capture capture, ApiContext context, ConstantSets constants) {
-    super(LOG, shell, client, Listener.class);
+  public AtomStream(Shell shell, ExceptionHandler handler, Client client, Capture capture,
+      ApiContext context, ConstantSets constants) {
+    super(LOG, shell, handler, client, Listener.class);
     this.capture = capture;
     this.context = context;
     this.constants = constants;

--- a/gapic/src/main/com/google/gapid/models/Capture.java
+++ b/gapic/src/main/com/google/gapid/models/Capture.java
@@ -31,6 +31,7 @@ import com.google.gapid.rpc.UiErrorCallback.ResultOrError;
 import com.google.gapid.server.Client;
 import com.google.gapid.server.Client.UnsupportedVersionException;
 import com.google.gapid.util.Events;
+import com.google.gapid.util.ExceptionHandler;
 import com.google.gapid.util.Loadable;
 
 import org.eclipse.swt.widgets.Shell;
@@ -51,8 +52,8 @@ public class Capture extends ModelBase<Path.Capture, File, Loadable.Message, Cap
   private final Settings settings;
   private String name = "";
 
-  public Capture(Shell shell, Client client, Settings settings) {
-    super(LOG, shell, client, Listener.class);
+  public Capture(Shell shell, ExceptionHandler handler, Client client, Settings settings) {
+    super(LOG, shell, handler, client, Listener.class);
     this.settings = settings;
   }
 
@@ -107,8 +108,10 @@ public class Capture extends ModelBase<Path.Capture, File, Loadable.Message, Cap
     } catch (UnsupportedVersionException e) {
       return error(Loadable.Message.error(e.getMessage()));
     } catch (RpcException e) {
+      handler.reportException(e);
       return error(Loadable.Message.error(e));
     } catch (ExecutionException e) {
+      handler.reportException(e);
       throttleLogRpcError(LOG, "Failed to load trace", e);
       return error(Loadable.Message.error(e.getCause().getMessage()));
     }
@@ -171,6 +174,7 @@ public class Capture extends ModelBase<Path.Capture, File, Loadable.Message, Cap
 
       @Override
       protected void onUiThreadError(Exception error) {
+        handler.reportException(error);
         throttleLogRpcError(LOG, "Couldn't save trace", error);
         showErrorDialog(shell, "Failed to save trace:\n  " + error.getMessage(), error);
       }

--- a/gapic/src/main/com/google/gapid/models/CaptureDependentModel.java
+++ b/gapic/src/main/com/google/gapid/models/CaptureDependentModel.java
@@ -21,6 +21,7 @@ import com.google.gapid.proto.service.Service;
 import com.google.gapid.proto.service.path.Path;
 import com.google.gapid.server.Client;
 import com.google.gapid.util.Events;
+import com.google.gapid.util.ExceptionHandler;
 import com.google.gapid.util.Loadable;
 
 import org.eclipse.swt.widgets.Shell;
@@ -33,9 +34,9 @@ import java.util.logging.Logger;
  */
 abstract class CaptureDependentModel<T, L extends Events.Listener>
     extends ModelBase.ForPath<T, Void, L> {
-  public CaptureDependentModel(
-      Logger log, Shell shell, Client client, Class<L> listenerClass, Capture capture) {
-    super(log, shell, client, listenerClass);
+  public CaptureDependentModel(Logger log, Shell shell, ExceptionHandler handler, Client client,
+      Class<L> listenerClass, Capture capture) {
+    super(log, shell, handler, client, listenerClass);
 
     capture.addListener(new Capture.Listener() {
       @Override
@@ -65,9 +66,9 @@ abstract class CaptureDependentModel<T, L extends Events.Listener>
 
   public abstract static class ForValue<T, L extends Events.Listener>
       extends CaptureDependentModel<T, L> {
-    public ForValue(
-        Logger log, Shell shell, Client client, Class<L> listenerClass, Capture capture) {
-      super(log, shell, client, listenerClass, capture);
+    public ForValue(Logger log, Shell shell, ExceptionHandler handler, Client client,
+        Class<L> listenerClass, Capture capture) {
+      super(log, shell, handler, client, listenerClass, capture);
     }
 
     @Override

--- a/gapic/src/main/com/google/gapid/models/Devices.java
+++ b/gapic/src/main/com/google/gapid/models/Devices.java
@@ -30,6 +30,7 @@ import com.google.gapid.rpc.SingleInFlight;
 import com.google.gapid.rpc.UiErrorCallback;
 import com.google.gapid.server.Client;
 import com.google.gapid.util.Events;
+import com.google.gapid.util.ExceptionHandler;
 import com.google.gapid.util.Loadable;
 import com.google.gapid.util.Paths;
 
@@ -48,12 +49,14 @@ public class Devices {
   private final Events.ListenerCollection<Listener> listeners = Events.listeners(Listener.class);
   private final SingleInFlight rpcController = new SingleInFlight();
   private final Shell shell;
+  protected final ExceptionHandler handler;
   private final Client client;
   private Path.Device replayDevice;
   private List<Device.Instance> devices;
 
-  public Devices(Shell shell, Client client, Capture capture) {
+  public Devices(Shell shell, ExceptionHandler handler, Client client, Capture capture) {
     this.shell = shell;
+    this.handler = handler;
     this.client = client;
 
     capture.addListener(new Capture.Listener() {
@@ -84,6 +87,7 @@ public class Devices {
           List<Path.Device> devs = result.get();
           return (devs == null || devs.isEmpty()) ? error(null) : success(devs.get(0));
         } catch (RpcException | ExecutionException e) {
+          handler.reportException(e);
           throttleLogRpcError(LOG, "LoadData error", e);
           return error(null);
         }

--- a/gapic/src/main/com/google/gapid/models/Models.java
+++ b/gapic/src/main/com/google/gapid/models/Models.java
@@ -16,11 +16,13 @@
 package com.google.gapid.models;
 
 import com.google.gapid.server.Client;
+import com.google.gapid.util.ExceptionHandler;
 
 import org.eclipse.swt.widgets.Shell;
 
 public class Models {
   public final Settings settings;
+  public final ExceptionHandler handler;
   public final Follower follower;
   public final Capture capture;
   public final Devices devices;
@@ -33,10 +35,12 @@ public class Models {
   public final Thumbnails thumbs;
   public final ConstantSets constants;
 
-  public Models(Settings settings, Follower follower, Capture capture, Devices devices,
-      AtomStream atoms, ApiContext contexts, Timeline timeline, Resources resources, ApiState state,
-      Reports reports, Thumbnails thumbs, ConstantSets constants) {
+  public Models(Settings settings, ExceptionHandler handler, Follower follower, Capture capture,
+      Devices devices, AtomStream atoms, ApiContext contexts, Timeline timeline,
+      Resources resources, ApiState state, Reports reports, Thumbnails thumbs,
+      ConstantSets constants) {
     this.settings = settings;
+    this.handler = handler;
     this.follower = follower;
     this.capture = capture;
     this.devices = devices;
@@ -50,20 +54,21 @@ public class Models {
     this.constants = constants;
   }
 
-  public static Models create(Shell shell, Settings settings, Client client) {
+  public static Models create(
+      Shell shell, Settings settings, ExceptionHandler handler, Client client) {
     ConstantSets constants = new ConstantSets(client);
     Follower follower = new Follower(shell, client);
-    Capture capture = new Capture(shell, client, settings);
-    Devices devices = new Devices(shell, client, capture);
-    ApiContext contexts = new ApiContext(shell, client, capture);
-    Timeline timeline = new Timeline(shell, client, capture, contexts);
-    AtomStream atoms = new AtomStream(shell, client, capture, contexts, constants);
-    Resources resources = new Resources(shell, client, capture);
-    ApiState state = new ApiState(shell, client, follower, atoms, contexts, constants);
-    Reports reports = new Reports(shell, client, capture, devices, contexts);
+    Capture capture = new Capture(shell, handler, client, settings);
+    Devices devices = new Devices(shell, handler, client, capture);
+    ApiContext contexts = new ApiContext(shell, handler, client, capture);
+    Timeline timeline = new Timeline(shell, handler, client, capture, contexts);
+    AtomStream atoms = new AtomStream(shell, handler, client, capture, contexts, constants);
+    Resources resources = new Resources(shell, handler, client, capture);
+    ApiState state = new ApiState(shell, handler, client, follower, atoms, contexts, constants);
+    Reports reports = new Reports(shell, handler, client, capture, devices, contexts);
     Thumbnails thumbs = new Thumbnails(client, devices, capture, settings);
-    return new Models(settings, follower, capture, devices, atoms, contexts, timeline, resources,
-        state, reports, thumbs, constants);
+    return new Models(settings, handler, follower, capture, devices, atoms, contexts, timeline,
+        resources, state, reports, thumbs, constants);
   }
 
   public void dispose() {

--- a/gapic/src/main/com/google/gapid/models/Reports.java
+++ b/gapic/src/main/com/google/gapid/models/Reports.java
@@ -22,6 +22,7 @@ import com.google.gapid.proto.service.Service;
 import com.google.gapid.proto.service.path.Path;
 import com.google.gapid.server.Client;
 import com.google.gapid.util.Events;
+import com.google.gapid.util.ExceptionHandler;
 
 import org.eclipse.swt.widgets.Shell;
 
@@ -35,8 +36,9 @@ public class Reports extends ModelBase.ForPath<Service.Report, Void, Reports.Lis
 
   private final Devices devices;
 
-  public Reports(Shell shell, Client client, Capture capture, Devices devices, ApiContext context) {
-    super(LOG, shell, client, Listener.class);
+  public Reports(Shell shell, ExceptionHandler handler, Client client, Capture capture,
+      Devices devices, ApiContext context) {
+    super(LOG, shell, handler, client, Listener.class);
     this.devices = devices;
 
     devices.addListener(new Devices.Listener() {

--- a/gapic/src/main/com/google/gapid/models/Resources.java
+++ b/gapic/src/main/com/google/gapid/models/Resources.java
@@ -19,6 +19,7 @@ import com.google.gapid.proto.service.Service;
 import com.google.gapid.proto.service.path.Path;
 import com.google.gapid.server.Client;
 import com.google.gapid.util.Events;
+import com.google.gapid.util.ExceptionHandler;
 
 import org.eclipse.swt.widgets.Shell;
 
@@ -32,8 +33,8 @@ public class Resources
     extends CaptureDependentModel.ForValue<Service.Resources, Resources.Listener> {
   private static final Logger LOG = Logger.getLogger(Resources.class.getName());
 
-  public Resources(Shell shell, Client client, Capture capture) {
-    super(LOG, shell, client, Listener.class, capture);
+  public Resources(Shell shell, ExceptionHandler handler, Client client, Capture capture) {
+    super(LOG, shell, handler, client, Listener.class, capture);
   }
 
   @Override

--- a/gapic/src/main/com/google/gapid/models/Settings.java
+++ b/gapic/src/main/com/google/gapid/models/Settings.java
@@ -84,6 +84,7 @@ public class Settings {
   public long lastCheckForUpdates = 0; // milliseconds since midnight, January 1, 1970 UTC.
   public String analyticsClientId = ""; // Empty means do not track.
   public boolean disableReplayOptimization = false;
+  public boolean reportExceptions = false;
 
   /**
    * Registers the listener for changes.
@@ -168,10 +169,6 @@ public class Settings {
         .toArray(l -> new String[l]);
   }
 
-  public boolean crashReportingEnabled() {
-    return false;
-  }
-
   public boolean analyticsEnabled() {
     return !analyticsClientId.isEmpty();
   }
@@ -213,7 +210,9 @@ public class Settings {
     lastCheckForUpdates = getLong(properties, "updates.lastCheck", 0);
     updateAvailable = getBoolean(properties, "updates.available", updateAvailable);
     analyticsClientId = properties.getProperty("analytics.clientId", "");
-    disableReplayOptimization = getBoolean(properties, "replay.disableOptimization", disableReplayOptimization);
+    disableReplayOptimization =
+        getBoolean(properties, "replay.disableOptimization", disableReplayOptimization);
+    reportExceptions = getBoolean(properties, "crash.reporting", reportExceptions);
   }
 
   private void updateTo(Properties properties) {
@@ -250,7 +249,9 @@ public class Settings {
     properties.setProperty("updates.lastCheck", Long.toString(lastCheckForUpdates));
     properties.setProperty("updates.available", Boolean.toString(updateAvailable));
     properties.setProperty("analytics.clientId", analyticsClientId);
-    properties.setProperty("replay.disableOptimization",  Boolean.toString(disableReplayOptimization));
+    properties.setProperty(
+        "replay.disableOptimization",  Boolean.toString(disableReplayOptimization));
+    properties.setProperty("crash.reporting", Boolean.toString(reportExceptions));
   }
 
   private static Point getPoint(Properties properties, String name) {

--- a/gapic/src/main/com/google/gapid/models/Timeline.java
+++ b/gapic/src/main/com/google/gapid/models/Timeline.java
@@ -24,6 +24,7 @@ import com.google.gapid.proto.service.Service;
 import com.google.gapid.proto.service.path.Path;
 import com.google.gapid.server.Client;
 import com.google.gapid.util.Events;
+import com.google.gapid.util.ExceptionHandler;
 
 import org.eclipse.swt.widgets.Shell;
 
@@ -38,8 +39,9 @@ public class Timeline extends CaptureDependentModel<List<Service.Event>, Timelin
   private final Capture capture;
   private final ApiContext context;
 
-  public Timeline(Shell shell, Client client, Capture capture, ApiContext context) {
-    super(LOG, shell, client, Listener.class, capture);
+  public Timeline(
+      Shell shell, ExceptionHandler handler, Client client, Capture capture, ApiContext context) {
+    super(LOG, shell, handler, client, Listener.class, capture);
     this.capture = capture;
     this.context = context;
 

--- a/gapic/src/main/com/google/gapid/util/Crash2ExceptionHandler.java
+++ b/gapic/src/main/com/google/gapid/util/Crash2ExceptionHandler.java
@@ -16,61 +16,65 @@
 package com.google.gapid.util;
 
 import static com.google.gapid.util.GapidVersion.GAPID_VERSION;
+import static java.util.logging.Level.INFO;
+import static java.util.logging.Level.SEVERE;
 
 import com.google.common.base.Throwables;
+import com.google.gapid.models.Settings;
 
-import com.squareup.okhttp.OkHttpClient;
 import com.squareup.okhttp.MultipartBuilder;
+import com.squareup.okhttp.OkHttpClient;
 import com.squareup.okhttp.Request;
-import com.squareup.okhttp.RequestBody;
 import com.squareup.okhttp.Response;
 
-import okio.Buffer;
-
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.io.PrintStream;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.util.logging.Logger;
-import java.util.logging.Level;
 
 /**
  * Handles uncaught exceptions and sends stacktraces to Crash2 server.
  */
-public class Crash2ExceptionHandler implements Thread.UncaughtExceptionHandler {
-  private static final Logger LOG = Logger.getLogger(Crash2ExceptionHandler.class.getName());
+public class Crash2ExceptionHandler implements Thread.UncaughtExceptionHandler, ExceptionHandler {
+  protected static final Logger LOG = Logger.getLogger(Crash2ExceptionHandler.class.getName());
 
   // TODO(baldwinn860): Send to production url when we get approval.
-  private static final String CRASH_REPORT_URL_BASE = "https://clients2.google.com/cr/staging_report?";
-  private static final String CRASH_REPORT_PRODUCT = "GAPID";
-  private static final String CRASH_REPORT_VERSION = "Client:" + GAPID_VERSION.toString();
-  private static final String CRASH_REPORT_VERSION_ENCODED;
-  private static final String CRASH_REPORT_URL_FIELDS;
-  private static final String CRASH_REPORT_URL;
-  static { 
-    String temp;
-    try {
-      temp = URLEncoder.encode(CRASH_REPORT_VERSION, "UTF-8");
-    } catch(UnsupportedEncodingException e) {
-      temp = "UnknownVersion";
-    }
-    CRASH_REPORT_VERSION_ENCODED = temp;
-    CRASH_REPORT_URL_FIELDS = "product=" + CRASH_REPORT_PRODUCT + "&version=" + CRASH_REPORT_VERSION_ENCODED;
-    CRASH_REPORT_URL = CRASH_REPORT_URL_BASE + CRASH_REPORT_URL_FIELDS;
-  }
+  protected static final String CRASH_REPORT_URL_BASE = "https://clients2.google.com/cr/staging_report?";
+  protected static final String CRASH_REPORT_PRODUCT = "GAPID";
+  protected static final String CRASH_REPORT_VERSION = "Client:" + GAPID_VERSION.toString();
+  protected static final String CRASH_REPORT_URL = CRASH_REPORT_URL_BASE + getUrlParameters();
 
+  private final Settings settings;
   private final Thread.UncaughtExceptionHandler previousHandler;
 
-  private Crash2ExceptionHandler(Thread.UncaughtExceptionHandler oldHandler) {
-    previousHandler = oldHandler;
+  private Crash2ExceptionHandler(Settings settings) {
+    this.settings = settings;
+    this.previousHandler = getChildHandler(Thread.getDefaultUncaughtExceptionHandler());
   }
 
-  public static void registerAsDefault() {
-    if (!(Thread.getDefaultUncaughtExceptionHandler() instanceof Crash2ExceptionHandler)) {
-      Crash2ExceptionHandler handler = new Crash2ExceptionHandler(Thread.getDefaultUncaughtExceptionHandler());
-      Thread.setDefaultUncaughtExceptionHandler(handler);
+  private static String getUrlParameters() {
+    StringBuilder result = new StringBuilder()
+        .append("product=").append(CRASH_REPORT_PRODUCT)
+        .append("&version=");
+    try {
+      result.append(URLEncoder.encode(CRASH_REPORT_VERSION, "UTF-8"));
+    } catch (UnsupportedEncodingException e) {
+      LOG.log(SEVERE, "UTF-8 not found", e);
+      result.append("UnknownVersion");
     }
+    return result.toString();
+  }
+
+  private static Thread.UncaughtExceptionHandler getChildHandler(
+      Thread.UncaughtExceptionHandler handler) {
+    return (handler instanceof Crash2ExceptionHandler) ?
+        getChildHandler(((Crash2ExceptionHandler)handler).previousHandler) : handler;
+  }
+
+  public static Crash2ExceptionHandler register(Settings settings) {
+    Crash2ExceptionHandler handler = new Crash2ExceptionHandler(settings);
+    Thread.setDefaultUncaughtExceptionHandler(handler);
+    return handler;
   }
 
   @Override
@@ -80,41 +84,38 @@ public class Crash2ExceptionHandler implements Thread.UncaughtExceptionHandler {
     previousHandler.uncaughtException(thread, thrown);
   }
 
-  public static void reportException(Throwable thrown) {
-    Thread uploadThread = new Thread(new StackTraceUploader(thrown));
-    uploadThread.start();
-  }
-
-  private static class StackTraceUploader implements Runnable {
-    private final Throwable thrown;
-
-    public StackTraceUploader(Throwable thrownIn) {
-      thrown = thrownIn;
+  @Override
+  public void reportException(Throwable thrown) {
+    if (!settings.crashReportingEnabled()) {
+      return;
     }
 
-    @Override
-    public void run() {
-      try {
-        // Creates a connection to crash2
-        OkHttpClient client = new OkHttpClient();
-        Response response = client.newCall(new Request.Builder()
-                .url(CRASH_REPORT_URL)
-                .post(new MultipartBuilder()
-                    .type(MultipartBuilder.FORM)
-                    .addFormDataPart("product", CRASH_REPORT_PRODUCT)
-                    .addFormDataPart("version", CRASH_REPORT_VERSION)
-                    .addFormDataPart("exception_info", Throwables.getStackTraceAsString(thrown))
-                    .build())
-                .build())
-            .execute();
-        if (response.isSuccessful()) {
-          LOG.log(Level.INFO, "Crash Report Uploaded Successfully; Crash Report ID: " + response.body().string());
-        } else {
-          LOG.log(Level.SEVERE, "Crash Report Not Uploaded; Response Code: " + response.code());
+    new Thread() {
+      @Override
+      public void run() {
+        try {
+          // Creates a connection to crash2
+          OkHttpClient client = new OkHttpClient();
+          Response response = client.newCall(new Request.Builder()
+                  .url(CRASH_REPORT_URL)
+                  .post(new MultipartBuilder()
+                      .type(MultipartBuilder.FORM)
+                      .addFormDataPart("product", CRASH_REPORT_PRODUCT)
+                      .addFormDataPart("version", CRASH_REPORT_VERSION)
+                      .addFormDataPart("exception_info", Throwables.getStackTraceAsString(thrown))
+                      .build())
+                  .build())
+              .execute();
+          if (response.isSuccessful()) {
+            LOG.log(INFO,
+                "Crash Report Uploaded Successfully; Crash Report ID: " + response.body().string());
+          } else {
+            LOG.log(SEVERE, "Crash Report Not Uploaded; Response Code: " + response.code());
+          }
+        } catch (IOException e) {
+          LOG.log(SEVERE, "Unable to upload exception to crash2", e);
         }
-      } catch (IOException e) {
-        LOG.log(Level.SEVERE, "Unable to upload exception to crash2", e);
       }
-    }
+    }.start();
   }
 }

--- a/gapic/src/main/com/google/gapid/util/Crash2ExceptionHandler.java
+++ b/gapic/src/main/com/google/gapid/util/Crash2ExceptionHandler.java
@@ -86,7 +86,7 @@ public class Crash2ExceptionHandler implements Thread.UncaughtExceptionHandler, 
 
   @Override
   public void reportException(Throwable thrown) {
-    if (!settings.crashReportingEnabled()) {
+    if (!settings.reportExceptions) {
       return;
     }
 

--- a/gapic/src/main/com/google/gapid/util/ExceptionHandler.java
+++ b/gapic/src/main/com/google/gapid/util/ExceptionHandler.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.gapid.util;
+
+/**
+ * Invoked for exceptions that are not otherwhise handled.
+ */
+public interface ExceptionHandler {
+  public void reportException(Throwable thrown);
+}


### PR DESCRIPTION
Once the UI is up and running, the UI thread captures exceptions and doesn't just let them propagate, as that would cause the app to close. This will cause the UI thread to report these caught exceptions and
similarly caught exceptions in the data models.

For #407