### PR TITLE
 Don't crash the client on OpenGL init failure.

### DIFF
--- a/gapic/src/main/com/google/gapid/util/Messages.java
+++ b/gapic/src/main/com/google/gapid/util/Messages.java
@@ -70,4 +70,6 @@ public interface Messages {
       "OS: " + OS.name + " " + OS.arch + "\n\n" +
       "Please provide detailed steps that led to the error and copy-paste the stack trace.\n" +
       "Extra details from the logs and the trace file would be extra helpful.\n\n";
+  public static final String NO_OPENGL =
+      "Failed to create an OpenGL context. OpenGL is required to use this application.";
 }

--- a/gapic/src/main/com/google/gapid/views/FramebufferView.java
+++ b/gapic/src/main/com/google/gapid/views/FramebufferView.java
@@ -89,7 +89,6 @@ public class FramebufferView extends Composite
   private final Models models;
   private final SingleInFlight rpcController = new SingleInFlight();
   protected final ImagePanel imagePanel;
-  protected final Loadable loading;
   private Service.RenderSettings renderSettings = RENDER_SHADED;
   private API.FramebufferAttachment target = API.FramebufferAttachment.Color0;
   private ToolItem targetItem;
@@ -103,7 +102,6 @@ public class FramebufferView extends Composite
 
     ToolBar toolBar = createToolBar(widgets.theme);
     imagePanel = new ImagePanel(this, View.Framebuffer, models.analytics, widgets, true);
-    loading = imagePanel.getLoading();
 
     toolBar.setLayoutData(new GridData(SWT.LEFT, SWT.FILL, false, true));
     imagePanel.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
@@ -188,14 +186,14 @@ public class FramebufferView extends Composite
   @Override
   public void onCaptureLoadingStart(boolean maintainState) {
     imagePanel.setImage(null);
-    loading.showMessage(Info, Messages.LOADING_CAPTURE);
+    imagePanel.showMessage(Info, Messages.LOADING_CAPTURE);
   }
 
   @Override
   public void onCaptureLoaded(Loadable.Message error) {
     if (error != null) {
       imagePanel.setImage(null);
-      loading.showMessage(Error, Messages.CAPTURE_LOAD_FAILURE);
+      imagePanel.showMessage(Error, Messages.CAPTURE_LOAD_FAILURE);
     }
   }
 
@@ -223,11 +221,11 @@ public class FramebufferView extends Composite
   private void updateBuffer() {
     AtomIndex atomPath = models.atoms.getSelectedAtoms();
     if (atomPath == null) {
-      loading.showMessage(Info, Messages.SELECT_ATOM);
+      imagePanel.showMessage(Info, Messages.SELECT_ATOM);
     } else if (!models.devices.hasReplayDevice()) {
-      loading.showMessage(Error, Messages.NO_REPLAY_DEVICE);
+      imagePanel.showMessage(Error, Messages.NO_REPLAY_DEVICE);
     } else {
-      loading.startLoading();
+      imagePanel.startLoading();
       rpcController.start().listen(
           FetchedImage.load(client, getImageInfoPath(atomPath.getCommand())),
           new UiErrorCallback<FetchedImage, MultiLayerAndLevelImage, Loadable.Message>(this, LOG) {
@@ -250,7 +248,7 @@ public class FramebufferView extends Composite
 
         @Override
         protected void onUiThreadError(Loadable.Message message) {
-          loading.showMessage(message);
+          imagePanel.showMessage(message);
         }
       });
     }

--- a/gapic/src/main/com/google/gapid/views/TextureView.java
+++ b/gapic/src/main/com/google/gapid/views/TextureView.java
@@ -106,8 +106,7 @@ public class TextureView extends Composite
   private final GotoAction gotoAction;
   private final TableViewer textureTable;
   private final ImageProvider imageProvider;
-  protected final Loadable loading;
-  private final ImagePanel imagePanel;
+  protected final ImagePanel imagePanel;
 
   public TextureView(Composite parent, Client client, Models models, Widgets widgets) {
     super(parent, SWT.NONE);
@@ -125,7 +124,6 @@ public class TextureView extends Composite
     Composite imageAndToolbar = createComposite(splitter, new GridLayout(2, false));
     ToolBar toolBar = new ToolBar(imageAndToolbar, SWT.VERTICAL | SWT.FLAT);
     imagePanel = new ImagePanel(imageAndToolbar, View.Textures, models.analytics, widgets, false);
-    loading = imagePanel.getLoading();
 
     splitter.setWeights(models.settings.texturesSplitterWeights);
     addListener(SWT.Dispose, e -> models.settings.texturesSplitterWeights = splitter.getWeights());
@@ -192,14 +190,14 @@ public class TextureView extends Composite
 
   @Override
   public void onCaptureLoadingStart(boolean maintainState) {
-    loading.showMessage(Info, Messages.LOADING_CAPTURE);
+    imagePanel.showMessage(Info, Messages.LOADING_CAPTURE);
     clear();
   }
 
   @Override
   public void onCaptureLoaded(Loadable.Message error) {
     if (error != null) {
-      loading.showMessage(Error, Messages.CAPTURE_LOAD_FAILURE);
+      imagePanel.showMessage(Error, Messages.CAPTURE_LOAD_FAILURE);
       clear();
     }
   }
@@ -234,13 +232,13 @@ public class TextureView extends Composite
       textureTable.setComparator(comparator);
 
       if (textures.isEmpty()) {
-        loading.showMessage(Info, Messages.NO_TEXTURES);
+        imagePanel.showMessage(Info, Messages.NO_TEXTURES);
       } else if (textureTable.getTable().getSelectionIndex() < 0) {
-        loading.showMessage(Info, Messages.SELECT_TEXTURE);
+        imagePanel.showMessage(Info, Messages.SELECT_TEXTURE);
       }
       updateSelection();
     } else {
-      loading.showMessage(Info, Messages.SELECT_ATOM);
+      imagePanel.showMessage(Info, Messages.SELECT_ATOM);
       clear();
     }
   }
