### PR TITLE
Fixes for Robot on Bazel.

### DIFF
--- a/cmd/embed/main.go
+++ b/cmd/embed/main.go
@@ -111,6 +111,7 @@ func run(ctx context.Context) error {
 			rel := ""
 			if root != "" {
 				// if Rel fails, we just fallback to basename in the loop below
+				root, err = filepath.Abs(root)
 				rel, _ = filepath.Rel(root, path)
 			} else {
 				rel = filepath.Base(path)

--- a/test/robot/replay/client.go
+++ b/test/robot/replay/client.go
@@ -183,7 +183,7 @@ func doReplay(ctx context.Context, action string, in *Input, store *stash.Client
 		return nil, err
 	}
 
-	output := fmt.Sprintf("%s\n\n%s", cmd, strings.TrimSpace(outBuf.String()))
+	output := fmt.Sprintf("%s\n\n%s\n%s\n\n", cmd, strings.TrimSpace(outBuf.String()), strings.TrimSpace(errBuf.String()))
 	log.I(ctx, output)
 	logID, err := store.UploadString(ctx, stash.Upload{Name: []string{"replay.log"}, Type: []string{"text/plain"}}, output)
 	if err != nil {

--- a/test/robot/web/BUILD.bazel
+++ b/test/robot/web/BUILD.bazel
@@ -20,12 +20,12 @@ load("//tools/build:rules.bzl", "embed")
 embed(
     name = "embed",
     srcs = glob([
-        "www/*.html",
-        "www/*.css",
-        "www/*.js",
-        "www/*.png",
-        "template/*.tmpl",
+        "www/**/*.html",
+        "www/**/*.css",
+        "www/**/*.js",
+        "www/**/*.png",
     ]),
+    root = "./test/robot/web/"
 )
 
 go_library(

--- a/test/robot/web/client/client.go
+++ b/test/robot/web/client/client.go
@@ -145,18 +145,22 @@ func robotTextPreview(path string, s interface{}) interface{} {
 	id := s.(string)
 
 	div := dom.NewDiv()
-	div.Element.Style.MaxWidth = 600
-	div.Element.Style.MaxHeight = 420
-	div.Element.Style.Overflow = "auto"
-	div.Element.Style.WhiteSpace = "pre"
+	a := robotEntityLink(path, s)
+	div.Append(a)
+	textDiv := dom.NewDiv()
+	textDiv.Element.Style.MaxWidth = 600
+	textDiv.Element.Style.MaxHeight = 420
+	textDiv.Element.Style.Overflow = "auto"
+	textDiv.Element.Style.WhiteSpace = "pre"
 	go func() {
 		fullText, err := queryRestEndpoint(fmt.Sprintf("/entities/%s", id))
 		if err != nil {
 			panic(err)
 		}
 
-		div.Append(string(fullText))
+		textDiv.Append(string(fullText))
 	}()
+	div.Append(textDiv)
 	return div
 }
 
@@ -206,7 +210,17 @@ func newView() *view {
 		},
 	).Add("/1/input/((gapi[irst])|gapid_apk|trace|subject|interceptor|vulkanLayer)", robotEntityLink).
 		Add("/1/input/layout", v.objView.Expandable).
-		Add("/1/output/(log|report|err)", robotTextPreview).
+		Add("/1/output/(log|report)", robotTextPreview).
+		Add("/1/output/err", func(path string, a interface{}) interface{} {
+			err := a.(string)
+			div := dom.NewDiv()
+			div.Element.Style.MaxWidth = 600
+			div.Element.Style.MaxHeight = 420
+			div.Element.Style.Overflow = "auto"
+			div.Element.Style.WhiteSpace = "pre"
+			div.Append(err)
+			return div
+		}).
 		Add("/1/output/video", robotVideoView).
 		Add("/0/", v.objView.Expandable)
 


### PR DESCRIPTION
This change enables embed to use a relative root path in order to
correctly configure filepaths when embedding. Also fixes the globbing in
the robot web build file to be recursive. Some fixes to the replay
client and the web client as well to get better logging information.

NOTE: this does not yet transpile grid.html from gopherjs as the plan is 
to remove the dependency. If you have golang 1.9 you can run 
`go get github.com/gopherjs/gopherjs`, if you have golang 1.10 you 
must manually download and build the [`go1.10` branch of gopherjs](https://github.com/gopherjs/gopherjs/tree/go1.10).
Then run the following command at the project root:
`gopherjs build --minify --output ./test/robot/web/www/grid/grid.js ./test/robot/web/client`