### PR TITLE
Add gapil/compiler/mangling and c, ia64 packages.

### DIFF
--- a/gapil/compiler/mangling/BUILD.bazel
+++ b/gapil/compiler/mangling/BUILD.bazel
@@ -1,0 +1,24 @@
+# Copyright (C) 2018 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "mangling.go",
+    ],
+    importpath = "github.com/google/gapid/gapil/compiler/mangling",
+    visibility = ["//visibility:public"],
+)

--- a/gapil/compiler/mangling/c/BUILD.bazel
+++ b/gapil/compiler/mangling/c/BUILD.bazel
@@ -1,0 +1,39 @@
+# Copyright (C) 2018 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "c.go",
+    ],
+    importpath = "github.com/google/gapid/gapil/compiler/mangling/c",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//gapil/compiler/mangling:go_default_library",
+    ]
+)
+
+go_test(
+    name = "go_default_xtest",
+    size = "small",
+    srcs = ["c_test.go"],
+    deps = [
+        "//core/assert:go_default_library",
+        "//core/log:go_default_library",
+        "//gapil/compiler/mangling:go_default_library",
+        ":go_default_library",
+    ]
+)

--- a/gapil/compiler/mangling/c/c.go
+++ b/gapil/compiler/mangling/c/c.go
@@ -1,0 +1,43 @@
+// Copyright (C) 2018 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package c implements a basic symbol mangling for that is compatible with C.
+package c
+
+import (
+	"bytes"
+
+	"github.com/google/gapid/gapil/compiler/mangling"
+)
+
+// Mangle returns the entity mangled conforming to the IA64 ABI.
+func Mangle(s mangling.Entity) string {
+	m := mangler{bytes.Buffer{}}
+	m.mangle(s)
+	return m.String()
+}
+
+type mangler struct {
+	bytes.Buffer
+}
+
+func (m *mangler) mangle(v mangling.Entity) {
+	if v, ok := v.(mangling.Scoped); ok {
+		if s := v.Scope(); s != nil {
+			m.mangle(s)
+			m.WriteString("__")
+		}
+	}
+	m.WriteString(v.(mangling.Named).GetName())
+}

--- a/gapil/compiler/mangling/c/c_test.go
+++ b/gapil/compiler/mangling/c/c_test.go
@@ -1,0 +1,126 @@
+// Copyright (C) 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package c_test
+
+import (
+	"testing"
+
+	"github.com/google/gapid/core/assert"
+	"github.com/google/gapid/core/log"
+	"github.com/google/gapid/gapil/compiler/mangling"
+	"github.com/google/gapid/gapil/compiler/mangling/c"
+)
+
+func TestC(t *testing.T) {
+	ctx := log.Testing(t)
+
+	/*
+	   namespace food {
+	   namespace fruit {
+
+	   class Apple {
+	   public:
+	       int yummy(int, char*);
+	       bool eat(void* person);
+	       int calories();
+	       bool looks_like(Apple*);
+	       static bool healthy();
+	       static int compare(Apple* a, Apple* b);
+	       template <typename T> bool same_as(T other); (T: int)
+	       template <typename X, typename Y> static void juice(); (X: int, Y: bool)
+	   };
+
+	   } // namespace fruit
+	   } // namespace food
+	*/
+	food := &mangling.Namespace{Name: "food"}
+	fruit := &mangling.Namespace{Name: "fruit", Parent: food}
+	apple := &mangling.Class{Name: "Apple", Parent: fruit}
+
+	yummy := &mangling.Function{
+		Name:       "yummy",
+		Return:     mangling.Int,
+		Parameters: []mangling.Type{mangling.Int, mangling.Pointer{To: mangling.Char}},
+		Parent:     apple,
+	}
+
+	eat := &mangling.Function{
+		Name:       "eat",
+		Return:     mangling.Bool,
+		Parameters: []mangling.Type{mangling.Pointer{To: mangling.Void}},
+		Parent:     apple,
+	}
+
+	calories := &mangling.Function{
+		Name:   "calories",
+		Return: mangling.Int,
+		Parent: apple,
+		Const:  true,
+	}
+
+	looksLike := &mangling.Function{
+		Name:       "looks_like",
+		Return:     mangling.Bool,
+		Parameters: []mangling.Type{mangling.Pointer{To: apple}},
+		Parent:     apple,
+	}
+
+	healthy := &mangling.Function{
+		Name:   "healthy",
+		Return: mangling.Bool,
+		Static: true,
+		Parent: apple,
+	}
+
+	compare := &mangling.Function{
+		Name:       "compare",
+		Return:     mangling.Int,
+		Parameters: []mangling.Type{mangling.Pointer{To: apple}, mangling.Pointer{To: apple}},
+		Parent:     apple,
+	}
+
+	sameAs := &mangling.Function{
+		Name:         "same_as",
+		Return:       mangling.Bool,
+		Parameters:   []mangling.Type{mangling.TemplateParameter(0)},
+		TemplateArgs: []mangling.Type{mangling.Int},
+		Parent:       apple,
+	}
+
+	juice := &mangling.Function{
+		Name:         "juice",
+		Return:       mangling.Void,
+		TemplateArgs: []mangling.Type{mangling.Int, mangling.Bool},
+		Parent:       apple,
+	}
+
+	for _, t := range []struct {
+		name     string
+		sym      mangling.Entity
+		expected string
+	}{
+		{"food::fruit::Apple", apple, "food__fruit__Apple"},
+		{"food::fruit::Apple::yummy", yummy, "food__fruit__Apple__yummy"},
+		{"food::fruit::Apple::eat", eat, "food__fruit__Apple__eat"},
+		{"food::fruit::Apple::calories", calories, "food__fruit__Apple__calories"},
+		{"food::fruit::Apple::looks_like", looksLike, "food__fruit__Apple__looks_like"},
+		{"food::fruit::Apple::healthy", healthy, "food__fruit__Apple__healthy"},
+		{"food::fruit::Apple::compare", compare, "food__fruit__Apple__compare"},
+		{"food::fruit::Apple::same_as", sameAs, "food__fruit__Apple__same_as"},
+		{"food::fruit::Apple::juice", juice, "food__fruit__Apple__juice"},
+	} {
+		assert.For(ctx, t.name).ThatString(c.Mangle(t.sym)).Equals(t.expected)
+	}
+}

