### PR TITLE
Work around a "feature" in mesa.

### DIFF
--- a/core/cc/dl_loader.cpp
+++ b/core/cc/dl_loader.cpp
@@ -57,8 +57,10 @@ void* load(const char* name, ConstCharPtrs... fallback_names) {
         }
     }
     ret = res;
-#else
+#elif TARGET_OS == GAPID_OS_ANDROID
     ret = dlopen(name, RTLD_NOW | RTLD_LOCAL);
+#else
+    ret = dlopen(name, RTLD_LAZY | RTLD_DEEPBIND);
 #endif // TARGET_OS
     if (ret == nullptr) {
         return load(fallback_names...);

--- a/core/cc/linux/get_gles_proc_address.cpp
+++ b/core/cc/linux/get_gles_proc_address.cpp
@@ -18,11 +18,25 @@
 #include "../get_gles_proc_address.h"
 #include "../log.h"
 
+#include <dlfcn.h>
+
 namespace {
 
 void* getGlesProcAddress(const char *name, bool bypassLocal) {
     using namespace core;
     typedef void* (*GPAPROC)(const char *name);
+
+    // The mesa driver does bad things with LLVM. Since we also use llvm, 
+    // we can't have the mesa driver do bad things to our code.
+    // Therefore we should preload any versions of llvm that may be required
+    // into the start of our address space.
+    // See: https://github.com/google/gapid/issues/1707 for more information
+    static void* _dummy0 = dlopen("libLLVM-3.0.so.1", RTLD_LAZY | RTLD_DEEPBIND);
+    static void* _dummy1 = dlopen("libLLVM-4.0.so.1", RTLD_LAZY | RTLD_DEEPBIND);
+    static void* _dummy2 = dlopen("libLLVM-5.0.so.1", RTLD_LAZY | RTLD_DEEPBIND);
+    (void)_dummy0;
+    (void)_dummy1;
+    (void)_dummy2;
 
     if (bypassLocal) {
         // Why .1 ?


### PR DESCRIPTION
In mesa drivers (at least those shipped with Ubuntu 17.10) they
dynamically link against libLLVM-*.so. This means that since we a
static version of LLVM, we get name collisions on llvm, and
subsequent failures. Instead of all of this, preload libLLVM*
with RTLD_DEEPBIND before we even try and load libGL.

This means those llvm symbols will not try and resolve
any of our symbols.

Fixes: #1707