### PR TITLE
llvm: Don't use strip optimizations in debug

### DIFF
--- a/tools/build/third_party/llvm/rules.bzl
+++ b/tools/build/third_party/llvm/rules.bzl
@@ -48,8 +48,6 @@ def llvmLibrary(name, path="", deps=[], excludes={}, extras={}):
             # optimized.
             "-O2",
             "-DNDEBUG",
-            "-ffunction-sections",
-            "-fdata-sections",
         ] + select({
             "@//tools/build:linux": [],
             "@//tools/build:darwin": [],
@@ -59,11 +57,6 @@ def llvmLibrary(name, path="", deps=[], excludes={}, extras={}):
                 "-fno-rtti",
                 "-fno-exceptions",
             ]
-        }),
-        linkopts = select({
-            # Optimized linker settings. See above.
-            "@//tools/build:darwin": ["-Wl,-dead_strip"],
-            "//conditions:default": ["-Wl,--gc-sections"],
         }),
     )
 


### PR DESCRIPTION
We care about performance in debug builds, less so size.

Worse still, the linker options pass down to the final executable, causing stripping on things outside of LLVM.