--- a/gapil/compiler/mangling/ia64/BUILD.bazel
+++ b/gapil/compiler/mangling/ia64/BUILD.bazel
@@ -1,0 +1,39 @@
+# Copyright (C) 2018 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "ia64.go",
+    ],
+    importpath = "github.com/google/gapid/gapil/compiler/mangling/ia64",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//gapil/compiler/mangling:go_default_library",
+    ]
+)
+
+go_test(
+    name = "go_default_xtest",
+    size = "small",
+    srcs = ["ia64_test.go"],
+    deps = [
+        "//core/assert:go_default_library",
+        "//core/log:go_default_library",
+        "//gapil/compiler/mangling:go_default_library",
+        ":go_default_library",
+    ]
+)

--- a/gapil/compiler/mangling/ia64/ia64.go
+++ b/gapil/compiler/mangling/ia64/ia64.go
@@ -1,0 +1,352 @@
+// Copyright (C) 2018 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package ia64 implements a subset of the symbol mangling for the itanium ABI
+// (standard for GCC).
+//
+// See: https://itanium-cxx-abi.github.io/cxx-abi/abi.html#mangling
+package ia64
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/google/gapid/gapil/compiler/mangling"
+)
+
+// Mangle returns the entity mangled conforming to the IA64 ABI.
+func Mangle(s mangling.Entity) string {
+	m := mangler{
+		bytes.Buffer{},
+		map[mangling.Entity]int{},
+	}
+	m.mangle(s)
+	return m.String()
+}
+
+type mangler struct {
+	bytes.Buffer
+	subs map[mangling.Entity]int
+}
+
+func (m *mangler) mangle(v mangling.Entity) {
+	m.WriteString("_Z")
+	m.encoding(v)
+}
+
+func (m *mangler) encoding(v mangling.Entity) {
+	if _, ok := v.(mangling.Named); !ok {
+		unhandled("encoding", v)
+	}
+	m.name(v)
+	if f, ok := v.(*mangling.Function); ok {
+		m.bareFunctionType(f)
+	}
+}
+
+func (m *mangler) name(v mangling.Entity) {
+	switch v := v.(type) {
+	case mangling.Scoped:
+		s := v.Scope()
+		switch {
+		case s == nil || isStdNamespace(s):
+			// Entities declared at global scope, or in namespace std, are
+			// mangled as unscoped names
+			m.unscoped(v)
+			return
+		case isFunction(s):
+			// Entities declared within a function, including members of local
+			// classes, are mangled with <local-name>.
+			m.local(v)
+		case isNamespace(s), isClass(s):
+			// Entities declared in a namespace or class scope are mangled with
+			// <nested-name>.
+			m.nested(v)
+		default:
+			unhandled("name", v)
+		}
+	}
+}
+
+func isFunction(v mangling.Entity) bool  { _, ok := v.(*mangling.Function); return ok }
+func isNamespace(v mangling.Entity) bool { _, ok := v.(*mangling.Namespace); return ok }
+func isClass(v mangling.Entity) bool     { _, ok := v.(*mangling.Class); return ok }
+
+func (m *mangler) bareFunctionType(f *mangling.Function) {
+	if isTemplated(f) {
+		m.ty(f.Return)
+	}
+
+	if len(f.Parameters) > 0 {
+		for _, p := range f.Parameters {
+			m.ty(p)
+		}
+	} else {
+		m.ty(mangling.Void)
+	}
+}
+
+func (m *mangler) nested(v mangling.Entity) {
+	m.WriteRune('N')
+	defer m.WriteRune('E')
+
+	m.cvQualifiers(v)
+	m.refQualifiers(v)
+
+	if isTemplated(v) {
+		m.templatePrefix(v)
+		m.templateArgs(v)
+	} else {
+		if scope := parentScope(v); scope != nil {
+			m.prefix(scope)
+		}
+		m.unqualified(v)
+	}
+
+	// TODO: N [<CV-qualifiers>] [<ref-qualifier>] <template-prefix> <template-args> E
+}
+
+func (m *mangler) unscoped(v mangling.Entity) {
+	if isStdNamespace(v) {
+		m.WriteString("St")
+	}
+	m.unqualified(v)
+}
+
+func (m *mangler) unqualified(v mangling.Entity) {
+	// TODO: <operator-name> [<abi-tags>]
+	// TODO: <ctor-dtor-name>
+	m.source(v)
+	// TODO: <unnamed-type-name>
+	// TODO: DC <source-name>+ E
+}
+
+func parentScope(v mangling.Entity) mangling.Scope {
+	if s, ok := v.(mangling.Scoped); ok {
+		return s.Scope()
+	}
+	return nil
+}
+
+func (m *mangler) templatePrefix(v mangling.Entity) {
+	// TODO: <template-param> # template template parameter
+	m.substitution(v, func() {
+		if scope := parentScope(v); scope != nil {
+			m.prefix(scope)
+		}
+		m.unqualified(v)
+	})
+}
+
+func (m *mangler) templateArgs(v mangling.Entity) {
+	m.WriteRune('I')
+	for _, t := range v.(mangling.Templated).TemplateArguments() {
+		m.ty(t)
+	}
+	m.WriteRune('E')
+}
+
+func (m *mangler) prefix(v mangling.Entity) {
+	m.substitution(v, func() {
+		switch {
+		case isClass(v), isNamespace(v):
+			if scope := parentScope(v); scope != nil {
+				m.prefix(scope)
+			}
+			m.unqualified(v)
+			return
+		}
+		unhandled("prefix", v)
+
+		// TODO: <template-prefix> <template-args>  # class template specialization
+		// TODO: <template-param>                   # template type parameter
+		// TODO: <decltype>                         # decltype qualifier
+		// TODO: <prefix> <data-member-prefix>      # initializer of a data member
+		// TODO: <substitution>
+	})
+}
+
+func (m *mangler) ty(t mangling.Type) {
+	switch t := t.(type) {
+	case mangling.Builtin: // <builtin-type>
+		m.builtin(t)
+	case *mangling.Class: // <class-enum-type>
+		m.substitution(t, func() { m.name(t) })
+	case mangling.Pointer: // # pointer
+		m.substitution(t, func() {
+			m.WriteRune('P')
+			m.ty(t.To)
+		})
+	case mangling.TemplateParameter:
+		m.substitution(t, func() {
+			m.WriteRune('T')
+			if t == 0 {
+				m.WriteRune('_')
+			} else {
+				m.WriteString(fmt.Sprintf("%d_", t-1))
+			}
+		})
+	default:
+		// TODO: <function-type>
+		// TODO: <qualified-type>
+		// TODO: <class-enum-type>
+		// TODO: <array-type>
+		// TODO: <pointer-to-member-type>
+		// TODO: <template-param>
+		// TODO: <template-template-param> <template-args>
+		// TODO: <decltype>
+		// TODO: R <type>        # l-value reference
+		// TODO: O <type>        # r-value reference (C++11)
+		// TODO: C <type>        # complex pair (C99)
+		// TODO: G <type>        # imaginary (C99)
+		unhandled("type", t)
+	}
+}
+
+func (m *mangler) qualifiedTy(t mangling.Type) {
+	m.qualifiers(t)
+	m.ty(t)
+}
+
+func (m *mangler) qualifiers(t mangling.Type) {
+	// extendedQualifiers
+	m.cvQualifiers(t)
+}
+
+func (m *mangler) cvQualifiers(v mangling.Entity) {
+	switch v := v.(type) {
+	case *mangling.Function:
+		if v.Const {
+			m.WriteRune('K')
+		}
+	}
+}
+
+func (m *mangler) local(v mangling.Entity) { panic("Not implemented") }
+
+func (m *mangler) builtin(t mangling.Type) {
+	switch t {
+	case mangling.Void:
+		m.WriteRune('v')
+	case mangling.WChar:
+		m.WriteRune('w')
+	case mangling.Bool:
+		m.WriteRune('b')
+	case mangling.Char:
+		m.WriteRune('c')
+	case mangling.SChar:
+		m.WriteRune('a')
+	case mangling.UChar:
+		m.WriteRune('h')
+	case mangling.Short:
+		m.WriteRune('s')
+	case mangling.UShort:
+		m.WriteRune('t')
+	case mangling.Int:
+		m.WriteRune('i')
+	case mangling.UInt:
+		m.WriteRune('j')
+	case mangling.Long:
+		m.WriteRune('l')
+	case mangling.ULong:
+		m.WriteRune('m')
+	case mangling.S64:
+		m.WriteRune('x')
+	case mangling.U64:
+		m.WriteRune('y')
+	case mangling.Float:
+		m.WriteRune('f')
+	case mangling.Double:
+		m.WriteRune('d')
+	case mangling.Ellipsis:
+		m.WriteRune('z')
+	default:
+		unhandled("builtin", t)
+	}
+}
+
+func (m *mangler) refQualifiers(v mangling.Entity) {}
+
+func (m *mangler) source(v mangling.Entity) {
+	n, ok := v.(mangling.Named)
+	if !ok {
+		unhandled("source", v)
+	}
+	name := n.GetName()
+	m.WriteString(fmt.Sprint(len(name)))
+	m.WriteString(name)
+}
+
+func isTemplated(v mangling.Entity) bool {
+	switch v := v.(type) {
+	case mangling.Templated:
+		return len(v.TemplateArguments()) > 0
+	}
+	return false
+}
+
+func isStdNamespace(v mangling.Entity) bool {
+	if n, ok := v.(*mangling.Namespace); ok {
+		return n.Name == "std" && n.Parent == nil
+	}
+	return false
+}
+
+func isStdAllocator(v mangling.Entity) bool {
+	if c, ok := v.(*mangling.Class); ok && c.Name == "allocator" {
+		return isStdNamespace(c.Parent)
+	}
+	return false
+}
+
+func isStdBasicString(v mangling.Entity) bool {
+	if c, ok := v.(*mangling.Class); ok && c.Name == "basic_string" {
+		return isStdNamespace(c.Parent)
+	}
+	return false
+}
+
+func (m *mangler) substitution(v mangling.Entity, f func()) {
+	switch {
+	case isStdNamespace(v):
+		m.WriteString("St")
+	case isStdAllocator(v):
+		m.WriteString("Sa")
+	case isStdBasicString(v):
+		m.WriteString("Sb")
+
+	default:
+		// TODO: Ss # ::std::basic_string < char,
+		//            ::std::char_traits<char>,
+		//            ::std::allocator<char> >
+		// TODO: Si # ::std::basic_istream<char,  std::char_traits<char> >
+		// TODO: So # ::std::basic_ostream<char,  std::char_traits<char> >
+		// TODO: Sd # ::std::basic_iostream<char, std::char_traits<char> >
+
+		if s, ok := m.subs[v]; ok {
+			if s == 0 {
+				m.WriteString("S_")
+			} else {
+				m.WriteString(fmt.Sprintf("S%v_", s-1))
+			}
+		} else {
+			f()
+			m.subs[v] = len(m.subs)
+		}
+	}
+}
+
+func unhandled(kind string, val mangling.Entity) {
+	panic(fmt.Errorf("Unhandled %v: %T(%+v)", kind, val, val))
+}

