### PR TITLE
Add VulkanDriver to the device::Instance trace header

### DIFF
--- a/cmd/gapit/video.go
+++ b/cmd/gapit/video.go
@@ -51,7 +51,7 @@ type videoVerb struct{ VideoFlags }
 
 func init() {
 	verb := &videoVerb{}
-	verb.Gapir.Device = "host"
+	verb.Gapir.Device = ""
 	// The maximum width and height need to match the values in spy.cpp
 	// in order to properly compare observed and rendered framebuffers.
 	verb.Max.Width = 1920

--- a/core/cc/android/get_vulkan_proc_address.cpp
+++ b/core/cc/android/get_vulkan_proc_address.cpp
@@ -71,5 +71,7 @@ namespace core {
 GetVulkanInstanceProcAddressFunc* GetVulkanInstanceProcAddress = getVulkanInstanceProcAddress;
 GetVulkanDeviceProcAddressFunc* GetVulkanDeviceProcAddress = getVulkanDeviceProcAddress;
 GetVulkanProcAddressFunc* GetVulkanProcAddress = getVulkanProcAddress;
-
+bool HasVulkanLoader() {
+  return DlLoader::can_load("libvulkan.so");
+}
 }  // namespace core

--- a/core/cc/armlinux/get_vulkan_proc_address.cpp
+++ b/core/cc/armlinux/get_vulkan_proc_address.cpp
@@ -71,5 +71,7 @@ namespace core {
 GetVulkanInstanceProcAddressFunc* GetVulkanInstanceProcAddress = getVulkanInstanceProcAddress;
 GetVulkanDeviceProcAddressFunc* GetVulkanDeviceProcAddress = getVulkanDeviceProcAddress;
 GetVulkanProcAddressFunc* GetVulkanProcAddress = getVulkanProcAddress;
-
+bool HasVulkanLoader() {
+  return DlLoader::can_load("libvulkan.so");
+}
 }  // namespace core

--- a/core/cc/dl_loader.cpp
+++ b/core/cc/dl_loader.cpp
@@ -69,7 +69,7 @@ void* must_load(const char* name) {
 }
 
 // resolve defs
-#if TARGET_OS ==  TARGET_OS_WINDOWS
+#if TARGET_OS ==  GAPID_OS_WINDOWS
 void* resolve(void* handle, const char* name) {
     return reinterpret_cast<void*>(GetProcAddress(reinterpret_cast<HMODULE>(handle), name));
 }

--- a/core/cc/dl_loader.h
+++ b/core/cc/dl_loader.h
@@ -34,6 +34,10 @@ public:
     // Returns nullptr if the function is not found.
     void* lookup(const char* name);
 
+    // can_load checks if the dynamic library specified with the given name can
+    // be loaded. Returns true if so, otherwise returns false.
+    static bool can_load(const char* lib_name);
+
 private:
     DlLoader() =default;
     DlLoader(const DlLoader&) =delete;

--- a/core/cc/get_vulkan_proc_address.h
+++ b/core/cc/get_vulkan_proc_address.h
@@ -35,6 +35,10 @@ extern GetVulkanProcAddressFunc* GetVulkanProcAddress;
 extern GetVulkanInstanceProcAddressFunc* GetVulkanInstanceProcAddress;
 extern GetVulkanDeviceProcAddressFunc* GetVulkanDeviceProcAddress;
 
+// HasVulkanLoader returns true if Vulkan loader is found, otherwise returns
+// false.
+bool HasVulkanLoader();
+
 }  // namespace core
 
 #endif  // CORE_GET_VULKAN_PROC_ADDRESS_H

--- a/core/cc/linux/get_vulkan_proc_address.cpp
+++ b/core/cc/linux/get_vulkan_proc_address.cpp
@@ -71,5 +71,7 @@ namespace core {
 GetVulkanInstanceProcAddressFunc* GetVulkanInstanceProcAddress = getVulkanInstanceProcAddress;
 GetVulkanDeviceProcAddressFunc* GetVulkanDeviceProcAddress = getVulkanDeviceProcAddress;
 GetVulkanProcAddressFunc* GetVulkanProcAddress = getVulkanProcAddress;
-
+bool HasVulkanLoader() {
+  return DlLoader::can_load("libvulkan.so");
+}
 }  // namespace core

--- a/core/cc/osx/get_vulkan_proc_address.cpp
+++ b/core/cc/osx/get_vulkan_proc_address.cpp
@@ -40,5 +40,5 @@ namespace core {
 GetVulkanInstanceProcAddressFunc* GetVulkanInstanceProcAddress = getVulkanInstanceProcAddress;
 GetVulkanDeviceProcAddressFunc* GetVulkanDeviceProcAddress = getVulkanDeviceProcAddress;
 GetVulkanProcAddressFunc* GetVulkanProcAddress = getVulkanProcAddress;
-
+bool HasVulkanLoader() { return false; }
 }  // namespace core

