### PR TITLE
Fix 2 small issues in DCE

### DIFF
--- a/gapis/api/vulkan/footprint_builder.go
+++ b/gapis/api/vulkan/footprint_builder.go
@@ -2228,6 +2228,7 @@ func (vb *FootprintBuilder) BuildFootprint(ctx context.Context,
 
 	// pipeline settings
 	case *VkCmdPushConstants:
+		read(ctx, bh, vkHandle(cmd.Layout))
 		vb.recordModifingDynamicStates(ctx, ft, bh, cmd.CommandBuffer)
 	case *VkCmdSetLineWidth:
 		vb.recordModifingDynamicStates(ctx, ft, bh, cmd.CommandBuffer)
@@ -2420,6 +2421,7 @@ func (vb *FootprintBuilder) BuildFootprint(ctx context.Context,
 		vb.writeCoherentMemoryData(ctx, cmd, bh)
 		if read(ctx, bh, vkHandle(cmd.Fence)) {
 			read(ctx, bh, vb.fences[cmd.Fence].unsignal)
+			write(ctx, bh, vb.fences[cmd.Fence].signal)
 		}
 		for _, sp := range vb.submitInfos[id].waitSemaphores {
 			if read(ctx, bh, vkHandle(sp)) {


### PR DESCRIPTION
We may kill off VkQueueSubmit, if the only thing they do is
signal a fence.

We may also kill off pipelineLayouts if they are only used to
update push constants.