--- a/gapil/compiler/mangling/ia64/ia64_test.go
+++ b/gapil/compiler/mangling/ia64/ia64_test.go
@@ -1,0 +1,126 @@
+// Copyright (C) 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ia64_test
+
+import (
+	"testing"
+
+	"github.com/google/gapid/core/assert"
+	"github.com/google/gapid/core/log"
+	"github.com/google/gapid/gapil/compiler/mangling"
+	"github.com/google/gapid/gapil/compiler/mangling/ia64"
+)
+
+func TestIA64(t *testing.T) {
+	ctx := log.Testing(t)
+
+	/*
+	   namespace food {
+	   namespace fruit {
+
+	   class Apple {
+	   public:
+	       int yummy(int, char*);
+	       bool eat(void* person);
+	       int calories();
+	       bool looks_like(Apple*);
+	       static bool healthy();
+	       static int compare(Apple* a, Apple* b);
+	       template <typename T> bool same_as(T other); (T: int)
+	       template <typename X, typename Y> static void juice(); (X: int, Y: bool)
+	   };
+
+	   } // namespace fruit
+	   } // namespace food
+	*/
+	food := &mangling.Namespace{Name: "food"}
+	fruit := &mangling.Namespace{Name: "fruit", Parent: food}
+	apple := &mangling.Class{Name: "Apple", Parent: fruit}
+
+	yummy := &mangling.Function{
+		Name:       "yummy",
+		Return:     mangling.Int,
+		Parameters: []mangling.Type{mangling.Int, mangling.Pointer{To: mangling.Char}},
+		Parent:     apple,
+	}
+
+	eat := &mangling.Function{
+		Name:       "eat",
+		Return:     mangling.Bool,
+		Parameters: []mangling.Type{mangling.Pointer{To: mangling.Void}},
+		Parent:     apple,
+	}
+
+	calories := &mangling.Function{
+		Name:   "calories",
+		Return: mangling.Int,
+		Parent: apple,
+		Const:  true,
+	}
+
+	looksLike := &mangling.Function{
+		Name:       "looks_like",
+		Return:     mangling.Bool,
+		Parameters: []mangling.Type{mangling.Pointer{To: apple}},
+		Parent:     apple,
+	}
+
+	healthy := &mangling.Function{
+		Name:   "healthy",
+		Return: mangling.Bool,
+		Static: true,
+		Parent: apple,
+	}
+
+	compare := &mangling.Function{
+		Name:       "compare",
+		Return:     mangling.Int,
+		Parameters: []mangling.Type{mangling.Pointer{To: apple}, mangling.Pointer{To: apple}},
+		Parent:     apple,
+	}
+
+	sameAs := &mangling.Function{
+		Name:         "same_as",
+		Return:       mangling.Bool,
+		Parameters:   []mangling.Type{mangling.TemplateParameter(0)},
+		TemplateArgs: []mangling.Type{mangling.Int},
+		Parent:       apple,
+	}
+
+	juice := &mangling.Function{
+		Name:         "juice",
+		Return:       mangling.Void,
+		TemplateArgs: []mangling.Type{mangling.Int, mangling.Bool},
+		Parent:       apple,
+	}
+
+	for _, t := range []struct {
+		name     string
+		sym      mangling.Entity
+		expected string
+	}{
+		{"food::fruit::Apple", apple, "_ZN4food5fruit5AppleE"},
+		{"food::fruit::Apple::yummy", yummy, "_ZN4food5fruit5Apple5yummyEiPc"},
+		{"food::fruit::Apple::eat", eat, "_ZN4food5fruit5Apple3eatEPv"},
+		{"food::fruit::Apple::calories", calories, "_ZNK4food5fruit5Apple8caloriesEv"},
+		{"food::fruit::Apple::looks_like", looksLike, "_ZN4food5fruit5Apple10looks_likeEPS1_"},
+		{"food::fruit::Apple::healthy", healthy, "_ZN4food5fruit5Apple7healthyEv"},
+		{"food::fruit::Apple::compare", compare, "_ZN4food5fruit5Apple7compareEPS1_S2_"},
+		{"food::fruit::Apple::same_as", sameAs, "_ZN4food5fruit5Apple7same_asIiEEbT_"},
+		{"food::fruit::Apple::juice", juice, "_ZN4food5fruit5Apple5juiceIibEEvv"},
+	} {
+		assert.For(ctx, t.name).ThatString(ia64.Mangle(t.sym)).Equals(t.expected)
+	}
+}

