### PR TITLE
Call XOpenDisplay(":0") if there's no default display.

### DIFF
--- a/core/os/device/deviceinfo/cc/linux/query.cpp
+++ b/core/os/device/deviceinfo/cc/linux/query.cpp
@@ -108,10 +108,15 @@ bool createContext(void* platform_data) {
         return false;
     }
 
-    gContext.mDisplay = XOpenDisplay(0);
-    if (!gContext.mDisplay) {
-		snprintf(gContext.mError, sizeof(gContext.mError),
-				 "XOpenDisplay returned nullptr");
+    gContext.mDisplay = XOpenDisplay(nullptr);
+    if (gContext.mDisplay == nullptr) {
+        // Default display was not found. This may be because we're executing in
+        // the bazel sandbox. Attempt to connect to the 0'th display instead.
+        gContext.mDisplay = XOpenDisplay(":0");
+    }
+    if (gContext.mDisplay == nullptr) {
+        snprintf(gContext.mError, sizeof(gContext.mError),
+                "XOpenDisplay returned nullptr");
         destroyContext();
         return false;
     }

--- a/gapir/cc/linux/gles_renderer.cpp
+++ b/gapir/cc/linux/gles_renderer.cpp
@@ -136,10 +136,15 @@ GlesRendererImpl::GlesRendererImpl(GlesRendererImpl* shared_context)
         mOwnsDisplay = false;
     } else {
         mDisplay = XOpenDisplay(nullptr);
-        mOwnsDisplay = true;
+        if (mDisplay == nullptr) {
+            // Default display was not found. This may be because we're executing in
+            // the bazel sandbox. Attempt to connect to the 0'th display instead.
+            mDisplay = XOpenDisplay(":0");
+        }
         if (mDisplay == nullptr) {
             GAPID_FATAL("Unable to to open X display");
         }
+        mOwnsDisplay = true;
     }
 
     int major;


### PR DESCRIPTION
This is a workaround for the bazel sandboxing that hides the default display.

Fixes tests that use deviceinfo or perform replays.