### PR TITLE
gapir: Various fixes for crashes on macOS

### DIFF
--- a/core/cc/log.cpp
+++ b/core/cc/log.cpp
@@ -71,12 +71,15 @@ void Logger::vlogf(unsigned level, const char* src_file, unsigned src_line, cons
     auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(t.time_since_epoch());
 
     for (FILE* file : mFiles) {
+        va_list args_copy;
+        va_copy(args_copy, args);
+
         // Print out the common part of the log messages
         fprintf(file, "%02d:%02d:%02d.%03d %c %s: [%s:%u] ", loc->tm_hour, loc->tm_min, loc->tm_sec,
                 static_cast<int>(ms.count() % 1000), "FEWIDV"[level], mSystem, src_file, src_line);
 
         // Print out the actual log message
-        vfprintf(file, format, args);
+        vfprintf(file, format, args_copy);
 
         // Always finish with a newline
         fprintf(file, "\n");

--- a/gapir/cc/osx/gles_renderer.mm
+++ b/gapir/cc/osx/gles_renderer.mm
@@ -73,8 +73,8 @@ GlesRendererImpl::GlesRendererImpl(GlesRendererImpl* shared_context)
         : mQueriedExtensions(false)
         , mWindow(nullptr)
         , mContext(nullptr)
-        , mNeedsResolve(true)
-        , mSharedContext(shared_context != nullptr ? shared_context->mContext : 0) {
+        , mSharedContext(shared_context != nullptr ? shared_context->mContext : 0)
+        , mNeedsResolve(true) {
 
     // Initialize with a default target.
     setBackbuffer(Backbuffer(

--- a/gapir/cc/osx/gles_renderer.mm
+++ b/gapir/cc/osx/gles_renderer.mm
@@ -182,6 +182,7 @@ void GlesRendererImpl::setBackbuffer(Backbuffer backbuffer) {
     }
 
     [mContext setView:[mWindow contentView]];
+    [mWindow display];
 
     mBackbuffer = backbuffer;
     mNeedsResolve = true;

--- a/gapis/api/templates/specific_gfx_api.cpp.tmpl
+++ b/gapis/api/templates/specific_gfx_api.cpp.tmpl
@@ -41,22 +41,32 @@
   #define __STDC_FORMAT_MACROS
   #include <inttypes.h>
 ¶
-  namespace gapir {«
   {{$api := Title (Global "API")}}
+  namespace {«
+    typedef bool (gapir::{{$api}}::*Function)(uint32_t, gapir::Stack*, bool);
+
+    {{$non_synthetics := $.Functions | WithoutAnnotation "synthetic"}}
+
+    Function functions[] = {
+      {{range $i, $c := $non_synthetics}}
+        {{if (not (GetAnnotation $c "pfn"))}}
+          {{$name := Macro "C++.Public" (Macro "CmdName" $c)}}
+          &gapir::{{$api}}::call{{$name}},
+        {{end}}
+      {{end}}
+      nullptr,
+    };
+  »}
+  namespace gapir {«
 ¶
   const char* {{$api}}::ID = "{{$api}}";
   uint8_t {{$api}}::INDEX = {{$.Index}};
 ¶
   {{$api}}::{{$api}}() {
     using namespace std::placeholders;
-    ¶
-    {{$non_synthetics := $.Functions | WithoutAnnotation "synthetic"}}
-    {{range $i, $c := $non_synthetics}}
-      {{if (not (GetAnnotation $c "pfn"))}}
-        {{$name := Macro "C++.Public" (Macro "CmdName" $c)}}
-        mFunctions.insert({{$i}}, std::bind(&{{$api}}::call{{$name}}, this, _1, _2, _3));
-      {{end}}
-    {{end}}
+    for (int i = 0; functions[i] != nullptr; i++) {
+        mFunctions.insert(i, std::bind(functions[i], this, _1, _2, _3));
+    }
   }
 ¶
   void {{$api}}::resolve() {

--- a/gapis/api/templates/specific_gfx_api.h.tmpl
+++ b/gapis/api/templates/specific_gfx_api.h.tmpl
@@ -101,7 +101,6 @@ class {{Title (Global "API")}} : public Api {
 ¶
   #include "gapir/cc/{{Global "API"}}_gfx_api.inc"
 ¶
-«private:»
   {{range $c := AllCommands $}}
     {{if and (not (GetAnnotation $c "synthetic")) (not (GetAnnotation $c "pfn"))}}
       {{$name := Macro "CmdName" $c}}


### PR DESCRIPTION
Fix for a stack overflow in non-optimized builds.
Work around a weird OS crash that appeared in High Sierra.
Fix for a crash caused by bad handling of `va_list` in `Logger:vlogf`.