### PR TITLE
Clean up queues and LastBoundQueue when we destroy a device.

### DIFF
--- a/gapis/api/vulkan/state.go
+++ b/gapis/api/vulkan/state.go
@@ -35,7 +35,7 @@ func (st *State) getSubmitAttachmentInfo(attachment api.FramebufferAttachment) (
 		return returnError("There have been no previous draws")
 	}
 
-	if lastDrawInfo.Framebuffer == nil {
+	if lastDrawInfo.Framebuffer == nil || !st.Framebuffers.Contains(lastDrawInfo.Framebuffer.VulkanHandle) {
 		return returnError("%s is not bound", attachment)
 	}
 

--- a/gapis/api/vulkan/vulkan.api
+++ b/gapis/api/vulkan/vulkan.api
@@ -2986,7 +2986,17 @@ cmd VkResult vkCreateDevice(
 cmd void vkDestroyDevice(
     VkDevice                     device,
     const VkAllocationCallbacks* pAllocator) {
-  // TODO: pAllocator
+  if (device in Devices) {
+    dev := Devices[device]
+    for _, _, v in dev.QueueObjects {
+      if LastBoundQueue == v {
+        LastBoundQueue = null
+      }
+      delete(Queues, v.VulkanHandle)
+    }
+  }
+  
+  // TODO: pAllocator  
   delete(Devices, device)
 }
 
@@ -3078,8 +3088,12 @@ cmd void vkGetDeviceQueue(
     u32      queueIndex,
     VkQueue* pQueue) {
   if !(device in Devices) { vkErrorInvalidDevice(device) }
+  dev := Devices[device]
   id := ?
   Queues[id] = new!QueueObject(Device: device,Family:  queueFamilyIndex,Index:  queueIndex,VulkanHandle:  id)
+  
+  dev.QueueObjects[len(dev.QueueObjects)] = Queues[id]
+
   if pQueue == null { vkErrorNullPointer("VkQueue") }
   pQueue[0] = id
 }
@@ -9272,6 +9286,7 @@ sub void clearLastDrawInfoDrawCommandParameters() {
   @unused map!(u32, string)         EnabledExtensions
   @unused map!(u32, string)         EnabledLayers
   @unused map!(u32, QueueInfo)      Queues
+  @unused map!(u32, ref!QueueObject)    QueueObjects
   @unused VkPhysicalDeviceFeatures  EnabledFeatures
   @unused VkDevice                  VulkanHandle
   @unused ref!VulkanDebugMarkerInfo DebugInfo


### PR DESCRIPTION
Otherwise we will try and create framebuffer requests
after a device has been deleted.