### PR TITLE
.gitignore: Remove *_embed.go rule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,9 +12,9 @@
 # General patterns
 *.gfxtrace
 *ycm_extra_conf.py*
-*_embed.go
 gapir.log
 gapis.log
+
 # Vim
 [._]*.s[a-w][a-z]
 [._]s[a-w][a-z]


### PR DESCRIPTION
These shouldn't be found in the tree any more