### PR TITLE
Adds a runfiles core/app/layout

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -23,7 +23,7 @@ github_repository(
     name = "io_bazel_rules_go",
     organization = "bazelbuild",
     project = "rules_go",
-    commit = "6b653a809d768269dedffe17a66c684dbbdf13fb",
+    commit = "c949c4d2235a3988ed3c7ac9beb70f707d29d465",
 )
 
 github_repository(

--- a/cmd/gapis/BUILD.bazel
+++ b/cmd/gapis/BUILD.bazel
@@ -43,6 +43,12 @@ go_library(
 
 go_binary(
     name = "gapis",
+    data = [
+        "//cmd/gapir/cc:gapir",
+        "//gapidapk/android/apk:arm64-v8a.apk",
+        "//gapidapk/android/apk:armeabi-v7a.apk",
+        "//gapidapk/android/apk:x86.apk",
+    ],
     embed = [":go_default_library"],
     visibility = ["//visibility:public"],
 )

--- a/cmd/gapit/BUILD.bazel
+++ b/cmd/gapit/BUILD.bazel
@@ -79,10 +79,15 @@ go_library(
 
 go_binary(
     name = "gapit",
+    data = [
+        "//cmd/gapis",
+        "//core/vulkan/vk_virtual_swapchain/cc:json",
+        "//core/vulkan/vk_virtual_swapchain/cc:libVkLayer_VirtualSwapchain",
+        "//gapii/cc:libgapii",
+        "//gapis/messages:stb",
+        "//gapii/vulkan/vk_graphics_spy/cc:json",
+
+    ],
     embed = [":go_default_library"],
-    #TODO: need to work out why this breaks the analysis phase
-    #data = [
-    #    "//:install-runtime",
-    #],
     visibility = ["//visibility:public"],
 )

--- a/gapis/client/BUILD.bazel
+++ b/gapis/client/BUILD.bazel
@@ -25,12 +25,11 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//core/app/auth:go_default_library",
+        "//core/app/layout:go_default_library",
         "//core/event:go_default_library",
         "//core/log:go_default_library",
         "//core/log/log_pb:go_default_library",
         "//core/net/grpcutil:go_default_library",
-        "//core/os/device:go_default_library",
-        "//core/os/device/host:go_default_library",
         "//core/os/file:go_default_library",
         "//core/os/process:go_default_library",
         "//gapis/api:go_default_library",

--- a/gapis/client/process.go
+++ b/gapis/client/process.go
@@ -57,8 +57,9 @@ func Connect(ctx context.Context, cfg Config) (Client, error) {
 		if cfg.Token != auth.NoAuth {
 			cfg.Args = append(cfg.Args, "--gapis-auth-token", string(cfg.Token))
 		}
+
 		cfg.Port, err = process.Start(ctx, cfg.Path.System(), process.StartOptions{
-			Args:    cfg.Args,
+			Args:    append(cfg.Args, layout.GoArgs(ctx)...),
 			Verbose: true,
 		})
 		if err != nil {

--- a/tools/build/mingw_toolchain/BUILD.bazel
+++ b/tools/build/mingw_toolchain/BUILD.bazel
@@ -40,3 +40,8 @@ filegroup(
     name = "empty",
     srcs = [],
 )
+
+filegroup(
+    name = "cc_wrapper",
+    srcs = [],
+)

--- a/tools/build/mingw_toolchain/CROSSTOOL.in
+++ b/tools/build/mingw_toolchain/CROSSTOOL.in
@@ -45,7 +45,7 @@ toolchain {
   objcopy_embed_flag: "-I"
   objcopy_embed_flag: "binary"
 
-  linking_mode_flags { mode: DYNAMIC  }
+  linking_mode_flags { mode: FULLY_STATIC }
 
   %{CXX_BUILTIN_INCLUDE_DIRECTORIES}
 

--- a/tools/build/rules/stringgen.bzl
+++ b/tools/build/rules/stringgen.bzl
@@ -47,4 +47,5 @@ stringgen = rule(
             default = Label("//cmd/stringgen:stringgen"),
         ),
     },
+    output_to_genfiles = True,
 )


### PR DESCRIPTION
Allows developers to now run `bazel run cmd/gapi[st]`