### PR TITLE
deviceinfo: Do not explode if there's no GL driver available.

### DIFF
--- a/core/os/device/deviceinfo/cc/android/query.cpp
+++ b/core/os/device/deviceinfo/cc/android/query.cpp
@@ -429,9 +429,9 @@ bool createContext(void* platform_data) {
     return true;
 }
 
-const char* contextError() {
-    return gContext.mError;
-}
+const char* contextError() { return gContext.mError; }
+
+bool hasGLorGLES() { return true; }
 
 int numABIs() { return gContext.mSupportedABIs.size(); }
 

--- a/core/os/device/deviceinfo/cc/gl.cpp
+++ b/core/os/device/deviceinfo/cc/gl.cpp
@@ -29,10 +29,6 @@ const char* safe_string(void* x) {
     return (x != nullptr) ? reinterpret_cast<const char*>(x) : "";
 }
 
-bool hasGLorGLES() {
-    return core::hasGLorGLES();
-}
-
 void glDriver(device::OpenGLDriver* driver) {
     GLint major_version = 2;
     GLint minor_version = 0;

--- a/core/os/device/deviceinfo/cc/query.h
+++ b/core/os/device/deviceinfo/cc/query.h
@@ -105,7 +105,8 @@ bool vkPhysicalDevices(
 // false.
 bool hasVulkanLoader();
 
-// hasGLorGLES returns true if libGL or libGLES can be found.
+// hasGLorGLES returns true if there is a OpenGL or OpenGL ES display driver
+// that can be used.
 bool hasGLorGLES();
 
 // The functions below are used by getDeviceInstance(), and are implemented


### PR DESCRIPTION
Taking the changes in #1658 further still.