### PR TITLE
Added a TempSlice mechanism that does not copy.

### DIFF
--- a/gapis/api/templates/api.go.tmpl
+++ b/gapis/api/templates/api.go.tmpl
@@ -284,8 +284,15 @@
   {{if $el_is_char}}
     // StringSlice returns a slice starting at p and ending at the first 0 byte null-terminator.
     func (p {{$ptr_ty}}) StringSlice(ϟctx context.Context, ϟs *api.GlobalState) Charˢ {
-      i, d := uint64(0), ϟs.MemoryDecoder(ϟctx, ϟs.Memory.MustGet(p.pool).At(p.addr))
+      numBytes := uint64(2^6)
+      i, d := uint64(0), ϟs.MemoryDecoder(ϟctx, ϟs.Memory.MustGet(p.pool).TempSlice(ϟmem.Range{Base: p.addr, Size: p.addr + numBytes}))
+
       for {
+        if i >= numBytes {
+          numBytes <<= 1
+          d = ϟs.MemoryDecoder(ϟctx, ϟs.Memory.MustGet(p.pool).TempSlice(ϟmem.Range{Base: p.addr + i, Size: p.addr + i + numBytes}))
+        }
+
         i++
         if b := d.U8(); b == 0 {
           return Charˢ(p.Slice(0, i, ϟs.MemoryLayout))


### PR DESCRIPTION
We hit a bad edge-case where a ton of strings were being used,
We were allocating and freeing these new ranges a lot, and they all
ended up being large. Instead, return a temporary slice into the
original range. During the StringSlice, there is no opportunity to
modify the pool, so we can save the pressure on the GC.