### PR TITLE
Update rules_go

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -10,7 +10,7 @@ github_repository(
     organization = "bazelbuild",
     project = "rules_go",
     branch = "master",
-    commit = "737df20c53499fd84b67f04c6ca9ccdee2e77089", # Comment to use the master branch of this repository
+    commit = "329d8f4ad28265e73c98c4475d49fc9eff57286b", # Comment to use the master branch of this repository
 )
 
 github_repository(

--- a/gapis/api/gles/BUILD.bazel
+++ b/gapis/api/gles/BUILD.bazel
@@ -27,12 +27,6 @@ apic(
     visibility = ["//visibility:public"],
 )
 
-filter(
-    name = "generated_go",
-    srcs = [":generated"],
-    suffix = [".go"],
-)
-
 go_library(
     name = "go_default_library",
     srcs = [
@@ -70,9 +64,11 @@ go_library(
         "version.go",
         "vertex_attribute_array.go",
         "wireframe.go",
-        ":generated_go",  # keep
     ],
-    embed = [":gles_go_proto"],
+    embed = [
+        ":generated",  # keep
+        ":gles_go_proto",
+    ],
     importpath = "github.com/google/gapid/gapis/api/gles",
     visibility = ["//visibility:public"],
     deps = [

--- a/gapis/api/gvr/BUILD.bazel
+++ b/gapis/api/gvr/BUILD.bazel
@@ -41,12 +41,6 @@ apic(
     visibility = ["//visibility:public"],
 )
 
-filter(
-    name = "generated_go",
-    srcs = [":generated"],
-    suffix = [".go"],
-)
-
 go_library(
     name = "go_default_library",
     srcs = [
@@ -55,7 +49,6 @@ go_library(
         "framebindings.go",
         "gvr.go",
         "importance.go",
-        ":generated_go",  # keep
     ],
     embed = [":gvr_go_proto"],
     importpath = "github.com/google/gapid/gapis/api/gvr",

--- a/gapis/api/templates/BUILD.bazel
+++ b/gapis/api/templates/BUILD.bazel
@@ -12,6 +12,22 @@ api_template(
     template = "api.go.tmpl",
     includes = [":templates"],
     outputs = ["api.go", "enum.go"],
+    deps = [
+        "//core/data:go_default_library",
+        "//core/data/binary:go_default_library",
+        "//core/data/dictionary:go_default_library",
+        "//core/data/id:go_default_library",
+        "//core/math/u64:go_default_library",
+        "//core/os/device:go_default_library",
+        "//gapis/api:go_default_library",
+        "//gapis/capture:go_default_library",
+        "//gapis/replay:go_default_library",
+        "//gapis/replay/builder:go_default_library",
+        "//gapis/replay/protocol:go_default_library",
+        "//gapis/replay/value:go_default_library",
+        "//gapis/service/path:go_default_library",
+        "//gapis/memory:go_default_library",
+    ],
 )
 
 api_template(

--- a/gapis/api/test/BUILD.bazel
+++ b/gapis/api/test/BUILD.bazel
@@ -22,18 +22,14 @@ apic(
     visibility = ["//visibility:public"],
 )
 
-filter(
-    name = "generated_go",
-    srcs = [":generated"],
-    suffix = [".go"],
-)
-
 go_library(
     name = "go_default_library",
     srcs = [
         "doc.go",
         "test.go",
-        ":generated_go",  # keep
+    ],
+    embed = [
+        ":generated",  # keep
     ],
     importpath = "github.com/google/gapid/gapis/api/test",
     visibility = ["//visibility:public"],

--- a/gapis/api/vulkan/BUILD.bazel
+++ b/gapis/api/vulkan/BUILD.bazel
@@ -29,13 +29,6 @@ apic(
     visibility = ["//visibility:public"],
 )
 
-filter(
-    #TODO: use GoEmbed so we also get the deps
-    name = "generated_go",
-    srcs = [":generated"],
-    suffix = [".go"],
-)
-
 go_library(
     name = "go_default_library",
     srcs = [
@@ -56,9 +49,11 @@ go_library(
         "vulkan.go",
         "vulkan_terminator.go",
         "wireframe.go",
-        ":generated_go",  # keep
     ],
-    embed = [":vulkan_go_proto"],
+    embed = [
+        ":generated",  # keep
+        ":vulkan_go_proto",
+    ],
     importpath = "github.com/google/gapid/gapis/api/vulkan",
     visibility = ["//visibility:public"],
     deps = [


### PR DESCRIPTION
Re-write the apic rule to use the new GoSource system.
This allows the template rules to also carry the dependancies, in theory we can
now remove most of the _ imports in the doc.go files