### PR TITLE
Handle SparseResidency sparse binding images

### DIFF
--- a/gapii/cc/vulkan_extras.inl
+++ b/gapii/cc/vulkan_extras.inl
@@ -153,6 +153,8 @@ void SpyOverride_RecreateBindImageMemory(VkDevice, VkImage, VkDeviceMemory,
                                          VkDeviceSize offset,
                                          uint32_t bindCount,
                                          VkSparseMemoryBind* binds) {}
+void SpyOverride_RecreateBindImageSparseMemoryBindings(
+    VkDevice, VkImage, uint32_t, VkSparseImageMemoryBind*) {}
 void SpyOverride_RecreateImageData(VkDevice, VkImage,
                                    uint32_t /*VkImageLayout*/,
                                    uint32_t hostMemoryIndex, VkQueue,

--- a/gapii/cc/vulkan_extras.inl
+++ b/gapii/cc/vulkan_extras.inl
@@ -147,18 +147,24 @@ void SpyOverride_RecreateSwapchain(VkDevice, const VkSwapchainCreateInfoKHR*,
                                    VkSwapchainKHR*) {}
 void SpyOverride_RecreateImage(
     VkDevice, const VkImageCreateInfo*, VkImage*,
-    VkMemoryRequirements* pMemoryRequirements, uint32_t sparseMemoryRequirementCount,
+    VkMemoryRequirements* pMemoryRequirements,
+    uint32_t sparseMemoryRequirementCount,
     VkSparseImageMemoryRequirements* pSparseMemoryRequirements) {}
-void SpyOverride_RecreateBindImageMemory(VkDevice, VkImage, VkDeviceMemory,
+void SpyOverride_RecreateImageMemoryBindings(VkDevice, VkImage, VkDeviceMemory,
                                          VkDeviceSize offset,
-                                         uint32_t bindCount,
-                                         VkSparseMemoryBind* binds) {}
-void SpyOverride_RecreateBindImageSparseMemoryBindings(
-    VkDevice, VkImage, uint32_t, VkSparseImageMemoryBind*) {}
-void SpyOverride_RecreateImageData(VkDevice, VkImage,
-                                   uint32_t /*VkImageLayout*/,
-                                   uint32_t hostMemoryIndex, VkQueue,
-                                   VkDeviceSize dataSize, void* data) {}
+                                         uint32_t opaqueBindCount,
+                                         VkSparseMemoryBind* pOpaqueBinds,
+                                         uint32_t imageBindCount,
+                                         VkSparseImageMemoryBind* pImageBinds) {}
+void SpyOverride_RecreateImageSubrangeData(VkDevice, VkImage,
+                                           uint32_t /*VkImageLayout*/,
+                                           VkImageSubresourceRange* range,
+                                           uint32_t hostMemoryIndex, VkQueue,
+                                           VkDeviceSize resourceOffset,
+                                           VkDeviceSize dataSize, void* data) {}
+void SpyOverride_RecreateSparseImageBindData(
+    VkDevice, VkImage, uint32_t /*VkImageLayout*/, VkSparseImageMemoryBind*,
+    uint32_t hostMemoryIndex, VkQueue, VkDeviceSize dataSize, void* data) {}
 void SpyOverride_RecreateImageView(VkDevice, const VkImageViewCreateInfo*,
                                    VkImageView*) {}
 void SpyOverride_RecreateSampler(VkDevice, const VkSamplerCreateInfo*,
@@ -176,13 +182,17 @@ void SpyOverride_RecreateComputePipeline(VkDevice, VkPipelineCache,
                                          const VkComputePipelineCreateInfo*,
                                          VkPipeline*) {}
 void SpyOverride_RecreateBuffer(VkDevice, VkBufferCreateInfo*, VkBuffer*) {}
-void SpyOverride_RecreateBindBufferMemory(VkDevice, VkBuffer, VkDeviceMemory,
-                                          VkDeviceSize offset,
-                                          uint32_t bindCount,
-                                          VkSparseMemoryBind* binds) {}
-void SpyOverride_RecreateBufferData(VkDevice, VkBuffer,
+void SpyOverride_RecreateBufferMemoryBindings(VkDevice, VkBuffer,
+                                              VkDeviceMemory,
+                                              VkDeviceSize offset,
+                                              uint32_t sparseBindCount,
+                                              VkSparseMemoryBind* binds) {}
+void SpyOverride_RecreateBufferData(VkDevice, VkBuffer, VkDeviceSize,
+                                    VkDeviceSize,
                                     uint32_t hostBufferMemoryIndex, VkQueue,
                                     void* data) {}
+void SpyOverride_RecreateSparseBufferData(VkDevice, VkBuffer, VkDeviceSize,
+                                          VkDeviceSize, void*) {}
 void SpyOverride_RecreateBufferView(VkDevice, const VkBufferViewCreateInfo*,
                                     VkBufferView*) {}
 void SpyOverride_RecreatePhysicalDeviceProperties(
@@ -222,7 +232,6 @@ uint32_t SpyOverride_createImageAndCacheMemoryRequirements(
 void SpyOverride_cacheImageSparseMemoryRequirements(
     VkDevice device, VkImage image, uint32_t count,
     VkSparseImageMemoryRequirements* pSparseMemoryRequirements);
-
 
 class SparseBindingInterval {
  public:

--- a/gapis/api/vulkan/externs.go
+++ b/gapis/api/vulkan/externs.go
@@ -1112,8 +1112,10 @@ func bindSparse(ctx context.Context, s *api.GlobalState, binds *QueuedSparseBind
 	}
 	for image, binds := range binds.ImageBinds.Range() {
 		for _, bind := range binds.SparseImageMemoryBinds.Range() {
-			log.W(ctx, "sparse binding: image: %v, bindinfo: %v", image, bind)
-			log.W(ctx, "Image sparse residency binding is currently not supported")
+			imgObj := st.Images.Get(image)
+			if imgObj != nil {
+				addSparseImageBinding(imgObj.SparseImageMemoryBindings, bind)
+			}
 		}
 	}
 }

--- a/gapis/api/vulkan/sparse_binding.go
+++ b/gapis/api/vulkan/sparse_binding.go
@@ -85,3 +85,36 @@ func fullyCover(orig, new VkSparseImageMemoryBind) bool {
 	}
 	return true
 }
+
+func partiallyCover(orig, new VkSparseImageMemoryBind) bool {
+	origAspect := orig.Subresource.AspectMask
+	newAspect := new.Subresource.AspectMask
+	if newAspect&origAspect != origAspect {
+		return false
+	}
+	if orig.Subresource.MipLevel != new.Subresource.MipLevel {
+		return false
+	}
+	if orig.Subresource.ArrayLayer != new.Subresource.ArrayLayer {
+		return false
+	}
+	if !rangeOverlap(orig.Offset.X, orig.Extent.Width, new.Offset.X, new.Extent.Width) {
+		return false
+	}
+	if !rangeOverlap(orig.Offset.Y, orig.Extent.Height, new.Offset.Y, new.Extent.Height) {
+		return false
+	}
+	if !rangeOverlap(orig.Offset.Z, orig.Extent.Depth, new.Offset.Z, new.Extent.Depth) {
+		return false
+	}
+	return true
+}
+
+func rangeOverlap(x1 int32, xd uint32, y1 int32, yd uint32) bool {
+	x2 := x1 + int32(xd)
+	y2 := y1 + int32(yd)
+	if x1 < y2 && y1 < x2 {
+		return true
+	}
+	return false
+}

--- a/gapis/api/vulkan/sparse_binding.go
+++ b/gapis/api/vulkan/sparse_binding.go
@@ -49,3 +49,39 @@ func addSparseBinding(l sparseBindingList, b *VkSparseMemoryBind) (sparseBinding
 	}
 	return sparseBindingList(nl), nil
 }
+
+func addSparseImageBinding(bs U32ːVkSparseImageMemoryBindᵐ, b VkSparseImageMemoryBind) {
+	last := uint32(0)
+	for i, eb := range bs.Range() {
+		if fullyCover(eb, b) {
+			bs.Delete(i)
+		}
+		if i > last {
+			last = i
+		}
+	}
+	bs.Set(last+1, b)
+}
+
+func fullyCover(orig, new VkSparseImageMemoryBind) bool {
+	origAspect := orig.Subresource.AspectMask
+	newAspect := new.Subresource.AspectMask
+	if newAspect&origAspect != origAspect {
+		return false
+	}
+	if orig.Subresource.MipLevel != new.Subresource.MipLevel {
+		return false
+	}
+	if orig.Subresource.ArrayLayer != new.Subresource.ArrayLayer {
+		return false
+	}
+	if new.Offset.X > orig.Offset.X || new.Offset.Y > orig.Offset.Y || new.Offset.Z > orig.Offset.Z {
+		return false
+	}
+	if new.Offset.X+int32(new.Extent.Width) < orig.Offset.X+int32(orig.Extent.Width) ||
+		new.Offset.Y+int32(new.Extent.Height) < orig.Offset.Y+int32(orig.Extent.Height) ||
+		new.Offset.Z+int32(new.Extent.Depth) < orig.Offset.Z+int32(orig.Extent.Depth) {
+		return false
+	}
+	return true
+}

--- a/gapis/api/vulkan/templates/vk_spy_helpers.cpp.tmpl
+++ b/gapis/api/vulkan/templates/vk_spy_helpers.cpp.tmpl
@@ -531,6 +531,39 @@ bool VulkanSpy::hasDynamicProperty(CallObserver* observer, VkPipelineDynamicStat
 void VulkanSpy::mapMemory(CallObserver*, void**, Slice<uint8_t>) {}
 void VulkanSpy::unmapMemory(CallObserver*, Slice<uint8_t>) {}
 
+namespace {
+// A helper function to check if a coming VkSparseImageMemoryBind can fully
+// cover (overwrite) an existing original bind.
+bool fullyCover(const VkSparseImageMemoryBind& orig,
+                const VkSparseImageMemoryBind& coming) {
+  auto orig_aspect = orig.msubresource.maspectMask;
+  auto coming_aspect = coming.msubresource.maspectMask;
+  if ((coming_aspect & orig_aspect) != orig_aspect) {
+    return false;
+  }
+  if (orig.msubresource.mmipLevel != coming.msubresource.mmipLevel) {
+    return false;
+  }
+  if (orig.msubresource.marrayLayer != coming.msubresource.marrayLayer) {
+    return false;
+  }
+  if (coming.moffset.mx > orig.moffset.mx ||
+      coming.moffset.my > orig.moffset.my ||
+      coming.moffset.mz > orig.moffset.mz) {
+    return false;
+  }
+  if (coming.moffset.mx + int32_t(coming.mextent.mWidth) <
+          orig.moffset.mx + int32_t(coming.mextent.mWidth) ||
+      coming.moffset.my + int32_t(coming.mextent.mHeight) <
+          orig.moffset.my + int32_t(coming.mextent.mHeight) ||
+      coming.moffset.mz + int32_t(coming.mextent.mDepth) <
+          orig.moffset.mz + int32_t(coming.mextent.mDepth)) {
+    return false;
+  }
+  return true;
+}
+}
+
 void VulkanSpy::execPendingCommands(CallObserver* observer, VkQueue queue) {
   LastBoundQueue = Queues[queue];
   U32ToCommandReference newPendingCommands;
@@ -585,6 +618,21 @@ void VulkanSpy::execPendingCommands(CallObserver* observer, VkQueue queue) {
             }
             Images[img]->mOpaqueSparseMemoryBindings[i] =
                 mOpaqueImageSparseBindings[img][i].sparseMemoryBind();
+          }
+          for (const auto& ib : cmd.mSparseBinds->mImageBinds) {
+            VkImage img = ib.first;
+            for (const auto& b : ib.second->mSparseImageMemoryBinds) {
+              uint32_t last = 0;
+              for (const auto& eb : Images[img]->mSparseImageMemoryBindings) {
+                if (eb.first > last) {
+                  last = eb.first;
+                }
+                if (fullyCover(eb.second, b.second)) {
+                  Images[img]->mSparseImageMemoryBindings.erase(eb.first);
+                }
+              }
+              Images[img]->mSparseImageMemoryBindings[last+1] = b.second;
+            }
           }
         }
       }

--- a/gapis/api/vulkan/vulkan.api
+++ b/gapis/api/vulkan/vulkan.api
@@ -3143,6 +3143,22 @@ cmd void RecreateBindImageMemory(
     }
 }
 
+@override
+@custom
+@no_replay
+cmd void RecreateBindImageSparseMemoryBindings(
+    VkDevice device,
+    VkImage image,
+    u32 count,
+    const VkSparseImageMemoryBind* pBinds) {
+  if count > 0 {
+    binds := pBinds[0:count]
+    for i in (0 .. count) {
+      _ = binds[i]
+    }
+  }
+}
+
 @indirect("VkDevice")
 cmd VkResult vkBindImageMemory(
     VkDevice       device,
@@ -9131,6 +9147,7 @@ enum SemaphoreUpdate {
   ref!DeviceMemoryObject    BoundMemory
   VkDeviceSize              BoundMemoryOffset
   map!(u32, VkSparseMemoryBind) OpaqueSparseMemoryBindings
+  map!(u32, VkSparseImageMemoryBind) SparseImageMemoryBindings
   @unused bool              IsSwapchainImage
   VkImage                   VulkanHandle
   ImageInfo                 Info

--- a/gapis/api/vulkan/vulkan.api
+++ b/gapis/api/vulkan/vulkan.api
@@ -1510,7 +1510,7 @@ class VkMemoryRequirements {
 }
 
 class VkSparseImageFormatProperties {
-  VkImageAspectFlagBits    aspectMask
+  VkImageAspectFlags       aspectMask
   VkExtent3D               imageGranularity
   VkSparseImageFormatFlags flags
 }
@@ -1544,7 +1544,7 @@ class VkSparseImageOpaqueMemoryBindInfo {
 }
 
 class VkImageSubresource {
-  VkImageAspectFlagBits aspectMask
+  VkImageAspectFlags    aspectMask
   u32                   mipLevel
   u32                   arrayLayer
 }
@@ -3077,6 +3077,8 @@ cmd void RecreateState() {
 cmd void RecreateBufferData(
     VkDevice device,
     VkBuffer buffer,
+    VkDeviceSize offset,
+    VkDeviceSize size,
     u32      hostBufferMemoryIndex,
     VkQueue  lastBoundQueue,
     void*    data) {
@@ -3086,7 +3088,7 @@ cmd void RecreateBufferData(
 @override
 @custom
 @no_replay
-cmd void RecreateBindBufferMemory(
+cmd void RecreateBufferMemoryBindings(
     VkDevice       device,
     VkBuffer       buffer,
     VkDeviceMemory memory,
@@ -3113,50 +3115,62 @@ cmd VkResult vkBindBufferMemory(
 @override
 @custom
 @no_replay
-cmd void RecreateImageData(
+cmd void RecreateImageSubrangeData(
     VkDevice      device,
     VkImage       image,
     VkImageLayout lastLayout,
+    const VkImageSubresourceRange* pRange,
     u32           hostMemoryIndex,
     VkQueue       lastBoundQueue,
+    VkDeviceSize  resourceOffset,
     VkDeviceSize  dataSize,
     void*         data) {
+  _ = pRange[0]
   read(as!u8*(data)[0:dataSize])
 }
 
 @override
 @custom
 @no_replay
-cmd void RecreateBindImageMemory(
-    VkDevice       device,
-    VkImage        image,
-    VkDeviceMemory memory,
-    VkDeviceSize   offset,
-    u32            opaqueSparseBindCount,
-    const VkSparseMemoryBind* pOpaqueSparseBinds) {
-    if opaqueSparseBindCount > 0 {
-      binds := pOpaqueSparseBinds[0:opaqueSparseBindCount]
-      for i in (0 .. opaqueSparseBindCount) {
-        bind := binds[i]
-        _ = bind
-      }
-    }
+cmd void RecreateSparseImageBindData(
+    VkDevice      device,
+    VkImage       image,
+    VkImageLayout lastLayout,
+    VkSparseImageMemoryBind* pImageSparseBind,
+    u32           hostMemoryIndex,
+    VkQueue       lastBoundQueue,
+    VkDeviceSize  dataSize,
+    void*         data) {
+  _ = pImageSparseBind[0]
+  read(as!u8*(data)[0:dataSize])
 }
 
 @override
 @custom
 @no_replay
-cmd void RecreateBindImageSparseMemoryBindings(
-    VkDevice device,
-    VkImage image,
-    u32 count,
-    const VkSparseImageMemoryBind* pBinds) {
-  if count > 0 {
-    binds := pBinds[0:count]
-    for i in (0 .. count) {
-      _ = binds[i]
+cmd void RecreateImageMemoryBindings(
+    VkDevice       device,
+    VkImage        image,
+    VkDeviceMemory memory,
+    VkDeviceSize   offset,
+    u32            opaqueSparseBindCount,
+    const VkSparseMemoryBind* pOpaqueSparseBinds,
+    u32            imageSparseBindCount,
+    const VkSparseImageMemoryBind* pImageSparseBinds) {
+    if opaqueSparseBindCount > 0 {
+      opaqueBinds := pOpaqueSparseBinds[0:opaqueSparseBindCount]
+      for i in (0 .. opaqueSparseBindCount) {
+        ob := opaqueBinds[i]
+        _ = ob
+      }
     }
-  }
+    if imageSparseBindCount > 0 {
+      imageBinds := pImageSparseBinds[0:imageSparseBindCount]
+      for i in (0 .. imageSparseBindCount) {
+        ib := imageBinds[i]
+        _ = ib
+      }
+    }
 }
 
 @indirect("VkDevice")


### PR DESCRIPTION
We actually can NOT interpret an image sparse binding area (specified with subresource, miplevel, arrayLayer, offset3D and extent3D) into a number of continuous linear ranges.
The reason is that:
- To calculate the address of each texel, we need to call `vkGetImageSubresourceLayout()`, which is only valid if the given image is created with `linear tiling`. However, SparseResidency does not work with `linear tiling` images
> A sparse image created using VK_IMAGE_CREATE_SPARSE_RESIDENCY_BIT supports all non-compressed color formats with power-of-two element size that non-sparse usage supports. Additional formats may also be supported and can be queried via vkGetPhysicalDeviceSparseImageFormatProperties. VK_IMAGE_TILING_LINEAR tiling is not supported.

This CL records all the sparse image bindings in the time order. If a later binding is found to fully overwrite a previous binding, then the previous one will be removed.
For MEC, the `memory` field of each `bind` will be checked with the state block to guarantee the memory exist.
However, this may still have some problems. For example, a not-fully-overwritten previous bound may have its overwritten part bound to something else at the time of resource enumeration, then it can be invalid to recover the whole bound in MEC, as the memory may have already been bound to other resources prior to the `RecreateBindImageSparseMemoryBinding` call.