### PR TITLE
gapis/api/gles: Fix panic when calling DataTypeSize(GL_INT)

### DIFF
--- a/gapis/api/gles/BUILD.bazel
+++ b/gapis/api/gles/BUILD.bazel
@@ -49,6 +49,7 @@ go_library(
         "compat_client.go",
         "context.go",
         "custom_replay.go",
+        "datatypes.go",
         "dependency_graph_behaviour_provider.go",
         "doc.go",
         "draw_call.go",
@@ -77,7 +78,6 @@ go_library(
         "tweaker.go",
         "undefined_framebuffer.go",
         "version.go",
-        "vertex_attribute_array.go",
         "wireframe.go",
     ],
     embed = [

--- a/gapis/api/gles/datatypes.go
+++ b/gapis/api/gles/datatypes.go
@@ -29,6 +29,7 @@ func DataTypeSize(t GLenum) int {
 		return 2
 	case GLenum_GL_FIXED,
 		GLenum_GL_FLOAT,
+		GLenum_GL_INT,
 		GLenum_GL_UNSIGNED_INT,
 		GLenum_GL_UNSIGNED_INT_2_10_10_10_REV:
 		return 4

--- a/gapis/api/gles/draw_call.go
+++ b/gapis/api/gles/draw_call.go
@@ -59,11 +59,7 @@ func getIndices(
 	first, count GLsizei,
 	ptr IndicesPointer) (drawCallIndices, error) {
 
-	indexSize := map[GLenum]uint64{
-		GLenum_GL_UNSIGNED_BYTE:  1,
-		GLenum_GL_UNSIGNED_SHORT: 2,
-		GLenum_GL_UNSIGNED_INT:   4,
-	}[ty]
+	indexSize := uint64(DataTypeSize(ty))
 	indexBuffer := c.Bound.VertexArray.ElementArrayBuffer
 	size := uint64(count) * indexSize
 	offset := uint64(first) * indexSize


### PR DESCRIPTION
Rename the file, and refactor another place we were calculating type size.