### PR TITLE
cmd/apic: Add option to dump IR

### DIFF
--- a/cmd/apic/compile.go
+++ b/cmd/apic/compile.go
@@ -19,6 +19,7 @@ import (
 	"flag"
 	"fmt"
 	"io/ioutil"
+	"os"
 	"strings"
 
 	"github.com/google/gapid/core/app"
@@ -67,9 +68,10 @@ type compileVerb struct {
 		Exec   bool `help:"Emit executor logic"`
 		Encode bool `help:"Emit encoder logic"`
 	}
-	Namespace string  `help:"Dot-delimited root namespace(s)"`
-	Symbols   symbols `help:"Symbol generation method."`
-	Optimize  bool
+	Namespace string        `help:"Dot-delimited root namespace(s)"`
+	Symbols   symbols       `help:"Symbol generation method"`
+	Optimize  bool          `help:"Optimize generated code"`
+	Dump      bool          `help:"Dump LLVM IR to stderr"`
 	Search    file.PathList `help:"The set of paths to search for includes"`
 }
 
@@ -129,6 +131,11 @@ func (v *compileVerb) Run(ctx context.Context, flags flag.FlagSet) error {
 
 	if v.Optimize {
 		prog.Module.Optimize()
+	}
+
+	if v.Dump {
+		fmt.Fprintln(os.Stderr, prog.Module.String())
+		return fmt.Errorf("IR dump")
 	}
 
 	obj, err := prog.Module.Object(v.Optimize)

--- a/tools/build/rules/apic.bzl
+++ b/tools/build/rules/apic.bzl
@@ -110,6 +110,7 @@ def _apic_compile_impl(ctx):
             "--target", target,
             "--output", outputs[0].path,
             "--optimize=%s" % ctx.attr.optimize,
+            "--dump=%s" % ctx.attr.dump,
             "--namespace", ctx.attr.namespace,
             "--symbols", ctx.attr.symbols,
         ] + ["--emit-" + emit for emit in ctx.attr.emit] + [
@@ -139,6 +140,7 @@ apic_compile = rule(
             ],
         ),
         "optimize": attr.bool(default = False),
+        "dump": attr.bool(default = False),
         "emit": attr.string_list(
             allow_empty = False,
             mandatory = True,


### PR DESCRIPTION
Useful at peeking at what we're attempting to compile.