### PR TITLE
Updated our hash implementations to match getween go and C++.

### DIFF
--- a/gapil/compiler/map.go
+++ b/gapil/compiler/map.go
@@ -179,7 +179,7 @@ func (c *C) hashValue(s *S, t semantic.Type, value *codegen.Value) *codegen.Valu
 			semantic.Uint32Type,
 			semantic.Int64Type,
 			semantic.Uint64Type:
-			return c.hash64Bit(s, value.Cast(u64Type))
+			return value.Cast(u64Type)
 		case semantic.Float32Type:
 			return c.hash64Bit(s, value.Bitcast(u32Type).Cast(u64Type))
 		case semantic.Float64Type:
@@ -190,9 +190,10 @@ func (c *C) hashValue(s *S, t semantic.Type, value *codegen.Value) *codegen.Valu
 			fail("Cannot determine the hash for %T, %v", t, t)
 			return nil
 		}
+	case *semantic.Enum:
+		return value.Cast(u64Type)
 	case *semantic.Pointer,
-		*semantic.Enum:
-		return c.hash64Bit(s, value.Cast(u64Type))
+		return s.ShiftRight(value.Cast(u64Type), s.Scalar(uint64(2))) 
 	case *semantic.StaticArray:
 		fail("Cannot use a static array as a hash key")
 		return nil

--- a/gapil/runtime/cc/hash.h
+++ b/gapil/runtime/cc/hash.h
@@ -1,0 +1,107 @@
+// Copyright (C) 2018 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef __GAPIL_RUNTIME_HASH_H__
+#define __GAPIL_RUNTIME_HASH_H__
+
+#include <cstdint>
+#include <cstring>
+
+#include "string.h"
+#include "core/cc/assert.h"
+
+// Note these implementations should match map.go
+namespace gapil {
+struct fixedValue {
+    uint64_t fixed64;
+};
+
+template<typename T, typename Enable=void>
+struct hash {
+    uint64_t operator()(const T& t) {
+        GAPID_ASSERT_MSG(false, "unknown hash type");
+        return 0;
+    }
+};
+
+inline uint64_t rotate_right(const uint64_t& v, const uint64_t bits) {
+    return (v >> bits) | (v << (64-bits));
+}
+
+inline uint64_t shift_left(const uint64_t& v, const uint64_t bits) {
+    return v << bits;
+}
+
+template<>
+struct hash<fixedValue, void> {
+    uint64_t operator() (const fixedValue& val) {
+        uint64_t v = val.fixed64;
+        v += shift_left(v, 21);
+        v ^= rotate_right(v, 24);
+        v += shift_left(v, 3) + shift_left(v, 8);
+        v ^= rotate_right(v, 14);
+        v += shift_left(v, 2) + shift_left(v, 4);
+        v ^= rotate_right(v, 28);
+        v += shift_left(v, 31);
+        return v;
+    }
+};
+
+template<>
+struct hash<float, void> {
+    uint64_t operator() (const float& f) {
+        uint32_t val;
+        memcpy(&val, &f, sizeof(uint32_t));
+        return hash<fixedValue>()(fixedValue{static_cast<uint64_t>(val)});
+    }
+};
+
+template<>
+struct hash<double, void> {
+    uint64_t operator() (const double& f) {
+        uint64_t val;
+        memcpy(&val, &f, sizeof(uint64_t));
+        return hash<fixedValue>()(fixedValue{val});
+    }
+};
+
+template<typename T>
+struct hash<T, typename std::enable_if<std::is_integral<T>::value>::type> {
+    uint64_t operator() (const T&  v) {
+        return static_cast<uint64_t>(v);
+    }
+};
+
+template<typename T>
+struct hash<T*, void> {
+    uint64_t operator() (const T* ptr) {
+        return static_cast<uint64_t>(reinterpret_cast<uintptr_t>(ptr) >> 2);
+    }
+};
+
+template<>
+struct hash<gapil::String, void> {
+    uint64_t operator() (const gapil::String& str) {
+        uint64_t h = 0;
+        const char* c_str = str.c_str();
+        for (size_t i = 0; i < str.length(); ++i) {
+            h += (h << 6) + (h << 16) + c_str[i];
+        }
+        return h;
+    }
+};
+
+} // namespace gapil
+
+#endif // __GAPIL_RUNTIME_HASH_H__

--- a/gapil/runtime/cc/map.inc
+++ b/gapil/runtime/cc/map.inc
@@ -16,7 +16,7 @@
 #define __GAPIL_RUNTIME_MAP_INC__
 
 #include "map.h"
