### PR TITLE
Add GAPIR Symbol production to linux/OS X builds

### DIFF
--- a/cmd/gapir/CMakeBuild.cmake
+++ b/cmd/gapir/CMakeBuild.cmake
@@ -39,5 +39,23 @@ if(NOT DISABLED_CXX)
     endif()
     if(NOT GAPII_TARGET)
         target_link_libraries(gapir gapir_static)
+        target_compile_options(gapir PUBLIC "-g")
+        if(APPLE)
+            add_custom_command(
+                TARGET gapir
+                POST_BUILD
+                COMMAND "dsymutil" "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/gapir" -o "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/../gapir.dSYM"
+                COMMAND dump_syms -g "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/../gapir.dSYM" "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/gapir" > "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/../gapir.sym"
+                COMMAND "rm" "-r" "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/../gapir.dSYM"
+                COMMAND "strip" "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/gapir"
+            )
+        elseif(NOT WIN32 AND NOT ANDROID)
+            add_custom_command(
+                TARGET gapir
+                POST_BUILD
+                COMMAND dump_syms "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/gapir" > "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/../gapir.sym"
+                COMMAND "strip" "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/gapir"
+            )
+        endif()
     endif()
 endif()

--- a/core/cc/CMakeBuild.cmake
+++ b/core/cc/CMakeBuild.cmake
@@ -74,6 +74,8 @@ if(NOT DISABLED_CXX)
     if(WIN32)
         find_package(Winsock REQUIRED)
         target_link_libraries(cc-core Winsock::Lib)
+    else()
+        target_compile_options(cc-core PUBLIC "-g")
     endif()
 
     if(NOT ANDROID AND NOT GAPII_TARGET)

--- a/gapir/cc/CMakeBuild.cmake
+++ b/gapir/cc/CMakeBuild.cmake
@@ -57,6 +57,10 @@ if(NOT DISABLED_CXX)
     set_target_properties(gapir_static PROPERTIES OUTPUT_NAME gapir)
     target_link_libraries(gapir_static cc-core)
 
+    if(NOT WIN32)
+        target_compile_options(gapir_static PUBLIC "-g")
+    endif()
+
     if(APPLE)
         find_package(Cocoa REQUIRED)
         target_link_libraries(gapir_static Cocoa::Lib)

--- a/kokoro/linux/common.cfg
+++ b/kokoro/linux/common.cfg
@@ -17,6 +17,7 @@ action {
   define_artifacts {
     regex: "out/dist/gapid*.deb"
     regex: "out/dist/gapid*.zip"
+    regex: "out/dist/gapir*.sym"
     strip_prefix: "out/dist"
   }
 }

--- a/kokoro/linux/package.sh
+++ b/kokoro/linux/package.sh
@@ -75,6 +75,9 @@ cd gapid/opt/
 zip -r ../../gapid-$VERSION-linux.zip gapid/
 cd ../../
 
+# Copy the GAPIR symbols
+cp ../current/gapir.sym gapir-$VERSION-linux.sym
+
 # Build the .deb package.
 echo "$(date): Building package."
 fakeroot dpkg-deb -v --build gapid

--- a/kokoro/macos/common.cfg
+++ b/kokoro/macos/common.cfg
@@ -17,6 +17,7 @@ action {
   define_artifacts {
     regex: "out/dist/gapid*.dmg"
     regex: "out/dist/gapid*.zip"
+    regex: "out/dist/gapir*.sym"
     strip_prefix: "out/dist"
   }
 }

--- a/kokoro/macos/package.sh
+++ b/kokoro/macos/package.sh
@@ -58,6 +58,9 @@ for i in 512 256 128 64 32 16; do
 done
 iconutil -c icns -o GAPID.app/Contents/Resources/GAPID.icns GAPID.iconset
 
+# Copy the GAPIR Symbols
+cp ../current/gapir.sym gapir-$VERSION-macos.sym
+
 # Make a dmg file.
 pip install --upgrade --user dmgbuild pyobjc-framework-Quartz
 cp "$SRC"/background*.png .

--- a/kokoro/windows/package.bat
+++ b/kokoro/windows/package.bat
@@ -53,13 +53,14 @@ call "%~dp0\copy_jre.bat" "%cd%\gapid\jre"
 REM Package up the zip file.
 zip -r gapid-%VERSION%-windows.zip gapid
 
+REM Copy the GAPIR symbols
+copy ..\current\gapir.sym gapir-%VERSION%-windows.sym
+
 REM Create an MSI installer.
 copy "%~dp0\gapid.wxs" .
 copy "%~dp0\*.bmp" .
 "%WIX%\heat.exe" dir gapid -ag -cg gapid -dr GAPID -template fragment -sreg -sfrag -srd -suid -o component.wxs
 "%WIX%\candle.exe" -dGAPIDVersion="%VERSION%" gapid.wxs component.wxs
 "%WIX%\light.exe" gapid.wixobj component.wixobj -b gapid -ext WixUIExtension -cultures:en-us -o gapid-%VERSION%-windows.msi
-
-copy ..\current\gapir.sym gapir-%VERSION%-windows.sym
 
 popd

--- a/third_party/breakpad.cmake
+++ b/third_party/breakpad.cmake
@@ -41,6 +41,29 @@ if(APPLE)
         "client/mac/Framework/Breakpad.mm"
         "client/mac/Framework/OnDemandServer.mm"
     )
