### PR TITLE
Re-work encoder.go so that it generates correct armv7.

### DIFF
--- a/core/codegen/output.go
+++ b/core/codegen/output.go
@@ -108,8 +108,9 @@ func (m *Module) Optimize() {
 	defer pass.Dispose()
 
 	// pass.AddFunctionInliningPass() // Way too slow with this pass
-	pass.AddConstantPropagationPass()
 	pass.AddInstructionCombiningPass()
+	pass.AddReassociatePass()
+	pass.AddConstantPropagationPass()
 	pass.AddPromoteMemoryToRegisterPass()
 	pass.AddGVNPass()
 	pass.AddCFGSimplificationPass()

--- a/gapil/compiler/plugins/encoder/encoder.go
+++ b/gapil/compiler/plugins/encoder/encoder.go
@@ -597,15 +597,15 @@ func (e *encoder) encodeValue(s *compiler.S, ptr, buf *codegen.Value, ty semanti
 		return
 	case *semantic.Slice:
 		e.writeBlob(s, buf, func(buf *codegen.Value) {
-			root := s.LocalInit("root", ptr.Index(0, compiler.SliceRoot).Load().Cast(e.T.Uint64))
-			base := s.LocalInit("base", ptr.Index(0, compiler.SliceBase).Load().Cast(e.T.Uint64))
+			root := s.LocalInit("root", ptr.Index(0, compiler.SliceRoot).Load().Cast(e.T.Size))
+			base := s.LocalInit("base", ptr.Index(0, compiler.SliceBase).Load().Cast(e.T.Size))
 			size := ptr.Index(0, compiler.SliceSize).Load()
 			pool := ptr.Index(0, compiler.SlicePool).Load()
 			count := s.Div(size, s.SizeOf(e.T.Storage(ty.To)))
 
 			s.If(s.Not(pool.IsNull()), func() {
 				// Adjust root and base to be relative to the pool base
-				offset := pool.Index(0, compiler.PoolBuffer).Load().Cast(e.T.Uint64)
+				offset := pool.Index(0, compiler.PoolBuffer).Load().Cast(e.T.Size)
 				root.Store(s.Sub(root.Load(), offset))
 				base.Store(s.Sub(base.Load(), offset))
 			})
@@ -615,12 +615,12 @@ func (e *encoder) encodeValue(s *compiler.S, ptr, buf *codegen.Value, ty semanti
 
 			s.If(s.NotEqual(root, s.Zero(root.Type())), func() {
 				e.writeWireAndTag(s, buf, proto.WireVarint, serialization.SliceRoot)
-				e.writeVarint(s, buf, root)
+				e.writeVarint(s, buf, root.Cast(e.T.Uint64))
 			})
 
 			s.If(s.NotEqual(base, s.Zero(base.Type())), func() {
 				e.writeWireAndTag(s, buf, proto.WireVarint, serialization.SliceBase)
-				e.writeVarint(s, buf, base)
+				e.writeVarint(s, buf, base.Cast(e.T.Uint64))
 			})
 
 			s.If(s.NotEqual(count, s.Zero(count.Type())), func() {


### PR DESCRIPTION
It looks like the code is correct in both cases, but previously
the instcombine pass would make armv7 generate incorrect
code that would end up overlapping the memory locations of
root and base, causing incorrect values.

We should still check to see if anything else can cause this,
but for now this unblocks tracing on armv7.