### PR TITLE
For android, fail the compilation if we have any outstanding symbols.

### DIFF
--- a/tools/build/rules/dynlib.bzl
+++ b/tools/build/rules/dynlib.bzl
@@ -98,6 +98,7 @@ def android_dynamic_library(name, exports = "", deps = [], linkopts = [], **kwar
         deps = deps + [name + ".ldscript"],
         linkopts = linkopts + [
             "-Wl,--version-script", name + ".ldscript",
+            "-Wl,--unresolved-symbols=report-all",
             "-Wl,--gc-sections",
             "-Wl,--exclude-libs,libgcc.a",
             "-Wl,-z,noexecstack,-z,relro,-z,now,-z,nocopyreloc",


### PR DESCRIPTION
This causes android to fail silently, making it very hard to diagnose
issues.

Fixes #1605