### PR TITLE
Add GAPIR MSVC to kokoro build.

### DIFF
--- a/kokoro/windows/build.bat
+++ b/kokoro/windows/build.bat
@@ -41,6 +41,11 @@ REM Fix up the MSYS environment: remove gcc and add mingw's gcc
 c:\tools\msys64\usr\bin\bash --login -c "pacman -R --noconfirm gcc"
 c:\tools\msys64\usr\bin\bash --login -c "pacman -S --noconfirm mingw-w64-x86_64-gcc"
 
+REM set up msvc build env
+set Platform="X64"
+set PreferredToolArchitecture="x64"
+call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" amd64
+
 REM Setup the build config file.
 (
   echo {
@@ -52,7 +57,8 @@ REM Setup the build config file.
   echo  "CMakePath": "c:\Program Files\Cmake\bin\cmake.exe",
   echo  "NinjaPath": "c:\ProgramData\chocolatey\bin\ninja.exe",
   echo  "PythonPath": "c:\Python35\python.exe",
-  echo  "MSYS2Path": "c:\tools\msys64"
+  echo  "MSYS2Path": "c:\tools\msys64",
+  echo  "MSVCWinGapir": true
   echo }
 ) > gapid-config
 type gapid-config

--- a/kokoro/windows/common.cfg
+++ b/kokoro/windows/common.cfg
@@ -17,6 +17,7 @@ action {
   define_artifacts {
     regex: "out/dist/gapid*.msi"
     regex: "out/dist/gapid*.zip"
+    regex: "out/dist/gapir*.sym"
     strip_prefix: "out/dist"
   }
 }

--- a/kokoro/windows/package.bat
+++ b/kokoro/windows/package.bat
@@ -60,4 +60,6 @@ copy "%~dp0\*.bmp" .
 "%WIX%\candle.exe" -dGAPIDVersion="%VERSION%" gapid.wxs component.wxs
 "%WIX%\light.exe" gapid.wixobj component.wixobj -b gapid -ext WixUIExtension -cultures:en-us -o gapid-%VERSION%-windows.msi
 
+copy ..\current\gapir.sym gapir-%VERSION%-windows.sym
+
 popd


### PR DESCRIPTION
This change adds gapir-msvc step to kokoro on windows as well as adding
the symbol file to the kokoro package.