### PR TITLE
Adds minimum frame limit to gapit video and robot.

### DIFF
--- a/cmd/gapit/flags.go
+++ b/cmd/gapit/flags.go
@@ -115,8 +115,9 @@ type (
 		Text     string    `help:"summary prefix (use '║' for aligned columns, '¶' for new line)"`
 		Commands bool      `help:"Treat every command as its own frame"`
 		Frames   struct {
-			Start int `help:"frame to start capture from"`
-			Count int `help:"number of frames after Start to capture: -1 for all frames"`
+			Start   int `help:"frame to start capture from"`
+			Count   int `help:"number of frames after Start to capture: -1 for all frames"`
+			Minimum int `help:"return error when less than this number of frames is found"`
 		}
 		CommandFilterFlags
 	}

--- a/cmd/gapit/sxs_video.go
+++ b/cmd/gapit/sxs_video.go
@@ -151,6 +151,9 @@ func (verb *videoVerb) sxsVideoSource(
 			numDrawCalls = 0
 		}
 	}
+	if verb.Frames.Minimum > len(videoFrames) {
+		return nil, log.Errf(ctx, nil, "Captured only %v frames, require %v frames at minimum", len(videoFrames), verb.Frames.Minimum)
+	}
 
 	// Get all the observed and rendered frames, and compare them.
 	start := time.Now()
@@ -179,6 +182,7 @@ func (verb *videoVerb) sxsVideoSource(
 		})
 	}
 	wg.Wait()
+
 	log.D(ctx, "Frames rendered in %v", time.Since(start))
 	for _, v := range videoFrames {
 		if v.renderError != nil {

--- a/cmd/gapit/video.go
+++ b/cmd/gapit/video.go
@@ -58,6 +58,7 @@ func init() {
 	verb.Max.Height = 1280
 	verb.FPS = 5
 	verb.Frames.Count = allTheWay
+	verb.Frames.Minimum = 1
 	app.AddVerb(&app.Verb{
 		Name:      "video",
 		ShortHelp: "Produce a video or sequence of frames from a .gfxtrace file",
@@ -95,6 +96,10 @@ func (verb *videoVerb) regularVideoSource(
 	eofEvents, err := getEvents(ctx, client, &requestEvents)
 	if err != nil {
 		return nil, log.Err(ctx, err, "Couldn't get frame events")
+	}
+
+	if verb.Frames.Minimum > len(eofEvents) {
+		return nil, log.Errf(ctx, nil, "Captured only %v frames, requires %v frames at minimum", len(eofEvents), verb.Frames.Minimum)
 	}
 
 	if verb.Frames.Start < len(eofEvents) {

--- a/test/robot/replay/client.go
+++ b/test/robot/replay/client.go
@@ -162,6 +162,7 @@ func doReplay(ctx context.Context, action string, in *Input, store *stash.Client
 	params := []string{
 		"video",
 		"-gapir-device", in.GetGapirDevice(),
+		"-frames-minimum", "10",
 		"-type", "sxs",
 		"-out", videofile.System(),
 		tracefile.System(),


### PR DESCRIPTION
Previously if a capture contained very few frames the video command
would happily output a super short (or even empty) video. This change
produces an error when the video command encounters a capture containing
less than some minimum number of frames. Specifically it allows robot to
show a failure when it encounters this, making such errors more visible.
The command currently defaults to 1 frame minimum, and robot requires 10
frames to not fail.