### PR TITLE
Fix several issues running Vulkan replays on robot.

### DIFF
--- a/cmd/gapir/cc/main.cpp
+++ b/cmd/gapir/cc/main.cpp
@@ -149,7 +149,8 @@ void android_main(struct android_app* app) {
       listenConnections(conn.get(), nullptr, nullptr, Connection::NO_TIMEOUT,
                         &memoryManager, crashHandler);
     });
-    while (true) {
+    bool alive = true;
+    while (alive) {
       int ident;
       int fdesc;
       int events;
@@ -162,6 +163,7 @@ void android_main(struct android_app* app) {
         }
         if (app->destroyRequested) {
           conn->close();
+          alive = false;
           break;
         }
       }

--- a/test/robot/replay/client.go
+++ b/test/robot/replay/client.go
@@ -59,6 +59,12 @@ func Run(ctx context.Context, store *stash.Client, manager Manager, tempDir file
 func (c *client) onDeviceAdded(ctx context.Context, host *device.Instance, target bind.Device) {
 	replayOnTarget := func(ctx context.Context, t *Task) error {
 		job.LockDevice(ctx, target)
+		defer func() {
+			// HACK: kill gapid.apk manually for now as subsequent reports/replays may freeze the app.
+			// Remove when https://github.com/google/gapid/issues/1666 is fixed.
+			target.Shell("am", "force-stop", "com.google.android.gapid.aarch64").Run(ctx)
+			target.Shell("am", "force-stop", "com.google.android.gapid.armeabi").Run(ctx)
+		}()
 		defer job.UnlockDevice(ctx, target)
 		if target.Status() != bind.Status_Online {
 			log.I(ctx, "Trying to replay %s on %s not started, device status %s",
@@ -178,6 +184,7 @@ func doReplay(ctx context.Context, action string, in *Input, store *stash.Client
 		}
 		errs = append(errs, err.Error())
 	}
+
 	errs = append(errs, strings.TrimSpace(errBuf.String()))
 	outputObj.Err = strings.Join(errs, "\n")
 	if err := worker.NeedsRetry(outputObj.Err, retryString); err != nil {


### PR DESCRIPTION
GapidAPK would previously freeze if it was relaunched by GAPIS when it
was already running. An unbroken infinite while caused an ANR issue from
the looks of things. Another issue is that it seems that GAPIS mistimes
sending the connection request when relaunching the apk. The current fix
for this is just a bandaid to get vulkan running on robot, by
force-stopping GapidAPK after the robot task finishes.