### PR TITLE
code/data/compare: Deref pointer diffs

### DIFF
--- a/core/data/compare/comparator.go
+++ b/core/data/compare/comparator.go
@@ -193,7 +193,7 @@ func (t Comparator) compareValues(v1, v2 reflect.Value, ptr bool) {
 	default:
 		// Normal equality suffices
 		if toValue(v1, false) != toValue(v2, false) {
-			t.Handler(t.Path.Diff(toValue(v1, ptr), toValue(v2, ptr)))
+			t.Handler(t.Path.Diff(toValue(v1, false), toValue(v2, false)))
 		}
 	}
 }

--- a/core/data/compare/compare_test.go
+++ b/core/data/compare/compare_test.go
@@ -202,7 +202,7 @@ var (
 			root.Diff(hidden1, hidden2),
 		}},
 		{"pointer!=", &valueBase, &valueDifferent, []compare.Path{
-			root.Diff(&valueBase, &valueDifferent),
+			root.Diff(valueBase, valueDifferent),
 		}},
 		{"custom", Special(1), Special(2), []compare.Path{
 			root.Diff(Special(1), Special(2)),

--- a/core/data/compare/path.go
+++ b/core/data/compare/path.go
@@ -110,7 +110,7 @@ func (p Path) Format(f fmt.State, r rune) {
 	if last.Operation != nil {
 		fmt.Fprint(f, last.Operation, " ")
 	}
-	fmt.Fprint(f, "⟦", last.Reference, "⟧ != ⟦", last.Value, "⟧")
+	fmt.Fprintf(f, "⟦%+v⟧ != ⟦%+v⟧", last.Reference, last.Value)
 	if len(remains) > 0 {
 		fmt.Fprint(f, " for v")
 		for _, e := range remains {


### PR DESCRIPTION
Previously it would just display two hex codes when it was actually comparing the pointee's data.