### PR TITLE
Remove the link-time requirement on libX11 and libGL.

### DIFF
--- a/core/cc/android/get_gles_proc_address.cpp
+++ b/core/cc/android/get_gles_proc_address.cpp
@@ -103,5 +103,11 @@ void* getGlesProcAddress(const char* name, bool bypassLocal) {
 namespace core {
 
 GetGlesProcAddressFunc* GetGlesProcAddress = getGlesProcAddress;
+bool hasGLorGLES() {
+    return DlLoader::can_load(SYSTEM_LIB_PATH "libEGL.so") ||
+           DlLoader::can_load(SYSTEM_LIB_PATH "libGLESv2.so") ||
+           DlLoader::can_load(SYSTEM_LIB_PATH SYSTEM_LIB_PATH "libGLESv1_CM.so");
+}
+
 
 }  // namespace core

--- a/core/cc/armlinux/get_gles_proc_address.cpp
+++ b/core/cc/armlinux/get_gles_proc_address.cpp
@@ -97,6 +97,11 @@ void* getGlesProcAddress(const char* name, bool bypassLocal) {
 }  // anonymous namespace
 
 namespace core {
+bool hasGLorGLES() {
+    return DlLoader::can_load(SYSTEM_LIB_PATH "libEGL.so") ||
+           DlLoader::can_load(SYSTEM_LIB_PATH "libGLESv2.so") ||
+           DlLoader::can_load(SYSTEM_LIB_PATH SYSTEM_LIB_PATH "libGLESv1_CM.so");
+}
 
 GetGlesProcAddressFunc* GetGlesProcAddress = getGlesProcAddress;
 

--- a/core/cc/get_gles_proc_address.h
+++ b/core/cc/get_gles_proc_address.h
@@ -27,6 +27,8 @@ typedef void* (GetGlesProcAddressFunc)(const char* name, bool bypassLocal);
 // context.
 extern GetGlesProcAddressFunc* GetGlesProcAddress;
 
+bool hasGLorGLES();
+
 }  // namespace core
 
 #endif  // CORE_GET_GLES_PROC_ADDRESS_H

--- a/core/cc/linux/get_gles_proc_address.cpp
+++ b/core/cc/linux/get_gles_proc_address.cpp
@@ -61,5 +61,9 @@ void* getGlesProcAddress(const char *name, bool bypassLocal) {
 namespace core {
 
 GetGlesProcAddressFunc* GetGlesProcAddress = getGlesProcAddress;
+bool hasGLorGLES() {
+    return DlLoader::can_load("libGL.so.1");
+}
+
 
 }  // namespace core

--- a/core/cc/osx/get_gles_proc_address.cpp
+++ b/core/cc/osx/get_gles_proc_address.cpp
@@ -67,5 +67,11 @@ void* getGlesProcAddress(const char *name, bool bypassLocal) {
 namespace core {
 
 GetGlesProcAddressFunc* GetGlesProcAddress = getGlesProcAddress;
+bool hasGLorGLES() {
+    return DlLoader::can_load(FRAMEWORK_ROOT "OpenGL") ||
+           DlLoader::can_load(FRAMEWORK_ROOT "Libraries/libGL.dylib") ||
+           DlLoader::can_load(FRAMEWORK_ROOT "Libraries/libGLU.dylib") ||
+           DlLoader::can_load(CORE_GRAPHICS);
+}
 
 }  // namespace core

--- a/core/cc/windows/get_gles_proc_address.cpp
+++ b/core/cc/windows/get_gles_proc_address.cpp
@@ -61,5 +61,8 @@ void* getGlesProcAddress(const char* name, bool bypassLocal) {
 namespace core {
 
 GetGlesProcAddressFunc* GetGlesProcAddress = getGlesProcAddress;
+bool hasGLorGLES() {
+    return DlLoader::can_load(systemOpengl32Path().c_str());
+}
 
 }  // namespace core

--- a/core/os/device/deviceinfo/cc/BUILD.bazel
+++ b/core/os/device/deviceinfo/cc/BUILD.bazel
@@ -39,7 +39,6 @@ cc_library(
     linkopts = select({
         "//tools/build:linux": [
             "-ldl",
-            "-lX11",
         ],
         "//tools/build:darwin": [
             "-framework Cocoa",

--- a/core/os/device/deviceinfo/cc/gl.cpp
+++ b/core/os/device/deviceinfo/cc/gl.cpp
@@ -45,6 +45,9 @@ void glDriver(device::OpenGLDriver* driver) {
     auto glGetString = reinterpret_cast<PFNGLGETSTRING>(core::GetGlesProcAddress("glGetString", true));
     auto glGetStringi = reinterpret_cast<PFNGLGETSTRINGI>(core::GetGlesProcAddress("glGetStringi", true));
 
+    GAPID_ASSERT(glGetError != nullptr);
+    GAPID_ASSERT(glGetString != nullptr);
+
     glGetIntegerv(GL_UNIFORM_BUFFER_OFFSET_ALIGNMENT, &uniformbufferalignment);
     glGetIntegerv(GL_MAX_TRANSFORM_FEEDBACK_SEPARATE_ATTRIBS, &maxtransformfeedbackseparateattribs);
     glGetIntegerv(GL_MAX_TRANSFORM_FEEDBACK_INTERLEAVED_COMPONENTS, &maxtransformfeedbackinterleavedcomponents);

--- a/core/os/device/deviceinfo/cc/gl.cpp
+++ b/core/os/device/deviceinfo/cc/gl.cpp
@@ -29,6 +29,9 @@ const char* safe_string(void* x) {
     return (x != nullptr) ? reinterpret_cast<const char*>(x) : "";
 }
 
+bool hasGLorGLES() {
+    return core::hasGLorGLES();
+}
 
 void glDriver(device::OpenGLDriver* driver) {
     GLint major_version = 2;
@@ -42,23 +45,18 @@ void glDriver(device::OpenGLDriver* driver) {
     auto glGetString = reinterpret_cast<PFNGLGETSTRING>(core::GetGlesProcAddress("glGetString", true));
     auto glGetStringi = reinterpret_cast<PFNGLGETSTRINGI>(core::GetGlesProcAddress("glGetStringi", true));
 
-    GAPID_ASSERT(glGetError != nullptr);
-    GAPID_ASSERT(glGetString != nullptr);
+    glGetIntegerv(GL_UNIFORM_BUFFER_OFFSET_ALIGNMENT, &uniformbufferalignment);
+    glGetIntegerv(GL_MAX_TRANSFORM_FEEDBACK_SEPARATE_ATTRIBS, &maxtransformfeedbackseparateattribs);
+    glGetIntegerv(GL_MAX_TRANSFORM_FEEDBACK_INTERLEAVED_COMPONENTS, &maxtransformfeedbackinterleavedcomponents);
 
-    if (glGetIntegerv != nullptr) {
-        glGetIntegerv(GL_UNIFORM_BUFFER_OFFSET_ALIGNMENT, &uniformbufferalignment);
-        glGetIntegerv(GL_MAX_TRANSFORM_FEEDBACK_SEPARATE_ATTRIBS, &maxtransformfeedbackseparateattribs);
-        glGetIntegerv(GL_MAX_TRANSFORM_FEEDBACK_INTERLEAVED_COMPONENTS, &maxtransformfeedbackinterleavedcomponents);
-
-        glGetError();  // Clear error state.
-        glGetIntegerv(GL_MAJOR_VERSION, &major_version);
-        glGetIntegerv(GL_MINOR_VERSION, &minor_version);
-        if (glGetError() != GL_NO_ERROR) {
-            // GL_MAJOR_VERSION/GL_MINOR_VERSION were introduced in GLES 3.0,
-            // so if the commands returned error we assume it is GLES 2.0.
-            major_version = 2;
-            minor_version = 0;
-        }
+    glGetError();  // Clear error state.
+    glGetIntegerv(GL_MAJOR_VERSION, &major_version);
+    glGetIntegerv(GL_MINOR_VERSION, &minor_version);
+    if (glGetError() != GL_NO_ERROR) {
+        // GL_MAJOR_VERSION/GL_MINOR_VERSION were introduced in GLES 3.0,
+        // so if the commands returned error we assume it is GLES 2.0.
+        major_version = 2;
+        minor_version = 0;
     }
 
     if (major_version >= 3) {

--- a/core/os/device/deviceinfo/cc/query.h
+++ b/core/os/device/deviceinfo/cc/query.h
@@ -105,6 +105,9 @@ bool vkPhysicalDevices(
 // false.
 bool hasVulkanLoader();
 
+// hasGLorGLES returns true if libGL or libGLES can be found.
+bool hasGLorGLES();
+
 // The functions below are used by getDeviceInstance(), and are implemented
 // in the target-dependent sub-directories.
 

--- a/core/os/device/host/host_linux.go
+++ b/core/os/device/host/host_linux.go
@@ -16,5 +16,5 @@
 
 package host
 
-// #cgo LDFLAGS: -lX11 -ldl
+// #cgo LDFLAGS: -ldl
 import "C"

--- a/gapii/cc/BUILD.bazel
+++ b/gapii/cc/BUILD.bazel
@@ -122,8 +122,6 @@ cc_library(
     linkopts = select({
         "//tools/build:linux": [
             "-ldl",
-            "-lGL",
-            "-lX11",
         ],
         "//tools/build:darwin": [
             "-framework Cocoa",
@@ -131,7 +129,6 @@ cc_library(
         ],
         "//tools/build:windows": [],
         "//conditions:default": [
-            "-lEGL",
             "-llog",
             "-lm",
         ],

--- a/gapir/cc/BUILD.bazel
+++ b/gapir/cc/BUILD.bazel
@@ -88,8 +88,6 @@ cc_library(
     linkopts = select({
         "//tools/build:linux": [
             "-ldl",
-            "-lGL",
-            "-lX11",
         ],
         "//tools/build:darwin": [
             "-framework Cocoa",

--- a/gapir/cc/context.cpp
+++ b/gapir/cc/context.cpp
@@ -191,6 +191,10 @@ void Context::registerCallbacks(Interpreter* interpreter) {
             // It is ok since correct replay will only reference what it is supposed to.
             if (!mRootGlesRenderer) {
                 mRootGlesRenderer.reset(GlesRenderer::create(nullptr));
+                if (!mRootGlesRenderer) {
+                    GAPID_ERROR("Could not create GLES renderer on this device");
+                    return false;
+                }
                 mRootGlesRenderer->bind();
                 mRootGlesRenderer->setBackbuffer(GlesRenderer::Backbuffer(
                     8, 8,
@@ -200,6 +204,10 @@ void Context::registerCallbacks(Interpreter* interpreter) {
                 ));
             }
             auto renderer = GlesRenderer::create(mRootGlesRenderer.get());
+            if (!renderer) {
+                GAPID_ERROR("Could not create GLES renderer on this device");
+                return false;
+            }
             renderer->setListener(this);
             mGlesRenderers[id] = renderer;
             return true;

--- a/gapis/api/gles/compat.go
+++ b/gapis/api/gles/compat.go
@@ -142,6 +142,9 @@ type scratchBuffer struct {
 
 func compat(ctx context.Context, device *device.Instance) (transform.Transformer, error) {
 	ctx = log.Enter(ctx, "compat")
+	if device.Configuration.Drivers.OpenGL == nil {
+		return nil, fmt.Errorf("Could not find OpenGL device on host")
+	}
 
 	glDev := device.Configuration.Drivers.OpenGL
 	target, version, err := getFeatures(ctx, glDev.Version, listToExtensions(glDev.Extensions))

--- a/gapis/api/templates/specific_gfx_api.cpp.tmpl
+++ b/gapis/api/templates/specific_gfx_api.cpp.tmpl
@@ -79,7 +79,7 @@
       {{if (Macro "IsRealDirectFunction" $c)}}
         {{$name := Macro "CmdName" $c}}
         mFunctionStubs.{{$name}} = reinterpret_cast<{{Template "C++.FunctionPtrType" $c}}>(§
-          core::Get{{$api}}ProcAddress("{{$name}}", false));
+          core::Get{{$api}}ProcAddress("{{$name}}", true));
       {{end}}
     {{end}}
   }


### PR DESCRIPTION
This is only on Linux. Now gapid can be built/run without
libX11 being present on the trace/replay device if it is
not required.