### PR TITLE
bazel: Rename apic to apic_template.

### DIFF
--- a/gapii/cc/BUILD.bazel
+++ b/gapii/cc/BUILD.bazel
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//tools/build:rules.bzl", "android_dynamic_library", "apic", "cc_copts", "cc_dynamic_library")
+load("//tools/build:rules.bzl", "android_dynamic_library", "apic_template", "cc_copts", "cc_dynamic_library")
 
-apic(
+apic_template(
     name = "gles",
     api = "//gapis/api/gles:api",
     templates = [
@@ -29,7 +29,7 @@ apic(
     ],
 )
 
-apic(
+apic_template(
     name = "vulkan",
     api = "//gapis/api/vulkan:api",
     templates = [
@@ -45,7 +45,7 @@ apic(
     ],
 )
 
-apic(
+apic_template(
     name = "gvr",
     api = "//gapis/api/gvr:api",
     templates = [
@@ -61,7 +61,7 @@ apic(
     ],
 )
 
-apic(
+apic_template(
     name = "gvr_install",
     api = "//gapis/api/gvr:api",
     templates = [
@@ -69,7 +69,7 @@ apic(
     ],
 )
 
-apic(
+apic_template(
     name = "osx_opengl_framework",
     api = "//gapis/api/gles:api",
     templates = [
@@ -77,7 +77,7 @@ apic(
     ],
 )
 
-apic(
+apic_template(
     name = "windows_opengl32",
     api = "//gapis/api/gles:api",
     templates = [

--- a/gapir/cc/BUILD.bazel
+++ b/gapir/cc/BUILD.bazel
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//tools/build:rules.bzl", "apic", "mm_library", "cc_copts")
+load("//tools/build:rules.bzl", "apic_template", "mm_library", "cc_copts")
 
-apic(
+apic_template(
     name = "gles_cc",
     api = "//gapis/api/gles:api",
     templates = [
@@ -22,7 +22,7 @@ apic(
     ],
 )
 
-apic(
+apic_template(
     name = "gles_h",
     api = "//gapis/api/gles:api",
     templates = [
@@ -30,7 +30,7 @@ apic(
     ],
 )
 
-apic(
+apic_template(
     name = "vulkan_cc",
     api = "//gapis/api/vulkan:api",
     templates = [
@@ -39,7 +39,7 @@ apic(
     ],
 )
 
-apic(
+apic_template(
     name = "vulkan_h",
     api = "//gapis/api/vulkan:api",
     templates = [

--- a/gapis/api/gles/BUILD.bazel
+++ b/gapis/api/gles/BUILD.bazel
@@ -14,7 +14,7 @@
 
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
-load("//tools/build:rules.bzl", "api_library", "apic", "filter")
+load("//tools/build:rules.bzl", "api_library", "apic_template", "filter")
 
 api_library(
     name = "api",
@@ -28,7 +28,7 @@ api_library(
     deps = ["//gapis/messages:api"],
 )
 
-apic(
+apic_template(
     name = "generated",
     api = ":api",
     templates = [

--- a/gapis/api/gles/gles_pb/BUILD.bazel
+++ b/gapis/api/gles/gles_pb/BUILD.bazel
@@ -14,9 +14,9 @@
 
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
-load("//tools/build:rules.bzl", "apic")
+load("//tools/build:rules.bzl", "apic_template")
 
-apic(
+apic_template(
     name = "api_proto",
     api = "//gapis/api/gles:api",
     templates = ["//gapis/api/templates:proto"],

--- a/gapis/api/gvr/BUILD.bazel
+++ b/gapis/api/gvr/BUILD.bazel
@@ -14,7 +14,7 @@
 
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
-load("//tools/build:rules.bzl", "api_library", "apic", "filter")
+load("//tools/build:rules.bzl", "api_library", "apic_template", "filter")
 
 proto_library(
     name = "gvr_proto",
@@ -42,7 +42,7 @@ api_library(
     deps = ["//gapis/messages:api"],
 )
 
-apic(
+apic_template(
     name = "generated",
     api = ":api",
     templates = [

--- a/gapis/api/gvr/gvr_pb/BUILD.bazel
+++ b/gapis/api/gvr/gvr_pb/BUILD.bazel
@@ -14,9 +14,9 @@
 
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
-load("//tools/build:rules.bzl", "apic")
+load("//tools/build:rules.bzl", "apic_template")
 
-apic(
+apic_template(
     name = "api_proto",
     api = "//gapis/api/gvr:api",
     templates = ["//gapis/api/templates:proto"],

--- a/gapis/api/test/BUILD.bazel
+++ b/gapis/api/test/BUILD.bazel
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
-load("//tools/build:rules.bzl", "api_library", "apic", "filter")
+load("//tools/build:rules.bzl", "api_library", "apic_template", "filter")
 
 api_library(
     name = "api",
@@ -24,7 +24,7 @@ api_library(
     deps = ["//gapis/messages:api"],
 )
 
-apic(
+apic_template(
     name = "generated",
     api = ":api",
     templates = [

--- a/gapis/api/test/test_pb/BUILD.bazel
+++ b/gapis/api/test/test_pb/BUILD.bazel
@@ -14,9 +14,9 @@
 
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
-load("//tools/build:rules.bzl", "apic")
+load("//tools/build:rules.bzl", "apic_template")
 
-apic(
+apic_template(
     name = "api_proto",
     api = "//gapis/api/test:api",
     templates = ["//gapis/api/templates:proto"],

--- a/gapis/api/vulkan/BUILD.bazel
+++ b/gapis/api/vulkan/BUILD.bazel
@@ -14,7 +14,7 @@
 
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
-load("//tools/build:rules.bzl", "api_library", "apic", "filter")
+load("//tools/build:rules.bzl", "api_library", "apic_template", "filter")
 
 api_library(
     name = "api",
@@ -30,7 +30,7 @@ api_library(
     deps = ["//gapis/messages:api"],
 )
 
-apic(
+apic_template(
     name = "generated",
     api = ":api",
     templates = [

--- a/gapis/api/vulkan/vulkan_pb/BUILD.bazel
+++ b/gapis/api/vulkan/vulkan_pb/BUILD.bazel
@@ -14,9 +14,9 @@
 
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
-load("//tools/build:rules.bzl", "apic")
+load("//tools/build:rules.bzl", "apic_template")
 
-apic(
+apic_template(
     name = "api_proto",
     api = "//gapis/api/vulkan:api",
     templates = ["//gapis/api/templates:proto"],

--- a/tools/build/rules.bzl
+++ b/tools/build/rules.bzl
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 load("//tools/build/rules:android.bzl", "android_native_app_glue", "android_native")
-load("//tools/build/rules:apic.bzl", "apic")
+load("//tools/build/rules:apic.bzl", "apic_template")
 load("//tools/build/rules:cc.bzl", "cc_copts")
 load("//tools/build/rules:common.bzl", "generate", "copy", "copy_to", "copy_tree", "filter")
 load("//tools/build/rules:dynlib.bzl", "android_dynamic_library", "cc_dynamic_library")

--- a/tools/build/rules/apic.bzl
+++ b/tools/build/rules/apic.bzl
@@ -25,7 +25,7 @@ def api_search_path(inputs):
 def _apic_library_to_source(go, attr, source, merge):
   for t in attr.templates: merge(source, t)
 
-def _apic_impl(ctx):
+def _apic_template_impl(ctx):
     go = go_context(ctx)
     api = ctx.attr.api
     apiname = api.apiname
@@ -60,9 +60,9 @@ def _apic_impl(ctx):
         DefaultInfo(files = depset(generated)),
     ]
 
-"""Adds an API compiler rule"""
-apic = rule(
-    _apic_impl,
+"""Adds an API template rule"""
+apic_template = rule(
+    _apic_template_impl,
     attrs = {
         "api": attr.label(
             allow_files = False,


### PR DESCRIPTION
apic does more than just templates, and we're going to want it to start compilin' stuff.