### PR TITLE
Actually use the -gapir-device to select the device to run gapir

### DIFF
--- a/cmd/gapit/video.go
+++ b/cmd/gapit/video.go
@@ -51,7 +51,7 @@ type videoVerb struct{ VideoFlags }
 
 func init() {
 	verb := &videoVerb{}
-	verb.Gapir.Device = "host"
+	verb.Gapir.Device = ""
 	// The maximum width and height need to match the values in spy.cpp
 	// in order to properly compare observed and rendered framebuffers.
 	verb.Max.Width = 1920


### PR DESCRIPTION
By default, the 'gapir-device' arg is empty, and has no effect on the device selection.
If 'gapir-device' is set to 'host', select only the host if 'host' is one of the compatible devices
if 'gapir-device' is set to 'android', uses only the android devices in the compatible device list
if 'gapir-device' is anything else, consider it as the serial number of an Android device, only the exactly matched Android device will be used.
