### PR TITLE
Fix for large text preview in web client slowdown.

### DIFF
--- a/test/robot/web/client/client.go
+++ b/test/robot/web/client/client.go
@@ -153,9 +153,11 @@ func robotTextPreview(path string, s interface{}) interface{} {
 	textDiv.Element.Style.Overflow = "auto"
 	textDiv.Element.Style.WhiteSpace = "pre"
 	go func() {
-		fullText, err := queryRestEndpoint(fmt.Sprintf("/entities/%s", id))
+		// if the text is larger than a megabyte, cut off early.
+		fullText, err := queryRestEndpointWithCutoff(fmt.Sprintf("/entities/%s", id), 1024*1024)
 		if err != nil {
-			panic(err)
+			textDiv.Append("Error previewing text:" + err.Error())
+			return
 		}
 
 		textDiv.Append(string(fullText))

--- a/test/robot/web/client/data.go
+++ b/test/robot/web/client/data.go
@@ -269,6 +269,16 @@ func itemGetter(idPattern string, displayPattern string, functions template.Func
 	}
 }
 
+func queryRestEndpointWithCutoff(path string, cutoff int64) ([]byte, error) {
+	head, err := http.Head(path)
+	if err != nil {
+		return nil, err
+	} else if head.ContentLength > cutoff {
+		return nil, fmt.Errorf("Content Length (%d) is larger than cutoff (%d)", head.ContentLength, cutoff)
+	}
+	return queryRestEndpoint(path)
+}
+
 func queryRestEndpoint(path string) ([]byte, error) {
 	resp, err := http.Get(path)
 	if err != nil {


### PR DESCRIPTION
Attempting to preview a log file that is very large (due to verbosity
and logcat) could cause a really long hang in the web ui. This adds a
quick check to limit these previews to 1MB or less.