### PR TITLE
Fix "failed to open minidump file".

### DIFF
--- a/core/cc/linux/crash_handler.cpp
+++ b/core/cc/linux/crash_handler.cpp
@@ -36,7 +36,7 @@ namespace {
 const char* GetTempDir() {
     const char* tmpdir = getenv("TMPDIR");
     if (!tmpdir) {
-        tmpdir = "/tmp/";
+        tmpdir = "/tmp";
     }
     return tmpdir;
 }

--- a/core/cc/osx/crash_handler.cpp
+++ b/core/cc/osx/crash_handler.cpp
@@ -26,6 +26,7 @@ static bool handleCrash(const char* minidumpDir, const char* minidumpId, void* c
     core::CrashHandler* crashHandler = reinterpret_cast<core::CrashHandler*>(crashHandlerPtr);
     std::string minidumpPath(minidumpDir);
     minidumpPath.append(minidumpId);
+    minidumpPath.append(".dmp");
     return crashHandler->handleMinidump(minidumpPath, succeeded);
 }
 


### PR DESCRIPTION
Crash Handler was not appending the file extension to the minidump path
when forwarding to the crash uploader on these platforms.

Fixes #1447 