### PR TITLE
Revert "Add GAPIR MSVC to kokoro build."

### DIFF
--- a/kokoro/windows/build.bat
+++ b/kokoro/windows/build.bat
@@ -41,11 +41,6 @@ REM Fix up the MSYS environment: remove gcc and add mingw's gcc
 c:\tools\msys64\usr\bin\bash --login -c "pacman -R --noconfirm gcc"
 c:\tools\msys64\usr\bin\bash --login -c "pacman -S --noconfirm mingw-w64-x86_64-gcc"
 
-REM set up msvc build env
-set Platform="X64"
-set PreferredToolArchitecture="x64"
-call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" amd64
-
 REM Setup the build config file.
 (
   echo {
@@ -57,8 +52,7 @@ REM Setup the build config file.
   echo  "CMakePath": "c:\Program Files\Cmake\bin\cmake.exe",
   echo  "NinjaPath": "c:\ProgramData\chocolatey\bin\ninja.exe",
   echo  "PythonPath": "c:\Python35\python.exe",
-  echo  "MSYS2Path": "c:\tools\msys64",
-  echo  "MSVCWinGapir": true
+  echo  "MSYS2Path": "c:\tools\msys64"
   echo }
 ) > gapid-config
 type gapid-config

--- a/kokoro/windows/common.cfg
+++ b/kokoro/windows/common.cfg
@@ -17,7 +17,6 @@ action {
   define_artifacts {
     regex: "out/dist/gapid*.msi"
     regex: "out/dist/gapid*.zip"
-    regex: "out/dist/gapir*.sym"
     strip_prefix: "out/dist"
   }
 }


### PR DESCRIPTION
We're experiencing crashes with the MSVC gapir executable.

This reverts commit fe594f4e003fe11dccf107412caeb27f55cb570a.