### PR TITLE
Vulkan: Handle D24 format correctly

### DIFF
--- a/gapii/cc/vulkan_mid_execution.cpp
+++ b/gapii/cc/vulkan_mid_execution.cpp
@@ -329,7 +329,8 @@ void VulkanSpy::prepareGPUBuffers(CallObserver *observer, PackEncoder *group,
     mImports.mVkDeviceFunctions[device.second->mVulkanHandle]
         .vkGetBufferMemoryRequirements(
             device.second->mVulkanHandle, buffer,
-            &mState.TransferBufferMemoryRequirements[device.second->mVulkanHandle]);
+            &mState.TransferBufferMemoryRequirements[device.second
+                                                         ->mVulkanHandle]);
     mImports.mVkDeviceFunctions[device.second->mVulkanHandle].vkDestroyBuffer(
         device.second->mVulkanHandle, buffer, nullptr);
   }
@@ -398,7 +399,8 @@ void VulkanSpy::prepareGPUBuffers(CallObserver *observer, PackEncoder *group,
     // We can either batch them, or spin up a second thread that
     // simply waits for the reads to be done before continuing.
     for (auto &bind : allBindings) {
-      if (mState.DeviceMemories.find(bind.mmemory) == mState.DeviceMemories.end()) {
+      if (mState.DeviceMemories.find(bind.mmemory) ==
+          mState.DeviceMemories.end()) {
         continue;
       }
       auto &deviceMemory = mState.DeviceMemories[bind.mmemory];
@@ -432,8 +434,10 @@ void VulkanSpy::prepareGPUBuffers(CallObserver *observer, PackEncoder *group,
           VkPipelineStageFlagBits::VK_PIPELINE_STAGE_HOST_BIT, 0, 0, nullptr, 1,
           &barrier, 0, nullptr);
 
-      commandBuffer.FinishAndSubmit(GetQueue(mState.Queues, buf)->mVulkanHandle);
-      device_functions.vkQueueWaitIdle(GetQueue(mState.Queues, buf)->mVulkanHandle);
+      commandBuffer.FinishAndSubmit(
+          GetQueue(mState.Queues, buf)->mVulkanHandle);
+      device_functions.vkQueueWaitIdle(
+          GetQueue(mState.Queues, buf)->mVulkanHandle);
 
       void *pData = stage.GetMappedMemory();
       auto resIndex = sendResource(VulkanSpy::kApiIndex, pData, bind.msize);
@@ -469,7 +473,8 @@ void VulkanSpy::prepareGPUBuffers(CallObserver *observer, PackEncoder *group,
     };
 
     auto block_pitch = [this](const VkExtent3D &extent, uint32_t format,
-                              uint32_t mip_level, uint32_t aspect_bit, bool in_buffer) -> pitch {
+                              uint32_t mip_level, uint32_t aspect_bit,
+                              bool in_buffer) -> pitch {
       auto elementAndTexelBlockSize =
           subGetElementAndTexelBlockSize(nullptr, nullptr, format);
       const uint32_t texel_width =
@@ -532,14 +537,14 @@ void VulkanSpy::prepareGPUBuffers(CallObserver *observer, PackEncoder *group,
           case VkImageAspectFlagBits::VK_IMAGE_ASPECT_COLOR_BIT:
             return elementAndTexelBlockSize.mElementSize;
           case VkImageAspectFlagBits::VK_IMAGE_ASPECT_DEPTH_BIT:
-            return subGetDepthElementSize(nullptr, nullptr, format,
-                                          in_buffer);
+            return subGetDepthElementSize(nullptr, nullptr, format, in_buffer);
           case VkImageAspectFlagBits::VK_IMAGE_ASPECT_STENCIL_BIT:
             return 1;
         }
         return 0;
       }();
-      const size_t size = width_in_blocks * height_in_blocks * depth * element_size;
+      const size_t size =
+          width_in_blocks * height_in_blocks * depth * element_size;
       const size_t next_multiple_of_8 = (size + 7) & (~7);
 
       return byte_size_and_extent{size, next_multiple_of_8, width, height,
@@ -557,11 +562,11 @@ void VulkanSpy::prepareGPUBuffers(CallObserver *observer, PackEncoder *group,
     };
 
     for (auto &a : img->mAspects) {
-      auto& aspect = a.second;
-      for (auto& l : aspect->mLayers) {
-        auto& layer = l.second;
-        for (auto& lev : layer->mLevels) {
-          auto& level = lev.second;
+      auto &aspect = a.second;
+      for (auto &l : aspect->mLayers) {
+        auto &layer = l.second;
+        for (auto &lev : layer->mLevels) {
+          auto &level = lev.second;
           byte_size_and_extent e =
               level_size(image_info.mExtent, image_info.mFormat, lev.first,
                          a.first, false);
@@ -686,7 +691,7 @@ void VulkanSpy::prepareGPUBuffers(CallObserver *observer, PackEncoder *group,
     {
       VkDeviceSize offset = 0;
       std::vector<VkBufferImageCopy> copies;
-      for (auto& range : opaque_ranges) {
+      for (auto &range : opaque_ranges) {
         auto aspect_bits = aspect_flag_bits(range.maspectMask);
         for (auto aspect_bit : aspect_bits) {
           for (size_t i = 0; i < range.mlevelCount; ++i) {
@@ -696,18 +701,17 @@ void VulkanSpy::prepareGPUBuffers(CallObserver *observer, PackEncoder *group,
                            aspect_bit, true);
             for (size_t j = 0; j < range.mlayerCount; j++) {
               uint32_t layer = range.mbaseArrayLayer + j;
-              copies.push_back(VkBufferImageCopy{
-                  offset,  // bufferOffset,
-                  0,       // bufferRowLength,
-                  0,       // bufferImageHeight,
-                  {
-                      aspect_bit,  // aspectMask
-                      mip_level,
-                      layer,  // baseArrayLayer
-                      1       // layerCount
-                  },
-                  {0, 0, 0},
-                  {e.width, e.height, e.depth}});
+              copies.push_back(VkBufferImageCopy{offset,  // bufferOffset,
+                                                 0,       // bufferRowLength,
+                                                 0,       // bufferImageHeight,
+                                                 {
+                                                     aspect_bit,  // aspectMask
+                                                     mip_level,
+                                                     layer,  // baseArrayLayer
+                                                     1       // layerCount
+                                                 },
+                                                 {0, 0, 0},
+                                                 {e.width, e.height, e.depth}});
               offset += e.aligned_level_size;
             }
           }
@@ -804,8 +808,10 @@ void VulkanSpy::prepareGPUBuffers(CallObserver *observer, PackEncoder *group,
           VkPipelineStageFlagBits::VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, 0, 0,
           nullptr, 1, &buf_barrier, 1, &img_barrier);
 
-      commandBuffer.FinishAndSubmit(GetQueue(mState.Queues, img)->mVulkanHandle);
-      device_functions.vkQueueWaitIdle(GetQueue(mState.Queues, img)->mVulkanHandle);
+      commandBuffer.FinishAndSubmit(
+          GetQueue(mState.Queues, img)->mVulkanHandle);
+      device_functions.vkQueueWaitIdle(
+          GetQueue(mState.Queues, img)->mVulkanHandle);
 
       uint8_t *pData = reinterpret_cast<uint8_t *>(stage.GetMappedMemory());
       size_t new_offset = 0;
@@ -813,11 +819,13 @@ void VulkanSpy::prepareGPUBuffers(CallObserver *observer, PackEncoder *group,
         auto &copy = copies[i];
         size_t next_offset =
             (i == copies.size() - 1) ? offset : copies[i + 1].mbufferOffset;
-        const uint32_t aspect_bit = (uint32_t) copy.mimageSubresource.maspectMask;
-        byte_size_and_extent e =
-            level_size(copy.mimageExtent, image_info.mFormat, 0, aspect_bit, false);
-        auto bp = block_pitch(copy.mimageExtent, image_info.mFormat,
-                              copy.mimageSubresource.mmipLevel, aspect_bit, false);
+        const uint32_t aspect_bit =
+            (uint32_t)copy.mimageSubresource.maspectMask;
+        byte_size_and_extent e = level_size(
+            copy.mimageExtent, image_info.mFormat, 0, aspect_bit, false);
+        auto bp =
+            block_pitch(copy.mimageExtent, image_info.mFormat,
+                        copy.mimageSubresource.mmipLevel, aspect_bit, false);
 
         if ((copy.mimageOffset.mx % bp.texel_width != 0) ||
             (copy.mimageOffset.my % bp.texel_height != 0)) {
@@ -829,34 +837,39 @@ void VulkanSpy::prepareGPUBuffers(CallObserver *observer, PackEncoder *group,
         uint32_t z = copy.mimageOffset.mz * bp.depth_pitch;
 
         if ((image_info.mFormat == VkFormat::VK_FORMAT_X8_D24_UNORM_PACK32 ||
-          image_info.mFormat == VkFormat::VK_FORMAT_D24_UNORM_S8_UINT) &&
-          (aspect_bit == VkImageAspectFlagBits::VK_IMAGE_ASPECT_DEPTH_BIT)) {
+             image_info.mFormat == VkFormat::VK_FORMAT_D24_UNORM_S8_UINT) &&
+            (aspect_bit == VkImageAspectFlagBits::VK_IMAGE_ASPECT_DEPTH_BIT)) {
           // The width of the depth channel are different for img buf copy.
-          byte_size_and_extent copy_e =
-            level_size(copy.mimageExtent, image_info.mFormat, 0, aspect_bit, true);
+          byte_size_and_extent copy_e = level_size(
+              copy.mimageExtent, image_info.mFormat, 0, aspect_bit, true);
           size_t element_size_in_img = 3;
           size_t element_size_in_buf = 4;
           // It is always the MSB byte to be stripped.
-          uint8_t* buf = pData + new_offset; 
-          for (size_t i = 0; i < copy_e.aligned_level_size/element_size_in_buf; i++) {
+          uint8_t *buf = pData + new_offset;
+          for (size_t i = 0;
+               i < copy_e.aligned_level_size / element_size_in_buf; i++) {
             if (i < 3) {
-              memmove(&buf[i*element_size_in_img], &buf[i*element_size_in_buf], element_size_in_img);
+              memmove(&buf[i * element_size_in_img],
+                      &buf[i * element_size_in_buf], element_size_in_img);
             } else {
-              memcpy(&buf[i*element_size_in_img], &buf[i*element_size_in_buf], element_size_in_img);
+              memcpy(&buf[i * element_size_in_img],
+                     &buf[i * element_size_in_buf], element_size_in_img);
             }
           }
         }
 
         auto resIndex = sendResource(VulkanSpy::kApiIndex, pData + new_offset,
-                                       e.level_size);
+                                     e.level_size);
         memory::Observation observation;
         const uint32_t mip_level = copy.mimageSubresource.mmipLevel;
         const uint32_t array_layer = copy.mimageSubresource.mbaseArrayLayer;
         observation.set_base(x + y + z);
         observation.set_size(e.level_size);
         observation.set_resindex(resIndex);
-        observation.set_pool(
-            img->mAspects[aspect_bit]->mLayers[array_layer]->mLevels[mip_level]->mData.pool_id());
+        observation.set_pool(img->mAspects[aspect_bit]
+                                 ->mLayers[array_layer]
+                                 ->mLevels[mip_level]
+                                 ->mData.pool_id());
         group->object(&observation);
         new_offset = next_offset;
       }

--- a/gapis/api/vulkan/image_rebuild_helper.go
+++ b/gapis/api/vulkan/image_rebuild_helper.go
@@ -345,7 +345,7 @@ func (h *imageRebuildHelper) renderStagingImages(inputImgs []*ImageObject, outpu
 	if err != nil {
 		return fmt.Errorf("[Creating fragment shader module] %v", err)
 	}
-	e := h.sb.levelSize(outputImg.Info.Extent, outputImg.Info.Format, level, aspect)
+	e := h.sb.levelSize(outputImg.Info.Extent, outputImg.Info.Format, level, aspect, false)
 	viewport := VkViewport{
 		0.0, 0.0,
 		float32(e.width), float32(e.height),
@@ -708,7 +708,7 @@ func (h *imageRebuildHelper) createTempFrameBufferForPriming(renderpass *RenderP
 	if len(imgViews) < 2 {
 		return nil, fmt.Errorf("requires at least two image views, %d are given", len(imgViews))
 	}
-	e := h.sb.levelSize(imgViews[0].Image.Info.Extent, imgViews[0].Image.Info.Format, level, aspect)
+	e := h.sb.levelSize(imgViews[0].Image.Info.Extent, imgViews[0].Image.Info.Format, level, aspect, false)
 	attachments := []VkImageView{}
 	for _, v := range imgViews {
 		attachments = append(attachments, v.VulkanHandle)

--- a/gapis/api/vulkan/vulkan.api
+++ b/gapis/api/vulkan/vulkan.api
@@ -6999,6 +6999,7 @@ sub void dovkCmdCopyBufferToImage(ref!vkCmdCopyBufferToImageArgs args) {
     rowLengthAndImageHeight := getRowLengthAndImageHeight(region)
     rowLength := as!u64(rowLengthAndImageHeight.RowLength / elementAndTexelBlockSize.TexelBlockSize.Width)
     imageHeight := as!u64(rowLengthAndImageHeight.ImageHeight / elementAndTexelBlockSize.TexelBlockSize.Height)
+    // The VkImageSubresourceLayer used for buffer image copy should specify only one aspect bit.
     for _, _, aspectBit in unpackImageAspectFlags(region.imageSubresource.aspectMask).Bits {
       elementSize := switch (aspectBit) {
         case VK_IMAGE_ASPECT_COLOR_BIT:
@@ -7021,23 +7022,36 @@ sub void dovkCmdCopyBufferToImage(ref!vkCmdCopyBufferToImageArgs args) {
       // TODO: (qining) Handle aspect mask
       for j in (0 .. region.imageSubresource.layerCount) {
         layerIndex := region.imageSubresource.baseArrayLayer + j
-        bufferLayerOffset := as!u64(j) * layerSize
+        bufferLayerOffset := as!u64(j) * layerSize + as!u64(region.bufferOffset)
         imageLevel := imageObject.Aspects[aspectBit].Layers[layerIndex].Levels[region.imageSubresource.mipLevel]
         imageLevelWidthInBlocks := as!u64(imageLevel.Width / elementAndTexelBlockSize.TexelBlockSize.Width)
         imageLevelHeightInBlocks := as!u64(imageLevel.Height / elementAndTexelBlockSize.TexelBlockSize.Height)
         // Iterate through depths and rows to copy
         for z in (zStart .. zEnd) {
+          zInExtent := z - zStart
           for y in (yStart .. yEnd) {
-            copySize := (xEnd - xStart) * elementSize
-            dstStart := ((((z * imageLevelHeightInBlocks) + y) * imageLevelWidthInBlocks) + xStart) * elementSize
-            dstEnd := dstStart + copySize
-            zInExtent := z - zStart
             yInExtent := y - yStart
-            rowStartInExtent := (((zInExtent * imageHeight) + yInExtent) * rowLength) * elementSize
-            srcStart := as!u64(bufferObject.MemoryOffset) + as!u64(region.bufferOffset) + bufferLayerOffset + rowStartInExtent
-            srcEnd := srcStart + copySize
-            readCoherentMemoryInBuffer(bufferObject, region.bufferOffset + as!VkDeviceSize(bufferLayerOffset + rowStartInExtent), as!VkDeviceSize(copySize))
-            copy(imageLevel.Data[dstStart:dstEnd], bufferObject.Memory.Data[srcStart:srcEnd])
+            rowStartBlock := ((z * imageLevelHeightInBlocks) + y) * imageLevelWidthInBlocks
+            rowStartBlockInExtent := ((zInExtent * imageHeight) + yInExtent) * rowLength
+            if ((format == VK_FORMAT_D24_UNORM_S8_UINT) || (format == VK_FORMAT_X8_D24_UNORM_PACK32)) && (aspectBit == VK_IMAGE_ASPECT_DEPTH_BIT) {
+              elementSizeInImage := as!u64(getDepthElementSize(format, false))
+              for x in (xStart .. xEnd) {
+                dstStart := (rowStartBlock + x) * elementSizeInImage
+                rowStartInExtent := (rowStartBlockInExtent + x) * elementSize
+                srcStart := as!u64(bufferObject.MemoryOffset) + bufferLayerOffset + rowStartInExtent
+                readCoherentMemory(bufferObject.Memory, as!VkDeviceSize(srcStart), as!VkDeviceSize(elementSize))
+                copy(imageLevel.Data[dstStart:dstStart+elementSizeInImage], bufferObject.Memory.Data[srcStart:srcStart+elementSize])
+              }
+            } else {
+              copySize := (xEnd - xStart) * elementSize
+              dstStart := (rowStartBlock + xStart) * elementSize
+              dstEnd := dstStart + copySize
+              rowStartInExtent := rowStartBlockInExtent * elementSize
+              srcStart := as!u64(bufferObject.MemoryOffset) + bufferLayerOffset + rowStartInExtent
+              srcEnd := srcStart + copySize
+              readCoherentMemoryInBuffer(bufferObject, as!VkDeviceSize(bufferLayerOffset + rowStartInExtent), as!VkDeviceSize(copySize))
+              copy(imageLevel.Data[dstStart:dstEnd], bufferObject.Memory.Data[srcStart:srcEnd])
+            }
           }
         }
       }

--- a/gapis/api/vulkan/vulkan.api
+++ b/gapis/api/vulkan/vulkan.api
@@ -4068,19 +4068,25 @@ sub u32 roundUpTo(u32 dividend, u32 divisor) {
 }
 
 // This should correspond to the data layout specified at VkBufferImageCopy
-sub u32 getDepthElementSizeForCopy(VkFormat format) {
-  d16Size := getElementAndTexelBlockSize(VK_FORMAT_D16_UNORM).ElementSize
-  d32Size := getElementAndTexelBlockSize(VK_FORMAT_D32_SFLOAT).ElementSize
+sub u32 getDepthElementSize(VkFormat format, bool inBuffer) {
+  d16Size := as!u32(2)
+  d24Size := as!u32(3)
+  d32Size := as!u32(4)
   return switch (format) {
     case VK_FORMAT_D16_UNORM, VK_FORMAT_D16_UNORM_S8_UINT:
       d16Size
     case VK_FORMAT_D32_SFLOAT, VK_FORMAT_D32_SFLOAT_S8_UINT:
       d32Size
     case VK_FORMAT_X8_D24_UNORM_PACK32, VK_FORMAT_D24_UNORM_S8_UINT:
-      // For those two formats, data is packed with one 32-bit word per texel
+      // For VkBufferImageCopy, data is packed with one 32-bit word per texel
       // with the D24 value in the LSBs of the word, and undefined values in
       // the eight MSBs.
-      d32Size
+      switch (inBuffer) {
+        case true:
+          d32Size
+        case false:
+          d24Size
+      }
     default:
       as!u32(0)
   }
@@ -4194,7 +4200,7 @@ cmd VkResult vkCreateImage(
         depth := getMipSize(info.extent.Depth, i)
         level := new!ImageLevel(Width: width,Height:  height,Depth:  depth)
         elementAndTexelBlockSize := getElementAndTexelBlockSize(object.Info.Format)
-        depthElementSize := getDepthElementSizeForCopy(object.Info.Format)
+        depthElementSize := getDepthElementSize(object.Info.Format, false)
         // Roundup the width and height in the number of blocks.
         widthInBlocks := roundUpTo(width, elementAndTexelBlockSize.TexelBlockSize.Width)
         heightInBlocks := roundUpTo(height, elementAndTexelBlockSize.TexelBlockSize.Height)
@@ -6531,10 +6537,10 @@ sub void dovkCmdCopyImage(ref!vkCmdCopyImageArgs args) {
 
   srcFormat := srcImageObject.Info.Format
   srcElementAndTexelBlockSize := getElementAndTexelBlockSize(srcFormat)
-  srcDepthElementSize := getDepthElementSizeForCopy(srcFormat)
+  srcDepthElementSize := getDepthElementSize(srcFormat, false)
   dstFormat := dstImageObject.Info.Format
   dstElementAndTexelBlockSize := getElementAndTexelBlockSize(dstFormat)
-  dstDepthElementSize := getDepthElementSizeForCopy(dstFormat)
+  dstDepthElementSize := getDepthElementSize(dstFormat, false)
   for r in (0 .. len(args.Regions)) {
     // TODO: (qining) Handle the apsect mask
     region := args.Regions[as!u32(r)]
@@ -6986,7 +6992,7 @@ sub void dovkCmdCopyBufferToImage(ref!vkCmdCopyBufferToImageArgs args) {
   imageObject := Images[args.DstImage]
   format := imageObject.Info.Format
   elementAndTexelBlockSize := getElementAndTexelBlockSize(format)
-  depthElementSize := getDepthElementSizeForCopy(format)
+  depthElementSize := getDepthElementSize(format, true)
   // Iterate through regions
   for i in (0 .. len(args.Regions)) {
     region := args.Regions[as!u32(i)]


### PR DESCRIPTION
For D24 format with either X8 or S8 channel, the depth element size is
different for copying through buffer and storing in the image. We need
to manually strip the MSB byte when processing the data if the data is
retrieved through buffer image copy.
