### PR TITLE
gapir: Fix crash on gles replay

### DIFF
--- a/core/cc/dl_loader.cpp
+++ b/core/cc/dl_loader.cpp
@@ -62,7 +62,9 @@ void* must_load(const char* name) {
 #if TARGET_OS == GAPID_OS_WINDOWS
     GAPID_FATAL("Can't load library %s: %d", name, GetLastError());
 #else
-    GAPID_FATAL("Can't load library %s: %s", name, dlerror());
+    if (name != nullptr) {
+        GAPID_FATAL("Can't load library %s: %s", name, dlerror());
+    }
 #endif // TARGET_OS
   }
   return res;


### PR DESCRIPTION
As the documentation for dl_loader states:

`// For *nix systems, a nullptr can be used to search the application's functions.`