### PR TITLE
Add the '--upgrade' flag to the pip command to fix OSX kokoro.

### DIFF
--- a/kokoro/macos/package.sh
+++ b/kokoro/macos/package.sh
@@ -59,7 +59,7 @@ done
 iconutil -c icns -o GAPID.app/Contents/Resources/GAPID.icns GAPID.iconset
 
 # Make a dmg file.
-pip install --user dmgbuild pyobjc-framework-Quartz
+pip install --upgrade --user dmgbuild pyobjc-framework-Quartz
 cp "$SRC"/background*.png .
 cp "$SRC/dmg-settings.py" .
 ~/Library/Python/2.7/bin/dmgbuild -s dmg-settings.py GAPID gapid-$VERSION-macos.dmg


### PR DESCRIPTION
The build is currently failing because of a new image, which now contains the pyobjc-framework-Quartz package, but at an old incompatibale version. Using the '--upgrade' flag will cause pip to install available updates of the requested packages and their deps.