### PR TITLE
Fixed segfault in deviceinfo for Vulkan.

### DIFF
--- a/core/os/device/deviceinfo/cc/vk.cpp
+++ b/core/os/device/deviceinfo/cc/vk.cpp
@@ -90,9 +90,9 @@ bool vkLayersAndExtensions(
     MUST_SUCCESS(vkEnumerateInstanceExtensionProperties(l.layerName, &ext_count,
                                                         ext_props.data()));
     driver->add_layers();
-    driver->mutable_layers(i)->set_name(l.layerName);
+    driver->mutable_layers(driver->layers_size() - 1)->set_name(l.layerName);
     for (size_t j = 0; j < ext_props.size(); j++) {
-      driver->mutable_layers(i)->add_extensions(ext_props[j].extensionName);
+      driver->mutable_layers(driver->layers_size() - 1)->add_extensions(ext_props[j].extensionName);
     }
   }
   // For implicit layers and ICD extensions


### PR DESCRIPTION
If we have layers after VkGraphicsSpy and VirtualSwapchain,
we would read out of bounds in a proto.