### PR TITLE
Robot: fail on output to stderr from tasks.

### DIFF
--- a/test/robot/replay/replay.proto
+++ b/test/robot/replay/replay.proto
@@ -61,8 +61,8 @@ message Output {
   string log = 1;
   // Video is the movie of the replay frame capture output.
   string video = 2;
-  // CallError is the error string returned by the call to gapit.
-  string call_error = 3;
+  // Err is the stderr buffer returned by the call to gapit.
+  string err = 3;
 }
 
 // Action holds the information about an execution of a task.

--- a/test/robot/report/client.go
+++ b/test/robot/report/client.go
@@ -15,8 +15,10 @@
 package report
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/google/gapid/core/app/crash"
@@ -35,6 +37,9 @@ import (
 
 const (
 	reportTimeout = time.Hour
+	// this string is returned when GAPIT fails to connect to the GAPIS, particularly due to ETXTBSY
+	// look at https://github.com/google/gapid/pull/933 for more information
+	retryString = "Failed to connect to the GAPIS server"
 )
 
 type client struct {
@@ -84,9 +89,9 @@ func (c *client) report(ctx context.Context, t *Task) error {
 	if err != nil {
 		status = job.Failed
 		log.E(ctx, "Error running report: %v", err)
-	} else if output.CallError != "" {
+	} else if output.Err != "" {
 		status = job.Failed
-		log.E(ctx, "Error during report: %v", output.CallError)
+		log.E(ctx, "Error during report: %v", output.Err)
 	}
 
 	return c.manager.Update(ctx, t.Action, status, output)
@@ -142,19 +147,23 @@ func doReport(ctx context.Context, action string, in *Input, store *stash.Client
 		tracefile.System(),
 	}
 	cmd := shell.Command(gapit.System(), params...)
-	output, callErr := cmd.Call(ctx)
-	if err := worker.NeedsRetry(output, "Failed to connect to the GAPIS server"); err != nil {
+	outBuf := &bytes.Buffer{}
+	errBuf := &bytes.Buffer{}
+	outputObj := &Output{}
+	errs := []string{}
+	if err := cmd.Capture(outBuf, errBuf).Run(ctx); err != nil {
+		if err := worker.NeedsRetry(err.Error()); err != nil {
+			return nil, err
+		}
+		errs = append(errs, err.Error())
+	}
+	errs = append(errs, strings.TrimSpace(errBuf.String()))
+	outputObj.Err = strings.Join(errs, "\n")
+	if err := worker.NeedsRetry(outputObj.Err, retryString); err != nil {
 		return nil, err
 	}
 
-	outputObj := &Output{}
-	if callErr != nil {
-		if err := worker.NeedsRetry(callErr.Error()); err != nil {
-			return nil, err
-		}
-		outputObj.CallError = callErr.Error()
-	}
-	output = fmt.Sprintf("%s\n\n%s", cmd, output)
+	output := fmt.Sprintf("%s\n\n%s", cmd, strings.TrimSpace(outBuf.String()))
 	log.I(ctx, output)
 	logID, err := store.UploadString(ctx, stash.Upload{Name: []string{"report.log"}, Type: []string{"text/plain"}}, output)
 	if err != nil {

--- a/test/robot/report/report.proto
+++ b/test/robot/report/report.proto
@@ -53,8 +53,8 @@ message Output{
   string log = 1;
   // Report is the stash id of the generated report file.
   string report = 2;
-  // CallError is the error string returned by the call to gapit.
-  string call_error = 3;
+  // Err is the stderr buffer returned by the call to gapit.
+  string err = 3;
 }
 
 // Action holds the information about an execution of a task.

--- a/test/robot/trace/client.go
+++ b/test/robot/trace/client.go
@@ -15,8 +15,10 @@
 package trace
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/golang/protobuf/ptypes"
@@ -37,6 +39,9 @@ import (
 
 const (
 	traceTimeout = time.Hour
+	// this string is returned when GAPIT fails to connect to the GAPIS, particularly due to ETXTBSY
+	// look at https://github.com/google/gapid/pull/933 for more information
+	retryString = "Failed to connect to the GAPIS server"
 )
 
 type client struct {
@@ -86,9 +91,9 @@ func (c *client) trace(ctx context.Context, d bind.Device, t *Task) error {
 	if err != nil {
 		status = job.Failed
 		log.E(ctx, "Error running trace: %v", err)
-	} else if output.CallError != "" {
+	} else if output.Err != "" {
 		status = job.Failed
-		log.E(ctx, "Error during trace: %v", output.CallError)
+		log.E(ctx, "Error during trace: %v", output.Err)
 	}
 
 	return c.manager.Update(ctx, t.Action, status, output)
@@ -155,19 +160,23 @@ func doTrace(ctx context.Context, action string, in *Input, store *stash.Client,
 		params = append(params, "-obb", obb.System())
 	}
 	cmd := shell.Command(gapit.System(), params...)
-	output, callErr := cmd.Call(ctx)
-	if err := worker.NeedsRetry(output, "Failed to connect to the GAPIS server"); err != nil {
+	outBuf := &bytes.Buffer{}
+	errBuf := &bytes.Buffer{}
+	outputObj := &Output{}
+	errs := []string{}
+	if err := cmd.Capture(outBuf, errBuf).Run(ctx); err != nil {
+		if err := worker.NeedsRetry(err.Error()); err != nil {
+			return nil, err
+		}
+		errs = append(errs, err.Error())
+	}
+	errs = append(errs, strings.TrimSpace(errBuf.String()))
+	outputObj.Err = strings.Join(errs, "\n")
+	if err := worker.NeedsRetry(outputObj.Err, retryString); err != nil {
 		return nil, err
 	}
 
-	outputObj := &Output{}
-	if callErr != nil {
-		if err := worker.NeedsRetry(callErr.Error()); err != nil {
-			return nil, err
-		}
-		outputObj.CallError = callErr.Error()
-	}
-	output = fmt.Sprintf("%s\n\n%s", cmd, output)
+	output := fmt.Sprintf("%s\n\n%s", cmd, strings.TrimSpace(outBuf.String()))
 	log.I(ctx, output)
 	logID, err := store.UploadString(ctx, stash.Upload{Name: []string{"trace.log"}, Type: []string{"text/plain"}}, output)
 	if err != nil {

--- a/test/robot/trace/trace.proto
+++ b/test/robot/trace/trace.proto
@@ -52,8 +52,8 @@ message Output {
   string log = 1;
   // Trace is the stash id of the generated trace file.
   string trace = 2;
-  // CallError is the error string returned by the call to gapit.
-  string call_error = 3;
+  // Err is the stderr buffer returned by the call to gapit.
+  string err = 3;
 }
 
 // Action holds the information about an execution of a task.

--- a/test/robot/web/client/client.go
+++ b/test/robot/web/client/client.go
@@ -206,7 +206,7 @@ func newView() *view {
 		},
 	).Add("/1/input/((gapi[irst])|gapid_apk|trace|subject|interceptor|vulkanLayer)", robotEntityLink).
 		Add("/1/input/layout", v.objView.Expandable).
-		Add("/1/output/(log|report)", robotTextPreview).
+		Add("/1/output/(log|report|err)", robotTextPreview).
 		Add("/1/output/video", robotVideoView).
 		Add("/0/", v.objView.Expandable)
 


### PR DESCRIPTION
An error inside gapit no longer results in a non-zero return code to
robot, this means that the only way robot detects failures is if the
calls to run gapit itself fails. This change now separates capturing
stdout from stderr and any non-empty stderr buffers will cause robot to
report a failure. This fixes some regression in robot causing false
positives.