### PR TITLE
Add core/memory/arena.

### DIFF
--- a/core/memory/arena/BUILD.bazel
+++ b/core/memory/arena/BUILD.bazel
@@ -1,0 +1,38 @@
+# Copyright (C) 2018 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "arena.go",
+    ],
+    cdeps = ["//core/memory/arena/cc"],
+    cgo = True,
+    clinkopts = [],  # keep
+    importpath = "github.com/google/gapid/core/memory/arena",
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_xtest",
+    size = "small",
+    srcs = ["arena_test.go"],
+    deps = [
+        "//core/assert:go_default_library",
+        "//core/log:go_default_library",
+        ":go_default_library",
+    ],
+)

--- a/core/memory/arena/arena.go
+++ b/core/memory/arena/arena.go
@@ -1,0 +1,179 @@
+// Copyright (C) 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package arena implements a memory arena.
+package arena
+
+import "unsafe"
+
+// #cgo LDFLAGS: -lcc-core -lcc-arena -lstdc++
+//
+// #include "core/memory/arena/cc/arena.h"
+import "C"
+
+// Arena is a native memory allocator that owns each of the allocations made by
+// Allocate() and Reallocate(). If there are any outstanding allocations when
+// the Arena is disposed then these allocations are automatically freed.
+// Because the memory is allocated outside of the Go environment it is important
+// to explicity free unused memory - either by calling Free() or calling
+// Dispose() on the Arena.
+// Failing to Dispose() the arena will leak memory.
+type Arena struct{ Pointer unsafe.Pointer }
+
+// New constructs a new arena.
+// You must call Dispose to free the arena object and any arena-owned
+// allocations.
+func New() Arena {
+	return Arena{Pointer: unsafe.Pointer(C.arena_create())}
+}
+
+// Dispose destructs and frees the arena and all arena-owned allocations.
+func (a Arena) Dispose() {
+	C.arena_destroy((*C.arena)(a.Pointer))
+}
+
+// Allocate returns a pointer to a new arena-owned, contiguous block of memory
+// of the specified size and alignment.
+func (a Arena) Allocate(size, alignment int) unsafe.Pointer {
+	return C.arena_alloc((*C.arena)(a.Pointer), C.uint32_t(size), C.uint32_t(alignment))
+}
+
+// Reallocate reallocates the memory at ptr to the new size and alignment.
+// ptr must have been allocated from this arena.
+func (a Arena) Reallocate(ptr unsafe.Pointer, size, alignment int) unsafe.Pointer {
+	return C.arena_realloc((*C.arena)(a.Pointer), ptr, C.uint32_t(size), C.uint32_t(alignment))
+}
+
+// Free releases the memory at ptr, which must have been previously allocated by
+// this arena.
+func (a Arena) Free(ptr unsafe.Pointer) {
+	C.arena_free((*C.arena)(a.Pointer), ptr)
+}
+
+// Stats holds statistics of an Arena.
+type Stats struct {
+	NumAllocations    int
+	NumBytesAllocated int
+}
+
+// Stats returns statistics of the current state of the Arena.
+func (a Arena) Stats() Stats {
+	var numAllocs, numBytes C.size_t
+	C.arena_stats((*C.arena)(a.Pointer), &numAllocs, &numBytes)
+	return Stats{int(numAllocs), int(numBytes)}
+}
+
+// Offsetable is used as an anonymous field of types that require a current
+// offset value.
+type Offsetable struct{ Offset int }
+
+// AlignUp rounds-up the current offset so that is is a multiple of n.
+func (o *Offsetable) AlignUp(n int) {
+	pad := n - o.Offset%n
+	if pad == n {
+		return
+	}
+	o.Offset += pad
+}
+
+// Writer provides methods to help allocate and populate a native buffer with
+// data. Use Arena.Writer() to construct.
+type Writer struct {
+	Offsetable // The current write-offset in bytes.
+	arena      Arena
+	size       int
+	alignment  int
+	base       unsafe.Pointer
+	frozen     bool
+}
+
+// NewWriter returns a new Writer to a new arena allocated buffer of the initial
+// size. The native buffer may grow if the writer exceeds the size of the
+// buffer. The buffer will always be of the specified alignment in memory.
+// The once the native buffer is no longer needed, the pointer returned by
+// Pointer() should be passed to Arena.Free().
+func (a Arena) NewWriter(size, alignment int) *Writer {
+	base := a.Allocate(size, alignment)
+	return &Writer{
+		arena:     a,
+		size:      size,
+		alignment: alignment,
+		base:      base,
+	}
+}
+
+// Reset sets the write offset back to the start of the buffer and unfreezes
+// the writer. This allows for efficient reuse of the writer's native buffer.
+func (w *Writer) Reset() {
+	w.Offset = 0
+	w.frozen = false
+}
+
+// Pointer returns the base address of the native buffer for the writer.
+// Calling Pointer() freezes the writer - once called no more writes to the
+// buffer can be made, unless Reset() is called. Freezing attempts to reduce the
+// chance of the stale pointer being used after a buffer reallocation.
+func (w *Writer) Pointer() unsafe.Pointer {
+	w.frozen = true
+	return w.base
+}
+
+// Write copies size bytes from src to the current writer's write offset.
+// If there is not enough space in the buffer for the write, then the buffer
+// is grown via reallocation.
+// Upon returning, the write offset is incremented by size bytes.
+func (w *Writer) Write(src unsafe.Pointer, size int) {
+	if w.frozen {
+		panic("Cannot write to Writer after calling Pointer()")
+	}
+	if needed := w.Offset + size; needed > w.size {
+		size := w.size
+		for needed > size {
+			size *= 2 // TODO: Snugger fit?
+		}
+		w.base = w.arena.Reallocate(w.base, size, w.alignment)
+		w.size = size
+	}
+	dst := uintptr(w.base) + uintptr(w.Offset)
+	for i := 0; i < size; i++ {
+		dst := (*byte)(unsafe.Pointer(dst + uintptr(i)))
+		src := (*byte)(unsafe.Pointer(uintptr(src) + uintptr(i)))
+		*dst = *src
+	}
+	w.Offset += size
+}
+
+// Reader provides the Read method to read native buffer data.
+// Use NewReader() to construct.
+type Reader struct {
+	Offsetable // The current read-offset in bytes.
+	base       unsafe.Pointer
+}
+
+// NewReader returns a new Reader to the native-buffer starting at ptr.
+func NewReader(ptr unsafe.Pointer) *Reader {
+	return &Reader{base: ptr}
+}
+
+// Read copies size bytes from the current read offset to dst.
+// Upon returning, the read offset is incremented by size bytes.
+func (r *Reader) Read(dst unsafe.Pointer, size int) {
+	src := uintptr(r.base) + uintptr(r.Offset)
+	for i := 0; i < size; i++ {
+		src := (*byte)(unsafe.Pointer(src + uintptr(i)))
+		dst := (*byte)(unsafe.Pointer(uintptr(dst) + uintptr(i)))
+		*dst = *src
+	}
+	r.Offset += size
+}

