### PR TITLE
Skip contexts that were never bound in the replay cleanup.

### DIFF
--- a/gapis/api/gles/replay.go
+++ b/gapis/api/gles/replay.go
@@ -303,6 +303,11 @@ func (t *destroyResourcesAtEOS) Flush(ctx context.Context, out transform.Writer)
 	// Now using a single thread, bind each context and delete all objects.
 	cb := CommandBuilder{Thread: 0}
 	for i, c := range GetState(s).EGLContexts.Range() {
+		if !c.Other.Initialized {
+			// This context was never bound. Skip it.
+			continue
+		}
+
 		cmds = append(cmds, cb.EglMakeCurrent(memory.Nullptr, memory.Nullptr, memory.Nullptr, i, 1))
 
 		// Delete all Renderbuffers.


### PR DESCRIPTION
At the end of a replay, the contexts are cleaned up by deleting all resources. This change will cause the cleanup to be skipped for contexts that were never bound. If an application creates a context, shares it with another, but never binds it, we would try to clean up the resources in the never-bound context. This would cause a bunch of errors in the replay, since the backbuffer for this context was never initialized due to the fact that this is done using the extras from any observed eglMakeCurrent, which are non-existent for any never-bound contexts.

Fixes #1435