### PR TITLE
GAPIR crash reporting

### DIFF
--- a/core/app/atexit.go
+++ b/core/app/atexit.go
@@ -85,7 +85,6 @@ func handleAbortSignals(cancel task.CancelFunc) {
 
 func handleCrashSignals(ctx context.Context, cancel task.CancelFunc) {
 	crash.Register(func(err interface{}, callstack stacktrace.Callstack) {
-		defer cancel()
 		log.F(ctx, false, "Crash: %v (%T)\n%v", err, err, callstack)
 	})
 }

--- a/core/app/crash/reporting/encoder_test.go
+++ b/core/app/crash/reporting/encoder_test.go
@@ -30,8 +30,7 @@ func TestEncoder(t *testing.T) {
 		appVersion: "V1.2.3",
 		osName:     "BobOS",
 		osVersion:  "10",
-		stacktrace: "foo1.bar 10:20\nfoo2.bar 20:30",
-	}.encode()
+	}.encodeStacktrace("foo1.bar 10:20\nfoo2.bar 20:30")
 	if assert.For(ctx, "err").ThatError(err).Succeeded() {
 		assert.For(ctx, "ty").ThatString(ty).Equals("multipart/form-data; boundary=" + multipartBoundary)
 		bytes, err := ioutil.ReadAll(r)

--- a/core/app/crash/reporting/reporting.go
+++ b/core/app/crash/reporting/reporting.go
@@ -80,6 +80,7 @@ func Disable() {
 	}
 }
 
