### PR TITLE
Remove the build dependency onto opengl32.dll from deviceinfo.

### DIFF
--- a/core/os/device/deviceinfo/cc/CMakeBuild.cmake
+++ b/core/os/device/deviceinfo/cc/CMakeBuild.cmake
@@ -48,7 +48,7 @@ if(NOT DISABLED_CXX)
     target_include_directories(deviceinfo-static PUBLIC "${CMAKE_SOURCE_DIR}/external/protobuf/src")
 
     find_package(GL REQUIRED)
-    target_link_libraries(deviceinfo-static cc-core protobuf cityhash GL::Lib)
+    target_link_libraries(deviceinfo-static cc-core protobuf cityhash)
 
     if(ANDROID)
         target_link_libraries(deviceinfo-static -llog)

--- a/core/os/device/host/host_linux.go
+++ b/core/os/device/host/host_linux.go
@@ -16,5 +16,5 @@
 
 package host
 
-// #cgo LDFLAGS: -lGL -lX11 -ldl
+// #cgo LDFLAGS: -lX11 -ldl
 import "C"

--- a/core/os/device/host/host_windows.go
+++ b/core/os/device/host/host_windows.go
@@ -16,5 +16,5 @@
 
 package host
 
-// #cgo LDFLAGS: -lopengl32 -lgdi32
+// #cgo LDFLAGS: -lgdi32
 import "C"

--- a/gapii/cc/CMakeBuild.cmake
+++ b/gapii/cc/CMakeBuild.cmake
@@ -117,7 +117,6 @@ if(NOT DISABLED_CXX)
           LINK_FLAGS "-Wl,--version-script,${CMAKE_CURRENT_SOURCE_DIR}/gapii.exports")
     elseif(NOT GAPII_TARGET)
         find_package(GL REQUIRED)
-        target_link_libraries(gapii GL::Lib)
 
         if(WIN32)
             install(TARGETS gapii RUNTIME DESTINATION "${TARGET_INSTALL_PATH}/lib")


### PR DESCRIPTION
This helps in building the windows libgapii.dll with bazel.