### PR TITLE
Also remove the MANIFEST.MF file before re-signing.

### DIFF
--- a/core/os/android/apk/debugifier.go
+++ b/core/os/android/apk/debugifier.go
@@ -124,7 +124,7 @@ func (a ApkDebugifier) makeApkDebuggableAndRemoveSignatureFiles(ctx context.Cont
 	w := zip.NewWriter(outFile)
 	defer w.Close()
 
-	jarSignatureFilePattern := regexp.MustCompile(`META-INF/[^/]*(DSA|RSA|SF)`)
+	jarSignatureFilePattern := regexp.MustCompile(`META-INF/([^/]*(DSA|RSA|SF)|MANIFEST\.MF)`)
 
 	for _, zf := range inZip.File {
 		if jarSignatureFilePattern.MatchString(zf.Name) {


### PR DESCRIPTION
This file is re-generated by the signer anyways and would cause issues if it contained a signature for the AndroidManifest.xml file.