+// ReportMinidump encodes and sends a minidump report to the crashURL endpoint.
 func ReportMinidump(r Reporter, minidumpName string, minidumpData []byte) error {
 	if disable != nil {
 		if err := r.reportMinidump(minidumpName, minidumpData, crashURL); err != nil {
@@ -89,6 +90,7 @@ func ReportMinidump(r Reporter, minidumpName string, minidumpData []byte) error 
 	return nil
 }
 
+// Reporter stores the common information sent in a crash report.
 type Reporter struct {
 	AppName    string
 	AppVersion string

--- a/core/app/crash/reporting/reporting_test.go
+++ b/core/app/crash/reporting/reporting_test.go
@@ -30,12 +30,12 @@ func TestReport(t *testing.T) {
 	if testCrashReport {
 		ctx := log.Testing(t)
 
-		err := reporter{
-			appName:    "crash-reporting-test",
-			appVersion: "0",
-			osName:     "unknown",
-			osVersion:  "unknown",
-		}.report(stacktrace.Capture(), crashStagingURL)
+		err := Reporter{
+			AppName:    "crash-reporting-test",
+			AppVersion: "0",
+			OSName:     "unknown",
+			OSVersion:  "unknown",
+		}.reportStacktrace(stacktrace.Capture(), crashStagingURL)
 
 		assert.For(ctx, "err").ThatError(err).Succeeded()
 	}

--- a/core/cc/CMakeFiles.cmake
+++ b/core/cc/CMakeFiles.cmake
@@ -25,6 +25,7 @@ set(files
     connection.h
     connection_test.cpp
     core_ptr_types.h
+    crash_handler.cpp
     crash_handler.h
     crash_handler_test.cpp
     debugger.h
@@ -33,6 +34,8 @@ set(files
     encoder.cpp
     encoder.h
     encoder_test.cpp
+    file_reader.cpp
+    file_writer.h
     file_writer.cpp
     file_writer.h
     get_gles_proc_address.h

--- a/core/cc/android/crash_handler.cpp
+++ b/core/cc/android/crash_handler.cpp
@@ -41,4 +41,4 @@ CrashHandler::CrashHandler() :
 // The incomplete type is the previously forward declared google_breakpad::ExceptionHandler.
 CrashHandler::~CrashHandler() = default;
 
-}
+} // namespace core

--- a/core/cc/android/crash_handler.cpp
+++ b/core/cc/android/crash_handler.cpp
@@ -30,8 +30,8 @@ static bool handleCrash(const google_breakpad::MinidumpDescriptor& descriptor, v
 
 namespace core {
 
-CrashHandler::CrashHandler(HandlerFunction handlerFunction) :
-    mHandlerFunction(handlerFunction),
+CrashHandler::CrashHandler() :
+    mHandlerFunction(),
     mHandler(new google_breakpad::ExceptionHandler(
             google_breakpad::MinidumpDescriptor("./crashes"),
             NULL, ::handleCrash, reinterpret_cast<void*>(this), true, -1)) {

--- a/core/cc/crash_handler.cpp
+++ b/core/cc/crash_handler.cpp
@@ -40,4 +40,4 @@ bool CrashHandler::handleMinidump(const std::string& minidumpPath, bool succeede
 }
 
 
-}
+} // namespace core

--- a/core/cc/crash_handler.cpp
+++ b/core/cc/crash_handler.cpp
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "core/cc/crash_handler.h"
+#include "core/cc/log.h"
+
+namespace core {
+
+CrashHandler::HandlerFunction CrashHandler::defaultHandlerFunction =
+        [] (const std::string& minidump_path, bool succeeded) {
+            if (!succeeded) {
+                GAPID_ERROR("Failed to write minidump out to %s", minidump_path.c_str());
+            }
+            return succeeded;
+        };
+
+void CrashHandler::setHandlerFunction(HandlerFunction newHandlerFunction) {
+    mHandlerFunction = newHandlerFunction;
+}
+
+void CrashHandler::unsetHandlerFunction() {
+    mHandlerFunction = defaultHandlerFunction;
+}
+
+bool CrashHandler::handleMinidump(const std::string& minidumpPath, bool succeeded) {
+    return mHandlerFunction(minidumpPath, succeeded);
+}
+
+
+}

--- a/core/cc/crash_handler.h
+++ b/core/cc/crash_handler.h
@@ -32,16 +32,19 @@ class CrashHandler {
 public:
     typedef std::function<bool(const std::string& minidumpPath, bool succeeded)> HandlerFunction;
 
-    CrashHandler(HandlerFunction handlerFunction);
+    CrashHandler();
     ~CrashHandler();
 
-    bool handleMinidump(const std::string& minidumpPath, bool succeeded) {
-        return mHandlerFunction(minidumpPath, succeeded);
-    }
+    void setHandlerFunction(HandlerFunction newHandlerFunction);
+    void unsetHandlerFunction();
+
+    bool handleMinidump(const std::string& minidumpPath, bool succeeded);
 
 private:
     HandlerFunction mHandlerFunction;
     std::unique_ptr<google_breakpad::ExceptionHandler> mHandler;
+
+    static HandlerFunction defaultHandlerFunction;
 };
 
 }

--- a/core/cc/file_reader.cpp
+++ b/core/cc/file_reader.cpp
@@ -56,4 +56,4 @@ uint64_t FileReader::size() {
     return size;
 }
 
-}
+} // namespace core

--- a/core/cc/file_reader.cpp
+++ b/core/cc/file_reader.cpp
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "file_reader.h"
+
+#include "log.h"
+
+namespace core {
+
+FileReader::FileReader(const char* path) {
+    mFile = fopen(path, "rb");
+}
+FileReader::~FileReader() {
+    fclose(mFile);
+}
+
+const char* FileReader::error() const {
+    if (mFile == 0) {
+        return "File did not open";
+    }
+    return 0;
+}
+
+uint64_t FileReader::read(void* data, uint64_t max_size) {
+    return fread(data, 1, max_size, mFile);
+}
+
+uint64_t FileReader::size() {
+    // TODO: this is not portable, need to move to platform file.
+    if (fseek(mFile, 0, SEEK_END) != 0) {
+        GAPID_ERROR("Failed to seek to the end of file");
+        return 0u;
+    }
+
+    long int sizeTemp = ftell(mFile);
+    if (sizeTemp == -1L) {
+        GAPID_ERROR("Failed to get size of file")
+        rewind(mFile);
+        return 0u;
+    }
+    uint64_t size = static_cast<uint64_t>(sizeTemp);
+    rewind(mFile);
+    return size;
+}
+
+}

--- a/core/cc/file_reader.h
+++ b/core/cc/file_reader.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef CORE_FILE_READER_H
+#define CORE_FILE_READER_H
+
+#include "stream_reader.h"
+
+#include <stdio.h>
+#include <stdint.h>
+
+namespace core {
+
+// FileReader is a pure-virtual interface used to read from binary files.
+class FileReader : public StreamReader {
+public:
+    FileReader(const char* path);
+    ~FileReader();
+
+    // error returns an error string if the reader has encountered an error.
+    const char* error() const;
+
+    // read attempts to read max_size bytes to the pointer data, blocking until
+    // the data is available. Returns the number of bytes successfully read,
+    // which may be less than size if the stream was closed or there was an
+    // error.
+    virtual uint64_t read(void* data, uint64_t max_size);
+
+    // size returns the number of bytes in the underlying file.
+    uint64_t size();
+private:
+    FILE* mFile;
+};
+
+}  // namespace core
+
+#endif  // CORE_STREAM_READER_H

--- a/core/cc/file_reader.h
+++ b/core/cc/file_reader.h
@@ -24,7 +24,8 @@
 
 namespace core {
 
-// FileReader is a pure-virtual interface used to read from binary files.
+// FileReader is an implementation of the StreamReader interface that reads
+// from binary files.
 class FileReader : public StreamReader {
 public:
     FileReader(const char* path);

--- a/core/cc/linux/crash_handler.cpp
+++ b/core/cc/linux/crash_handler.cpp
@@ -43,4 +43,4 @@ CrashHandler::CrashHandler() :
 // The incomplete type is the previously forward declared google_breakpad::ExceptionHandler.
 CrashHandler::~CrashHandler() = default;
 
-}
+} // namespace core

--- a/core/cc/linux/crash_handler.cpp
+++ b/core/cc/linux/crash_handler.cpp
@@ -18,6 +18,8 @@
 
 #include "client/linux/handler/exception_handler.h"
 
+#include <stdlib.h>
+
 namespace {
 
 static bool handleCrash(const google_breakpad::MinidumpDescriptor& descriptor, void* crashHandlerPtr, bool succeeded) {
@@ -30,10 +32,10 @@ static bool handleCrash(const google_breakpad::MinidumpDescriptor& descriptor, v
 
 namespace core {
 
-CrashHandler::CrashHandler(HandlerFunction handlerFunction) :
-    mHandlerFunction(handlerFunction),
+CrashHandler::CrashHandler() :
+    mHandlerFunction(defaultHandlerFunction),
     mHandler(new google_breakpad::ExceptionHandler(
-            google_breakpad::MinidumpDescriptor("./crashes"),
+            google_breakpad::MinidumpDescriptor(getenv("TMPDIR")),
             NULL, ::handleCrash, reinterpret_cast<void*>(this), true, -1)) {
 }
 

--- a/core/cc/osx/crash_handler.cpp
+++ b/core/cc/osx/crash_handler.cpp
@@ -18,6 +18,8 @@
 
 #include "client/mac/handler/exception_handler.h"
 
+#include <stdlib.h>
+
 namespace {
 
 static bool handleCrash(const char* minidumpDir, const char* minidumpId, void* crashHandlerPtr, bool succeeded) {
@@ -31,10 +33,10 @@ static bool handleCrash(const char* minidumpDir, const char* minidumpId, void* c
 
 namespace core {
 
-CrashHandler::CrashHandler(HandlerFunction handlerFunction) :
-    mHandlerFunction(handlerFunction),
+CrashHandler::CrashHandler() :
+    mHandlerFunction(defaultHandlerFunction),
     mHandler(new google_breakpad::ExceptionHandler(
-            "./", NULL, ::handleCrash, reinterpret_cast<void*>(this), true, NULL)) {
+            getenv("TMPDIR"), NULL, ::handleCrash, reinterpret_cast<void*>(this), true, NULL)) {
 }
 
 // this prevents unique_ptr<CrashHandler> from causing an incomplete type error from inlining the destructor.

--- a/core/cc/osx/crash_handler.cpp
+++ b/core/cc/osx/crash_handler.cpp
@@ -43,4 +43,4 @@ CrashHandler::CrashHandler() :
 // The incomplete type is the previously forward declared google_breakpad::ExceptionHandler.
 CrashHandler::~CrashHandler() = default;
 
-}
+} // namespace core

--- a/core/cc/windows/crash_handler.cpp
+++ b/core/cc/windows/crash_handler.cpp
@@ -59,4 +59,4 @@ CrashHandler::CrashHandler() : mHandlerFunction(defaultHandlerFunction) {
 // The incomplete type is the previously forward declared google_breakpad::ExceptionHandler.
 CrashHandler::~CrashHandler() = default;
 
-}
+} // namespace core

--- a/gapir/cc/CMakeFiles.cmake
+++ b/gapir/cc/CMakeFiles.cmake
@@ -23,6 +23,8 @@ set(files
     context.cpp
     context.h
     context_test.cpp
+    crash_uploader.cpp
+    crash_uploader.h
     function_table.h
     gfx_api.h
     gles_gfx_api.cpp

--- a/gapir/cc/crash_uploader.cpp
+++ b/gapir/cc/crash_uploader.cpp
@@ -51,7 +51,7 @@ CrashUploader::CrashUploader(
             return false;
         }
 
-        if (!mConnection.crash(minidumpPath, minidumpData.get(), minidumpSize)) {
+        if (!mConnection.postCrashdump(minidumpPath, minidumpData.get(), minidumpSize)) {
             GAPID_ERROR("Failed to send minidump to server");
             return false;
         }
@@ -64,4 +64,4 @@ CrashUploader::~CrashUploader() {
     mCrashHandler.unsetHandlerFunction();
 }
 
-}
+} // namespace gapir

--- a/gapir/cc/crash_uploader.h
+++ b/gapir/cc/crash_uploader.h
@@ -37,6 +37,6 @@ private:
   const ServerConnection& mConnection;
 };
 
-}
+} // namespace gapir
 
 #endif // GAPIR_CRASH_REPORTER_H

--- a/gapir/cc/crash_uploader.h
+++ b/gapir/cc/crash_uploader.h
@@ -14,28 +14,29 @@
  * limitations under the License.
  */
 
-#include "crash_handler.h"
+#ifndef GAPIR_CRASH_REPORTER_H
+#define GAPIR_CRASH_REPORTER_H
 
-#include <gtest/gtest.h>
+#include "core/cc/crash_handler.h"
+#include "gapir/cc/server_connection.h"
 
-#include <stdlib.h>
-#include <iostream>
+#include <memory>
+#include <string>
 
-namespace core {
-namespace test {
+namespace gapir {
 
-TEST(CrashHandlerTest, HandleCrash) {
-    CrashHandler crashHandler;
-    crashHandler.setHandlerFunction([] (const std::string& minidumpPath, bool succeeded) {
-        if (succeeded)
-            std::cerr << "crash handled.";
-        else
-            std::cerr << "crash not handled.";
-        return succeeded;
-    });
+// CrashUploader uploads crash minidumps from a CrashHandler to GAPIS via a ServerConnection.
+class CrashUploader {
+public:
+  CrashUploader(core::CrashHandler& crash_handler, const ServerConnection& conn);
+  ~CrashUploader();
 
-    EXPECT_DEATH({ int i = *((volatile int*)(0)); }, "crash handled.");
+private:
+
+  core::CrashHandler& mCrashHandler;
+  const ServerConnection& mConnection;
+};
+
 }
 
-} // namespace test
-} // namespace core
+#endif // GAPIR_CRASH_REPORTER_H

--- a/gapir/cc/server_connection.cpp
+++ b/gapir/cc/server_connection.cpp
@@ -126,8 +126,8 @@ bool ServerConnection::post(const void* postData, uint32_t postSize) const {
     return true;
 }
 
-bool ServerConnection::crash(const std::string& filename, const void* crashData, uint32_t crashSize) const {
-    GAPID_DEBUG("CRASH: [%s] %p (%d)", filename.c_str(), crashData, crashSize);
+bool ServerConnection::postCrashdump(const std::string& filename, const void* crashData, uint32_t crashSize) const {
+    GAPID_WARNING("CRASH: [%s] %p (%d)", filename.c_str(), crashData, crashSize);
 
     MessageType type = MESSAGE_TYPE_CRASH;
     if (mConn->send(&type, sizeof(type)) != sizeof(type)) {

--- a/gapir/cc/server_connection.cpp
+++ b/gapir/cc/server_connection.cpp
@@ -126,4 +126,31 @@ bool ServerConnection::post(const void* postData, uint32_t postSize) const {
     return true;
 }
 
+bool ServerConnection::crash(const std::string& filename, const void* crashData, uint32_t crashSize) const {
+    GAPID_DEBUG("CRASH: [%s] %p (%d)", filename.c_str(), crashData, crashSize);
+
+    MessageType type = MESSAGE_TYPE_CRASH;
+    if (mConn->send(&type, sizeof(type)) != sizeof(type)) {
+        GAPID_WARNING("Failed to send CRASH messageType to the server. Error: %s", mConn->error());
+        return false;
+    }
+
+    if (!mConn->sendString(filename)) {
+        GAPID_WARNING("Failed to send CRASH filename to the server. Error: %s", mConn->error());
+        return false;
+    }
+
+    if (mConn->send(&crashSize, sizeof(crashSize)) != sizeof(crashSize)) {
+        GAPID_WARNING("Failed to send CRASH length to the server. Error: %s", mConn->error());
+        return false;
+    }
+
+    if (mConn->send(crashData, crashSize) != crashSize) {
+        GAPID_WARNING("Failed to send CRASH content to the server. Error: %s", mConn->error());
+        return false;
+    }
+
+    return true;
+}
+
 }  // namespace gapir

--- a/gapir/cc/server_connection.h
+++ b/gapir/cc/server_connection.h
@@ -56,11 +56,16 @@ public:
     // the posting was successful false otherwise.
     bool post(const void* postData, uint32_t postSize) const;
 
+    // Post a crash minidump from the given address with the given filename to the server. Returns
+    // true if the posting was successful false otherwise.
+    bool crash(const std::string& filename, const void* crashData, uint32_t crashSize) const;
+
     // Type of the message sent to the server. It have to be consistent with the values expected by
     // the server
     enum MessageType : uint8_t {
-        MESSAGE_TYPE_GET  = 0,
-        MESSAGE_TYPE_POST = 1,
+        MESSAGE_TYPE_GET   = 0,
+        MESSAGE_TYPE_POST  = 1,
+        MESSAGE_TYPE_CRASH = 2,
     };
 
 private:

--- a/gapir/cc/server_connection.h
+++ b/gapir/cc/server_connection.h
@@ -58,7 +58,7 @@ public:
 
     // Post a crash minidump from the given address with the given filename to the server. Returns
     // true if the posting was successful false otherwise.
-    bool crash(const std::string& filename, const void* crashData, uint32_t crashSize) const;
+    bool postCrashdump(const std::string& filename, const void* crashData, uint32_t crashSize) const;
 
     // Type of the message sent to the server. It have to be consistent with the values expected by
     // the server

--- a/gapis/replay/batch.go
+++ b/gapis/replay/batch.go
@@ -188,6 +188,7 @@ func (m *Manager) execute(
 			decoder,
 			connection,
 			replayABI.MemoryLayout,
+			d.Instance().GetConfiguration().GetOS(),
 		)
 	})
 	return err

--- a/gapis/replay/protocol/replay_protocol.proto
+++ b/gapis/replay/protocol/replay_protocol.proto
@@ -33,6 +33,8 @@ enum MessageType {
     Get = 0;
     // Post is sent for a packet containing postback data.
     Post = 1;
+    // Crash is sent for a packet containing a breakpad minidump.
+    Crash = 2;
 }
 
 // Type is one of the primitive types supported by the replay virtual machine.

--- a/test/integration/replay/postback_test.go
+++ b/test/integration/replay/postback_test.go
@@ -49,6 +49,7 @@ func doReplay(t *testing.T, f func(*builder.Builder)) {
 	device := bind.Host(ctx)
 	client := gapir.New(ctx)
 	abi := device.Instance().GetConfiguration().PreferredABI(nil)
+	os := device.Instance().GetConfiguration().GetOS()
 	connection, err := client.Connect(ctx, device, abi)
 	if err != nil {
 		t.Errorf("Failed to connect to '%v': %v", device, err)
@@ -64,7 +65,7 @@ func doReplay(t *testing.T, f func(*builder.Builder)) {
 		t.Errorf("Build failed with error: %v", err)
 	}
 
-	err = executor.Execute(ctx, payload, decoder, connection, abi.MemoryLayout)
+	err = executor.Execute(ctx, payload, decoder, connection, abi.MemoryLayout, os)
 	if err != nil {
 		t.Errorf("Executor failed with error: %v", err)
 	}


### PR DESCRIPTION
Now crash dumps in GAPIR will get uploaded to GAPIS via the server connection such that GAPIS can do the final upload to the crash server. Fixes the GAPIR crash reporting sub-task of #407.