### PR TITLE
core/app/crash/reporting: Declare ReportMinidump stub.

### DIFF
--- a/core/app/crash/reporting/CMakeFiles.cmake
+++ b/core/app/crash/reporting/CMakeFiles.cmake
@@ -20,10 +20,11 @@
 set(files
     encoder.go
     encoder_test.go
+    reporter.go
     reporting.go
     reporting_test.go
     stubs.go
 )
 set(dirs
-    
+
 )

--- a/core/app/crash/reporting/reporter.go
+++ b/core/app/crash/reporting/reporter.go
@@ -1,0 +1,23 @@
+// Copyright (C) 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package reporting
+
+// Reporter stores the common information sent in a crash report.
+type Reporter struct {
+	AppName    string
+	AppVersion string
+	OSName     string
+	OSVersion  string
+}

--- a/core/app/crash/reporting/reporting.go
+++ b/core/app/crash/reporting/reporting.go
@@ -90,14 +90,6 @@ func ReportMinidump(r Reporter, minidumpName string, minidumpData []byte) error 
 	return nil
 }
 
-// Reporter stores the common information sent in a crash report.
-type Reporter struct {
-	AppName    string
-	AppVersion string
-	OSName     string
-	OSVersion  string
-}
-
 func (r Reporter) sendReport(body io.Reader, contentType, endpoint string) error {
 	appNameAndVersion := r.AppName + ":" + r.AppVersion
 	url := fmt.Sprintf("%v?product=%v&version=%v", endpoint, url.QueryEscape(crashProduct), url.QueryEscape(appNameAndVersion))

--- a/core/app/crash/reporting/stubs.go
+++ b/core/app/crash/reporting/stubs.go
@@ -30,3 +30,6 @@ func Enable(ctx context.Context, appName, appVersion string) {}
 
 // Disable turns off crash reporting previously enabled by Enable()
 func Disable() {}
+
+// ReportMinidump encodes and sends a minidump report to the crashURL endpoint.
+func ReportMinidump(r Reporter, minidumpName string, minidumpData []byte) error { return nil }


### PR DESCRIPTION
If the crashreporting build tag isn't defined, we fallback to a no-op stub implementation. This stub was missing the new `ReportMinidump` function, breaking builds that didn't have the crashreporting tag defined.