### PR TITLE
core/app/crash: Minor fixes and improvements.

### DIFF
--- a/core/app/crash/reporting/encoder.go
+++ b/core/app/crash/reporting/encoder.go
@@ -28,7 +28,10 @@ type encoder struct {
 	stacktrace string
 }
 
-const multipartBoundary = "::multipart-boundary::"
+const (
+	crashProduct      = "GAPID"
+	multipartBoundary = "::multipart-boundary::"
+)
 
 func (e encoder) encode() (io.Reader, string, error) {
 	buf := bytes.Buffer{}
@@ -37,10 +40,10 @@ func (e encoder) encode() (io.Reader, string, error) {
 		return nil, "", err
 	}
 	defer w.Close()
-	if err := w.WriteField("product", e.appName); err != nil {
+	if err := w.WriteField("product", crashProduct); err != nil {
 		return nil, "", err
 	}
-	if err := w.WriteField("version", e.appVersion); err != nil {
+	if err := w.WriteField("version", e.appName+":"+e.appVersion); err != nil {
 		return nil, "", err
 	}
 	if e.osName != "" {

--- a/core/app/crash/reporting/encoder_test.go
+++ b/core/app/crash/reporting/encoder_test.go
@@ -39,11 +39,11 @@ func TestEncoder(t *testing.T) {
 			expect := "--" + multipartBoundary + "\r\n" +
 				"Content-Disposition: form-data; name=\"product\"\r\n" +
 				"\r\n" +
-				"TestApp\r\n" +
+				"GAPID\r\n" +
 				"--" + multipartBoundary + "\r\n" +
 				"Content-Disposition: form-data; name=\"version\"\r\n" +
 				"\r\n" +
-				"V1.2.3\r\n" +
+				"TestApp:V1.2.3\r\n" +
 				"--" + multipartBoundary + "\r\n" +
 				"Content-Disposition: form-data; name=\"osName\"\r\n" +
 				"\r\n" +

--- a/core/app/crash/reporting/reporting.go
+++ b/core/app/crash/reporting/reporting.go
@@ -30,6 +30,12 @@ import (
 	"github.com/google/gapid/core/os/device/host"
 )
 
+// TODO(baldwinn860): Send to production url when we get approval.
+const (
+	crashStagingURL = "https://clients2.google.com/cr/staging_report"
+	crashURL        = crashStagingURL
+)
+
 // Enable turns on crash reporting if the running processes panics inside a
 // crash.Go block.
 func Enable(ctx context.Context, appName, appVersion string) {
@@ -41,18 +47,12 @@ func Enable(ctx context.Context, appName, appVersion string) {
 				osVersion = fmt.Sprintf("%v %v.%v.%v", os.GetBuild(), os.GetMajor(), os.GetMinor(), os.GetPoint())
 			}
 		}
-		err := reporter{appName, appVersion, osName, osVersion}.report(s)
+		err := reporter{appName, appVersion, osName, osVersion}.report(s, crashURL)
 		if err != nil {
 			log.E(ctx, "%v", err)
 		}
 	})
 }
-
-const (
-	// TODO(baldwinn860): Send to production url when we get approval.
-	crashURL     = "https://clients2.google.com/cr/staging_report"
-	crashProduct = "GAPID"
-)
 
 type reporter struct {
 	appName    string
@@ -61,7 +61,7 @@ type reporter struct {
 	osVersion  string
 }
 
-func (r reporter) report(s stacktrace.Callstack) error {
+func (r reporter) report(s stacktrace.Callstack, endpoint string) error {
 	stacktrace := s.String()
 
 	url := fmt.Sprintf("%v?product=%v&version=%v", crashURL, url.QueryEscape(r.appName), url.QueryEscape(r.appVersion))

--- a/core/app/crash/reporting/reporting_test.go
+++ b/core/app/crash/reporting/reporting_test.go
@@ -35,7 +35,7 @@ func TestReport(t *testing.T) {
 			appVersion: "0",
 			osName:     "unknown",
 			osVersion:  "unknown",
-		}.report(stacktrace.Capture())
+		}.report(stacktrace.Capture(), crashStagingURL)
 
 		assert.For(ctx, "err").ThatError(err).Succeeded()
 	}


### PR DESCRIPTION
The product must always be GAPID. We put the exe name into the version.

Always use the staging URL for the tests.