--- a/core/memory/arena/arena_test.go
+++ b/core/memory/arena/arena_test.go
@@ -1,0 +1,34 @@
+// Copyright (C) 2018 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package arena_test
+
+import (
+	"testing"
+
+	"github.com/google/gapid/core/assert"
+	"github.com/google/gapid/core/log"
+	"github.com/google/gapid/core/memory/arena"
+)
+
+func TestArenaStats(t *testing.T) {
+	ctx := log.Testing(t)
+
+	a := arena.New()
+	assert.For(ctx, "empty arena").That(a.Stats()).Equals(arena.Stats{})
+
+	a.Allocate(10, 4)
+	assert.For(ctx, "num alloc").ThatInteger(a.Stats().NumAllocations).Equals(1)
+	assert.For(ctx, "bytes alloc").ThatInteger(a.Stats().NumBytesAllocated).IsAtLeast(10)
+}

--- a/core/memory/arena/cc/BUILD.bazel
+++ b/core/memory/arena/cc/BUILD.bazel
@@ -1,0 +1,26 @@
+# Copyright (C) 2018 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("//tools/build:rules.bzl", "cc_copts")
+
+cc_library(
+    name = "cc",
+    srcs = glob(["*.cpp"]),
+    deps = [
+        "//core/cc",
+    ],
+    hdrs = glob(["*.h"]),
+    copts = cc_copts(),
+    visibility = ["//visibility:public"],
+)

