### PR TITLE
cmd/apic: Remove unused dependency generation logic

### DIFF
--- a/cmd/apic/BUILD.bazel
+++ b/cmd/apic/BUILD.bazel
@@ -19,6 +19,7 @@ go_library(
     srcs = [
         "format.go",
         "main.go",
+        "resolve.go",
         "template.go",
         "validate.go",
     ],
@@ -33,8 +34,10 @@ go_library(
         "//gapil:go_default_library",
         "//gapil/format:go_default_library",
         "//gapil/parser:go_default_library",
+        "//gapil/resolver:go_default_library",
         "//gapil/template:go_default_library",
         "//gapil/validate:go_default_library",
+        "//gapil/semantic:go_default_library",
     ],
 )
 

--- a/cmd/apic/resolve.go
+++ b/cmd/apic/resolve.go
@@ -1,0 +1,43 @@
+// Copyright (C) 2018 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	"github.com/google/gapid/core/os/file"
+	"github.com/google/gapid/gapil"
+	"github.com/google/gapid/gapil/resolver"
+	"github.com/google/gapid/gapil/semantic"
+)
+
+func resolve(ctx context.Context, search file.PathList, flags flag.FlagSet) (*semantic.API, *resolver.Mappings, error) {
+	args := flags.Args()
+	if len(args) < 1 {
+		return nil, nil, fmt.Errorf("Missing api file")
+	}
+	path := args[0]
+	processor := gapil.NewProcessor()
+	if len(search) > 0 {
+		processor.Loader = gapil.NewSearchLoader(search)
+	}
+	compiled, errs := processor.Resolve(path)
+	if err := gapil.CheckErrors(path, errs, maxErrors); err != nil {
+		return nil, nil, err
+	}
+	return compiled, processor.Mappings, nil
+}

--- a/cmd/apic/template.go
+++ b/cmd/apic/template.go
@@ -27,7 +27,6 @@ import (
 	"github.com/google/gapid/core/app/flags"
 	"github.com/google/gapid/core/log"
 	"github.com/google/gapid/core/os/file"
-	"github.com/google/gapid/gapil"
 	"github.com/google/gapid/gapil/template"
 )
 
@@ -44,20 +43,17 @@ func init() {
 type templateVerb struct {
 	Dir        string        `help:"The output directory"`
 	Tracer     string        `help:"The template function trace expression"`
-	Deps       string        `help:"The dependancies file to generate"`
-	Cmake      string        `help:"The cmake dependancies file to generate"`
 	Gopath     string        `help:"the go path to use when looking up packages"`
 	GlobalList flags.Strings `help:"A global value setting for the template"`
 	Search     file.PathList `help:"The set of paths to search for includes"`
 }
 
 func (v *templateVerb) Run(ctx context.Context, flags flag.FlagSet) error {
-	args := flags.Args()
-	if len(args) < 1 {
-		app.Usage(ctx, "Missing api file")
-		return nil
+	api, mappings, err := resolve(ctx, v.Search, flags)
+	if err != nil {
+		return err
 	}
-	apiName := args[0]
+	args := flags.Args()
 	if len(args) < 2 {
 		app.Usage(ctx, "Missing template file")
 		return nil
@@ -66,66 +62,25 @@ func (v *templateVerb) Run(ctx context.Context, flags flag.FlagSet) error {
 		build.Default.GOPATH = filepath.FromSlash(v.Gopath)
 	}
 	mainTemplate := args[1]
-	log.D(ctx, "Reading %v", apiName)
-	processor := gapil.NewProcessor()
-	if len(v.Search) > 0 {
-		processor.Loader = gapil.NewSearchLoader(v.Search)
-	}
-	compiled, errs := processor.Resolve(apiName)
-	for path := range processor.Parsed {
-		template.InputDep(path)
-	}
-	if err := gapil.CheckErrors(apiName, errs, maxErrors); err != nil {
-		return err
-	}
+	log.D(ctx, "Reading %v", api.Name())
 	options := template.Options{
 		Dir:     v.Dir,
-		APIFile: apiName,
+		APIFile: api.Name(),
 		Loader:  ioutil.ReadFile,
 		Globals: v.GlobalList.Strings(),
 		Tracer:  v.Tracer,
 	}
-	f, err := template.NewFunctions(ctx, compiled, processor.Mappings, options)
+	f, err := template.NewFunctions(ctx, api, mappings, options)
 	if err != nil {
 		return err
 	}
 	if err := f.Include(mainTemplate); err != nil {
 		return fmt.Errorf("%s: %s\n", mainTemplate, err)
 	}
-	v.writeDeps(ctx)
-	v.writeCMake(ctx)
 	return nil
 }
 
 func cwd() string {
 	p, _ := os.Getwd()
 	return p
-}
-
-func (v *templateVerb) writeDeps(ctx context.Context) error {
-	if len(v.Deps) == 0 {
-		return nil
-	}
-	log.D(ctx, "Writing deps %v", v.Deps)
-	file, err := os.Create(v.Deps)
-	if err != nil {
-		return err
-	}
-	defer file.Close()
-	template.WriteDeps(ctx, file)
-	return file.Close()
-}
-
-func (v *templateVerb) writeCMake(ctx context.Context) error {
-	if len(v.Cmake) == 0 {
-		return nil
-	}
-	log.D(ctx, "Writing cmake %v", v.Cmake)
-	file, err := os.Create(v.Cmake)
-	if err != nil {
-		return err
-	}
-	defer file.Close()
-	template.WriteCMake(ctx, file)
-	return file.Close()
 }


### PR DESCRIPTION
With the switch to bazel this is no longer used.