-#include "string.h"
+#include "hash.h"
 
 #include "core/cc/assert.h"
 #include "core/memory/arena/cc/arena.h"
@@ -25,99 +25,6 @@
 
 static_assert((GAPIL_MIN_MAP_SIZE & (GAPIL_MIN_MAP_SIZE - 1)) == 0, "Map size must be a power of 2");
 static_assert((GAPIL_MAP_GROW_MULTIPLIER & (GAPIL_MAP_GROW_MULTIPLIER - 1)) == 0, "Map size must be a power of 2");
-
-// Note these implementations should match map.go
-
-namespace {
-struct fixedValue {
-    uint64_t fixed64;
-};
-
-template<typename T>
-struct gapil_hash {
-    uint64_t operator()(const T& t) {
-        GAPID_ASSERT_MSG(false, "unknown hash type");
-        return 0;
-    }
-};
-
-uint64_t rotate_right(const uint64_t& v, const uint64_t bits) {
-    return (v >> bits) | (v << (64-bits));
-}
-
-uint64_t shift_left(const uint64_t& v, const uint64_t bits) {
-    return v << bits;
-}
-
-template<>
-struct gapil_hash<fixedValue> {
-    uint64_t operator() (const fixedValue& val) {
-        uint64_t v = val.fixed64;
-        v += shift_left(v, 21);
-        v ^= rotate_right(v, 24);
-        v += shift_left(v, 3) + shift_left(v, 8);
-        v ^= rotate_right(v, 14);
-        v += shift_left(v, 2) + shift_left(v, 4);
-        v ^= rotate_right(v, 28);
-        v += shift_left(v, 31);
-        return v;
-    }
-};
-
-template<>
-struct gapil_hash<float> {
-    uint64_t operator() (const float& f) {
-        return gapil_hash<fixedValue>()(fixedValue{static_cast<uint64_t>(*reinterpret_cast<const uint32_t*>(&f))});
-    }
-};
-
-template<>
-struct gapil_hash<double> {
-    uint64_t operator() (const double& f) {
-        return gapil_hash<fixedValue>()(fixedValue{*reinterpret_cast<const uint64_t*>(&f)});
-    }
-};
-
-#define HASH_INTEGER(type) \
-template<> \
-struct gapil_hash<type> {\
-    uint64_t operator() (const type&  v) { \
-        return static_cast<uint64_t>(v); \
-    } \
-};
-
-HASH_INTEGER(bool)
-HASH_INTEGER(uint8_t)
-HASH_INTEGER(int8_t)
-HASH_INTEGER(uint16_t)
-HASH_INTEGER(int16_t)
-HASH_INTEGER(uint32_t)
-HASH_INTEGER(int32_t)
-HASH_INTEGER(uint64_t)
-HASH_INTEGER(int64_t)
-
-#undef HASH_INTEGER
-
-template<typename T>
-struct gapil_hash<T*> {
-    uint64_t operator() (const T* ptr) {
-        return static_cast<uint64_t>(reinterpret_cast<uintptr_t>(ptr) >> 2);
-    }
-};
-
-template<>
-struct gapil_hash<gapil::String> {
-    uint64_t operator() (const gapil::String& str) {
-        uint64_t h = 0;
-        const char* c_str = str.c_str();
-        for (size_t i = 0; i < str.length(); ++i) {
-            h += (h << 6) + (h << 16) + c_str[i];
-        }
-        return h;
-    }
-};
-
-} // anonymous namespace
 
 namespace gapil {
 
@@ -198,7 +105,7 @@ bool Map<K, V>::Allocation::contains(K key) {
 
 template<typename K, typename V>
 V* Map<K, V>::Allocation::index(K key, bool insert) {
-    auto hasher = gapil_hash<K>{};
+    auto hasher = gapil::hash<K>{};
     auto eq = std::equal_to<K>{};
     uint64_t hash = hasher(key);
 
@@ -292,7 +199,7 @@ V Map<K, V>::Allocation::lookup(K key) {
 
 template<typename K, typename V>
 void Map<K, V>::Allocation::remove(K key) {
-    auto hasher = gapil_hash<K>{};
+    auto hasher = gapil::hash<K>{};
     auto eq = std::equal_to<K>{};
     uint64_t hash = hasher(key);
     auto elems = els();

--- a/gapil/runtime/cc/map.inc
+++ b/gapil/runtime/cc/map.inc
@@ -16,6 +16,7 @@
 #define __GAPIL_RUNTIME_MAP_INC__
 
 #include "map.h"
+#include "string.h"
 
 #include "core/cc/assert.h"
 #include "core/memory/arena/cc/arena.h"
@@ -24,6 +25,99 @@
 
 static_assert((GAPIL_MIN_MAP_SIZE & (GAPIL_MIN_MAP_SIZE - 1)) == 0, "Map size must be a power of 2");
 static_assert((GAPIL_MAP_GROW_MULTIPLIER & (GAPIL_MAP_GROW_MULTIPLIER - 1)) == 0, "Map size must be a power of 2");
+
+// Note these implementations should match map.go
+
+namespace {
+struct fixedValue {
+    uint64_t fixed64;
+};
+
+template<typename T>
+struct gapil_hash {
+    uint64_t operator()(const T& t) {
+        GAPID_ASSERT_MSG(false, "unknown hash type");
+        return 0;
+    }
+};
+
+uint64_t rotate_right(const uint64_t& v, const uint64_t bits) {
+    return (v >> bits) | (v << (64-bits));
+}
+
+uint64_t shift_left(const uint64_t& v, const uint64_t bits) {
+    return v << bits;
+}
+
+template<>
+struct gapil_hash<fixedValue> {
+    uint64_t operator() (const fixedValue& val) {
+        uint64_t v = val.fixed64;
+        v += shift_left(v, 21);
+        v ^= rotate_right(v, 24);
+        v += shift_left(v, 3) + shift_left(v, 8);
+        v ^= rotate_right(v, 14);
+        v += shift_left(v, 2) + shift_left(v, 4);
+        v ^= rotate_right(v, 28);
+        v += shift_left(v, 31);
+        return v;
+    }
+};
+
+template<>
+struct gapil_hash<float> {
+    uint64_t operator() (const float& f) {
+        return gapil_hash<fixedValue>()(fixedValue{static_cast<uint64_t>(*reinterpret_cast<const uint32_t*>(&f))});
+    }
+};
+
+template<>
+struct gapil_hash<double> {
+    uint64_t operator() (const double& f) {
+        return gapil_hash<fixedValue>()(fixedValue{*reinterpret_cast<const uint64_t*>(&f)});
+    }
+};
+
+#define HASH_INTEGER(type) \
+template<> \
+struct gapil_hash<type> {\
+    uint64_t operator() (const type&  v) { \
+        return static_cast<uint64_t>(v); \
+    } \
+};
+
+HASH_INTEGER(bool)
+HASH_INTEGER(uint8_t)
+HASH_INTEGER(int8_t)
+HASH_INTEGER(uint16_t)
+HASH_INTEGER(int16_t)
+HASH_INTEGER(uint32_t)
+HASH_INTEGER(int32_t)
+HASH_INTEGER(uint64_t)
+HASH_INTEGER(int64_t)
+
+#undef HASH_INTEGER
+
+template<typename T>
+struct gapil_hash<T*> {
+    uint64_t operator() (const T* ptr) {
+        return static_cast<uint64_t>(reinterpret_cast<uintptr_t>(ptr) >> 2);
+    }
+};
+
+template<>
+struct gapil_hash<gapil::String> {
+    uint64_t operator() (const gapil::String& str) {
+        uint64_t h = 0;
+        const char* c_str = str.c_str();
+        for (size_t i = 0; i < str.length(); ++i) {
+            h += (h << 6) + (h << 16) + c_str[i];
+        }
+        return h;
+    }
+};
+
+} // anonymous namespace
 
 namespace gapil {
 
@@ -104,7 +198,7 @@ bool Map<K, V>::Allocation::contains(K key) {
 
 template<typename K, typename V>
 V* Map<K, V>::Allocation::index(K key, bool insert) {
-    auto hasher = std::hash<K>{};
+    auto hasher = gapil_hash<K>{};
     auto eq = std::equal_to<K>{};
     uint64_t hash = hasher(key);
 
@@ -198,7 +292,7 @@ V Map<K, V>::Allocation::lookup(K key) {
 
 template<typename K, typename V>
 void Map<K, V>::Allocation::remove(K key) {
-    auto hasher = std::hash<K>{};
+    auto hasher = gapil_hash<K>{};
     auto eq = std::equal_to<K>{};
     uint64_t hash = hasher(key);
     auto elems = els();


### PR DESCRIPTION
This sits on top of https://github.com/google/gapid/pull/1654.
Only the last change is relevant.