### PR TITLE
 Fix two bugs in Vulkan DCE

### DIFF
--- a/gapii/cc/vulkan_extras.inl
+++ b/gapii/cc/vulkan_extras.inl
@@ -25,16 +25,6 @@ PFN_vkVoidFunction SpyOverride_vkGetInstanceProcAddr(VkInstance instance,
                                                      const char* pName);
 PFN_vkVoidFunction SpyOverride_vkGetDeviceProcAddr(VkDevice device,
                                                    const char* pName);
-void SpyOverride_prefetchPhysicalDeviceQueueFamilyProperties(
-    VkInstance instance, VkPhysicalDevice physicalDevice,
-    uint32_t* pQueueFamilyPropertyCount,
-    VkQueueFamilyProperties* pQueueFamilyProperties);
-void SpyOverride_prefetchPhysicalDeviceProperties(
-    VkInstance instance, VkPhysicalDevice physicalDevice,
-    VkPhysicalDeviceProperties* pProperties);
-uint32_t SpyOverride_vkEnumeratePhysicalDevices(
-    VkInstance instance, uint32_t* pPhysicalDeviceCount,
-    VkPhysicalDevice* pPhysicalDevices);
 uint32_t SpyOverride_vkEnumerateInstanceExtensionProperties(
     const char* pLayerName, uint32_t* pCount,
     VkExtensionProperties* pProperties);
@@ -231,5 +221,9 @@ static uint32_t CreateBufferAndGetMemoryRequirements(VkDevice,
                                                      VkBufferCreateInfo*,
                                                      VkAllocationCallbacks*,
                                                      VkBuffer*);
+
+static uint32_t EnumeratePhysicalDevicesAndCacheProperties(
+    VkInstance, uint32_t* pPhysicalDeviceCount,
+    VkPhysicalDevice* pPhysicalDevices);
 
 bool m_coherent_memory_tracking_enabled = false;

