### PR TITLE
UI support for the -android-additionalargs trace flag.

### DIFF
--- a/gapic/src/main/com/google/gapid/models/Settings.java
+++ b/gapic/src/main/com/google/gapid/models/Settings.java
@@ -77,6 +77,7 @@ public class Settings {
   public String traceCwd = "";
   public boolean traceMidExecution = false;
   public int traceFrameCount = 0;
+  public String traceIntentArgs = "";
   public boolean skipWelcomeScreen = false;
   public boolean skipFirstRunDialog = false;
   public String[] recentFiles = new String[0];
@@ -213,6 +214,7 @@ public class Settings {
     traceCwd  = properties.getProperty("trace.cwd", traceCwd);
     traceMidExecution = getBoolean(properties, "trace.midExecution", traceMidExecution);
     traceFrameCount = getInt(properties, "trace.frameCount", traceFrameCount);
+    traceIntentArgs = properties.getProperty("trace.intentArgs", traceIntentArgs);
     skipWelcomeScreen = getBoolean(properties, "skip.welcome", skipWelcomeScreen);
     skipFirstRunDialog = getBoolean(properties, "skip.firstTime", skipFirstRunDialog);
     recentFiles = getStringList(properties, "open.recent", recentFiles);
@@ -253,6 +255,7 @@ public class Settings {
     properties.setProperty("trace.cwd", traceCwd);
     properties.setProperty("trace.midExecution", Boolean.toString(traceMidExecution));
     properties.setProperty("trace.frameCount", Integer.toString(traceFrameCount));
+    properties.setProperty("trace.intentArgs", traceIntentArgs);
     properties.setProperty("skip.welcome", Boolean.toString(skipWelcomeScreen));
     properties.setProperty("skip.firstTime", Boolean.toString(skipFirstRunDialog));
     setStringList(properties, "open.recent", recentFiles);

--- a/gapic/src/main/com/google/gapid/server/Tracer.java
+++ b/gapic/src/main/com/google/gapid/server/Tracer.java
@@ -165,23 +165,25 @@ public class Tracer {
     public final String pkg;
     public final String activity;
     public final String action;
+    public final String intentArgs;
     public final boolean clearCache;
     public final boolean disablePcs;
 
-    public AndroidTraceRequest(Api api, Device.Instance device, String action, File output,
-        int frameCount, boolean midExecution, boolean clearCache, boolean disablePcs) {
-      this(api, device, null, null, action, output, frameCount, midExecution, clearCache,
-          disablePcs);
+    public AndroidTraceRequest(Api api, Device.Instance device, String action, String intentArgs,
+        File output, int frameCount, boolean midExecution, boolean clearCache, boolean disablePcs) {
+      this(api, device, null, null, action, intentArgs, output, frameCount, midExecution,
+          clearCache, disablePcs);
     }
 
     public AndroidTraceRequest(Api api, Device.Instance device, String pkg, String activity,
-        String action, File output, int frameCount, boolean midExecution, boolean clearCache,
-        boolean disablePcs) {
+        String action, String intentArgs, File output, int frameCount, boolean midExecution,
+        boolean clearCache, boolean disablePcs) {
       super(api, output, frameCount, midExecution);
       this.device = device;
       this.pkg = pkg;
       this.activity = activity;
       this.action = action;
+      this.intentArgs = intentArgs;
       this.clearCache = clearCache;
       this.disablePcs = disablePcs;
     }
@@ -197,6 +199,11 @@ public class Tracer {
       cmd.add("-clear-cache=" + Boolean.toString(clearCache));
 
       cmd.add("-disable-pcs=" + Boolean.toString(disablePcs));
+
+      if (!intentArgs.isEmpty()) {
+        cmd.add("-android-additionalargs");
+        cmd.add(intentArgs);
+      }
 
       if (pkg != null) {
         cmd.add("-android-package");

--- a/gapic/src/main/com/google/gapid/views/TracerDialog.java
+++ b/gapic/src/main/com/google/gapid/views/TracerDialog.java
@@ -373,6 +373,7 @@ public class TracerDialog {
       private Label pcsWarning;
       private Link adbWarning;
       private ActionTextbox traceTarget;
+      private Text arguments;
       private Button clearCache;
       private Button disablePcs;
       private List<Device.Instance> devices;
@@ -475,11 +476,9 @@ public class TracerDialog {
           }
         }, new GridData(SWT.FILL, SWT.FILL, true, false));
 
-        // Space used by the desktop trace tab, helps line things up a bit.
-        if (!OS.isMac) {
-          createLabel(this, "");
-          createLabel(this, "");
-        }
+        createLabel(this, "Intent Arguments:");
+        arguments = withLayoutData(createTextbox(this, models.settings.traceIntentArgs),
+            new GridData(SWT.FILL, SWT.FILL, true, false));
       }
 
       @Override
@@ -556,6 +555,7 @@ public class TracerDialog {
 
         settings.traceDevice = getSelectedDevice().getSerial();
         settings.tracePackage = traceTarget.getText();
+        settings.traceIntentArgs = arguments.getText();
         settings.traceClearCache = clearCache.getSelection();
         settings.traceDisablePcs = disablePcs.getSelection();
 
@@ -564,10 +564,11 @@ public class TracerDialog {
           String pkg = target.substring(actionSep + 1, pkgSep);
           String activity = target.substring(pkgSep + 1);
           return new AndroidTraceRequest(traceApi, getSelectedDevice(), pkg, activity, action,
-              output, frames, midExecution, clearCache.getSelection(), disablePcs.getSelection());
+              arguments.getText(), output, frames, midExecution, clearCache.getSelection(),
+              disablePcs.getSelection());
         } else {
-          return new AndroidTraceRequest(traceApi, getSelectedDevice(), target, output,
-              frames, midExecution, clearCache.getSelection(), disablePcs.getSelection());
+          return new AndroidTraceRequest(traceApi, getSelectedDevice(), target, arguments.getText(),
+              output, frames, midExecution, clearCache.getSelection(), disablePcs.getSelection());
         }
       }
 


### PR DESCRIPTION
Allows the user to specify extra arguments to be passed to am start. See: https://developer.android.com/studio/command-line/adb.html#IntentSpec

Fixes #826 