### PR TITLE
gapic: Add various caches to reduce loading times of images.

### DIFF
--- a/gapic/src/main/com/google/gapid/image/ArrayImage.java
+++ b/gapic/src/main/com/google/gapid/image/ArrayImage.java
@@ -19,14 +19,12 @@ import static com.google.gapid.util.Colors.DARK_LUMINANCE8_THRESHOLD;
 import static com.google.gapid.util.Colors.DARK_LUMINANCE_THRESHOLD;
 import static com.google.gapid.util.Colors.clamp;
 
-import com.google.common.primitives.UnsignedBytes;
 import com.google.common.collect.Sets;
+import com.google.common.primitives.UnsignedBytes;
 import com.google.gapid.glviewer.gl.Texture;
 import com.google.gapid.proto.stream.Stream.Channel;
 import com.google.gapid.util.Colors;
 
-import java.nio.DoubleBuffer;
-import java.util.Set;
 import org.eclipse.swt.graphics.ImageData;
 import org.lwjgl.BufferUtils;
 import org.lwjgl.opengl.GL11;
@@ -34,8 +32,10 @@ import org.lwjgl.opengl.GL30;
 
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.nio.DoubleBuffer;
 import java.nio.FloatBuffer;
 import java.util.Arrays;
+import java.util.Set;
 
 /**
  * An {@link Image} backed by a byte array.
@@ -44,6 +44,7 @@ public abstract class ArrayImage implements Image {
   public final int width, height, depth, bytesPerPixel;
   protected final byte[] data;
   private final int internalFormat, format, type;
+  private final int hash;
 
   public ArrayImage(int width, int height, int depth, int bytesPerPixel, byte[] data,
       int internalFormat, int format, int type) {
@@ -55,6 +56,41 @@ public abstract class ArrayImage implements Image {
     this.internalFormat = internalFormat;
     this.format = format;
     this.type = type;
+    this.hash = calculateHash();
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    if (other.getClass() != getClass()) {
+      return false;
+    }
+    ArrayImage o = (ArrayImage)other;
+    return o.width == width &&
+        o.height == height &&
+        o.depth == depth &&
+        o.bytesPerPixel == bytesPerPixel &&
+        o.internalFormat == internalFormat &&
+        o.format == format &&
+        o.type == type &&
+        Arrays.equals(o.data, data); // Keep last as it is the most expensive.
+  }
+
+  private int calculateHash() {
+    int h = 0;
+    h = h * 31 + width;
+    h = h * 31 + height;
+    h = h * 31 + depth;
+    h = h * 31 + bytesPerPixel;
+    h = h * 31 + internalFormat;
+    h = h * 31 + format;
+    h = h * 31 + type;
+    h = h * 31 + Arrays.hashCode(data);
+    return h;
+  }
+
+  @Override
+  public int hashCode() {
+    return hash;
   }
 
   @Override

--- a/gapic/src/main/com/google/gapid/widgets/ImagePanel.java
+++ b/gapic/src/main/com/google/gapid/widgets/ImagePanel.java
@@ -117,6 +117,8 @@ public class ImagePanel extends Composite {
   private final StatusBar status;
   protected final ImageComponent imageComponent;
   private final BackgroundSelection backgroundSelection;
+  private final Histogram.Cache histogramCache = new Histogram.Cache(8, NUM_HISTOGRAM_BINS);
+
   private ToolItem zoomFitItem, backgroundItem, saveItem, colorChanelsItem;
   private MultiLayerAndLevelImage image = MultiLayerAndLevelImage.EMPTY;
   private Image[] layers = NO_LAYERS;
@@ -458,15 +460,7 @@ public class ImagePanel extends Composite {
     }
     ListenableFuture<LevelData> future = Futures.transform(Futures.allAsList(layerFutures), imageList -> {
       Image[] images = imageList.toArray(new Image[imageList.size()]);
-
-      boolean isHDR = false;
-      for (Image image : images) {
-        if (image.isHDR()) {
-          isHDR = true;
-        }
-      }
-
-      Histogram histogram = new Histogram(images, NUM_HISTOGRAM_BINS, isHDR);
+      Histogram histogram = histogramCache.get(images);
       return new LevelData(images, histogram);
     });
 

--- a/gapic/src/main/com/google/gapid/widgets/ImagePanel.java
+++ b/gapic/src/main/com/google/gapid/widgets/ImagePanel.java
@@ -1022,9 +1022,9 @@ public class ImagePanel extends Composite {
     private static final int PREVIEW_SIZE = 7;
 
     private final Map<Image, Texture> imageToTexture = Maps.newHashMap();
+    private final ArrayList<Texture> textures = new ArrayList<>();
 
     private Shader shader;
-    private Texture[] textures;
     private SceneData data;
 
     private final float[] uChannels = new float[] { 1, 1, 1, 1 };
@@ -1046,14 +1046,24 @@ public class ImagePanel extends Composite {
     @Override
     public void update(Renderer renderer, SceneData newData) {
       // Release textures that are no longer in data.
+      Set<Image> oldSet = imageToTexture.keySet();
       Set<Image> newSet = Sets.newHashSet(newData.images);
-      for (Map.Entry<Image, Texture> entry : imageToTexture.entrySet()) {
-        if (!newSet.contains(entry.getKey())) {
-          entry.getValue().delete();
-        }
+
+      for (Image removed : Sets.difference(oldSet, newSet)) {
+        imageToTexture.remove(removed).delete();
       }
 
-      this.textures = new Texture[newData.images.length];
+      for (Image added : Sets.difference(newSet, oldSet)) {
+        Texture texture = renderer
+            .newTexture(GL11.GL_TEXTURE_2D)
+            .setMinMagFilter(GL11.GL_LINEAR, GL11.GL_NEAREST)
+            .setBorderColor(newData.borderColor);
+        added.uploadToTexture(texture);
+        imageToTexture.put(added, texture);
+      }
+
+      textures.clear();
+
       for (int i = 0; i < newData.images.length; i++) {
         Image image = newData.images[i];
         Texture texture = imageToTexture.get(image);
@@ -1065,8 +1075,7 @@ public class ImagePanel extends Composite {
           image.uploadToTexture(texture);
           imageToTexture.put(image, texture);
         }
-
-        this.textures[i] = texture;
+        textures.add(texture);
       }
 
       float rangeMin = (float)newData.displayRange.min;
@@ -1121,9 +1130,10 @@ public class ImagePanel extends Composite {
       shader.setUniform("uTextureOffset", new float[] { 0, 0 });
       shader.setUniform("uChannels", uChannels);
       shader.setUniform("uFlipped", data.flipped ? 1 : 0);
-      for (int i = 0; i < textures.length; i++) {
-        textures[i].setWrapMode(GL12.GL_CLAMP_TO_EDGE, GL12.GL_CLAMP_TO_EDGE);
-        shader.setUniform("uTexture", textures[i]);
+      for (int i = 0; i < textures.size(); i++) {
+        Texture texture = textures.get(i);
+        texture.setWrapMode(GL12.GL_CLAMP_TO_EDGE, GL12.GL_CLAMP_TO_EDGE);
+        shader.setUniform("uTexture", texture);
         renderer.drawQuad(data.transforms[i], shader);
       }
     }
@@ -1151,7 +1161,7 @@ public class ImagePanel extends Composite {
           (float)(data.previewPixel.y - PREVIEW_HEIGHT / 2) / image.getHeight()
       };
 
-      Texture texture = textures[imageIndex];
+      Texture texture = textures.get(imageIndex);
       texture.setWrapMode(GL13.GL_CLAMP_TO_BORDER, GL13.GL_CLAMP_TO_BORDER);
       shader.setUniform("uTexture", texture);
       shader.setUniform("uTextureSize", texScale);


### PR DESCRIPTION
Cache the unboxing of byte arrays so that we don’t end up with a different array for each call to Pods.getBytes().

Add comparable logic to ArrayImage.

Fixes: #655