### PR TITLE
Fix templates.

### DIFF
--- a/gapis/api/gles/BUILD.bazel
+++ b/gapis/api/gles/BUILD.bazel
@@ -37,6 +37,7 @@ apic(
         "//gapis/api/templates:constant_sets",
         "//gapis/api/templates:convert",
         "//gapis/api/templates:proto",
+        "//gapis/api/templates:state_serialize",
     ],
     visibility = ["//visibility:public"],
 )

--- a/gapis/api/templates/BUILD.bazel
+++ b/gapis/api/templates/BUILD.bazel
@@ -55,6 +55,13 @@ api_template(
 )
 
 api_template(
+    name = "state_serialize",
+    includes = [":templates"],
+    outputs = ["state_serialize.go"],
+    template = "state_serialize.go.tmpl",
+)
+
+api_template(
     name = "constant_sets",
     includes = [":templates"],
     outputs = ["constant_sets.go"],

--- a/gapis/api/vulkan/BUILD.bazel
+++ b/gapis/api/vulkan/BUILD.bazel
@@ -39,6 +39,7 @@ apic(
         "//gapis/api/templates:constant_sets",
         "//gapis/api/templates:convert",
         "//gapis/api/templates:proto",
+        "//gapis/api/templates:state_serialize",
     ],
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
There was a merge issue with the new MEC stuff and Bazel.
Bazel was missing some template generation that was necessary to
properly read a trace that was created with mid-execution capture.