### PR TITLE
Allow DlLoader to have multiple fallback names when searching for a library

### DIFF
--- a/core/cc/armlinux/get_vulkan_proc_address.cpp
+++ b/core/cc/armlinux/get_vulkan_proc_address.cpp
@@ -72,6 +72,6 @@ GetVulkanInstanceProcAddressFunc* GetVulkanInstanceProcAddress = getVulkanInstan
 GetVulkanDeviceProcAddressFunc* GetVulkanDeviceProcAddress = getVulkanDeviceProcAddress;
 GetVulkanProcAddressFunc* GetVulkanProcAddress = getVulkanProcAddress;
 bool HasVulkanLoader() {
-  return DlLoader::can_load("libvulkan.so");
+  return DlLoader::can_load("libvulkan.so") || DlLoader::can_load("libvulkan.so.1");
 }
 }  // namespace core

--- a/core/cc/dl_loader.cpp
+++ b/core/cc/dl_loader.cpp
@@ -144,7 +144,7 @@ DL(CC _1, CC _2);
 DL(CC _1, CC _2, CC _3);
 DL(CC _1, CC _2, CC _3, CC _4);
 DL(CC _1, CC _2, CC _3, CC _4, CC _5);
-#undef DLLOADER
+#undef DL
 #undef CC
 
 }  // namespace core

--- a/core/cc/dl_loader.cpp
+++ b/core/cc/dl_loader.cpp
@@ -30,9 +30,15 @@
 namespace {
 
 // load defs
-void* load(const char* name) {
+void* load() {
+    return nullptr;
+}
+
+template<typename... ConstCharPtrs>
+void* load(const char* name, ConstCharPtrs... fallback_names) {
+    void* ret = nullptr;
 #if TARGET_OS == GAPID_OS_WINDOWS
-    return reinterpret_cast<void*>(LoadLibraryExA(name, NULL, 0));
+    ret = reinterpret_cast<void*>(LoadLibraryExA(name, NULL, 0));
 #elif TARGET_OS == GAPID_OS_OSX
     if (name == nullptr) {
         return nullptr;
@@ -50,14 +56,19 @@ void* load(const char* name) {
             remove(tmp);
         }
     }
-    return res;
+    ret = res;
 #else
-    return dlopen(name, RTLD_NOW | RTLD_LOCAL);
+    ret = dlopen(name, RTLD_NOW | RTLD_LOCAL);
 #endif // TARGET_OS
+    if (ret == nullptr) {
+        return load(fallback_names...);
+    }
+    return ret;
 }
 
-void* must_load(const char* name) {
-  void* res = load(name);
+template<typename... ConstCharPtrs>
+void* must_load(const char* name, ConstCharPtrs... fallback_names) {
+  void* res = load(name, fallback_names...);
   if (res == nullptr) {
 #if TARGET_OS == GAPID_OS_WINDOWS
     GAPID_FATAL("Can't load library %s: %d", name, GetLastError());
@@ -100,8 +111,8 @@ void close(void* lib) {
 }  // anonymous namespace
 
 namespace core {
-
-DlLoader::DlLoader(const char* name) : mLibrary(must_load(name)) {}
+template<typename... ConstCharPtrs>
+DlLoader::DlLoader(const char* name, ConstCharPtrs... fallback_names) : mLibrary(must_load(name, fallback_names...)) {}
 
 DlLoader::~DlLoader() {
     close(mLibrary);
@@ -124,5 +135,16 @@ bool DlLoader::can_load(const char* lib_name) {
   }
   return false;
 }
+
+#define CC const char*
+#define DL(...) \
+    template DlLoader::DlLoader(__VA_ARGS__)
+DL(CC _1);
+DL(CC _1, CC _2);
+DL(CC _1, CC _2, CC _3);
+DL(CC _1, CC _2, CC _3, CC _4);
+DL(CC _1, CC _2, CC _3, CC _4, CC _5);
+#undef DLLOADER
+#undef CC
 
 }  // namespace core

--- a/core/cc/dl_loader.h
+++ b/core/cc/dl_loader.h
@@ -25,7 +25,8 @@ public:
     // Loads the specified dynamic library.
     // If the library cannot be loaded then this is a fatal error.
     // For *nix systems, a nullptr can be used to search the application's functions.
-    DlLoader(const char* name);
+    template<typename... ConstCharPtrs>
+    DlLoader(const char* name, ConstCharPtrs... fallback_names);
 
     // Unloads the library loaded in the constructor.
     ~DlLoader();

--- a/core/cc/dl_loader.h
+++ b/core/cc/dl_loader.h
@@ -22,9 +22,10 @@ namespace core {
 // Utility class for retrieving function pointers from dynamic libraries.
 class DlLoader {
 public:
-    // Loads the specified dynamic library.
-    // If the library cannot be loaded then this is a fatal error.
-    // For *nix systems, a nullptr can be used to search the application's functions.
+    // Loads the dynamic library specified by the given name and fallback names
+    // (if any). Names will be used to try to find the library in order. If the
+    // library cannot be loaded then this is a fatal error. For *nix systems,
+    // a nullptr can be used to search the application's functions.
     template<typename... ConstCharPtrs>
     DlLoader(const char* name, ConstCharPtrs... fallback_names);
 

--- a/core/cc/linux/get_vulkan_proc_address.cpp
+++ b/core/cc/linux/get_vulkan_proc_address.cpp
@@ -30,7 +30,7 @@ typedef size_t VkInstance;
 void* getVulkanInstanceProcAddress(size_t instance, const char *name, bool bypassLocal) {
     typedef PFN_vkVoidFunction (*VPAPROC)(VkInstance instance, const char *name);
 
-    static DlLoader dylib("libvulkan.so");
+    static DlLoader dylib("libvulkan.so", "libvulkan.so.1");
 
     if (VPAPROC vpa = reinterpret_cast<VPAPROC>(dylib.lookup("vkGetInstanceProcAddr"))) {
         if (void* proc = vpa(instance, name)) {

--- a/core/cc/linux/get_vulkan_proc_address.cpp
+++ b/core/cc/linux/get_vulkan_proc_address.cpp
@@ -72,6 +72,6 @@ GetVulkanInstanceProcAddressFunc* GetVulkanInstanceProcAddress = getVulkanInstan
 GetVulkanDeviceProcAddressFunc* GetVulkanDeviceProcAddress = getVulkanDeviceProcAddress;
 GetVulkanProcAddressFunc* GetVulkanProcAddress = getVulkanProcAddress;
 bool HasVulkanLoader() {
-  return DlLoader::can_load("libvulkan.so");
+  return DlLoader::can_load("libvulkan.so") || DlLoader::can_load("libvulkan.so.1");
 }
 }  // namespace core


### PR DESCRIPTION
Fix #1634 