### PR TITLE
GLES DCE tweaks.

### DIFF
--- a/gapis/api/gles/replay.go
+++ b/gapis/api/gles/replay.go
@@ -140,9 +140,6 @@ func (a API) Replay(
 				rf = &readFramebuffer{}
 			}
 			deadCodeElimination.Request(req.after)
-			// HACK: Also ensure we have framebuffer before the command.
-			// TODO: Remove this and handle swap-buffers better.
-			deadCodeElimination.Request(req.after - 1)
 
 			thread := cmds[req.after].Thread()
 			switch req.attachment {


### PR DESCRIPTION
Do mutate before rather then after. It didn't matter in the initial
prototype, but we have since added more complex code.  Doing it
before guards us from malformed commands, and having the state
already mutated seems to be more expected behaviour.

Simplify and improve texture reading based the new uniform model.

Remove the old -1 hack which was needed when we used to request
framebuffer right after eglSwapBuffers.