### PR TITLE
Add Dedupe to core/data.

### DIFF
--- a/core/data/BUILD.bazel
+++ b/core/data/BUILD.bazel
@@ -12,11 +12,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
-    srcs = ["assignable.go"],
+    srcs = [
+        "assignable.go",
+        "dedupe.go",
+    ],
     importpath = "github.com/google/gapid/core/data",
     visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_xtest",
+    size = "small",
+    srcs = ["dedupe_test.go"],
+    deps = [
+        ":go_default_library",
+        "//core/assert:go_default_library",
+        "//core/log:go_default_library",
+    ],
 )

--- a/core/data/dedupe.go
+++ b/core/data/dedupe.go
@@ -1,0 +1,58 @@
+// Copyright (C) 2018 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package data
+
+import (
+	"bytes"
+	"sort"
+)
+
+// Dedupe returns a new byte slice containing the concatenated bytes of slices
+// with duplicates removed, along with indices that map slices into the new
+// slice.
+func Dedupe(slices [][]byte) ([]byte, []int) {
+	if len(slices) == 0 {
+		return nil, nil
+	}
+
+	type lenidx struct {
+		len, idx int
+	}
+
+	lis := make([]lenidx, len(slices))
+	for i, slice := range slices {
+		lis[i] = lenidx{len(slice), i}
+	}
+	sort.Slice(lis, func(i, j int) bool { return lis[i].len > lis[j].len })
+
+	idxs := make([]int, len(slices))
+
+	buf := bytes.Buffer{}
+	buf.Write(slices[lis[0].idx])
+	idxs[lis[0].idx] = 0
+
+	for _, li := range lis[1:] {
+		s := slices[li.idx]
+		idx := bytes.Index(buf.Bytes(), s)
+		if idx < 0 {
+			idxs[li.idx] = buf.Len()
+			buf.Write(s)
+		} else {
+			idxs[li.idx] = idx
+		}
+	}
+
+	return buf.Bytes(), idxs
+}

--- a/core/data/dedupe_test.go
+++ b/core/data/dedupe_test.go
@@ -1,0 +1,44 @@
+// Copyright (C) 2018 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package data_test
+
+import (
+	"testing"
+
+	"github.com/google/gapid/core/assert"
+	"github.com/google/gapid/core/data"
+	"github.com/google/gapid/core/log"
+)
+
+func TestDedupe(t *testing.T) {
+	ctx := log.Testing(t)
+
+	B := func(s string) []byte { return ([]byte)(s) }
+	slices := [][]byte{
+		B("cat says meow"),
+		B("says"),
+		B("the cat says meow. the dog says woof. "),
+		B("fish says blub"),
+	}
+	expected := B("the cat says meow. the dog says woof. fish says blub")
+	deduped, indices := data.Dedupe(slices)
+	if assert.For(ctx, "got").ThatString(string(deduped)).Equals(string(expected)) {
+		for i, slice := range slices {
+			g := string(deduped[indices[i] : indices[i]+len(slice)])
+			e := string(slice)
+			assert.For(ctx, "%v", i).ThatString(g).Equals(e)
+		}
+	}
+}


### PR DESCRIPTION
Dedupe returns a new byte slice containing the concatenated bytes of slices with duplicates removed, along with indices that map slices into the into the new slice.