--- a/gapil/compiler/mangling/mangling.go
+++ b/gapil/compiler/mangling/mangling.go
@@ -1,0 +1,138 @@
+// Copyright (C) 2018 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package mangling exposes a minimal collection of types used to build mangled
+// strings using any of the sub-packages.
+package mangling
+
+// Mangler is a function that mangles the entity into a string.
+type Mangler func(Entity) string
+
+// Entity is implemented by all types in this package.
+type Entity interface {
+	isEntity()
+}
+
+// Scoped is the interface implemented by entities that can belong to a scope.
+type Scoped interface {
+	Entity
+	Scope() Scope
+}
+
+// Named is the interface for entities that have a source name.
+type Named interface {
+	Entity
+	GetName() string
+}
+
+// Scope is a namespace or class.
+type Scope interface {
+	Entity
+	isScope()
+}
+
+// Type is a POD or Class type.
+type Type interface {
+	Entity
+	isType()
+}
+
+// Templated is type that can has template arguments.
+type Templated interface {
+	Entity
+	TemplateArguments() []Type
+}
+
+// Builtin is a builtin type.
+type Builtin int
+
+const (
+	Void = Builtin(iota)
+	WChar
+	Bool
+	Char
+	SChar
+	UChar
+	Short
+	UShort
+	Int
+	UInt
+	Long
+	ULong
+	S64
+	U64
+	Float
+	Double
+	Ellipsis
+)
+
+func (Builtin) isType()     {}
+func (b Builtin) isEntity() {}
+
+// Pointer is a pointer type.
+type Pointer struct {
+	To Type
+}
+
+func (Pointer) isType()     {}
+func (p Pointer) isEntity() {}
+
+// TemplateParameter is a template parameter type index.
+type TemplateParameter int
+
+func (TemplateParameter) isType()     {}
+func (t TemplateParameter) isEntity() {}
+
+// Namespace represents a C++ namespace.
+type Namespace struct {
+	Parent Scope
+	Name   string
+}
+
+func (*Namespace) isScope()          {}
+func (n *Namespace) Scope() Scope    { return n.Parent }
+func (n *Namespace) GetName() string { return n.Name }
+func (n *Namespace) isEntity()       {}
+
+// Class represents a C++ struct or class.
+type Class struct {
+	Parent       Scope
+	Name         string
+	TemplateArgs []Type
+}
+
+func (*Class) isScope()                    {}
+func (*Class) isEntity()                   {}
+func (*Class) isType()                     {}
+func (c *Class) Scope() Scope              { return c.Parent }
+func (c *Class) GetName() string           { return c.Name }
+func (c *Class) TemplateArguments() []Type { return c.TemplateArgs }
+
+// Function is a function declaration.
+type Function struct {
+	Parent       Scope
+	Name         string
+	Return       Type
+	Parameters   []Type
+	TemplateArgs []Type
+	Const        bool
+	Static       bool
+}
+
+func (*Function) isScope()                    {}
+func (*Function) isEntity()                   {}
+func (*Function) isType()                     {}
+func (f *Function) Scope() Scope              { return f.Parent }
+func (f *Function) GetName() string           { return f.Name }
+func (f *Function) TemplateArguments() []Type { return f.TemplateArgs }


### PR DESCRIPTION
Provides a very minimal mangler to let the compiler implement C++ methods directly, instead of requiring a C++ -> C stub.