### PR TITLE
Cleans up some of the logcat output.

### DIFF
--- a/cmd/gapit/trace.go
+++ b/cmd/gapit/trace.go
@@ -196,6 +196,8 @@ func (verb *traceVerb) captureADB(ctx context.Context, flags flag.FlagSet, start
 
 	if options.monitorLogcat {
 		c := make(chan android.LogcatMessage, 32)
+		// this is to prevent logcat messages from triggering failures in robot
+		ctx := log.PutHandler(ctx, log.Channel(app.Flags.Log.Style.Handler(log.Stdout()), 32))
 		go func() {
 			for m := range c {
 				m.Log(ctx)

--- a/core/os/android/adb/logcat.go
+++ b/core/os/android/adb/logcat.go
@@ -123,7 +123,7 @@ func (b *binding) Logcat(ctx context.Context, msgs chan<- android.LogcatMessage)
 		}
 	})
 
-	if err := b.Command("logcat", "-v", "long", "-T", "0").Capture(stdout, nil).Run(ctx); err != nil {
+	if err := b.Command("logcat", "-v", "long", "-T", "0", "GAPID:V", "*:W").Capture(stdout, nil).Run(ctx); err != nil {
 		stdout.Close()
 		return err
 	}


### PR DESCRIPTION
Enabling logcat capturing during a trace will cause the whole system to
dump informational levels of logs, and ignores debug and verbose
messages from GAPID, so a quick change makes logcat produce warnings and
above from non-GAPID logs, and verbose and above from GAPID. The other
change is to clear the state of logcat before monitoring, and to force
all logcat messages to be printed on stdout such that it does not
produce an error in robot.