### PR TITLE
build: Fix gapid.apk hash not being applied on windows.

### DIFF
--- a/cmd/filehash/main.go
+++ b/cmd/filehash/main.go
@@ -72,5 +72,8 @@ func run(ctx context.Context) error {
 	if *out == "" {
 		fmt.Print(result)
 	}
+	if result == string(data) {
+		return fmt.Errorf("'%v' was not found in file %v", *replace, *in)
+	}
 	return ioutil.WriteFile(*out, []byte(result), 0777)
 }

--- a/gapidapk/android/apk/AndroidManifest.xml.in
+++ b/gapidapk/android/apk/AndroidManifest.xml.in
@@ -17,7 +17,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.google.android.gapid.${name}"
     android:versionCode="1"
-    android:versionName="0.1 (£{srchash})"
+    android:versionName="0.1 ({srchash})"
     >
     <application
         android:allowBackup="true"

--- a/gapidapk/android/apk/rules.bzl
+++ b/gapidapk/android/apk/rules.bzl
@@ -69,7 +69,7 @@ def gapid_apk(name = "", abi = "", pkg = "", libs = {}):
         template = "AndroidManifest.xml.in",
         out = name + "/" + "AndroidManifest.xml",
         replace = "{srchash}",
-        srcs = fatapks + ["//gapidapk/android/app/src/main:gapid"],
+        srcs = fatapks + ["//gapidapk/android/app/src/main:source"],
         visibility = ["//visibility:public"],
     )
     native.cc_library(

--- a/gapidapk/android/apk/rules.bzl
+++ b/gapidapk/android/apk/rules.bzl
@@ -68,7 +68,7 @@ def gapid_apk(name = "", abi = "", pkg = "", libs = {}):
         name = name+"_manifest",
         template = "AndroidManifest.xml.in",
         out = name + "/" + "AndroidManifest.xml",
-        replace = "£{srchash}",
+        replace = "{srchash}",
         srcs = fatapks + ["//gapidapk/android/app/src/main:gapid"],
         visibility = ["//visibility:public"],
     )

--- a/gapidapk/android/app/src/main/BUILD.bazel
+++ b/gapidapk/android/app/src/main/BUILD.bazel
@@ -12,11 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-android_library(
-    name = "gapid",
+filegroup(
+    name = "source",
     srcs = glob([
         "java/com/google/android/gapid/*.java",
     ]),
+    visibility = ["//visibility:public"],
+)
+
+android_library(
+    name = "gapid",
+    srcs = [":source"],
     manifest = "//tools/build/rules:AndroidManifest.xml",
     resource_files = [
         "res/drawable-xxxhdpi/logo.png",

--- a/tools/build/rules/filehash.bzl
+++ b/tools/build/rules/filehash.bzl
@@ -49,4 +49,5 @@ filehash = rule(
             default = Label("//cmd/filehash:filehash"),
         ),
     },
+    output_to_genfiles = True,
 )


### PR DESCRIPTION
Partially fixes issue where APKs are not being pushed to the device (there's another issue we're trying to uncover)