### PR TITLE
Reworked memory functions to rely less on reflection.

### DIFF
--- a/gapis/api/templates/api.go.tmpl
+++ b/gapis/api/templates/api.go.tmpl
@@ -232,6 +232,9 @@
   // IsNullptr returns true if the address is 0 and the pool is ϟmem.ApplicationPool.
   func (p {{$ptr_ty}}) IsNullptr() bool { return p.addr == 0 && p.pool == ϟmem.ApplicationPool }
 
+  // APointer implements the ReflectPointer interface
+  func (p {{$ptr_ty}}) APointer() { return }
+
   // Address returns the pointer's memory address.
   func (p {{$ptr_ty}}) Address() uint64 { return p.addr }
 

--- a/gapis/api/testcmd/cmds.go
+++ b/gapis/api/testcmd/cmds.go
@@ -108,6 +108,7 @@ var _ memory.Pointer = &Pointer{}
 
 func (p Pointer) String() string                            { return memory.PointerToString(p) }
 func (p Pointer) IsNullptr() bool                           { return p.addr == 0 && p.pool == memory.ApplicationPool }
+func (p Pointer) APointer()                                 { return }
 func (p Pointer) Address() uint64                           { return p.addr }
 func (p Pointer) Pool() memory.PoolID                       { return p.pool }
 func (p Pointer) Offset(n uint64) memory.Pointer            { panic("not implemented") }

