### PR TITLE
Vulkan: Prime depth image data

### DIFF
--- a/core/stream/fmts/BUILD.bazel
+++ b/core/stream/fmts/BUILD.bazel
@@ -33,6 +33,7 @@ go_library(
         "rgb.go",
         "rgba.go",
         "rgbe.go",
+        "s.go",
         "sd.go",
         "x.go",
         "xy.go",

--- a/core/stream/fmts/s.go
+++ b/core/stream/fmts/s.go
@@ -1,0 +1,27 @@
+// Copyright (C) 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fmts
+
+import "github.com/google/gapid/core/stream"
+
+var (
+	S_U8 = &stream.Format{
+		Components: []*stream.Component{{
+			DataType: &stream.U8,
+			Sampling: stream.Linear,
+			Channel:  stream.Channel_Stencil,
+		}},
+	}
+)

--- a/gapis/api/vulkan/resources.go
+++ b/gapis/api/vulkan/resources.go
@@ -444,6 +444,8 @@ func getImageFormatFromVulkanFormat(vkfmt VkFormat) (*image.Format, error) {
 		return image.NewUncompressed("VK_FORMAT_X8_D24_UNORM_PACK32", fmts.ЖD_U8U24_NORM), nil
 	case VkFormat_VK_FORMAT_D24_UNORM_S8_UINT:
 		return image.NewUncompressed("VK_FORMAT_D24_UNORM_S8_UINT", fmts.DS_NU24S8), nil
+	case VkFormat_VK_FORMAT_S8_UINT:
+		return image.NewUncompressed("VK_FORMAT_S8_UINT", fmts.S_U8), nil
 	default:
 		return nil, &unsupportedVulkanFormatError{Format: vkfmt}
 	}


### PR DESCRIPTION
If the depth image has TRANSFER_DST usage bit, copy into it through
buffer.

If the depth image can be rendered, render to it using an staginge
image.

This does not prime the stencil aspect data unless the image has
TRANSFER_DST bit.

TODO:
 - [x] Staging image allocation should respect the given aspect bit