### PR TITLE
gapii/cc/android: Add missing include.

### DIFF
--- a/gapii/cc/android/installer.cpp
+++ b/gapii/cc/android/installer.cpp
@@ -21,6 +21,7 @@
 #include "core/cc/get_gles_proc_address.h"
 #include "core/cc/log.h"
 
+#include <cstring>
 #include <dlfcn.h>
 
 #include <unordered_map>


### PR DESCRIPTION
I'm unsure why this only affects the mac build.