### PR TITLE
Gapir crash improvements

### DIFF
--- a/core/app/crash/reporting/reporting.go
+++ b/core/app/crash/reporting/reporting.go
@@ -66,7 +66,7 @@ func Enable(ctx context.Context, appName, appVersion string) {
 			}.reportStacktrace(s, crashURL)
 			if err != nil {
 				log.E(ctx, "%v", err)
-			} else {
+			} else if res != "" {
 				log.I(ctx, "%v", res)
 			}
 		})
@@ -86,11 +86,7 @@ func Disable() {
 // ReportMinidump encodes and sends a minidump report to the crashURL endpoint.
 func ReportMinidump(r Reporter, minidumpName string, minidumpData []byte) (string, error) {
 	if disable != nil {
-		if res, err := r.reportMinidump(minidumpName, minidumpData, crashURL); err != nil {
-			return "", err
-		} else {
-			return res, nil
-		}
+		return r.reportMinidump(minidumpName, minidumpData, crashURL)
 	}
 	return "Error reporting disabled", nil
 }

--- a/core/app/crash/reporting/reporting_test.go
+++ b/core/app/crash/reporting/reporting_test.go
@@ -30,7 +30,7 @@ func TestReport(t *testing.T) {
 	if testCrashReport {
 		ctx := log.Testing(t)
 
-		err := Reporter{
+		_, err := Reporter{
 			AppName:    "crash-reporting-test",
 			AppVersion: "0",
 			OSName:     "unknown",

--- a/gapis/replay/executor/executor.go
+++ b/gapis/replay/executor/executor.go
@@ -156,7 +156,6 @@ func (e executor) handleReplayCommunication(ctx context.Context, connection io.R
 				return fmt.Errorf("Failed to send replay resource data: %v", err)
 			}
 		case protocol.MessageType_Crash:
-			log.I(ctx, "Crash from GAPIR incoming")
 			if err := e.handleCrash(ctx, r); err != nil {
 				return fmt.Errorf("Failed to handle crash sent by gapir: %v", err)
 			}
@@ -189,13 +188,15 @@ func (e executor) handleCrash(ctx context.Context, r binary.Reader) error {
 	}
 
 	// TODO(baldwinn860): get the actual version from GAPIR in case it ever goes out of sync
-	if err := reporting.ReportMinidump(reporting.Reporter{
+	if res, err := reporting.ReportMinidump(reporting.Reporter{
 		AppName:    "GAPIR",
 		AppVersion: app.Version.String(),
 		OSName:     e.OS.GetName(),
 		OSVersion:  fmt.Sprintf("%v %v.%v.%v", e.OS.GetBuild(), e.OS.GetMajor(), e.OS.GetMinor(), e.OS.GetPoint()),
 	}, filename, crashData); err != nil {
 		return log.Err(ctx, err, "Failed to report crash in GAPIR")
+	} else {
+		log.I(ctx, "Crash Report Uploaded; ID: %v", res)
 	}
 	return nil
 }

--- a/gapis/replay/executor/executor.go
+++ b/gapis/replay/executor/executor.go
@@ -29,6 +29,7 @@ import (
 	"github.com/google/gapid/core/data/id"
 	"github.com/google/gapid/core/log"
 	"github.com/google/gapid/core/os/device"
+	"github.com/google/gapid/core/os/file"
 	"github.com/google/gapid/gapis/database"
 	"github.com/google/gapid/gapis/replay/builder"
 	"github.com/google/gapid/gapis/replay/protocol"
@@ -197,6 +198,7 @@ func (e executor) handleCrash(ctx context.Context, r binary.Reader) error {
 		return log.Err(ctx, err, "Failed to report crash in GAPIR")
 	} else {
 		log.I(ctx, "Crash Report Uploaded; ID: %v", res)
+		file.Remove(file.Abs(filename))
 	}
 	return nil
 }


### PR DESCRIPTION
Just a few improvements for crash reporting.

Logging the report ID is helpful for debugging and is something the client already
does, this just adds it to GAPIS.

Deleting the minidump file keeps the user's disk space from getting cluttered with 
our crashes.