### PR TITLE
jdwp-loader: Drop workaround for N preview.

### DIFF
--- a/gapii/client/jdwp_loader.go
+++ b/gapii/client/jdwp_loader.go
@@ -298,8 +298,7 @@ func (p *Process) loadAndConnectViaJDWP(
 
 		// Load the library.
 		log.D(ctx, "Loading GAPII library...")
-		// Work around for loading libraries in the N previews. See b/29441142.
-		j.Class("java.lang.Runtime").Call("getRuntime").Call("doLoad", gapiiPath, nil)
+		j.Class("java.lang.System").Call("load", gapiiPath)
 		log.D(ctx, "Library loaded")
 		return nil
 	})


### PR DESCRIPTION
There's devices that will only work with `System.load()` now.