### PR TITLE
gles: Fixes for unused VAAs that have no data.

### DIFF
--- a/gapis/api/gles/tweaker.go
+++ b/gapis/api/gles/tweaker.go
@@ -91,6 +91,15 @@ func (t *tweaker) glDisable(ctx context.Context, name GLenum) {
 	}
 }
 
+func (t *tweaker) glDisableVertexAttribArray(ctx context.Context, l AttributeLocation) {
+	arr := t.c.Bound.VertexArray.VertexAttributeArrays.Get(l)
+	if arr != nil && arr.Enabled == GLboolean_GL_TRUE {
+		t.doAndUndo(ctx,
+			t.cb.GlDisableVertexAttribArray(l),
+			t.cb.GlEnableVertexAttribArray(l))
+	}
+}
+
 func (t *tweaker) glDepthMask(ctx context.Context, v GLboolean) {
 	if o := t.c.Pixel.DepthWritemask; o != v {
 		t.doAndUndo(ctx,


### PR DESCRIPTION
On some drivers having a vertex attribute array enabled with no bound data will cause `GL_INVALID_OPERATION` errors, even though that vertex attribute is not used by the program.

This is a compat workaround for this case where we temporarily disable the vertex attribute array if we believe the program does not use it.