### PR TITLE
core/app: Remove the build number from the build version.

### DIFF
--- a/core/app/default_version.go.in
+++ b/core/app/default_version.go.in
@@ -19,6 +19,6 @@ func init() {
 		Major: @GAPID_VERSION_MAJOR@,
 		Minor: @GAPID_VERSION_MINOR@,
 		Point: @GAPID_VERSION_POINT@,
-		Build: "@GAPID_BUILD_NUMBER@:@GAPID_BUILD_SHA@",
+		Build: "@GAPID_BUILD_SHA@",
 	}
 }

--- a/gapic/src/main/com/google/gapid/util/GapidVersion.java.in
+++ b/gapic/src/main/com/google/gapid/util/GapidVersion.java.in
@@ -19,5 +19,5 @@ package com.google.gapid.util;
  */
 @javax.annotation.Generated("by GAPID cmake")
 public interface GapidVersion {
-  public static final Version GAPID_VERSION = new Version(@GAPID_VERSION_MAJOR@, @GAPID_VERSION_MINOR@, @GAPID_VERSION_POINT@, "@GAPID_BUILD_NUMBER@:@GAPID_BUILD_SHA@");
+  public static final Version GAPID_VERSION = new Version(@GAPID_VERSION_MAJOR@, @GAPID_VERSION_MINOR@, @GAPID_VERSION_POINT@, "@GAPID_BUILD_SHA@");
 }


### PR DESCRIPTION
This just makes identifying analytics / crash reports by version horrible as each OS will get a different build number.