### PR TITLE
Resolve function pointers for extensions we do not support.

### DIFF
--- a/gapis/api/vulkan/templates/vk_spy_helpers.cpp.tmpl
+++ b/gapis/api/vulkan/templates/vk_spy_helpers.cpp.tmpl
@@ -142,7 +142,19 @@ PFN_vkVoidFunction VulkanSpy::SpyOverride_vkGetDeviceProcAddr(VkDevice device, c
     {{end}}
     // This is not strictly correct, but some applications incorrectly
     // call vkGetDeviceProcAddr, when they actually mean vkGetInstanceProcAddr.
-    return SpyOverride_vkGetInstanceProcAddr(PhysicalDevices[Devices[device]->mPhysicalDevice]->mInstance, pName);
+    PFN_vkVoidFunction f = SpyOverride_vkGetInstanceProcAddr(PhysicalDevices[Devices[device]->mPhysicalDevice]->mInstance, pName);
+
+    // If we do not support the function as an instance function OR a device function, then defer to the actual device.
+    // It is likely that this will cause a failure in the future, as we will miss any state
+    // that is modified by this function, but we avoid modifying the application.
+    if (!f && device) {
+        f = mImports.mVkDeviceFunctions[device].vkGetDeviceProcAddr(device, pName);
+        if (f) {
+            GAPID_ERROR("Unknown function %s resolved, it may be called but will not be tracked", pName);
+        }
+    }
+
+    return f;
 }
 
 uint32_t VulkanSpy::SpyOverride_vkEnumerateInstanceExtensionProperties(const char *pLayerName, uint32_t *pCount, VkExtensionProperties *pProperties) {


### PR DESCRIPTION
This means that if we come across an unknown function pointer,
it is less likely to crash entirely.

This does run into the problem that the state block may
end up in an inconsistent state because functions are not
tracked. However without this, any calls to the functions
will just be a segfault, and even more difficult to track down.