--- a/gapii/cc/vulkan_extras.inl
+++ b/gapii/cc/vulkan_extras.inl
@@ -181,10 +181,6 @@ void SpyOverride_RecreateGraphicsPipeline(VkDevice, VkPipelineCache,
 void SpyOverride_RecreateComputePipeline(VkDevice, VkPipelineCache,
                                          const VkComputePipelineCreateInfo*,
                                          VkPipeline*) {}
-uint32_t SpyOverride_createBufferAndCacheMemoryRequirements(
-    VkDevice device, VkBufferCreateInfo* pCreateInfo,
-    VkAllocationCallbacks* pAllocator, VkBuffer* pBuffer,
-    VkMemoryRequirements* pMemoryRequirements);
 void SpyOverride_RecreateBuffer(VkDevice, VkBufferCreateInfo*, VkBuffer*,
                                 VkMemoryRequirements*) {}
 void SpyOverride_RecreateBufferMemoryBindings(VkDevice, VkBuffer,
@@ -227,13 +223,13 @@ void SpyOverride_RecreateMirSurfaceKHR(VkDevice,
 
 void EnumerateVulkanResources(CallObserver* observer);
 
+static uint32_t CreateImageAndGetMemoryRequirements(VkDevice,
+                                                    VkImageCreateInfo*,
+                                                    VkAllocationCallbacks*,
+                                                    VkImage*);
+static uint32_t CreateBufferAndGetMemoryRequirements(VkDevice,
+                                                     VkBufferCreateInfo*,
+                                                     VkAllocationCallbacks*,
+                                                     VkBuffer*);
+
 bool m_coherent_memory_tracking_enabled = false;
-
-uint32_t SpyOverride_createImageAndCacheMemoryRequirements(
-    VkDevice device, VkImageCreateInfo* pCreateInfo,
-    VkAllocationCallbacks* pAllocator, VkImage* pImage,
-    VkMemoryRequirements* pMemoryRequirements);
-
-void SpyOverride_cacheImageSparseMemoryRequirements(
-    VkDevice device, VkImage image, uint32_t count,
-    VkSparseImageMemoryRequirements* pSparseMemoryRequirements);

--- a/gapis/api/transform/dce_test.go
+++ b/gapis/api/transform/dce_test.go
@@ -66,7 +66,7 @@ func (m *dummyMachine) Clear() {
 	m.undefined = map[dummyDefUseVar]struct{}{}
 }
 
-func (m *dummyMachine) FramebufferRequest(uint64, *dependencygraph.Footprint) {}
+func (m *dummyMachine) FramebufferRequest(api.CmdID, *dependencygraph.Footprint) {}
 
 func TestDCE(t *testing.T) {
 	ctx := log.Testing(t)

--- a/gapis/api/vulkan/footprint_builder.go
+++ b/gapis/api/vulkan/footprint_builder.go
@@ -2978,9 +2978,7 @@ func (vb *FootprintBuilder) BuildFootprint(ctx context.Context,
 	case *VkCreateInstance,
 		*RecreateInstance:
 		bh.Alive = true
-	case *VkEnumeratePhysicalDevices,
-		*PrefetchPhysicalDeviceProperties,
-		*PrefetchPhysicalDeviceQueueFamilyProperties:
+	case *VkEnumeratePhysicalDevices:
 		bh.Alive = true
 	case *VkCreateDevice,
 		*RecreateDevice,

--- a/gapis/api/vulkan/templates/vk_spy_helpers.cpp.tmpl
+++ b/gapis/api/vulkan/templates/vk_spy_helpers.cpp.tmpl
@@ -119,7 +119,11 @@ PFN_vkVoidFunction VulkanSpy::SpyOverride_vkGetInstanceProcAddr(VkInstance insta
         {{if (Macro "IsIndirected" "Command" $c "IndirectOn" "VkInstance")}}
             {{$name := Macro "CmdName" $c}}
             if(!strcmp(pName, "{{$name}}"))
+            {{if eq $name "vkEnumeratePhysicalDevices"}}
+              return reinterpret_cast<PFN_vkVoidFunction>(VulkanSpy::EnumeratePhysicalDevicesAndCacheProperties);
+            {{else}}
               return reinterpret_cast<PFN_vkVoidFunction>(gapii::{{$name}});
+            {{end}}
         {{end}}
     {{end}}
 
@@ -652,46 +656,6 @@ uint32_t VulkanSpy::SpyOverride_vkAllocateMemory(VkDevice device, VkMemoryAlloca
     return r;
 }
 
-void VulkanSpy::SpyOverride_prefetchPhysicalDeviceProperties(
-    VkInstance instance, VkPhysicalDevice physicalDevice,
-    VkPhysicalDeviceProperties* pProperties) {
-  return mImports.mVkInstanceFunctions[instance].vkGetPhysicalDeviceProperties(
-      physicalDevice, pProperties);
-}
-
-void VulkanSpy::SpyOverride_prefetchPhysicalDeviceQueueFamilyProperties(
-    VkInstance instance, VkPhysicalDevice physicalDevice,
-    uint32_t* pQueueFamilyPropertyCount,
-    VkQueueFamilyProperties* pQueueFamilyProperties) {
-  return mImports.mVkInstanceFunctions[instance]
-      .vkGetPhysicalDeviceQueueFamilyProperties(
-          physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties);
-}
-
-uint32_t VulkanSpy::SpyOverride_vkEnumeratePhysicalDevices(
-VkInstance instance, uint32_t* pPhysicalDeviceCount,
-VkPhysicalDevice* pPhysicalDevices) {
-    uint32_t fill_count = pPhysicalDevices? *pPhysicalDeviceCount : 0;
-    uint32_t r = mImports.mVkInstanceFunctions[instance].vkEnumeratePhysicalDevices(instance, pPhysicalDeviceCount, pPhysicalDevices);
-    if (fill_count > *pPhysicalDeviceCount) {
-        fill_count = *pPhysicalDeviceCount;
-    }
-    for (size_t i = 0; i < fill_count; ++i) {
-        VkPhysicalDeviceProperties properties;
-        gapii::prefetchPhysicalDeviceProperties(instance, pPhysicalDevices[i],
-                                                &properties);
-        uint32_t queue_family_prop_count = 0;
-        gapii::prefetchPhysicalDeviceQueueFamilyProperties(
-            instance, pPhysicalDevices[i], &queue_family_prop_count, nullptr);
-        std::vector<VkQueueFamilyProperties> queue_family_properties(
-            queue_family_prop_count, VkQueueFamilyProperties{});
-        gapii::prefetchPhysicalDeviceQueueFamilyProperties(
-            instance, pPhysicalDevices[i], &queue_family_prop_count,
-            queue_family_properties.data());
-    }
-    return r;
-}
-
 uint32_t VulkanSpy::numberOfPNext(CallObserver* observer, void* pNext) {
   uint32_t counter = 0;
   while (pNext) {
@@ -737,6 +701,31 @@ uint32_t VulkanSpy::CreateBufferAndGetMemoryRequirements(
   if (result == gapii::VkResult::VK_SUCCESS) {
     gapii::VkMemoryRequirements mem_req{};
     gapii::vkGetBufferMemoryRequirements(device, *pBuffer, &mem_req);
+  }
+  return result;
+}
+
+uint32_t VulkanSpy::EnumeratePhysicalDevicesAndCacheProperties(
+    VkInstance instance, uint32_t* pPhysicalDeviceCount,
+    VkPhysicalDevice* pPhysicalDevices) {
+  uint32_t result = gapii::vkEnumeratePhysicalDevices(
+      instance, pPhysicalDeviceCount, pPhysicalDevices);
+  if ((result == gapii::VkResult::VK_SUCCESS) &&
+      (pPhysicalDevices != nullptr)) {
+    uint32_t dev_count = *pPhysicalDeviceCount;
+    std::vector<VkPhysicalDevice> devs(pPhysicalDevices,
+                                       pPhysicalDevices + dev_count);
+    for (VkPhysicalDevice dev : devs) {
+      gapii::VkPhysicalDeviceProperties dev_prop{};
+      gapii::vkGetPhysicalDeviceProperties(dev, &dev_prop);
+      uint32_t queue_family_count = 0;
+      gapii::vkGetPhysicalDeviceQueueFamilyProperties(dev, &queue_family_count,
+                                                      nullptr);
+      std::vector<VkQueueFamilyProperties> queue_family_props(
+          queue_family_count, VkQueueFamilyProperties{});
+      gapii::vkGetPhysicalDeviceQueueFamilyProperties(
+          dev, &queue_family_count, queue_family_props.data());
+    }
   }
   return result;
 }

--- a/gapis/api/vulkan/templates/vk_spy_helpers.cpp.tmpl
+++ b/gapis/api/vulkan/templates/vk_spy_helpers.cpp.tmpl
@@ -137,7 +137,13 @@ PFN_vkVoidFunction VulkanSpy::SpyOverride_vkGetDeviceProcAddr(VkDevice device, c
         {{if (Macro "IsIndirected" "Command" $c "IndirectOn" "VkDevice")}}
             {{$name := Macro "CmdName" $c}}
             if(!strcmp(pName, "{{$name}}"))
-                return reinterpret_cast<PFN_vkVoidFunction>(gapii::{{$name}});
+            {{if eq $name "vkCreateImage"}}
+              return reinterpret_cast<PFN_vkVoidFunction>(VulkanSpy::CreateImageAndGetMemoryRequirements);
+            {{else if eq $name "vkCreateBuffer"}}
+              return reinterpret_cast<PFN_vkVoidFunction>(VulkanSpy::CreateBufferAndGetMemoryRequirements);
+            {{else}}
+              return reinterpret_cast<PFN_vkVoidFunction>(gapii::{{$name}});
+            {{end}}
         {{end}}
     {{end}}
     // This is not strictly correct, but some applications incorrectly
@@ -418,93 +424,35 @@ uint32_t VulkanSpy::SpyOverride_vkCreateDevice(VkPhysicalDevice physicalDevice, 
     return result;
 }
 
-uint32_t VulkanSpy::SpyOverride_createBufferAndCacheMemoryRequirements(
+uint32_t VulkanSpy::SpyOverride_vkCreateBuffer(
     VkDevice device, VkBufferCreateInfo* pCreateInfo,
-    VkAllocationCallbacks* pAllocator, VkBuffer* pBuffer,
-    VkMemoryRequirements* pMemoryRequirements) {
-  uint32_t result = VkResult::VK_SUCCESS;
+    VkAllocationCallbacks* pAllocator, VkBuffer* pBuffer) {
   if (is_suspended()) {
     VkBufferCreateInfo override_create_info = *pCreateInfo;
     override_create_info.musage |=
         VkBufferUsageFlagBits::VK_BUFFER_USAGE_TRANSFER_SRC_BIT;
-    result = mImports.mVkDeviceFunctions[device].vkCreateBuffer(
+    return mImports.mVkDeviceFunctions[device].vkCreateBuffer(
         device, &override_create_info, pAllocator, pBuffer);
   } else {
-    result = mImports.mVkDeviceFunctions[device].vkCreateBuffer(
+    return mImports.mVkDeviceFunctions[device].vkCreateBuffer(
         device, pCreateInfo, pAllocator, pBuffer);
   }
-  if (result != VkResult::VK_SUCCESS) {
-    return result;
-  }
-  if (pMemoryRequirements != nullptr) {
-    mImports.mVkDeviceFunctions[device].vkGetBufferMemoryRequirements(
-        device, *pBuffer, pMemoryRequirements);
-  }
-  return result;
 }
-uint32_t VulkanSpy::SpyOverride_vkCreateBuffer(
-    VkDevice device, VkBufferCreateInfo* pCreateInfo,
-    VkAllocationCallbacks* pAllocator, VkBuffer* pBuffer) {
-  VkMemoryRequirements memReq;
-  return gapii::createBufferAndCacheMemoryRequirements(
-      device, pCreateInfo, pAllocator, pBuffer, &memReq);
-}
-
-uint32_t VulkanSpy::SpyOverride_createImageAndCacheMemoryRequirements(
-    VkDevice device, VkImageCreateInfo* pCreateInfo,
-    VkAllocationCallbacks* pAllocator, VkImage* pImage,
-    VkMemoryRequirements* pMemoryRequirements) {
-  uint32_t result = VkResult::VK_SUCCESS;
-  if (is_suspended() || is_observing()) {
-    VkImageCreateInfo override_create_info = *pCreateInfo;
-    override_create_info.musage |=
-        VkImageUsageFlagBits::VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
-    result = mImports.mVkDeviceFunctions[device].vkCreateImage(
-        device, &override_create_info, pAllocator, pImage);
-  } else {
-    result = mImports.mVkDeviceFunctions[device].vkCreateImage(
-        device, pCreateInfo, pAllocator, pImage);
-  }
-  if (result != VkResult::VK_SUCCESS) {
-    return result;
-  }
-
-  if (pMemoryRequirements != nullptr) {
-    mImports.mVkDeviceFunctions[device].vkGetImageMemoryRequirements(
-        device, *pImage, pMemoryRequirements);
-  }
-  return result;
-}
-
-void VulkanSpy::SpyOverride_cacheImageSparseMemoryRequirements(
-    VkDevice device, VkImage image, uint32_t count,
-    VkSparseImageMemoryRequirements* pSparseMemoryRequirements) {}
 
 uint32_t VulkanSpy::SpyOverride_vkCreateImage(VkDevice device,
                                               VkImageCreateInfo* pCreateInfo,
                                               VkAllocationCallbacks* pAllocator,
                                               VkImage* pImage) {
-  VkMemoryRequirements memReq;
-  uint32_t result = gapii::createImageAndCacheMemoryRequirements(
-      device, pCreateInfo, pAllocator, pImage, &memReq);
-  if (result != VkResult::VK_SUCCESS) {
-    return result;
+  if (is_suspended() || is_observing()) {
+    VkImageCreateInfo override_create_info = *pCreateInfo;
+    override_create_info.musage |=
+        VkImageUsageFlagBits::VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
+    return mImports.mVkDeviceFunctions[device].vkCreateImage(
+        device, &override_create_info, pAllocator, pImage);
+  } else {
+    return mImports.mVkDeviceFunctions[device].vkCreateImage(
+        device, pCreateInfo, pAllocator, pImage);
   }
-  // sparse memory requirement is only necessary if the image is created with
-  // VK_IMAGE_CREATE_SPARSE_RESIDENCY_BIT.
-  if ((pCreateInfo->mflags &
-       VkImageCreateFlagBits::VK_IMAGE_CREATE_SPARSE_RESIDENCY_BIT) != 0) {
-    uint32_t sparseMemReqCount = 0;
-    mImports.mVkDeviceFunctions[device].vkGetImageSparseMemoryRequirements(
-        device, *pImage, &sparseMemReqCount, nullptr);
-    std::vector<VkSparseImageMemoryRequirements> sparseMemReqs(
-        sparseMemReqCount, VkSparseImageMemoryRequirements{});
-    mImports.mVkDeviceFunctions[device].vkGetImageSparseMemoryRequirements(
-        device, *pImage, &sparseMemReqCount, sparseMemReqs.data());
-    gapii::cacheImageSparseMemoryRequirements(
-        device, *pImage, sparseMemReqCount, sparseMemReqs.data());
-  }
-  return result;
 }
 
 uint32_t VulkanSpy::SpyOverride_vkCreateSwapchainKHR(
@@ -758,5 +706,39 @@ void VulkanSpy::popDebugMarker(CallObserver*) {}
 void VulkanSpy::pushRenderPassMarker(CallObserver*, VkRenderPass) {}
 void VulkanSpy::popRenderPassMarker(CallObserver*) {}
 void VulkanSpy::popAndPushMarkerForNextSubpass(CallObserver*, uint32_t) {}
+
+uint32_t VulkanSpy::CreateImageAndGetMemoryRequirements(
+    VkDevice device, VkImageCreateInfo* pCreateInfo,
+    VkAllocationCallbacks* pAllocator, VkImage* pImage) {
+  uint32_t result =
+      gapii::vkCreateImage(device, pCreateInfo, pAllocator, pImage);
+  if (result == gapii::VkResult::VK_SUCCESS) {
+    gapii::VkMemoryRequirements mem_req{};
+    gapii::vkGetImageMemoryRequirements(device, *pImage, &mem_req);
+    if ((pCreateInfo->mflags &
+         VkImageCreateFlagBits::VK_IMAGE_CREATE_SPARSE_BINDING_BIT) != 0) {
+      uint32_t sparse_mem_req_count = 0;
+      gapii::vkGetImageSparseMemoryRequirements(device, *pImage,
+                                                &sparse_mem_req_count, nullptr);
+      std::vector<VkSparseImageMemoryRequirements> sparse_mem_reqs(
+          sparse_mem_req_count, VkSparseImageMemoryRequirements{});
+      gapii::vkGetImageSparseMemoryRequirements(
+          device, *pImage, &sparse_mem_req_count, sparse_mem_reqs.data());
+    }
+  }
+  return result;
+}
+
+uint32_t VulkanSpy::CreateBufferAndGetMemoryRequirements(
+    VkDevice device, VkBufferCreateInfo* pCreateInfo,
+    VkAllocationCallbacks* pAllocator, VkBuffer* pBuffer) {
+  uint32_t result =
+      gapii::vkCreateBuffer(device, pCreateInfo, pAllocator, pBuffer);
+  if (result == gapii::VkResult::VK_SUCCESS) {
+    gapii::VkMemoryRequirements mem_req{};
+    gapii::vkGetBufferMemoryRequirements(device, *pBuffer, &mem_req);
+  }
+  return result;
+}
 }
 {{end}}

--- a/gapis/api/vulkan/vulkan.api
+++ b/gapis/api/vulkan/vulkan.api
@@ -2404,60 +2404,7 @@ cmd void RecreatePhysicalDeviceProperties(
 }
 
 @threadSafety("system")
-@override
-@no_replay
-cmd void prefetchPhysicalDeviceProperties(
-    VkInstance instance,
-    VkPhysicalDevice physicalDevice,
-    VkPhysicalDeviceProperties* pProperties) {
-  pProperties[0] = ?
-  object := switch (PhysicalDevices[physicalDevice] == null) {
-    case true:
-      new!PhysicalDeviceObject()
-    case false:
-      PhysicalDevices[physicalDevice]
-  }
-  object.PhysicalDeviceProperties = pProperties[0]
-  PhysicalDevices[physicalDevice] = object
-}
-
-@threadSafety("system")
-@override
-@no_replay
-cmd void prefetchPhysicalDeviceQueueFamilyProperties(
-    VkInstance instance,
-    VkPhysicalDevice physicalDevice,
-    u32* pQueueFamilyPropertyCount,
-    VkQueueFamilyProperties* pQueueFamilyProperties) {
-  if pQueueFamilyPropertyCount == null {vkErrorNullPointer("uint32_t")}
-  _ = pQueueFamilyPropertyCount[0]
-  fence
-  if pQueueFamilyProperties == null {
-    pQueueFamilyPropertyCount[0] = ?
-  } else {
-    count := as!u32(?)
-    properties := pQueueFamilyProperties[0:count]
-    for i in (0 .. count) {
-      properties[i] = ?
-    }
-    pQueueFamilyPropertyCount[0] = count
-    if !(physicalDevice in PhysicalDevices) {vkErrorInvalidPhysicalDevice(physicalDevice)}
-    object := switch (PhysicalDevices[physicalDevice] == null) {
-      case true:
-        new!PhysicalDeviceObject()
-      case false:
-        PhysicalDevices[physicalDevice]
-    }
-    for i in (0 .. count) {
-      object.QueueFamilyProperties[i] = properties[i]
-    }
-    PhysicalDevices[physicalDevice] = object
-  }
-}
-
-@threadSafety("system")
 @indirect("VkInstance")
-@override
 cmd VkResult vkEnumeratePhysicalDevices(
     VkInstance        instance,
     u32*              pPhysicalDeviceCount,
@@ -2535,6 +2482,8 @@ cmd void vkGetPhysicalDeviceProperties(
     VkPhysicalDeviceProperties* pProperties) {
   if pProperties == null {vkErrorNullPointer("VkPhysicalDeviceProperties")}
   pProperties[0] = ?
+  if !(physicalDevice in PhysicalDevices) {vkErrorInvalidPhysicalDevice(physicalDevice)}
+  PhysicalDevices[physicalDevice].PhysicalDeviceProperties = pProperties[0]
 }
 
 @indirect("VkPhysicalDevice", "VkInstance")

--- a/gapis/api/vulkan/vulkan.api
+++ b/gapis/api/vulkan/vulkan.api
@@ -2683,7 +2683,7 @@ cmd VkResult vkEnumerateDeviceExtensionProperties(
     string                 pLayerName,
     u32*                   pPropertyCount,
     VkExtensionProperties* pProperties) {
-  if !(physicalDevice in PhysicalDevices) {vkErrorInvalidPhysicalDevice(physicalDevice)}
+  // Do not check validness of physicalDevice as the loader may feed 0 to it.
   queryExtensionProperties(pPropertyCount, pProperties)
 
   return ?
@@ -2719,7 +2719,7 @@ cmd VkResult vkEnumerateDeviceLayerProperties(
     VkPhysicalDevice   physicalDevice,
     u32*               pPropertyCount,
     VkLayerProperties* pProperties) {
-  if !(physicalDevice in PhysicalDevices) {vkErrorInvalidPhysicalDevice(physicalDevice)}
+  // Do not check validness of physicalDevice as the loader may feed 0 to it.
   queryLayerProperties(pPropertyCount, pProperties)
   return ?
 }
@@ -3234,6 +3234,7 @@ cmd void vkGetBufferMemoryRequirements(
   requirements := ?
   if pMemoryRequirements == null {vkErrorNullPointer("VkMemoryRequirements")}
   pMemoryRequirements[0] = requirements
+  Buffers[buffer].MemoryRequirements = requirements
 }
 
 @indirect("VkDevice")
@@ -3246,6 +3247,7 @@ cmd void vkGetImageMemoryRequirements(
   requirements := ?
   if pMemoryRequirements == null {vkErrorNullPointer("VkMemoryRequirements")}
   pMemoryRequirements[0] = requirements
+  Images[image].MemoryRequirements = requirements
 }
 
 @indirect("VkDevice")
@@ -3259,6 +3261,8 @@ cmd void vkGetImageSparseMemoryRequirements(
   if pSparseMemoryRequirementCount == null {vkErrorNullPointer("uint32_t")}
   read(pSparseMemoryRequirementCount[0:1])
 
+  fence
+
   if pSparseMemoryRequirements == null {
     pSparseMemoryRequirementCount[0] = ?
   } else {
@@ -3266,6 +3270,8 @@ cmd void vkGetImageSparseMemoryRequirements(
     requirements := pSparseMemoryRequirements[0:count]
     for i in (0 .. count) {
       requirements[i] = ?
+      aspect := requirements[i].formatProperties.aspectMask
+      Images[image].SparseMemoryRequirements[as!u32(aspect)] = requirements[i]
     }
     pSparseMemoryRequirementCount[0] = count
   }
@@ -3758,43 +3764,6 @@ cmd void RecreateBuffer(
 }
 
 @threadSafety("system")
-@override
-@no_replay
-cmd VkResult createBufferAndCacheMemoryRequirements(
-  VkDevice device,
-  const VkBufferCreateInfo* pCreateInfo,
-  const VkAllocationCallbacks* pAllocator,
-  VkBuffer* pBuffer,
-  VkMemoryRequirements* pMemoryRequirements) {
-  // TODO: pAllocator
-  buffer_create_info := pCreateInfo[0]
-
-  read(buffer_create_info.pQueueFamilyIndices[0:buffer_create_info.queueFamilyIndexCount])
-
-  // Handle pNext
-  if buffer_create_info.pNext != null {
-    numPNext := numberOfPNext(buffer_create_info.pNext)
-    next := MutableVoidPtr(as!void*(buffer_create_info.pNext))
-    for i in (0 .. numPNext) {
-      sType := as!const VkStructureType*(next.Ptr)[0:1][0]
-      switch sType {
-        case VK_STRUCTURE_TYPE_DEDICATED_ALLOCATION_BUFFER_CREATE_INFO_NV: {
-          read(as!VkDedicatedAllocationBufferCreateInfoNV*(next.Ptr)[0:1])
-        }
-      }
-      next.Ptr = as!VulkanStructHeader*(next.Ptr)[0:1][0].PNext
-    }
-  }
-
-  buffer := ?
-  pBuffer[0] = buffer
-  bufferObject := new!BufferObject()
-  bufferObject.MemoryRequirements = pMemoryRequirements[0]
-  Buffers[buffer] = bufferObject
-  return ?
-}
-
-@threadSafety("system")
 @indirect("VkDevice")
 @override
 cmd VkResult vkCreateBuffer(
@@ -3837,20 +3806,14 @@ cmd VkResult vkCreateBuffer(
     }
   }
 
-
   buffer := ?
   if pBuffer == null {vkErrorNullPointer("VkBuffer")}
   pBuffer[0] = buffer
-
-  bufferObject := switch (Buffers[buffer] == null){
-    case true:
-       new!BufferObject()
-    case false:
-      Buffers[buffer]
-  }
-  bufferObject.Device = device
-  bufferObject.VulkanHandle = buffer
-  bufferObject.Info = bufferInfo
+  bufferObject := new!BufferObject(
+    Device: device,
+    VulkanHandle: buffer,
+    Info: bufferInfo,
+  )
   Buffers[buffer] = bufferObject
 
   return ?
@@ -3975,15 +3938,15 @@ cmd void RecreateImage(
 }
 
 @threadSafety("system")
+@indirect("VkDevice")
 @override
-@no_replay
-cmd VkResult createImageAndCacheMemoryRequirements(
-    VkDevice device,
-    const VkImageCreateInfo* pCreateInfo,
+cmd VkResult vkCreateImage(
+    VkDevice                     device,
+    const VkImageCreateInfo*     pCreateInfo,
     const VkAllocationCallbacks* pAllocator,
-    VkImage* pImage,
-    VkMemoryRequirements* pMemoryRequirements) {
-
+    VkImage*                     pImage) {
+  if !(device in Devices) {vkErrorInvalidDevice(device)}
+  if pCreateInfo == null {vkErrorNullPointer("VkImageCreateInfo")}
   // TODO: pAllocator
   info := pCreateInfo[0]
   queueFamilyIndices := info.pQueueFamilyIndices[0:info.queueFamilyIndexCount]
@@ -4022,83 +3985,6 @@ cmd VkResult createImageAndCacheMemoryRequirements(
       default:
         VK_IMAGE_ASPECT_COLOR_BIT
     })
-
-  // Handle pNext
-  if info.pNext != null {
-    numPNext := numberOfPNext(info.pNext)
-    next := MutableVoidPtr(as!void*(info.pNext))
-    for i in (0 .. numPNext) {
-      sType := as!const VkStructureType*(next.Ptr)[0:1][0]
-      switch sType {
-        case VK_STRUCTURE_TYPE_DEDICATED_ALLOCATION_IMAGE_CREATE_INFO_NV: {
-          read(as!VkDedicatedAllocationImageCreateInfoNV*(next.Ptr)[0:1])
-        }
-      }
-      next.Ptr = as!VulkanStructHeader*(next.Ptr)[0:1][0].PNext
-    }
-  }
-
-  handle := ?
-  pImage[0] = handle
-  memReq := ?
-  pMemoryRequirements[0] = memReq
-  object := new!ImageObject(
-    Device: device,
-    IsSwapchainImage: false,
-    VulkanHandle: handle,
-    Info: imageInfo,
-    ImageAspect: imageAspect,
-    MemoryRequirements: memReq,
-  )
-  Images[handle] = object
-  return ?
-}
-
-@threadSafety("system")
-@override
-@no_replay
-cmd void cacheImageSparseMemoryRequirements(
-    VkDevice device,
-    VkImage image,
-    u32 count,
-    VkSparseImageMemoryRequirements* pSparseMemoryRequirements) {
-  if (count > 0) && (pSparseMemoryRequirements != null) {
-  reqs := pSparseMemoryRequirements[0:count]
-  for i in (0 .. count) {
-    aspect := as!u32(reqs[i].formatProperties.aspectMask)
-    Images[image].SparseMemoryRequirements[aspect] = reqs[i]
-  }
-  }
-}
-
-@threadSafety("system")
-@indirect("VkDevice")
-@override
-cmd VkResult vkCreateImage(
-    VkDevice                     device,
-    const VkImageCreateInfo*     pCreateInfo,
-    const VkAllocationCallbacks* pAllocator,
-    VkImage*                     pImage) {
-  // TODO: pAllocator
-
-  if !(device in Devices) {vkErrorInvalidDevice(device)}
-  if pCreateInfo == null {vkErrorNullPointer("VkImageCreateInfo")}
-  info := pCreateInfo[0]
-  queueFamilyIndices := info.pQueueFamilyIndices[0:info.queueFamilyIndexCount]
-
-  imageInfo := ImageInfo(
-    Flags:        info.flags,
-    ImageType:    info.imageType,
-    Format:       info.format,
-    Extent:       info.extent,
-    MipLevels:    info.mipLevels,
-    ArrayLayers:  info.arrayLayers,
-    Samples:      info.samples,
-    Tiling:       info.tiling,
-    Usage:        info.usage,
-    SharingMode:  info.sharingMode,
-    Layout:       info.initialLayout,
-  )
 
   // Handle pNext
   if info.pNext != null {
@@ -4118,42 +4004,16 @@ cmd VkResult vkCreateImage(
     }
   }
 
-  for i in (0 .. info.queueFamilyIndexCount) {
-    imageInfo.QueueFamilyIndices[i] = queueFamilyIndices[i]
-  }
-
-  imageAspect := as!VkImageAspectFlags(
-    switch info.format {
-      case VK_FORMAT_D16_UNORM,
-          VK_FORMAT_X8_D24_UNORM_PACK32,
-          VK_FORMAT_D32_SFLOAT:
-        VK_IMAGE_ASPECT_DEPTH_BIT
-      case VK_FORMAT_S8_UINT:
-        VK_IMAGE_ASPECT_STENCIL_BIT
-      case VK_FORMAT_D16_UNORM_S8_UINT,
-          VK_FORMAT_D24_UNORM_S8_UINT,
-          VK_FORMAT_D32_SFLOAT_S8_UINT:
-        VK_IMAGE_ASPECT_DEPTH_BIT |
-        VK_IMAGE_ASPECT_COLOR_BIT
-      default:
-        VK_IMAGE_ASPECT_COLOR_BIT
-    })
-
   handle := ?
   if pImage == null {vkErrorNullPointer("VkImage")}
   pImage[0] = handle
-  object := switch (Images[handle] == null) {
-    case true:
-      new!ImageObject(
-        Device: device,
-        IsSwapchainImage: false,
-        VulkanHandle: handle,
-        Info: imageInfo,
-        ImageAspect: imageAspect,
-      )
-    case false:
-      Images[handle]
-  }
+  object := new!ImageObject(
+    Device: device,
+    IsSwapchainImage: false,
+    VulkanHandle: handle,
+    Info: imageInfo,
+    ImageAspect: imageAspect,
+  )
 
   for j in (0 .. info.arrayLayers) {
     layer := new!ImageLayer()

--- a/gapis/resolve/dependencygraph/footprint.go
+++ b/gapis/resolve/dependencygraph/footprint.go
@@ -132,10 +132,10 @@ type BackPropagationMachine interface {
 	RecordBehaviorEffects(behaviorIndex uint64, ft *Footprint) []uint64
 	// Clear clears the internal state of the BackPropagationMachine.
 	Clear()
-	// FramebufferRequest marks the behavior indexed by the given index as where
-	// framebuffer will be requested, so a 'use' will be added for each image
-	// attachment.
-	FramebufferRequest(behaviorIndex uint64, ft *Footprint)
+	// FramebufferRequest finds the framebuffer data at the given command index
+	// and records a read to the framebuffer data, so the dependencies of the
+	// data will be kept alive for backpropagation.
+	FramebufferRequest(id api.CmdID, ft *Footprint)
 }
 
 // dummyMachine does nothing but marks all the incoming Behaviors as alive.
@@ -147,8 +147,8 @@ func (m *dummyMachine) RecordBehaviorEffects(behaviorIndex uint64,
 	return []uint64{behaviorIndex}
 }
 
-func (m *dummyMachine) Clear()                                {}
-func (m *dummyMachine) FramebufferRequest(uint64, *Footprint) {}
+func (m *dummyMachine) Clear()                                   {}
+func (m *dummyMachine) FramebufferRequest(api.CmdID, *Footprint) {}
 
 // BehaviorIndex returns the index of the last Behavior in the Footprint
 // which belongs to the command or subcomand indexed by the given SubCmdIdx. In


### PR DESCRIPTION
Sits on top of #1402 

1. 'Read' the correct framebuffer image data for queue submissions
2. Fix the bug of missing buffer descriptor offsets