--- a/gapis/memory/alignof_sizeof.go
+++ b/gapis/memory/alignof_sizeof.go
@@ -24,95 +24,120 @@ import (
 
 // AlignOf returns the byte alignment of the type t.
 func AlignOf(t reflect.Type, m *device.MemoryLayout) uint64 {
-	switch {
-	case t.Implements(tyPointer):
-		return uint64(m.GetPointer().GetAlignment())
-	case t.Implements(tyCharTy):
-		return uint64(m.GetChar().GetAlignment())
-	case t.Implements(tyIntTy), t.Implements(tyUintTy):
-		return uint64(m.GetInteger().GetAlignment())
-	case t.Implements(tySizeTy):
-		return uint64(m.GetSize().GetAlignment())
-	default:
-
-		switch t.Kind() {
-		case reflect.Bool, reflect.Int8, reflect.Uint8:
-			return uint64(m.GetI8().GetAlignment())
-		case reflect.Int16, reflect.Uint16:
-			return uint64(m.GetI16().GetAlignment())
-		case reflect.Int32, reflect.Uint32:
-			return uint64(m.GetI32().GetAlignment())
-		case reflect.Float32:
-			return uint64(m.GetF32().GetAlignment())
-		case reflect.Float64:
-			return uint64(m.GetF64().GetAlignment())
-		case reflect.Int64, reflect.Uint64:
-			return uint64(m.GetI64().GetAlignment())
-		case reflect.Int, reflect.Uint:
-			return uint64(m.GetInteger().GetAlignment())
-		case reflect.Array, reflect.Slice:
-			return AlignOf(t.Elem(), m)
-		case reflect.String:
-			return 1
-		case reflect.Struct:
-			alignment := uint64(1)
-			for i, c := 0, t.NumField(); i < c; i++ {
-				if a := AlignOf(t.Field(i).Type, m); alignment < a {
-					alignment = a
-				}
-			}
-			return alignment
-		default:
-			panic(fmt.Errorf("MemoryLayout.AlignOf not implemented for type %v (%v)", t, t.Kind()))
+	handlePointer := func() (uint64, bool) {
+		if t.Implements(tyPointer) {
+			return uint64(m.GetPointer().GetAlignment()), true
 		}
+		return 0, false
+	}
+
+	switch t.Kind() {
+	case reflect.Uint8:
+		if t.Implements(tyCharTy) {
+			return uint64(m.GetChar().GetAlignment())
+		}
+		return uint64(m.GetI8().GetAlignment())
+	case reflect.Bool, reflect.Int8:
+		return uint64(m.GetI8().GetAlignment())
+	case reflect.Int16, reflect.Uint16:
+		return uint64(m.GetI16().GetAlignment())
+	case reflect.Int32, reflect.Uint32:
+		return uint64(m.GetI32().GetAlignment())
+	case reflect.Float32:
+		return uint64(m.GetF32().GetAlignment())
+	case reflect.Float64:
+		return uint64(m.GetF64().GetAlignment())
+	case reflect.Int64, reflect.Uint64:
+		if t.Implements(tyIntTy) || t.Implements(tyUintTy) {
+			return uint64(m.GetInteger().GetAlignment())
+		}
+		if t.Implements(tySizeTy) {
+			return uint64(m.GetSize().GetAlignment())
+		}
+		return uint64(m.GetI64().GetAlignment())
+	case reflect.Int, reflect.Uint:
+		return uint64(m.GetInteger().GetAlignment())
+	case reflect.Array, reflect.Slice:
+		return AlignOf(t.Elem(), m)
+	case reflect.String:
+		return 1
+	case reflect.Struct:
+		if size, ok := handlePointer(); ok {
+			return size
+		}
+		alignment := uint64(1)
+		for i, c := 0, t.NumField(); i < c; i++ {
+			if a := AlignOf(t.Field(i).Type, m); alignment < a {
+				alignment = a
+			}
+		}
+		return alignment
+	default:
+		if size, ok := handlePointer(); ok {
+			return size
+		}
+		panic(fmt.Errorf("MemoryLayout.AlignOf not implemented for type %v (%v)", t, t.Kind()))
 	}
 }
 
 // SizeOf returns the byte size of the type t.
 func SizeOf(t reflect.Type, m *device.MemoryLayout) uint64 {
-	switch {
-	case t.Implements(tyPointer):
-		return uint64(m.GetPointer().GetSize())
-	case t.Implements(tyCharTy):
-		return uint64(m.GetChar().GetSize())
-	case t.Implements(tyIntTy), t.Implements(tyUintTy):
-		return uint64(m.GetInteger().GetSize())
-	case t.Implements(tySizeTy):
-		return uint64(m.GetSize().GetSize())
-	default:
 
-		switch t.Kind() {
-		case reflect.Bool, reflect.Int8, reflect.Uint8:
-			return uint64(m.GetI8().GetSize())
-		case reflect.Int16, reflect.Uint16:
-			return uint64(m.GetI16().GetSize())
-		case reflect.Int32, reflect.Uint32:
-			return uint64(m.GetI32().GetSize())
-		case reflect.Float32:
-			return uint64(m.GetF32().GetSize())
-		case reflect.Float64:
-			return uint64(m.GetF64().GetSize())
-		case reflect.Int64, reflect.Uint64:
-			return uint64(m.GetI64().GetSize())
-		case reflect.Int, reflect.Uint:
-			return uint64(m.GetInteger().GetSize())
-		case reflect.Array:
-			return SizeOf(t.Elem(), m) * uint64(t.Len())
-		case reflect.String:
-			return 1
-		case reflect.Struct:
-			var size, align uint64
-			for i, c := 0, t.NumField(); i < c; i++ {
-				f := t.Field(i)
-				a := AlignOf(f.Type, m)
-				size = u64.AlignUp(size, a)
-				size += SizeOf(f.Type, m)
-				align = u64.Max(align, a)
-			}
-			size = u64.AlignUp(size, align)
-			return size
-		default:
-			panic(fmt.Errorf("MemoryLayout.SizeOf not implemented for type %v (%v)", t, t.Kind()))
+	handlePointer := func() (uint64, bool) {
+		if t.Implements(tyPointer) {
+			return uint64(m.GetPointer().GetSize()), true
 		}
+		return 0, false
+	}
+
+	switch t.Kind() {
+	case reflect.Uint8:
+		if t.Implements(tyCharTy) {
+			return uint64(m.GetChar().GetSize())
+		}
+		return uint64(m.GetI8().GetSize())
+	case reflect.Bool, reflect.Int8:
+		return uint64(m.GetI8().GetSize())
+	case reflect.Int16, reflect.Uint16:
+		return uint64(m.GetI16().GetSize())
+	case reflect.Int32, reflect.Uint32:
+		return uint64(m.GetI32().GetSize())
+	case reflect.Float32:
+		return uint64(m.GetF32().GetSize())
+	case reflect.Float64:
+		return uint64(m.GetF64().GetSize())
+	case reflect.Int64, reflect.Uint64:
+		if t.Implements(tyIntTy) || t.Implements(tyUintTy) {
+			return uint64(m.GetInteger().GetSize())
+		}
+		if t.Implements(tySizeTy) {
+			return uint64(m.GetSize().GetSize())
+		}
+		return uint64(m.GetI64().GetSize())
+	case reflect.Int, reflect.Uint:
+		return uint64(m.GetInteger().GetSize())
+	case reflect.Array:
+		return SizeOf(t.Elem(), m) * uint64(t.Len())
+	case reflect.String:
+		return 1
+	case reflect.Struct:
+		if size, ok := handlePointer(); ok {
+			return size
+		}
+		var size, align uint64
+		for i, c := 0, t.NumField(); i < c; i++ {
+			f := t.Field(i)
+			a := AlignOf(f.Type, m)
+			size = u64.AlignUp(size, a)
+			size += SizeOf(f.Type, m)
+			align = u64.Max(align, a)
+		}
+		size = u64.AlignUp(size, align)
+		return size
+	default:
+		if size, ok := handlePointer(); ok {
+			return size
+		}
+		panic(fmt.Errorf("MemoryLayout.SizeOf not implemented for type %v (%v)", t, t.Kind()))
 	}
 }

--- a/gapis/memory/types.go
+++ b/gapis/memory/types.go
@@ -17,7 +17,7 @@ package memory
 import "reflect"
 
 var (
-	tyPointer = reflect.TypeOf((*Pointer)(nil)).Elem()
+	tyPointer = reflect.TypeOf((*ReflectPointer)(nil)).Elem()
 	tyCharTy  = reflect.TypeOf((*CharTy)(nil)).Elem()
 	tyIntTy   = reflect.TypeOf((*IntTy)(nil)).Elem()
 	tyUintTy  = reflect.TypeOf((*UintTy)(nil)).Elem()


### PR DESCRIPTION
This re-orders the methods so that we can decode memory much quicker.
It brings decoding time down for Vulkan traces by ~75%.

When we do have to do reflection, optimize it such that the interfaces
that must be matched are smaller.