### PR TITLE
Building gapidapk with bazel.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -119,8 +119,8 @@ copy(
 
 copy(
     name = "install-properties",
-    src = "//tools/build:source.properties",
-    dst = "source.properties",
+    src = "//tools/build:build.properties",
+    dst = "build.properties",
     tags = ["manual"],
     visibility = ["//visibility:private"],
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -56,12 +56,12 @@ windows_sdk(
 
 android_sdk_repository(
     name="androidsdk",
-    api_level=27,
+    api_level=21,
 )
 
 android_ndk_repository(
     name="androidndk",
-    api_level=14,
+    api_level=21,
 )
 
 ####################################

--- a/core/cc/BUILD.bazel
+++ b/core/cc/BUILD.bazel
@@ -20,7 +20,7 @@ cc_library(
         "//tools/build:linux": glob(["linux/*.cpp"]),
         "//tools/build:darwin": glob(["osx/*.cpp"]),
         "//tools/build:windows": glob(["windows/*.cpp"]),
-        "//conditions:default": glob(["android/*.cpp"]),
+        "//conditions:default": glob(["android/*.cpp", "android/*.h"]),
     }),
     defines = cc_defines(),
     copts = cc_copts(),

--- a/core/cc/android/compatibility.cpp
+++ b/core/cc/android/compatibility.cpp
@@ -26,6 +26,8 @@
 
 extern "C" {
 
+/* TODO - delete this file?
+
 int sigemptyset(sigset_t *set) {
     memset(set, 0, sizeof *set);
     return 0;
@@ -34,5 +36,6 @@ int sigemptyset(sigset_t *set) {
 int getpagesize(void) {
   return 4096; // doesn't really matter - we're just satisfying the linker.
 }
+*/
 
 } // extern "C"

--- a/core/memory_tracker/cc/posix/memory_tracker.h
+++ b/core/memory_tracker/cc/posix/memory_tracker.h
@@ -20,6 +20,7 @@
 #include "core/memory_tracker/cc/memory_protections.h"
 
 #include <cstdint>
+#include <pthread.h>
 #include <signal.h>
 #include <stdlib.h>
 #include <sys/mman.h>
@@ -33,7 +34,7 @@ inline bool set_protection(void* p, size_t size, PageProtections prot) {
   uint32_t protections = (prot == PageProtections::kRead) ? PROT_READ :
                     (prot == PageProtections::kWrite) ? PROT_WRITE :
                 (prot == PageProtections::kReadWrite) ? PROT_READ | PROT_WRITE: 0;
-  return mprotect(p, size, protections); 
+  return mprotect(p, size, protections);
 }
 
 // SignalBlocker blocks the specified signal when it is constructed, and

--- a/gapii/cc/BUILD.bazel
+++ b/gapii/cc/BUILD.bazel
@@ -77,7 +77,7 @@ cc_library(
         "//tools/build:linux": glob(["linux/*.cpp"]),
         "//tools/build:darwin": ["//gapii/cc/osx:generated"],
         "//tools/build:windows": ["//gapii/cc/windows:srcs"],
-        "//conditions:default": glob(["android/*.cpp"]),
+        "//conditions:default": glob(["android/*.cpp", "android/*.h"]),
     }),
     hdrs = [":headers"],
     defines = cc_defines(),

--- a/gapir/cc/BUILD.bazel
+++ b/gapir/cc/BUILD.bazel
@@ -45,10 +45,7 @@ mm_library(
     name = "darwin_renderer",
     srcs = glob(["osx/*.mm"]),
     defines = cc_defines(),
-    deps = [
-        ":gles_lib",
-        ":vulkan_lib",
-    ],
+    deps = [":api_lib"],
 )
 
 cc_library(

--- a/tools/build/BUILD.bazel
+++ b/tools/build/BUILD.bazel
@@ -4,6 +4,7 @@ gapid_version(
     name = "build_properties",
     template = ":build_host_and_time",
     out = "build.properties",
+    visibility = ["//visibility:public"],
 )
 
 # Note, this genrule reads the volatile-status.txt file, but is *not* executed on each build.

--- a/tools/build/third_party/llvm.BUILD
+++ b/tools/build/third_party/llvm.BUILD
@@ -210,7 +210,7 @@ cc_binary(
     deps = [":TableGen"],
     linkopts = select({
         "@//tools/build:linux": ["-ldl", "-lpthread", "-lcurses"],
-        "@//tools/build:darwin": ["-framework Cocoa"],
+        "@//tools/build:darwin": ["-framework Cocoa", "-lcurses"],
         "@//tools/build:windows": [],
     }),
     copts = cc_copts(),


### PR DESCRIPTION
- Use API level 21, since we claim to support back to L
- Fix some missing includes
- Get rid of compatibility.cpp
- Get breakpad building on android
- Get llvm TableGen building on osx

```
$ bazel build install
INFO: Analysed target //:install (0 packages loaded).
INFO: Found 1 target...
Target //:install up-to-date:
  bazel-bin/osx/x86_64/gapic.jar
  bazel-bin/osx/x86_64/gapic
  bazel-bin/osx/x86_64/gapit
  bazel-bin/osx/x86_64/gapir
  bazel-bin/osx/x86_64/gapis
  bazel-bin/build.properties
  bazel-bin/strings/en-us.stb
  bazel-bin/android/armeabi-v7a/gapid.apk
INFO: Elapsed time: 1.043s, Critical Path: 0.00s
INFO: Build completed successfully, 1 total action
```