@@ -258,7 +256,7 @@ public class TextureView extends Composite
       setImage(null);
       gotoAction.clear();
     } else {
-      loading.startLoading();
+      imagePanel.startLoading();
       Data data = (Data)textureTable.getElementAt(selection);
       rpcController.start().listen(FetchedImage.load(client, data.path.getResourceData()),
           new UiErrorCallback<FetchedImage, FetchedImage, String>(this, LOG) {
@@ -280,7 +278,7 @@ public class TextureView extends Composite
         @Override
         protected void onUiThreadError(String error) {
           setImage(null);
-          loading.showMessage(Info, error);
+          imagePanel.showMessage(Info, error);
         }
       });
       gotoAction.setAtomIds(data.info.getAccessesList(), data.path.getResourceData().getAfter());

--- a/gapic/src/main/com/google/gapid/widgets/ScenePanel.java
+++ b/gapic/src/main/com/google/gapid/widgets/ScenePanel.java
@@ -54,6 +54,11 @@ public class ScenePanel<T> extends GlCanvas {
     this.scene = scene;
     renderer = new Renderer();
 
+    if (!isOpenGL()) {
+      caps = null;
+      return;
+    }
+
     setCurrent();
     caps = GL.createCapabilities();
     initialize();
@@ -66,6 +71,11 @@ public class ScenePanel<T> extends GlCanvas {
   // regardless of the number of listeners that request renders.
   @Override
   public void addListener(int eventType, Listener listener) {
+    if (!isOpenGL()) {
+      super.addListener(eventType, listener);
+      return;
+    }
+
     if (eventListeners == null) {
       eventListeners = Maps.newHashMap();
     }
@@ -97,6 +107,10 @@ public class ScenePanel<T> extends GlCanvas {
 
   @Override
   protected void terminate() {
+    if (!isOpenGL()) {
+      return;
+    }
+
     setCurrent();
     GL.setCapabilities(caps);
     renderer.terminate();
@@ -111,7 +125,7 @@ public class ScenePanel<T> extends GlCanvas {
 
   private void dispatchEvents(Event event) {
     withSuspendedUpdate(() -> {
-      if (event.type == SWT.Resize) {
+      if (event.type == SWT.Resize && isOpenGL()) {
         Point size = DPIUtil.autoScaleUp(getSize());
         setCurrent();
         renderer.setSize(size.x, size.y);
@@ -144,15 +158,17 @@ public class ScenePanel<T> extends GlCanvas {
       return;
     }
 
-    setCurrent();
-    GL.setCapabilities(caps);
-    T newData = sceneData.getAndSet(null);
-    if (newData != null) {
-      scene.update(renderer, newData);
-    }
-    if (render) {
-      scene.render(renderer);
-      swapBuffers();
+    if (isOpenGL()) {
+      setCurrent();
+      GL.setCapabilities(caps);
+      T newData = sceneData.getAndSet(null);
+      if (newData != null) {
+        scene.update(renderer, newData);
+      }
+      if (render) {
+        scene.render(renderer);
+        swapBuffers();
+      }
     }
   }
 }

--- a/gapic/src/platform/linux/com/google/gapid/glcanvas/GlCanvas.java
+++ b/gapic/src/platform/linux/com/google/gapid/glcanvas/GlCanvas.java
@@ -38,6 +38,11 @@ public abstract class GlCanvas extends GLCanvas {
     return result;
   }
 
+  public boolean isOpenGL() {
+    // TODO: do our own initialization, so we can handle the failure case.
+    return true;
+  }
+
   /**
    * Override to perform GL cleanup handling.
    */


### PR DESCRIPTION
On Windows and OSX, where we are doing our own GL initilization, if we fail to create a GL context, don't SWT.error, but just fallback to a regular canvas and show an error message in the Geometry, Framebuffer and Texture views.

For #1356