### PR TITLE
Stop looping on GetFenceStatus if the return is VK_ERROR_DEVICE_LOST

### DIFF
--- a/gapis/api/templates/vulkan_gfx_api_extras.tmpl
+++ b/gapis/api/templates/vulkan_gfx_api_extras.tmpl
@@ -359,7 +359,8 @@ bool Vulkan::replayGetFenceStatus(Stack* stack, bool pushReturn) {
               // to vkWaitForFences() once the issue is fixed.
               do {
                 return_value = mVkDeviceFunctionStubs[device].vkGetFenceStatus(device, fence);
-              } while (return_value != gapir::Vulkan::VkResult::VK_SUCCESS);
+              } while (return_value != gapir::Vulkan::VkResult::VK_SUCCESS &&
+                         return_value != gapir::Vulkan::VkResult::VK_ERROR_DEVICE_LOST);
             } else {
               return_value = mVkDeviceFunctionStubs[device].vkGetFenceStatus(device, fence);
             }


### PR DESCRIPTION
If we get into this case, we will end up looping forever,
which is not actually useful.