### PR TITLE
Fix destroying objects out of a hash map.

### DIFF
--- a/gapis/api/vulkan/vulkan.api
+++ b/gapis/api/vulkan/vulkan.api
@@ -4870,8 +4870,17 @@ cmd VkResult vkResetDescriptorPool(
   sets := DescriptorPools[descriptorPool].DescriptorSets
   for _ , s , _ in sets {
     delete(DescriptorSets, s)
-    delete(DescriptorPools[descriptorPool].DescriptorSets, s)
   }
+  old_object := DescriptorPools[descriptorPool]
+  pool := new!DescriptorPoolObject(
+    Device:   old_object.Device,
+    VulkanHandle: old_object.VulkanHandle,
+    Flags:    old_object.Flags,
+    MaxSets:  old_object.MaxSets,
+    Sizes: old_object.Sizes,
+    DebugInfo: old_object.DebugInfo
+  )
+  DescriptorPools[descriptorPool] = pool
   return ?
 }
 


### PR DESCRIPTION
We were looping over the objects, but this invalidated iterators
on linux.