+    set(dump_syms_srcs
+        "common/dwarf/dwarf2diehandler.cc"
+        "common/dwarf/elf_reader.cc"
+        "common/dwarf/dwarf2reader.cc"
+        "common/dwarf/bytereader.cc"
+        "common/dwarf_cfi_to_module.cc"
+        "common/dwarf_cu_to_module.cc"
+        "common/dwarf_line_to_module.cc"
+        "common/language.cc"
+        "common/mac/arch_utilities.cc"
+        "common/mac/dump_syms.cc"
+        "common/mac/file_id.cc"
+        "common/mac/macho_id.cc"
+        "common/mac/macho_reader.cc"
+        "common/mac/macho_utilities.cc"
+        "common/mac/macho_walker.cc"
+        "common/md5.cc"
+        "common/module.cc"
+        "common/path_helper.cc"
+        "common/stabs_reader.cc"
+        "common/stabs_to_module.cc"
+        "tools/mac/dump_syms/dump_syms_tool.cc"
+    )
 elseif(WIN32)
     set(breakpad_srcs
         "client/windows/crash_generation/client_info.cc"
@@ -76,6 +99,31 @@ else()
         "common/md5.cc"
         "common/string_conversion.cc"
     )
+    set(dump_syms_srcs
+        "common/dwarf/bytereader.cc"
+        "common/dwarf/dwarf2diehandler.cc"
+        "common/dwarf/dwarf2reader.cc"
+        "common/dwarf/elf_reader.cc"
+        "common/dwarf_cfi_to_module.cc"
+        "common/dwarf_cu_to_module.cc"
+        "common/dwarf_line_to_module.cc"
+        "common/language.cc"
+        "common/linux/crc32.cc"
+        "common/linux/dump_symbols.cc"
+        "common/linux/dump_symbols.h"
+        "common/linux/elf_symbols_to_module.cc"
+        "common/linux/elf_symbols_to_module.h"
+        "common/linux/elfutils.cc"
+        "common/linux/file_id.cc"
+        "common/linux/linux_libc_support.cc"
+        "common/linux/memory_mapped_file.cc"
+        "common/linux/safe_readlink.cc"
+        "common/module.cc"
+        "common/path_helper.cc"
+        "common/stabs_reader.cc"
+        "common/stabs_to_module.cc"
+        "tools/linux/dump_syms/dump_syms.cc"
+    )
 endif()
 
 abs_list(breakpad_srcs ${breakpad_dir})
@@ -88,6 +136,14 @@ if(NOT DISABLED_CXX)
     add_library(breakpad STATIC ${breakpad_srcs})
     target_include_directories(breakpad PUBLIC ${breakpad_dir})
 
+    if(NOT WIN32)
+        target_compile_options(breakpad PUBLIC "-g")
+        abs_list(dump_syms_srcs ${breakpad_dir})
+        add_executable(dump_syms ${dump_syms_srcs})
+        target_include_directories(dump_syms PUBLIC ${breakpad_dir})
+        target_compile_definitions(dump_syms PRIVATE "N_UNDF=0x0")
+    endif()
+
     if(ANDROID)
         set_property(SOURCE "${breakpad_dir}/common/android/breakpad_getcontext.S" PROPERTY LANGUAGE C)
         target_sources(breakpad PRIVATE "${breakpad_dir}/common/android/breakpad_getcontext.S")
@@ -98,33 +154,6 @@ if(NOT DISABLED_CXX)
         find_library(FOUNDATION_LIBRARY Foundation)
         find_library(COCOA_LIBRARY Cocoa)
 
-        set(dump_syms_srcs
-            "common/dwarf/dwarf2diehandler.cc"
-            "common/dwarf/elf_reader.cc"
-            "common/dwarf/dwarf2reader.cc"
-            "common/dwarf/bytereader.cc"
-            "common/dwarf_cfi_to_module.cc"
-            "common/dwarf_cu_to_module.cc"
-            "common/dwarf_line_to_module.cc"
-            "common/language.cc"
-            "common/mac/arch_utilities.cc"
-            "common/mac/dump_syms.cc"
-            "common/mac/file_id.cc"
-            "common/mac/macho_id.cc"
-            "common/mac/macho_reader.cc"
-            "common/mac/macho_utilities.cc"
-            "common/mac/macho_walker.cc"
-            "common/md5.cc"
-            "common/module.cc"
-            "common/path_helper.cc"
-            "common/stabs_reader.cc"
-            "common/stabs_to_module.cc"
-            "tools/mac/dump_syms/dump_syms_tool.cc"
-        )
-        abs_list(dump_syms_srcs ${breakpad_dir})
-        add_executable(dump_syms ${dump_syms_srcs})
-        target_include_directories(dump_syms PUBLIC ${breakpad_dir})
-        target_compile_definitions(dump_syms PRIVATE "N_UNDF=0x0")
         target_compile_options(dump_syms PRIVATE "-Wno-deprecated")
         target_link_libraries(dump_syms ${FOUNDATION_LIBRARY})
 


### PR DESCRIPTION
This change adds symbol generation to the cmake scripts for linux and
OS X. The libraries that GAPIR depends on now use '-g' to store debug
symbols, and generate dump_syms executable to then produce a .sym file
(OS X produces an intermediary .dSYM file) and store it in the base
output directory.

This should close #407 