--- a/core/memory/arena/cc/arena.cpp
+++ b/core/memory/arena/cc/arena.cpp
@@ -1,0 +1,121 @@
+/*
+ * Copyright (C) 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "arena.h"
+
+#include "core/cc/target.h"
+#include "core/cc/assert.h"
+
+#include <stdlib.h>
+
+#if TARGET_OS == GAPID_OS_OSX
+#include <malloc/malloc.h> // malloc_size
+#else
+#include <malloc.h> // malloc_size,malloc_usable_size, dlmalloc_usable_size
+#endif
+
+namespace {
+
+size_t alloc_size(void* ptr) {
+    WINDOWS_ONLY(return _msize(ptr));
+    OSX_ONLY(return malloc_size(ptr));
+    LINUX_ONLY(return malloc_usable_size(ptr));
+    ANDROID_ONLY(return malloc_usable_size(ptr));
+    return 0;
+}
+
+}  // anonymous namespace
+
+namespace core {
+
+Arena::Arena() {}
+
+Arena::~Arena() {
+    for (void* ptr : allocations) {
+        ::free(ptr);
+    }
+    allocations.clear();
+}
+
+void* Arena::allocate(uint32_t size, uint32_t align) {
+    void* ptr = malloc(size); // TODO: alignment
+    allocations.insert(ptr);
+    return ptr;
+}
+
+void* Arena::reallocate(void* ptr, uint32_t size, uint32_t align) {
+    GAPID_ASSERT_MSG(this->owns(ptr), "ptr: %p", ptr);
+    void* newptr = realloc(ptr, size); // TODO: alignment
+    allocations.erase(ptr);
+    allocations.insert(newptr);
+    return newptr;
+}
+
+void Arena::free(void* ptr) {
+    GAPID_ASSERT_MSG(this->owns(ptr), "ptr: %p", ptr);
+    allocations.erase(ptr);
+    ::free(ptr);
+}
+
+bool Arena::owns(void* ptr) {
+    return allocations.count(ptr) == 1;
+}
+
+size_t Arena::num_allocations() const {
+    return allocations.size();
+}
+
+size_t Arena::num_bytes_allocated() const {
+    size_t bytes = 0;
+    for (void* ptr : allocations) {
+        bytes += alloc_size(ptr);
+    }
+    return bytes;
+}
+
+}  // namespace core
+
+extern "C" {
+
+arena* arena_create() {
+    return reinterpret_cast<arena*>(new core::Arena());
+}
+
+void arena_destroy(arena* a) {
+    delete reinterpret_cast<core::Arena*>(a);
+}
+
+void* arena_alloc(arena* a, uint32_t size, uint32_t align) {
+    return reinterpret_cast<core::Arena*>(a)->allocate(size, align);
+}
+
+void* arena_realloc(arena* a, void* ptr, uint32_t size, uint32_t align) {
+    return reinterpret_cast<core::Arena*>(a)->reallocate(ptr, size, align);
+}
+
+void arena_free(arena* a, void* ptr) {
+    reinterpret_cast<core::Arena*>(a)->free(ptr);
+}
+
+// arena_stats returns statistics of the current state of the arena.
+void arena_stats(arena* a, size_t* num_allocations, size_t* num_bytes_allocated) {
+    auto arena = reinterpret_cast<core::Arena*>(a);
+    *num_allocations = arena->num_allocations();
+    *num_bytes_allocated = arena->num_bytes_allocated();
+}
+
+} // extern "C"
+

--- a/core/memory/arena/cc/arena.h
+++ b/core/memory/arena/cc/arena.h
@@ -1,0 +1,117 @@
+// Copyright (C) 2017 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef CORE_ARENA_H
+#define CORE_ARENA_H
+
+#include <stdint.h>
+#include <stddef.h>
+
+#ifdef __cplusplus
+
+#include <unordered_set>
+
+namespace core {
+
+// Arena is a memory allocator that owns each of the allocations made by it.
+// If there are any outstanding allocations when the Arena is destructed then
+// these allocations are automatically freed.
+class Arena {
+public:
+    Arena();
+    ~Arena();
+
+    // allocates a contiguous block of memory of at least the requested size and
+    // alignment.
+    void* allocate(uint32_t size, uint32_t align);
+
+    // reallocates a block of memory previously allocated by this arena.
+    // Data held in the previous allocation will be copied to the reallocated
+    // address, but data may be trimmed if the new size is smaller than the
+    // previous allocation.
+    void* reallocate(void* ptr, uint32_t size, uint32_t align);
+
+    // free releases the memory previously allocated by this arena.
+    // Once the memory is freed, it must not be used.
+    void free(void* ptr);
+
+    // owns returns true if ptr is owned by this arena.
+    bool owns(void* ptr);
+
+    // create constructs and returns a pointer to a new T.
+    template<typename T>
+    inline T* create();
+
+    // destroy destructs an object constructed with create<T>().
+    template<typename T>
+    inline void destroy(T* ptr);
+
+    // returns the total number of allocations owned by this arena.
+    size_t num_allocations() const;
+
+    // returns the total number of bytes allocated by this arena.
+    size_t num_bytes_allocated() const;
+
+private:
+    std::unordered_set<void*> allocations;
+};
+
+template<typename T>
+inline T* Arena::create() {
+    auto buf = allocate(sizeof(T), alignof(T));
+    return new(buf) T;
+}
+
+template<typename T>
+inline void Arena::destroy(T* ptr) {
+    ptr->~T();
+    free(ptr);
+}
+
+
+}  // namespace core
+
+extern "C" {
+#endif
+
+// C handle for an arena.
+typedef struct arena_t arena;
+
+// arena_create constructs and returns a new arena.
+arena* arena_create();
+
+// arena_destroy destructs the specified arena, freeing all allocations
+// made by that arena. Once destroyed, you must not use the arena.
+void arena_destroy(arena* arena);
+
+// arena_alloc creates a memory allocation in the specified arena of the
+// given size and alignment.
+void* arena_alloc(arena* arena, uint32_t size, uint32_t align);
+
+// arena_realloc reallocates the memory at ptr to the new size and
+// alignment. ptr must have been allocated from arena.
+void* arena_realloc(arena* arena, void* ptr, uint32_t size, uint32_t align);
+
+// arena_free deallocates the memory at ptr. ptr must have been allocated
+// from arena.
+void arena_free(arena* arena, void* ptr);
+
+// arena_stats returns statistics of the current state of the arena.
+void arena_stats(arena* arena, size_t* num_allocations, size_t* num_bytes_allocated);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+#endif //  CORE_ARENA_H


### PR DESCRIPTION
Arena is a native memory allocator that owns each of the allocations made by `Allocate()` and `Reallocate()`.

Used heavily by the gapil runtime.