--- a/core/cc/windows/get_vulkan_proc_address.cpp
+++ b/core/cc/windows/get_vulkan_proc_address.cpp
@@ -87,7 +87,7 @@ namespace core {
 GetVulkanInstanceProcAddressFunc* GetVulkanInstanceProcAddress = getVulkanInstanceProcAddress;
 GetVulkanDeviceProcAddressFunc* GetVulkanDeviceProcAddress = getVulkanDeviceProcAddress;
 GetVulkanProcAddressFunc* GetVulkanProcAddress = getVulkanProcAddress;
-bool hasVulkanLoader() {
+bool HasVulkanLoader() {
   return DlLoader::can_load(systemVulkanPath().c_str()) ||
          DlLoader::can_load("vulkan-1.dll");
 }

--- a/core/cc/windows/get_vulkan_proc_address.cpp
+++ b/core/cc/windows/get_vulkan_proc_address.cpp
@@ -87,5 +87,8 @@ namespace core {
 GetVulkanInstanceProcAddressFunc* GetVulkanInstanceProcAddress = getVulkanInstanceProcAddress;
 GetVulkanDeviceProcAddressFunc* GetVulkanDeviceProcAddress = getVulkanDeviceProcAddress;
 GetVulkanProcAddressFunc* GetVulkanProcAddress = getVulkanProcAddress;
-
+bool hasVulkanLoader() {
+  return DlLoader::can_load(systemVulkanPath().c_str()) ||
+         DlLoader::can_load("vulkan-1.dll");
+}
 }  // namespace core

--- a/core/os/device/device.proto
+++ b/core/os/device/device.proto
@@ -204,12 +204,32 @@ message OpenGLDriver {
 
 // VulkanDriver describes the device driver support for the Vulkan API.
 message VulkanDriver {
-    // Supported extensions.
-    repeated string Extensions = 1;
-    // Driver name. e.g. "Adreno (TM) 320".
-    string Renderer = 2;
-    // Driver vendor name. e.g. "Qualcomm".
-    string Vendor = 3;
-    // Renderer version. e.g. "OpenGL ES 3.0 V@53.0 AU@  (CL@)".
-    string Version = 4;
+    // Enumerated instance layers.
+    repeated VulkanLayer Layers = 1;
+    // Instance extensions provided by Vulkan implementations and implicit
+    // layers.
+    repeated string IcdAndImplicitLayerExtensions = 2;
+    // Physical devices that have Vulkan supports.
+    repeated VulkanPhysicalDevice PhysicalDevices = 3;
+}
+
+message VulkanLayer {
+  string Name = 1;
+  repeated string Extensions = 2;
+}
+
+// VulkanPhysicalDevice describes a Vulkan physical device
+message VulkanPhysicalDevice {
+  //  ApiVerison is the version of Vulkan supported by the device, encoded as
+  //  described in the Vulkan Spec: API Version Numbers and Semantics section.
+  uint32 ApiVersion = 1;
+  // driverVersion is the vendor-specified version of the driver.
+  uint32 DriverVersion = 2;
+  // vendorID is the unique identifier for the vendor of the physical device.
+  uint32 VendorID = 3;
+  // deviceID is a unique identifier for the physical device among devices
+  // available from the vendor.
+  uint32 DeviceID = 4;
+  // deviceName is a null-terminated string containing the name of the device.
+  string DeviceName = 5;
 }

--- a/core/os/device/device.proto
+++ b/core/os/device/device.proto
@@ -209,10 +209,12 @@ message VulkanDriver {
     // Instance extensions provided by Vulkan implementations and implicit
     // layers.
     repeated string IcdAndImplicitLayerExtensions = 2;
-    // Physical devices that have Vulkan supports.
+    // Physical devices that have Vulkan support.
     repeated VulkanPhysicalDevice PhysicalDevices = 3;
 }
 
+// VulkanLayer describes the layers currently installed on the device,
+// including the layers' name and its supported extensions.
 message VulkanLayer {
   string Name = 1;
   repeated string Extensions = 2;

--- a/core/os/device/deviceinfo/cc/CMakeFiles.cmake
+++ b/core/os/device/deviceinfo/cc/CMakeFiles.cmake
@@ -20,10 +20,13 @@
 set(files
     cpu.cpp
     gl.cpp
+    gl_lite.h
     instance.cpp
     instance.h
     query.cpp
     query.h
+    vk.cpp
+    vk_lite.h
 )
 set(dirs
     android

--- a/core/os/device/deviceinfo/cc/instance.cpp
+++ b/core/os/device/deviceinfo/cc/instance.cpp
@@ -22,9 +22,9 @@ extern "C" {
 device_instance get_device_instance(void* platform_data) {
     device_instance out = {};
 
-    auto instance = query::getDeviceInstance(platform_data);
-    // VkGraphicsSpy layer must NOT be loaded.
-    query::updateVulkanDriver(instance);
+    query::Option query_opt;
+    query_opt.vulkan.QueryLayersAndExtensions().QueryPhysicalDevices();
+    auto instance = query::getDeviceInstance(query_opt, platform_data);
     if (!instance) {
         return out;
     }

--- a/core/os/device/deviceinfo/cc/instance.cpp
+++ b/core/os/device/deviceinfo/cc/instance.cpp
@@ -23,6 +23,8 @@ device_instance get_device_instance(void* platform_data) {
     device_instance out = {};
 
     auto instance = query::getDeviceInstance(platform_data);
+    // VkGraphicsSpy layer must NOT be loaded.
+    query::updateVulkanDriver(instance);
     if (!instance) {
         return out;
     }

--- a/core/os/device/deviceinfo/cc/instance.cpp
+++ b/core/os/device/deviceinfo/cc/instance.cpp
@@ -23,7 +23,8 @@ device_instance get_device_instance(void* platform_data) {
     device_instance out = {};
 
     query::Option query_opt;
-    query_opt.vulkan.QueryLayersAndExtensions().QueryPhysicalDevices();
+    query_opt.vulkan.set_query_layers_and_extensions(true)
+        .set_query_physical_devices(true);
     auto instance = query::getDeviceInstance(query_opt, platform_data);
     if (!instance) {
         return out;

--- a/core/os/device/deviceinfo/cc/query.cpp
+++ b/core/os/device/deviceinfo/cc/query.cpp
@@ -101,10 +101,10 @@ void buildDeviceInstance(const query::Option& opt, void* platform_data,
   // populates the VulkanDriver message.
   if (query::hasVulkanLoader()) {
     auto vulkan_driver = new VulkanDriver();
-    if (opt.vulkan.query_layers_and_extensions) {
+    if (opt.vulkan.query_layers_and_extensions()) {
       query::vkLayersAndExtensions(vulkan_driver);
     }
-    if (opt.vulkan.query_physical_devices) {
+    if (opt.vulkan.query_physical_devices()) {
       query::vkPhysicalDevices(vulkan_driver);
     }
     drivers->set_allocated_vulkan(vulkan_driver);

--- a/core/os/device/deviceinfo/cc/query.h
+++ b/core/os/device/deviceinfo/cc/query.h
@@ -23,9 +23,41 @@
 
 namespace query {
 
+// VulkanOption specifies whether Vulkan layers/extentions info or Vulkan
+// physical devices info should be queried with query::getDeviceInstance().
+// By default, layers/extensions info and physical devices info will not be
+// queried.
+struct VulkanOption {
+  // Default VulkanOption specifies NOT to query layers/extensions and physical
+  // devices info.
+  VulkanOption()
+      : query_layers_and_extensions(false), query_physical_devices(false) {}
+  // QueryLayerAndExtensions set the flag which specifies layers and extensions
+  // info should be queried.
+  VulkanOption& QueryLayersAndExtensions() {
+    this->query_layers_and_extensions = true;
+    return *this;
+  }
+  // QueryPhysicalDevices set the flag which specifies physical devices info
+  // should be queried.
+  VulkanOption& QueryPhysicalDevices() {
+    this->query_physical_devices = true;
+    return *this;
+  }
+  // Flags to indicate whether some info should be queried.
+  bool query_layers_and_extensions;
+  bool query_physical_devices;
+};
+
+// Option specifies how some optional device info to be queried with
+// query::getDeviceInstance().
+struct Option {
+  VulkanOption vulkan;
+};
+
 // getDeviceInstance returns the device::Instance proto message for the
 // current device. It must be freed with delete.
-device::Instance* getDeviceInstance(void* platform_data);
+device::Instance* getDeviceInstance(const Option& opt, void* platform_data);
 
 // updateVulkanPhysicalDevices modifies the given device::Instance by adding
 // device::VulkanPhysicalDevice to the device::Instance. If a

--- a/core/os/device/deviceinfo/cc/query.h
+++ b/core/os/device/deviceinfo/cc/query.h
@@ -42,8 +42,7 @@ device::Instance* getDeviceInstance(void* platform_data);
 // addresses from loader will cause a infinite calling stack and may deadlock
 // in the loader.
 bool updateVulkanDriver(
-    device::Instance* inst,
-    size_t vk_inst_handle = 0,
+    device::Instance* inst, size_t vk_inst_handle = 0,
     std::function<void*(size_t, const char*)> get_inst_proc_addr = nullptr);
 
 // vkLayersAndExtensions populates the layers and extension fields in the given
@@ -60,8 +59,7 @@ bool vkLayersAndExtensions(
 // vkGetInstanceProcAddress function is given, that function will be used to
 // resolve Vulkan API calls, otherwise Vulkan loader will be used.
 bool vkPhysicalDevices(
-    device::VulkanDriver*,
-    size_t vk_inst = 0,
+    device::VulkanDriver*, size_t vk_inst = 0,
     std::function<void*(size_t, const char*)> get_inst_proc_addr = nullptr);
 
 // hasVulkanLoader returns true if Vulkan loader is found, otherwise returns

--- a/core/os/device/deviceinfo/cc/query.h
+++ b/core/os/device/deviceinfo/cc/query.h
@@ -27,26 +27,33 @@ namespace query {
 // physical devices info should be queried with query::getDeviceInstance().
 // By default, layers/extensions info and physical devices info will not be
 // queried.
-struct VulkanOption {
+class VulkanOption {
+ public:
   // Default VulkanOption specifies NOT to query layers/extensions and physical
   // devices info.
   VulkanOption()
-      : query_layers_and_extensions(false), query_physical_devices(false) {}
-  // QueryLayerAndExtensions set the flag which specifies layers and extensions
-  // info should be queried.
-  VulkanOption& QueryLayersAndExtensions() {
-    this->query_layers_and_extensions = true;
+      : query_layers_and_extensions_(false), query_physical_devices_(false) {}
+  // set_query_layers_and_extensions sets the flag to indicate whether layers
+  // and extensions info should be queried.
+  VulkanOption& set_query_layers_and_extensions(bool f) {
+    this->query_layers_and_extensions_ = f;
     return *this;
   }
-  // QueryPhysicalDevices set the flag which specifies physical devices info
-  // should be queried.
-  VulkanOption& QueryPhysicalDevices() {
-    this->query_physical_devices = true;
+  // set_query_physical_devices sets the flag to indicate whether physical
+  // devices info should be queried.
+  VulkanOption& set_query_physical_devices(bool f) {
+    this->query_physical_devices_ = f;
     return *this;
   }
+  inline bool query_layers_and_extensions() const {
+    return query_layers_and_extensions_;
+  }
+  inline bool query_physical_devices() const { return query_physical_devices_; }
+
+ private:
   // Flags to indicate whether some info should be queried.
-  bool query_layers_and_extensions;
-  bool query_physical_devices;
+  bool query_layers_and_extensions_;
+  bool query_physical_devices_;
 };
 
 // Option specifies how some optional device info to be queried with

--- a/core/os/device/deviceinfo/cc/vk.cpp
+++ b/core/os/device/deviceinfo/cc/vk.cpp
@@ -1,0 +1,170 @@
+/*
+ * Copyright (C) 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "query.h"
+#include "vk_lite.h"
+
+#include "core/cc/assert.h"
+#include "core/cc/dl_loader.h"
+#include "core/cc/get_vulkan_proc_address.h"
+#include "core/cc/target.h"
+
+#include <functional>
+#include <string>
+#include <vector>
+
+namespace query {
+
+bool hasVulkanLoader() {
+  return core::HasVulkanLoader();
+}
+
+#define MUST_SUCCESS(expr)                                      \
+  if (VK_SUCCESS != expr) {                                     \
+    GAPID_WARNING("Does not return VK_SUCCESS: " #expr          \
+                  " for getting Vulkan physical device info."); \
+    return false;                                               \
+  }
+
+#define RETURN_IF_NOT_RESOLVED(FuncName)                        \
+  if (FuncName == nullptr) {                                    \
+    GAPID_WARNING("Failed at resolving: " #FuncName             \
+                  " for getting Vulkan physical device info."); \
+    return false;                                               \
+  }
+
+bool vkLayersAndExtensions(
+    device::VulkanDriver* driver,
+    std::function<void*(size_t, const char*)> get_inst_proc_addr) {
+  if (!driver) {
+    return false;
+  }
+
+// Resolve functions.
+#define MUST_RESOLVE(FuncType, FuncName)                 \
+  FuncType FuncName = reinterpret_cast<FuncType>(        \
+      get_inst_proc_addr == nullptr                      \
+          ? core::GetVulkanProcAddress(#FuncName, false) \
+          : get_inst_proc_addr(0, #FuncName));           \
+  RETURN_IF_NOT_RESOLVED(FuncName)
+  MUST_RESOLVE(PFNVKENUMERATEINSTANCELAYERPROPERTIES,
+               vkEnumerateInstanceLayerProperties);
+  MUST_RESOLVE(PFNVKENUMERATEINSTANCEEXTENSIONPROPERTIES,
+               vkEnumerateInstanceExtensionProperties);
+#undef MUST_RESOLVE
+  // Layers and extensions supported by those layers.
+  uint32_t layer_count = 0;
+  MUST_SUCCESS(vkEnumerateInstanceLayerProperties(&layer_count, nullptr));
+  std::vector<VkLayerProperties> inst_layer_props(layer_count,
+                                                  VkLayerProperties{});
+  MUST_SUCCESS(vkEnumerateInstanceLayerProperties(&layer_count,
+                                                  inst_layer_props.data()));
+  driver->clear_layers();
+  for (size_t i = 0; i < inst_layer_props.size(); i++) {
+    auto& l = inst_layer_props[i];
+    uint32_t ext_count = 0;
+    // Skip our layers.
+    if (!strcmp(l.layerName, "VkGraphicsSpy") ||
+        !strcmp(l.layerName, "VirtualSwapchain")) {
+      continue;
+    }
+    MUST_SUCCESS(vkEnumerateInstanceExtensionProperties(l.layerName, &ext_count,
+                                                        nullptr));
+    std::vector<VkExtensionProperties> ext_props(ext_count,
+                                                 VkExtensionProperties{});
+    MUST_SUCCESS(vkEnumerateInstanceExtensionProperties(l.layerName, &ext_count,
+                                                        ext_props.data()));
+    driver->add_layers();
+    driver->mutable_layers(i)->set_name(l.layerName);
+    for (size_t j = 0; j < ext_props.size(); j++) {
+      driver->mutable_layers(i)->add_extensions(ext_props[j].extensionName);
+    }
+  }
+  // For implicit layers and ICD extensions
+  driver->clear_icdandimplicitlayerextensions();
+  uint32_t ext_count = 0;
+  MUST_SUCCESS(
+      vkEnumerateInstanceExtensionProperties(nullptr, &ext_count, nullptr));
+  std::vector<VkExtensionProperties> ext_props(ext_count,
+                                               VkExtensionProperties{});
+  MUST_SUCCESS(vkEnumerateInstanceExtensionProperties(nullptr, &ext_count,
+                                                      ext_props.data()));
+  for (size_t i = 0; i < ext_props.size(); i++) {
+    driver->add_icdandimplicitlayerextensions(ext_props[i].extensionName);
+  }
+  return true;
+}
+
+bool vkPhysicalDevices(
+    device::VulkanDriver* driver, size_t vk_inst_handle,
+    std::function<void*(size_t, const char*)> get_inst_proc_addr) {
+  if (!driver) {
+    return false;
+  }
+  driver->clear_physicaldevices();
+
+// Resolve functions, create vkInstance handle if the given handle is NULL.
+#define MUST_RESOLVE(FuncType, FuncName)                                  \
+  FuncType FuncName = reinterpret_cast<FuncType>(                         \
+      get_inst_proc_addr == nullptr                                       \
+          ? core::GetVulkanInstanceProcAddress(vk_inst_handle, #FuncName, \
+                                               false)                     \
+          : get_inst_proc_addr(vk_inst_handle, #FuncName));               \
+  RETURN_IF_NOT_RESOLVED(FuncName)
+
+  if (vk_inst_handle == 0) {
+    MUST_RESOLVE(PFNVKCREATEINSTANCE, vkCreateInstance);
+    VkInstanceCreateInfo inst_create_info{
+        VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO,  // sType
+        nullptr,                                 // pNext
+        VkInstanceCreateFlags(0),                // flags
+        nullptr,
+        0,
+        nullptr,
+        0,
+        nullptr};
+    MUST_SUCCESS(vkCreateInstance(&inst_create_info, nullptr, &vk_inst_handle));
+  }
+  MUST_RESOLVE(PFNVKENUMERATEPHYSICALDEVICES, vkEnumeratePhysicalDevices);
+  MUST_RESOLVE(PFNVKGETPHYSICALDEVICEPROPERTIES, vkGetPhysicalDeviceProperties);
+#undef MUST_RESOLVE
+
+  uint32_t phy_dev_count = 0;
+  MUST_SUCCESS(
+      vkEnumeratePhysicalDevices(vk_inst_handle, &phy_dev_count, nullptr));
+  std::vector<VkPhysicalDevice> phy_devs(phy_dev_count, VkPhysicalDevice(0));
+  MUST_SUCCESS(vkEnumeratePhysicalDevices(vk_inst_handle, &phy_dev_count,
+                                          phy_devs.data()));
+
+  for (size_t i = 0; i < phy_devs.size(); i++) {
+    auto phy_dev = phy_devs[i];
+    VkPhysicalDeviceProperties prop;
+    vkGetPhysicalDeviceProperties(phy_dev, &prop);
+    driver->add_physicaldevices();
+    driver->mutable_physicaldevices(i)->set_apiversion(prop.apiVersion);
+    driver->mutable_physicaldevices(i)->set_driverversion(prop.driverVersion);
+    driver->mutable_physicaldevices(i)->set_vendorid(prop.vendorID);
+    driver->mutable_physicaldevices(i)->set_deviceid(prop.deviceID);
+    driver->mutable_physicaldevices(i)->set_devicename(
+        std::string(prop.deviceName));
+  }
+
+  return true;
+}
+
+#undef RETURN_IF_NOT_RESOLVED
+#undef MUST_SUCCESS
+}  // namespace query

--- a/core/os/device/deviceinfo/cc/vk.cpp
+++ b/core/os/device/deviceinfo/cc/vk.cpp
@@ -30,17 +30,21 @@ namespace query {
 
 bool hasVulkanLoader() { return core::HasVulkanLoader(); }
 
-#define MUST_SUCCESS(expr)                                      \
-  if (VK_SUCCESS != expr) {                                     \
-    GAPID_WARNING("Does not return VK_SUCCESS: " #expr          \
-                  " for getting Vulkan physical device info."); \
-    return false;                                               \
+#define MUST_SUCCESS(expr)                              \
+  {                                                     \
+    auto r = expr;                                      \
+    if (VK_SUCCESS != r) {                              \
+      GAPID_WARNING("Return: %d != VK_SUCCESS: " #expr  \
+                    " for getting Vulkan Driver info.", \
+                    r);                                 \
+      return false;                                     \
+    }                                                   \
   }
 
 #define RETURN_IF_NOT_RESOLVED(FuncName)                        \
   if (FuncName == nullptr) {                                    \
     GAPID_WARNING("Failed at resolving: " #FuncName             \
-                  " for getting Vulkan physical device info."); \
+                  " for getting Vulkan Driver info."); \
     return false;                                               \
   }
 

--- a/core/os/device/deviceinfo/cc/vk.cpp
+++ b/core/os/device/deviceinfo/cc/vk.cpp
@@ -28,9 +28,7 @@
 
 namespace query {
 
-bool hasVulkanLoader() {
-  return core::HasVulkanLoader();
-}
+bool hasVulkanLoader() { return core::HasVulkanLoader(); }
 
 #define MUST_SUCCESS(expr)                                      \
   if (VK_SUCCESS != expr) {                                     \

--- a/core/os/device/deviceinfo/cc/vk_lite.h
+++ b/core/os/device/deviceinfo/cc/vk_lite.h
@@ -1,0 +1,272 @@
+/*
+ * Copyright (C) 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef GAPID_CORE_OS_DEVICEINFO_VK_LITE
+#define GAPID_CORE_OS_DEVICEINFO_VK_LITE
+
+#include "core/cc/static_array.h"
+#include "core/cc/vulkan_ptr_types.h"
+
+// Enums
+typedef enum VkStructureType {
+  VK_STRUCTURE_TYPE_APPLICATION_INFO = 0,
+  VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO = 1,
+} VkStructureType;
+
+typedef enum VkResult {
+  VK_SUCCESS = 0,
+  VK_NOT_READY = 1,
+  VK_TIMEOUT = 2,
+  VK_EVENT_SET = 3,
+  VK_EVENT_RESET = 4,
+  VK_INCOMPLETE = 5,
+  VK_ERROR_OUT_OF_HOST_MEMORY = 4294967295,
+  VK_ERROR_OUT_OF_DEVICE_MEMORY = 4294967294,
+  VK_ERROR_INITIALIZATION_FAILED = 4294967293,
+  VK_ERROR_DEVICE_LOST = 4294967292,
+  VK_ERROR_MEMORY_MAP_FAILED = 4294967291,
+  VK_ERROR_LAYER_NOT_PRESENT = 4294967290,
+  VK_ERROR_EXTENSION_NOT_PRESENT = 4294967289,
+  VK_ERROR_FEATURE_NOT_PRESENT = 4294967288,
+  VK_ERROR_INCOMPATIBLE_DRIVER = 4294967287,
+  VK_ERROR_TOO_MANY_OBJECTS = 4294967286,
+  VK_ERROR_FORMAT_NOT_SUPPORTED = 4294967285,
+  VK_ERROR_SURFACE_LOST_KHR = 3294967296,
+  VK_ERROR_NATIVE_WINDOW_IN_USE_KHR = 3294967295,
+  VK_SUBOPTIMAL_KHR = 1000001003,
+  VK_ERROR_OUT_OF_DATE_KHR = 3294966292,
+  VK_ERROR_INCOMPATIBLE_DISPLAY_KHR = 3294964295,
+  VK_ERROR_VALIDATION_FAILED_EXT = 3294956295,
+  VK_ERROR_INVALID_SHADER_NV = 1000012000,
+} VkResult;
+
+enum class VkPhysicalDeviceType : uint32_t {
+  VK_PHYSICAL_DEVICE_TYPE_OTHER = 0,
+  VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU = 1,
+  VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU = 2,
+  VK_PHYSICAL_DEVICE_TYPE_VIRTUAL_GPU = 3,
+  VK_PHYSICAL_DEVICE_TYPE_CPU = 4,
+};
+
+// Type alias
+typedef uint32_t VkBool32;
+typedef uint32_t VkFlags;
+typedef uint64_t VkDeviceSize;
+typedef size_t VkInstance;
+typedef size_t VkPhysicalDevice;
+
+typedef VkFlags VkInstanceCreateFlags;
+typedef VkFlags VkSampleCountFlags;
+
+typedef void* PFN_vkAllocationFunction;
+typedef void* PFN_vkReallocationFunction;
+typedef void* PFN_vkFreeFunction;
+typedef void* PFN_vkInternalAllocationNotification;
+typedef void* PFN_vkInternalFreeNotification;
+typedef void* PFN_vkVoidFunction;
+
+// Structs
+typedef struct {
+  core::StaticArray<char, 256> layerName;
+  uint32_t specVersion;
+  uint32_t implementationVersion;
+  core::StaticArray<char, 256> description;
+} VkLayerProperties;
+
+typedef struct {
+  core::StaticArray<char, 256> extensionName;
+  uint32_t specVersion;
+} VkExtensionProperties;
+
+typedef struct {
+  VkStructureType sType;
+  void* pNext;
+  char* pApplicationName;
+  uint32_t applicationVersion;
+  char* pEngineName;
+  uint32_t engineVersion;
+  uint32_t apiVersion;
+} VkApplicationInfo;
+
+typedef struct {
+  VkStructureType sType;
+  void* pNext;
+  VkInstanceCreateFlags flags;
+  VkApplicationInfo* pApplicationInfo;
+  uint32_t enabledLayerCount;
+  char** ppEnabledLayerNames;
+  uint32_t enabledExtensionCount;
+  char** ppEnabledExtensionNames;
+} VkInstanceCreateInfo;
+
+typedef struct {
+  uint32_t maxImageDimension1D;
+  uint32_t maxImageDimension2D;
+  uint32_t maxImageDimension3D;
+  uint32_t maxImageDimensionCube;
+  uint32_t maxImageArrayLayers;
+  uint32_t maxTexelBufferElements;
+  uint32_t maxUniformBufferRange;
+  uint32_t maxStorageBufferRange;
+  uint32_t maxPushConstantsSize;
+  uint32_t maxMemoryAllocationCount;
+  uint32_t maxSamplerAllocationCount;
+  VkDeviceSize bufferImageGranularity;
+  VkDeviceSize sparseAddressSpaceSize;
+  uint32_t maxBoundDescriptorSets;
+  uint32_t maxPerStageDescriptorSamplers;
+  uint32_t maxPerStageDescriptorUniformBuffers;
+  uint32_t maxPerStageDescriptorStorageBuffers;
+  uint32_t maxPerStageDescriptorSampledImages;
+  uint32_t maxPerStageDescriptorStorageImages;
+  uint32_t maxPerStageDescriptorInputAttachments;
+  uint32_t maxPerStageResources;
+  uint32_t maxDescriptorSetSamplers;
+  uint32_t maxDescriptorSetUniformBuffers;
+  uint32_t maxDescriptorSetUniformBuffersDynamic;
+  uint32_t maxDescriptorSetStorageBuffers;
+  uint32_t maxDescriptorSetStorageBuffersDynamic;
+  uint32_t maxDescriptorSetSampledImages;
+  uint32_t maxDescriptorSetStorageImages;
+  uint32_t maxDescriptorSetInputAttachments;
+  uint32_t maxVertexInputAttributes;
+  uint32_t maxVertexInputBindings;
+  uint32_t maxVertexInputAttributeOffset;
+  uint32_t maxVertexInputBindingStride;
+  uint32_t maxVertexOutputComponents;
+  uint32_t maxTessellationGenerationLevel;
+  uint32_t maxTessellationPatchSize;
+  uint32_t maxTessellationControlPerVertexInputComponents;
+  uint32_t maxTessellationControlPerVertexOutputComponents;
+  uint32_t maxTessellationControlPerPatchOutputComponents;
+  uint32_t maxTessellationControlTotalOutputComponents;
+  uint32_t maxTessellationEvaluationInputComponents;
+  uint32_t maxTessellationEvaluationOutputComponents;
+  uint32_t maxGeometryShaderInvocations;
+  uint32_t maxGeometryInputComponents;
+  uint32_t maxGeometryOutputComponents;
+  uint32_t maxGeometryOutputVertices;
+  uint32_t maxGeometryTotalOutputComponents;
+  uint32_t maxFragmentInputComponents;
+  uint32_t maxFragmentOutputAttachments;
+  uint32_t maxFragmentDualSrcAttachments;
+  uint32_t maxFragmentCombinedOutputResources;
+  uint32_t maxComputeSharedMemorySize;
+  core::StaticArray<uint32_t, 3> maxComputeWorkGroupCount;
+  uint32_t maxComputeWorkGroupInvocations;
+  core::StaticArray<uint32_t, 3> maxComputeWorkGroupSize;
+  uint32_t subPixelPrecisionBits;
+  uint32_t subTexelPrecisionBits;
+  uint32_t mipmapPrecisionBits;
+  uint32_t maxDrawIndexedIndexValue;
+  uint32_t maxDrawIndirectCount;
+  float maxSamplerLodBias;
+  float maxSamplerAnisotropy;
+  uint32_t maxViewports;
+  core::StaticArray<uint32_t, 2> maxViewportDimensions;
+  core::StaticArray<float, 2> viewportBoundsRange;
+  uint32_t viewportSubPixelBits;
+  size_t minMemoryMapAlignment;
+  VkDeviceSize minTexelBufferOffsetAlignment;
+  VkDeviceSize minUniformBufferOffsetAlignment;
+  VkDeviceSize minStorageBufferOffsetAlignment;
+  int32_t minTexelOffset;
+  uint32_t maxTexelOffset;
+  int32_t minTexelGatherOffset;
+  uint32_t maxTexelGatherOffset;
+  float minInterpolationOffset;
+  float maxInterpolationOffset;
+  uint32_t subPixelInterpolationOffsetBits;
+  uint32_t maxFramebufferWidth;
+  uint32_t maxFramebufferHeight;
+  uint32_t maxFramebufferLayers;
+  VkSampleCountFlags framebufferColorSampleCounts;
+  VkSampleCountFlags framebufferDepthSampleCounts;
+  VkSampleCountFlags framebufferStencilSampleCounts;
+  VkSampleCountFlags framebufferNoAttachmentSampleCounts;
+  uint32_t maxColorAttachments;
+  VkSampleCountFlags sampledImageColorSampleCounts;
+  VkSampleCountFlags sampledImageIntegerSampleCounts;
+  VkSampleCountFlags sampledImageDepthSampleCounts;
+  VkSampleCountFlags sampledImageStencilSampleCounts;
+  VkSampleCountFlags storageImageSampleCounts;
+  uint32_t maxSampleMaskWords;
+  VkBool32 timestampComputeAndGraphics;
+  float timestampPeriod;
+  uint32_t maxClipDistances;
+  uint32_t maxCullDistances;
+  uint32_t maxCombinedClipAndCullDistances;
+  uint32_t discreteQueuePriorities;
+  core::StaticArray<float, 2> pointSizeRange;
+  core::StaticArray<float, 2> lineWidthRange;
+  float pointSizeGranularity;
+  float lineWidthGranularity;
+  VkBool32 strictLines;
+  VkBool32 standardSampleLocations;
+  VkDeviceSize optimalBufferCopyOffsetAlignment;
+  VkDeviceSize optimalBufferCopyRowPitchAlignment;
+  VkDeviceSize nonCoherentAtomSize;
+} VkPhysicalDeviceLimits;
+
+typedef struct {
+  VkBool32 residencyStandard2DBlockShape;
+  VkBool32 residencyStandard2DMultisampleBlockShape;
+  VkBool32 residencyStandard3DBlockShape;
+  VkBool32 residencyAlignedMipSize;
+  VkBool32 residencyNonResidentStrict;
+} VkPhysicalDeviceSparseProperties;
+
+typedef struct {
+  uint32_t apiVersion;
+  uint32_t driverVersion;
+  uint32_t vendorID;
+  uint32_t deviceID;
+  VkPhysicalDeviceType deviceType;
+  core::StaticArray<char, 256> deviceName;
+  core::StaticArray<uint8_t, 16> pipelineCacheUUID;
+  VkPhysicalDeviceLimits limits;
+  VkPhysicalDeviceSparseProperties sparseProperties;
+} VkPhysicalDeviceProperties;
+
+typedef struct {
+  void* pUserData;
+  PFN_vkAllocationFunction pfnAllocation;
+  PFN_vkReallocationFunction pfnReallocation;
+  PFN_vkFreeFunction pfnFree;
+  PFN_vkInternalAllocationNotification pfnInternalAllocation;
+  PFN_vkInternalFreeNotification pfnInternalFree;
+} VkAllocationCallbacks;
+
+// Function types
+typedef PFN_vkVoidFunction(VULKAN_API_PTR* PFNVKGETINSTANCEPROCADDR)(
+    VkInstance instance, const char* pName);
+typedef VkResult(VULKAN_API_PTR* PFNVKENUMERATEINSTANCELAYERPROPERTIES)(
+    uint32_t* pPropertyCount, VkLayerProperties* pProperties);
+typedef VkResult(VULKAN_API_PTR* PFNVKENUMERATEINSTANCEEXTENSIONPROPERTIES)(
+    const char* pLayerName, uint32_t* pPropertyCount,
+    VkExtensionProperties* pProperties);
+typedef VkResult(VULKAN_API_PTR* PFNVKCREATEINSTANCE)(
+    VkInstanceCreateInfo* pCreateInfo, VkAllocationCallbacks* pAllocator,
+    VkInstance* pInstance);
+typedef void(VULKAN_API_PTR* PFNVKDESTROYINSTANCE)(
+    VkInstance instance, VkAllocationCallbacks* pAllocator);
+typedef VkResult(VULKAN_API_PTR* PFNVKENUMERATEPHYSICALDEVICES)(
+    VkInstance instance, uint32_t* pPhysicalDeviceCount,
+    VkPhysicalDevice* pPhysicalDevices);
+typedef void(VULKAN_API_PTR* PFNVKGETPHYSICALDEVICEPROPERTIES)(
+    VkPhysicalDevice physicalDevice, VkPhysicalDeviceProperties* pProperties);
+
+#endif  // GAPID_CORE_OS_DEVICEINFO_VK_LITE

--- a/core/os/process/client.go
+++ b/core/os/process/client.go
@@ -141,7 +141,9 @@ func Start(ctx context.Context, name string, opts StartOptions) (int, error) {
 
 	c, cancel := task.WithCancel(ctx)
 	defer cancel()
-	crash.Go(func() { stdout.waitForFile(c) })
+	crash.Go(func() {
+		stdout.waitForFile(c)
+	})
 	crash.Go(func() {
 		cmd := shell.
 			Command(name, opts.Args...).

--- a/gapii/cc/spy.cpp
+++ b/gapii/cc/spy.cpp
@@ -38,10 +38,6 @@
 #include <vector>
 #include <memory>
 
-// CurrentCaptureVersion is incremented on breaking changes to the capture format.
-// NB: Also update equally named field in capture.go
-static const int CurrentCaptureVersion = 1;
-
 #if TARGET_OS == GAPID_OS_WINDOWS
 #include "windows/wgl.h"
 #endif //  TARGET_OS == GAPID_OS_WINDOWS
@@ -189,7 +185,11 @@ Spy::Spy()
     // writeHeader needs to come before the installer is created as the
     // deviceinfo queries want to call into EGL / GL commands which will be
     // patched.
-    writeHeader();
+    SpyBase::set_device_instance(query::getDeviceInstance(queryPlatformData()));
+    SpyBase::set_current_abi(query::currentABI());
+    if (!SpyBase::writeHeader()) {
+      GAPID_ERROR("Failed at writing trace header.");
+    }
 
 #if TARGET_OS == GAPID_OS_ANDROID
     if (strlen(header.mLibInterceptorPath) > 0) {
@@ -224,7 +224,6 @@ Spy::Spy()
 
 void Spy::writeHeader() {
     capture::Header file_header;
-    file_header.set_version(CurrentCaptureVersion);
     file_header.set_allocated_device(query::getDeviceInstance(queryPlatformData()));
     file_header.set_allocated_abi(query::currentABI());
     mEncoder->object(&file_header);

--- a/gapii/cc/spy.cpp
+++ b/gapii/cc/spy.cpp
@@ -185,7 +185,9 @@ Spy::Spy()
     // writeHeader needs to come before the installer is created as the
     // deviceinfo queries want to call into EGL / GL commands which will be
     // patched.
-    SpyBase::set_device_instance(query::getDeviceInstance(queryPlatformData()));
+    query::Option query_opt;
+    SpyBase::set_device_instance(
+        query::getDeviceInstance(query_opt, queryPlatformData()));
     SpyBase::set_current_abi(query::currentABI());
     if (!SpyBase::writeHeader()) {
       GAPID_ERROR("Failed at writing trace header.");
@@ -220,13 +222,6 @@ Spy::Spy()
     }
     set_suspended(mSuspendCaptureFrames.load() != 0);
     set_observing(mObserveFrameFrequency != 0 || mObserveDrawFrequency != 0);
-}
-
-void Spy::writeHeader() {
-    capture::Header file_header;
-    file_header.set_allocated_device(query::getDeviceInstance(queryPlatformData()));
-    file_header.set_allocated_abi(query::currentABI());
-    mEncoder->object(&file_header);
 }
 
 void Spy::resolveImports() {

--- a/gapii/cc/spy_base.cpp
+++ b/gapii/cc/spy_base.cpp
@@ -52,12 +52,10 @@ void SpyBase::init(CallObserver* observer) {
 
 void SpyBase::lock(CallObserver* observer) {
     mMutex.lock();
-  GAPID_WARNING("SpyBase: locked");
 }
 
 void SpyBase::unlock() {
     mMutex.unlock();
-  GAPID_WARNING("SpyBase: unlocked");
 }
 
 void SpyBase::abort() {

--- a/gapis/api/gles/replay.go
+++ b/gapis/api/gles/replay.go
@@ -74,7 +74,7 @@ type framebufferRequest struct {
 // replaying this trace on the given device.
 // A lower number represents a higher priority, and Zero represents
 // an inability for the trace to be replayed on the given device.
-func (a API) GetReplayPriority(ctx context.Context, i *device.Instance, l *device.MemoryLayout) uint32 {
+func (a API) GetReplayPriority(ctx context.Context, i *device.Instance, h *capture.Header) uint32 {
 	if i.GetConfiguration().GetOS().GetKind() != device.Android {
 		return 1
 	}
@@ -91,7 +91,7 @@ func (a API) Replay(
 	capture *capture.Capture,
 	out transform.Writer) error {
 
-	if a.GetReplayPriority(ctx, device, capture.Header.Abi.MemoryLayout) == 0 {
+	if a.GetReplayPriority(ctx, device, capture.Header) == 0 {
 		return log.Errf(ctx, nil, "Cannot replay GLES commands on device '%v'", device.Name)
 	}
 

--- a/gapis/api/vulkan/replay.go
+++ b/gapis/api/vulkan/replay.go
@@ -61,28 +61,30 @@ func (a API) GetReplayPriority(ctx context.Context, i *device.Instance, h *captu
 	}
 
 	for _, abi := range devAbis {
-		if abi.GetMemoryLayout().SameAs(h.GetAbi().GetMemoryLayout()) {
-			// If there is no physical devices, the trace must not contain
-			// vkCreateInstance, any ABI compatible Vulkan device should be able to
-			// replay.
-			if len(traceVkDriver.GetPhysicalDevices()) == 0 {
-				return 1
-			}
-			// Requires same vendor, device and version of API.
-			for _, devPhyInfo := range devVkDriver.GetPhysicalDevices() {
-				for _, tracePhyInfo := range traceVkDriver.GetPhysicalDevices() {
-					// TODO: More sophisticated rules
-					if devPhyInfo.GetVendorID() != tracePhyInfo.GetVendorID() {
-						continue
-					}
-					if devPhyInfo.GetDeviceID() != tracePhyInfo.GetDeviceID() {
-						continue
-					}
-					if devPhyInfo.GetApiVersion() != tracePhyInfo.GetApiVersion() {
-						continue
-					}
-					return 1
+		// Memory layout must match.
+		if !abi.GetMemoryLayout().SameAs(h.GetAbi().GetMemoryLayout()) {
+			continue
+		}
+		// If there is no physical devices, the trace must not contain
+		// vkCreateInstance, any ABI compatible Vulkan device should be able to
+		// replay.
+		if len(traceVkDriver.GetPhysicalDevices()) == 0 {
+			return 1
+		}
+		// Requires same vendor, device and version of API.
+		for _, devPhyInfo := range devVkDriver.GetPhysicalDevices() {
+			for _, tracePhyInfo := range traceVkDriver.GetPhysicalDevices() {
+				// TODO: More sophisticated rules
+				if devPhyInfo.GetVendorID() != tracePhyInfo.GetVendorID() {
+					continue
 				}
+				if devPhyInfo.GetDeviceID() != tracePhyInfo.GetDeviceID() {
+					continue
+				}
+				if devPhyInfo.GetApiVersion() != tracePhyInfo.GetApiVersion() {
+					continue
+				}
+				return 1
 			}
 		}
 	}

--- a/gapis/api/vulkan/templates/vk_spy_helpers.cpp.tmpl
+++ b/gapis/api/vulkan/templates/vk_spy_helpers.cpp.tmpl
@@ -259,7 +259,7 @@ uint32_t VulkanSpy::SpyOverride_vkCreateInstance(VkInstanceCreateInfo *pCreateIn
     // Send a header with Vulkan info added if we haven't done so.
     auto should_send_header = [&]() {
       const device::Drivers& drivers =
-          SpyBase::device_instance()->configuration().drivers();
+        this->SpyBase::device_instance()->configuration().drivers();
       // If the has_vulkan() returns false, it means the Vulkan loader is not
       // found in the first time we get device instance. However, if this
       // vkCreateInstance is called (so we are here), the loader must be

--- a/gapis/api/vulkan/templates/vk_spy_helpers.cpp.tmpl
+++ b/gapis/api/vulkan/templates/vk_spy_helpers.cpp.tmpl
@@ -32,6 +32,8 @@
 #include "gapii/cc/vulkan_imports.h"
 #include "gapii/cc/vulkan_spy.h"
 ¶
+#include "core/os/device/deviceinfo/cc/query.h"
+¶
 extern "C" {«
 // For this to function on Android the entry-point names for GetDeviceProcAddr
 // and GetInstanceProcAddr must be ${layer_name}/Get*ProcAddr.
@@ -233,7 +235,7 @@ uint32_t VulkanSpy::SpyOverride_vkCreateInstance(VkInstanceCreateInfo *pCreateIn
 
     // Grab the pointer to the next vkGetInstanceProcAddr in the chain.
     gapii::VulkanImports::PFNVKGETINSTANCEPROCADDR get_instance_proc_addr =
-        layer_info->u.pLayerInfo->pfnNextGetInstanceProcAddr;
+    layer_info->u.pLayerInfo->pfnNextGetInstanceProcAddr;
 
     // From that get the next vkCreateInstance function.
     gapii::VulkanImports::PFNVKCREATEINSTANCE create_instance = reinterpret_cast<gapii::VulkanImports::PFNVKCREATEINSTANCE>(
@@ -253,6 +255,37 @@ uint32_t VulkanSpy::SpyOverride_vkCreateInstance(VkInstanceCreateInfo *pCreateIn
 
     // Actually call vkCreateInstance, and keep track of the result.
     uint32_t result = create_instance(pCreateInfo, pAllocator, pInstance);
+
+    // Send a header with Vulkan info added if we haven't done so.
+    auto should_send_header = [&]() {
+      const device::Drivers& drivers =
+          SpyBase::device_instance()->configuration().drivers();
+      // If the has_vulkan() returns false, it means the Vulkan loader is not
+      // found in the first time we get device instance. However, if this
+      // vkCreateInstance is called (so we are here), the loader must be
+      // working now, so we should populate the Vulkan driver info in the
+      // device::Instance.
+      if (!drivers.has_vulkan()) {
+        return true;
+      }
+      // If has_vulkan() returns true, but VulkanDriver is empty, we should
+      // populate the VulkanDriver and send the new header.
+      if (drivers.vulkan().layers_size() == 0 &&
+          drivers.vulkan().icdandimplicitlayerextensions_size() == 0 &&
+          drivers.vulkan().physicaldevices_size() == 0) {
+        return true;
+      }
+      return false;
+    };
+    if (should_send_header()) {
+      if (query::updateVulkanDriver(SpyBase::device_instance(), *pInstance,
+                                    get_instance_proc_addr)) {
+        SpyBase::writeHeader();
+      } else {
+        GAPID_ERROR(
+            "Cannot update device info with Vulkan physical device info.");
+      }
+    }
 
     // If it failed, then we don't need to track this instance.
     if (result != VkResult::VK_SUCCESS) return result;

--- a/gapis/api/vulkan/templates/vk_spy_helpers.cpp.tmpl
+++ b/gapis/api/vulkan/templates/vk_spy_helpers.cpp.tmpl
@@ -257,7 +257,7 @@ uint32_t VulkanSpy::SpyOverride_vkCreateInstance(VkInstanceCreateInfo *pCreateIn
     uint32_t result = create_instance(pCreateInfo, pAllocator, pInstance);
 
     // Send a header with Vulkan info added if we haven't done so.
-    auto should_send_header = [&]() {
+    auto should_send_header = [this]() {
       const device::Drivers& drivers =
         this->SpyBase::device_instance()->configuration().drivers();
       // If the has_vulkan() returns false, it means the Vulkan loader is not

--- a/gapis/api/vulkan/templates/vk_spy_helpers.cpp.tmpl
+++ b/gapis/api/vulkan/templates/vk_spy_helpers.cpp.tmpl
@@ -257,27 +257,21 @@ uint32_t VulkanSpy::SpyOverride_vkCreateInstance(VkInstanceCreateInfo *pCreateIn
     uint32_t result = create_instance(pCreateInfo, pAllocator, pInstance);
 
     // Send a header with Vulkan info added if we haven't done so.
-    auto should_send_header = [this]() {
-      const device::Drivers& drivers =
+    const device::Drivers& drivers =
         this->SpyBase::device_instance()->configuration().drivers();
-      // If the has_vulkan() returns false, it means the Vulkan loader is not
-      // found in the first time we get device instance. However, if this
-      // vkCreateInstance is called (so we are here), the loader must be
-      // working now, so we should populate the Vulkan driver info in the
-      // device::Instance.
-      if (!drivers.has_vulkan()) {
-        return true;
-      }
-      // If has_vulkan() returns true, but VulkanDriver is empty, we should
-      // populate the VulkanDriver and send the new header.
-      if (drivers.vulkan().layers_size() == 0 &&
-          drivers.vulkan().icdandimplicitlayerextensions_size() == 0 &&
-          drivers.vulkan().physicaldevices_size() == 0) {
-        return true;
-      }
-      return false;
-    };
-    if (should_send_header()) {
+    bool should_send_header =
+        // If the has_vulkan() returns false, it means the Vulkan loader is not
+        // found in the first time we get device instance. However, if this
+        // vkCreateInstance is called (so we are here), the loader must be
+        // working now, so we should populate the Vulkan driver info in the
+        // device::Instance.
+        (!drivers.has_vulkan()) ||
+        // If VulkanDriver does present, but is empty, we should populate the
+        // VulkanDriver and send the new header.
+        (drivers.vulkan().layers_size() == 0 &&
+         drivers.vulkan().icdandimplicitlayerextensions_size() == 0 &&
+         drivers.vulkan().physicaldevices_size() == 0);
+    if (should_send_header) {
       if (query::updateVulkanDriver(SpyBase::device_instance(), *pInstance,
                                     get_instance_proc_addr)) {
         SpyBase::writeHeader();

--- a/gapis/replay/devices/devices.go
+++ b/gapis/replay/devices/devices.go
@@ -57,7 +57,7 @@ func ForReplay(ctx context.Context, p *path.Capture) ([]*path.Device, error) {
 				"api":    fmt.Sprintf("%T", api),
 				"device": instance.Name,
 			}.Bind(ctx)
-			priority := api.GetReplayPriority(ctx, instance, c.Header.Abi.MemoryLayout)
+			priority := api.GetReplayPriority(ctx, instance, c.Header)
 			p = p * priority
 			if priority != 0 {
 				log.D(ctx, "Compatible %d", priority)

--- a/gapis/replay/interfaces.go
+++ b/gapis/replay/interfaces.go
@@ -20,6 +20,7 @@ import (
 	"github.com/google/gapid/core/image"
 	"github.com/google/gapid/core/os/device"
 	"github.com/google/gapid/gapis/api"
+	"github.com/google/gapid/gapis/capture"
 	"github.com/google/gapid/gapis/service"
 )
 
@@ -30,7 +31,7 @@ type Support interface {
 	// replaying this trace on the given device.
 	// A lower number represents a higher priority, and Zero represents
 	// an inability for the trace to be replayed on the given device.
-	GetReplayPriority(context.Context, *device.Instance, *device.MemoryLayout) uint32
+	GetReplayPriority(context.Context, *device.Instance, *capture.Header) uint32
 }
 
 // QueryIssues is the interface implemented by types that can verify the replay


### PR DESCRIPTION
Sits on top of #1457, but actually is totally independent.

An empty VulkanDriver will be created along with GL driver and other
generic information if Vulkan loader can be found. Real content of
VulkanDriver will be populated in the first vkCreateInstance call of the
tracing application.

When VulkanDriver is populated, another header with updated
device::Instance will be sent (ID rehased also). Decoder of the trace
file should always use the latest header.

The device::Instance is cached in `SpyBase`. Also moved `writeHeader()` from `Spy` to `SpyBase`.

States of VulkanDriver in the header:
1) Does not exist: The tracing device does not support Vulkan.
2) Exist but empty: The trace does not contain vkCreateInstance, the
trace should be replayable on all ABI compatible Vulkan device.
3) Exist and not empty: The trace contains vkCreateInstance, replay will
be initiated only on same vendor/device/api version device.