### PR TITLE
Removed -lGL from deviceinfo linker options.

### DIFF
--- a/core/os/device/deviceinfo/cc/BUILD.bazel
+++ b/core/os/device/deviceinfo/cc/BUILD.bazel
@@ -39,7 +39,6 @@ cc_library(
     linkopts = select({
         "//tools/build:linux": [
             "-ldl",
-            "-lGL",
             "-lX11",
         ],
         "//tools/build:darwin": [


### PR DESCRIPTION
We no longer statically need -lGL to build, we link to it at
runtime.