### PR TITLE
gapic/UpdateWatcher: Don't check for pre-releases.

### DIFF
--- a/gapic/src/main/com/google/gapid/util/UpdateWatcher.java
+++ b/gapic/src/main/com/google/gapid/util/UpdateWatcher.java
@@ -27,7 +27,7 @@ import java.util.concurrent.TimeUnit;
  */
 public class UpdateWatcher {
   private static final long CHECK_INTERVAL_MS = TimeUnit.HOURS.toMillis(8);
-  private static final boolean INCLUDE_PRE_RELEASES = true;
+  private static final boolean INCLUDE_PRE_RELEASES = false;
 
   private final Settings settings;
   private final Client client;


### PR DESCRIPTION
Longer term we should probably have this on a setting.