### PR TITLE
Geometry view fixes

### DIFF
--- a/gapic/src/main/com/google/gapid/glviewer/gl/Renderer.java
+++ b/gapic/src/main/com/google/gapid/glviewer/gl/Renderer.java
@@ -161,6 +161,7 @@ public final class Renderer {
   public static void draw(Shader shader, int primitive, int vertexCount) {
     shader.bind();
     GL11.glDrawArrays(primitive, 0, vertexCount);
+    shader.unbind();
   }
 
   /**
@@ -171,6 +172,7 @@ public final class Renderer {
     shader.bind();
     indices.bind();
     GL11.glDrawElements(primitive, indices.count, indices.type, 0);
+    shader.unbind();
   }
 
   /**

--- a/gapic/src/main/com/google/gapid/views/GeometryView.java
+++ b/gapic/src/main/com/google/gapid/views/GeometryView.java
@@ -203,7 +203,7 @@ public class GeometryView extends Composite implements Tab, Capture.Listener, At
     createToolItem(bar, theme.cullingDisabled(), e -> {
       boolean cull = data.culling == GeometryScene.Culling.OFF; // cull represents the new value.
       models.analytics.postInteraction(View.Geometry, cull ? "cullOn" : "cullOff", Invoke);
-      ((ToolItem)e.widget).setImage(cull ? theme.cullingDisabled() : theme.cullingEnabled());
+      ((ToolItem)e.widget).setImage(cull ? theme.cullingEnabled() : theme.cullingDisabled());
       setSceneData(data.withToggledCulling());
     }, "Toggle backface culling");
     createSeparator(bar);


### PR DESCRIPTION
- Fixes the state of the culling toggle button.
The button was OK in it's initial state, but then on each toggle of the button it was incorrect (i.e. the first click didn't actually toggle the button).
- Unbinds the shader after each draw to fix the flat shading being blank.
Unbinding the shader calls glDisableVertexAttribArray on all atributes, where it previously was enabled. When switching between draw modes, the number of attribues varies and if left over attributes remain array enabled, the draw call fails.

Fixes #1441 and #1442