### PR TITLE
core/log: Don't implicity stop the process on fatal messages.

### DIFF
--- a/core/app/log.go
+++ b/core/app/log.go
@@ -23,12 +23,7 @@ import (
 	"github.com/google/gapid/core/os/file"
 )
 
-const (
-	// FatalSeverity Is the level at which logging causes panics.
-	FatalSeverity = log.Fatal
-
-	logChanBufferSize = 100
-)
+const logChanBufferSize = 100
 
 // LogHandler is the primary application logger target.
 // It is assigned to the main context on startup and is closed on shutdown.
@@ -46,7 +41,7 @@ func wrapHandler(to log.Handler) log.Handler {
 	to = log.Channel(to, logChanBufferSize)
 	return log.NewHandler(func(m *log.Message) {
 		to.Handle(m)
-		if m.Severity >= FatalSeverity {
+		if m.StopProcess {
 			to.Close()
 			panic(FatalExit)
 		}

--- a/core/log/err.go
+++ b/core/log/err.go
@@ -22,13 +22,13 @@ import (
 // Err creates a new error that wraps cause with the current logging
 // information.
 func (l *Logger) Err(cause error, msg string) error {
-	return &err{cause, l.Message(Error, msg)}
+	return &err{cause, l.Message(Error, false, msg)}
 }
 
 // Errf creates a new error that wraps cause with the current logging
 // information.
 func (l *Logger) Errf(cause error, fmt string, args ...interface{}) error {
-	return &err{cause, l.Messagef(Error, fmt, args...)}
+	return &err{cause, l.Messagef(Error, false, fmt, args...)}
 }
 
 type err struct {

--- a/core/log/log_test.go
+++ b/core/log/log_test.go
@@ -51,7 +51,7 @@ func (m testMessage) send(h log.Handler) {
 	ctx = log.PutTag(ctx, m.tag)
 	ctx = log.PutClock(ctx, testClock)
 	ctx = m.values.Bind(ctx)
-	log.From(ctx).Logf(m.severity, m.msg, m.args...)
+	log.From(ctx).Logf(m.severity, false, m.msg, m.args...)
 }
 
 var testMessages = []testMessage{

--- a/core/log/message.go
+++ b/core/log/message.go
@@ -29,6 +29,9 @@ type Message struct {
 	// The severity of the message.
 	Severity Severity
 
+	// StopProcess is true if the message indicates the process should stop.
+	StopProcess bool
+
 	// The tag associated with the log record.
 	Tag string
 

--- a/core/log/severity.go
+++ b/core/log/severity.go
@@ -31,7 +31,7 @@ const (
 	Warning Severity = 3
 	// Error indicates non terminal failure conditions that may have an effect on results.
 	Error Severity = 4
-	// Fatal indicates a fatal error and the process should be terminated.
+	// Fatal indicates a fatal error.
 	Fatal Severity = 5
 )
 

--- a/core/os/android/device.go
+++ b/core/os/android/device.go
@@ -99,7 +99,7 @@ func (m LogcatMessage) Log(ctx context.Context) {
 		"pid": m.ProcessID,
 		"tid": m.ThreadID,
 	}.Bind(ctx)
-	log.From(ctx).Log(m.Priority.Severity(), m.Message)
+	log.From(ctx).Log(m.Priority.Severity(), false, m.Message)
 }
 
 // LogcatPriority represents the priority of a logcat message.

--- a/gapir/client/session.go
+++ b/gapir/client/session.go
@@ -105,7 +105,7 @@ func (s *session) newHost(ctx context.Context, d bind.Device, launchArgs []strin
 				h.Handle(m)
 				return nil
 			}
-			log.From(ctx).Log(severity, line)
+			log.From(ctx).Log(severity, false, line)
 			return nil
 		})
 	}


### PR DESCRIPTION
The design of the logging system lets you log messages from other processes (like logcat).

Just because another process has a fatal message does not mean the listener should shut down.