### PR TITLE
core/os/device: Declare ABIs for OSes we care about.

### DIFF
--- a/core/os/device/abi.go
+++ b/core/os/device/abi.go
@@ -20,10 +20,10 @@ var (
 	// AndroidARM defaults to v7a which is the lowest that we support.
 	AndroidARM = abi("armeabi", Android, ARMv7a, Little32)
 
-	AndroidARMv7a   = abi("armeabi-v7a", Android, ARMv7a, Little32)
-	AndroidARM64v8a = abi("arm64-v8a", Android, ARMv8a, Little64)
-	AndroidX86      = abi("x86", Android, X86, Little32)
-	AndroidX86_64   = abi("x86-64", Android, X86_64, Little64)
+	AndroidARMv7a   = abi("armeabi-v7a", Android, ARMv7a, ARMv7aLayout)
+	AndroidARM64v8a = abi("arm64-v8a", Android, ARMv8a, ARM64v8aLayout)
+	AndroidX86      = abi("x86", Android, X86, X86IA32Layout)
+	AndroidX86_64   = abi("x86-64", Android, X86_64, X86_64Layout)
 	AndroidMIPS     = abi("mips", Android, MIPS, Little32)
 	AndroidMIPS64   = abi("mips64", Android, MIPS64, Little64)
 

--- a/core/os/device/device.go
+++ b/core/os/device/device.go
@@ -45,6 +45,74 @@ const (
 )
 
 var (
+	// ARMv7aLayout is the memory layout for the armv7a ABI.
+	// http://infocenter.arm.com/help/topic/com.arm.doc.ihi0042f/IHI0042F_aapcs.pdf
+	// 4 DATA TYPES AND ALIGNMENT
+	ARMv7aLayout = &MemoryLayout{
+		Endian:  LittleEndian,
+		Pointer: &DataTypeLayout{Size: 4, Alignment: 4},
+		Integer: &DataTypeLayout{Size: 4, Alignment: 4},
+		Size:    &DataTypeLayout{Size: 4, Alignment: 4},
+		Char:    &DataTypeLayout{Size: 1, Alignment: 1},
+		I64:     &DataTypeLayout{Size: 8, Alignment: 8},
+		I32:     &DataTypeLayout{Size: 4, Alignment: 4},
+		I16:     &DataTypeLayout{Size: 2, Alignment: 2},
+		I8:      &DataTypeLayout{Size: 1, Alignment: 1},
+		F64:     &DataTypeLayout{Size: 8, Alignment: 8},
+		F32:     &DataTypeLayout{Size: 4, Alignment: 4},
+		F16:     &DataTypeLayout{Size: 2, Alignment: 2},
+	}
+
+	// ARM64v8aLayout is the memory layout for the arm64v8a ABI.
+	// http://infocenter.arm.com/help/topic/com.arm.doc.ihi0055b/IHI0055B_aapcs64.pdf
+	// 4 DATA TYPES AND ALIGNMENT
+	ARM64v8aLayout = &MemoryLayout{
+		Endian:  LittleEndian,
+		Pointer: &DataTypeLayout{Size: 8, Alignment: 8},
+		Integer: &DataTypeLayout{Size: 8, Alignment: 8},
+		Size:    &DataTypeLayout{Size: 8, Alignment: 8},
+		Char:    &DataTypeLayout{Size: 1, Alignment: 1},
+		I64:     &DataTypeLayout{Size: 8, Alignment: 8},
+		I32:     &DataTypeLayout{Size: 4, Alignment: 4},
+		I16:     &DataTypeLayout{Size: 2, Alignment: 2},
+		I8:      &DataTypeLayout{Size: 1, Alignment: 1},
+		F64:     &DataTypeLayout{Size: 8, Alignment: 8},
+		F32:     &DataTypeLayout{Size: 4, Alignment: 4},
+		F16:     &DataTypeLayout{Size: 2, Alignment: 2},
+	}
+
+	// X86IA32Layout is the memory layout for the x86 IA-32 ABI.
+	X86IA32Layout = &MemoryLayout{
+		Endian:  LittleEndian,
+		Pointer: &DataTypeLayout{Size: 4, Alignment: 4},
+		Integer: &DataTypeLayout{Size: 4, Alignment: 4},
+		Size:    &DataTypeLayout{Size: 4, Alignment: 4},
+		Char:    &DataTypeLayout{Size: 1, Alignment: 1},
+		I64:     &DataTypeLayout{Size: 8, Alignment: 4},
+		I32:     &DataTypeLayout{Size: 4, Alignment: 4},
+		I16:     &DataTypeLayout{Size: 2, Alignment: 2},
+		I8:      &DataTypeLayout{Size: 1, Alignment: 1},
+		F64:     &DataTypeLayout{Size: 8, Alignment: 4},
+		F32:     &DataTypeLayout{Size: 4, Alignment: 4},
+		F16:     &DataTypeLayout{Size: 2, Alignment: 2},
+	}
+
+	// X86_64Layout is the memory layout for the x86_64 ABI.
+	X86_64Layout = &MemoryLayout{
+		Endian:  LittleEndian,
+		Pointer: &DataTypeLayout{Size: 8, Alignment: 8},
+		Integer: &DataTypeLayout{Size: 4, Alignment: 4},
+		Size:    &DataTypeLayout{Size: 4, Alignment: 4},
+		Char:    &DataTypeLayout{Size: 1, Alignment: 1},
+		I64:     &DataTypeLayout{Size: 8, Alignment: 8},
+		I32:     &DataTypeLayout{Size: 4, Alignment: 4},
+		I16:     &DataTypeLayout{Size: 2, Alignment: 2},
+		I8:      &DataTypeLayout{Size: 1, Alignment: 1},
+		F64:     &DataTypeLayout{Size: 8, Alignment: 8},
+		F32:     &DataTypeLayout{Size: 4, Alignment: 4},
+		F16:     &DataTypeLayout{Size: 2, Alignment: 2},
+	}
+
 	Little32 = &MemoryLayout{
 		Endian:  LittleEndian,
 		Pointer: &DataTypeLayout{Size: 4, Alignment: 4},


### PR DESCRIPTION
These were fluffy definions before, where some memory layouts were actually incorrect.