### PR TITLE
Fixes for  OBB support.

### DIFF
--- a/cmd/gapit/trace.go
+++ b/cmd/gapit/trace.go
@@ -239,7 +239,7 @@ func (verb *traceVerb) captureADB(ctx context.Context, flags flag.FlagSet, start
 				pkg.RemoveOBB(ctx)
 			}()
 			if err := pkg.GrantExternalStorageRW(ctx); err != nil {
-				return log.Err(ctx, err, "Grant OBB Read/Write Permission")
+				log.W(ctx, "Failed to grant OBB read/write permission, ensure your app already has this privilege")
 			}
 		}
 		defer func() {

--- a/core/os/android/installed_package.go
+++ b/core/os/android/installed_package.go
@@ -146,7 +146,7 @@ func (p *InstalledPackage) obbStoragePath(ctx context.Context) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return fmt.Sprintf("%s/obb/%s/main.%d.%[2]s.obb", storage, p.Name, p.VersionCode), nil
+	return fmt.Sprintf("%s/Android/obb/%s/main.%d.%[2]s.obb", storage, p.Name, p.VersionCode), nil
 }
 
 // OBBExists checks whether an OBB file exists in the matching location for this APK on


### PR DESCRIPTION
APKs that already have READ/WRITE permissions for external storage will
give an error if you try to request it again. We don't need to fail the
trace in this case, so ignore it. Released APKs actually store OBBs in
`<external_storage>/Android/obb/<package_name>` so now we use the correct
path.