### PR TITLE
gapii: Fixes for PCSs

### DIFF
--- a/gapii/cc/spy_disable_precompiled_shaders.cpp
+++ b/gapii/cc/spy_disable_precompiled_shaders.cpp
@@ -26,10 +26,21 @@
 
 namespace {
 
-const char* kOESGetProgramBinary  = "OES_get_program_binary";
-const char* kReplacementExtension = "__GAPID_PCS_DISABLED__"; // Must be the same length as kOESGetProgramBinary
-
 #define NELEM(x) (sizeof(x) / sizeof(x[0]))
+
+const char* kProgramBinaryExtensions[] = {
+    "OES_get_program_binary",
+    "ARB_get_program_binary",
+};
+
+const char* kProgramBinaryReplacements[] = {
+    // These *must* match the length of each string in kProgramBinaryExtensions
+    "__GAPID_PCS_DISABLED__",
+    "__GAPID_PCS_DISABLED__",
+};
+
+static_assert(NELEM(kProgramBinaryExtensions) == NELEM(kProgramBinaryReplacements),
+        "length of kProgramBinaryExtensions must match kProgramBinaryReplacements");
 
 // HACK: Workaround for devices that do not check the error status after calling
 // glProgramBinary() or glProgramBinaryOES(). As the error is not checked, this
@@ -40,21 +51,21 @@ const char* kReplacementExtension = "__GAPID_PCS_DISABLED__"; // Must be the sam
 const core::Id kProgramHashesForNoError[] = {
     // https://github.com/google/gapid/issues/1456
     // 0xe14cc04bd723f9c2c46eeef948b08a379f090235
-    {0xe1, 0x4c, 0xc0, 0x4b, 0xd7, 0x23, 0xf9, 0xc2, 0xc4, 0x6e,
-     0xee, 0xf9, 0x48, 0xb0, 0x8a, 0x37, 0x9f, 0x09, 0x02, 0x35},
+    {{0xe1, 0x4c, 0xc0, 0x4b, 0xd7, 0x23, 0xf9, 0xc2, 0xc4, 0x6e,
+      0xee, 0xf9, 0x48, 0xb0, 0x8a, 0x37, 0x9f, 0x09, 0x02, 0x35}},
 
     // 0xc231a3a4b597f45244a4745fecdcba918bb8eacc
-    {0xc2, 0x31, 0xa3, 0xa4, 0xb5, 0x97, 0xf4, 0x52, 0x44, 0xa4,
-     0x74, 0x5f, 0xec, 0xdc, 0xba, 0x91, 0x8b, 0xb8, 0xea, 0xcc},
+    {{0xc2, 0x31, 0xa3, 0xa4, 0xb5, 0x97, 0xf4, 0x52, 0x44, 0xa4,
+      0x74, 0x5f, 0xec, 0xdc, 0xba, 0x91, 0x8b, 0xb8, 0xea, 0xcc}},
 
     // 0x55626b9bc73964f52fd5bcf6710659df97997d83
-    {0x55, 0x62, 0x6b, 0x9b, 0xc7, 0x39, 0x64, 0xf5, 0x2f, 0xd5,
-     0xbc, 0xf6, 0x71, 0x06, 0x59, 0xdf, 0x97, 0x99, 0x7d, 0x83},
+    {{0x55, 0x62, 0x6b, 0x9b, 0xc7, 0x39, 0x64, 0xf5, 0x2f, 0xd5,
+      0xbc, 0xf6, 0x71, 0x06, 0x59, 0xdf, 0x97, 0x99, 0x7d, 0x83}},
 
     // https://github.com/google/gapid/issues/1525
     // 0xc6b9efad92959f4af5f6fb67a21d94b22f746838
-    {0xc6, 0xb9, 0xef, 0xad, 0x92, 0x95, 0x9f, 0x4a, 0xf5, 0xf6,
-     0xfb, 0x67, 0xa2, 0x1d, 0x94, 0xb2, 0x2f, 0x74, 0x68, 0x38},
+    {{0xc6, 0xb9, 0xef, 0xad, 0x92, 0x95, 0x9f, 0x4a, 0xf5, 0xf6,
+      0xfb, 0x67, 0xa2, 0x1d, 0x94, 0xb2, 0x2f, 0x74, 0x68, 0x38}},
 };
 
 bool shouldErrorForProgram(const core::Id& id) {
@@ -88,7 +99,7 @@ void Spy::glProgramBinary(CallObserver* observer, uint32_t program, uint32_t bin
             setFakeGlError(observer, GL_INVALID_ENUM);
         }
 
-        observer->encode(cmd::glProgramBinary{
+        observer->enter(cmd::glProgramBinary{
             observer->getCurrentThread(), program, binary_format, binary, binary_size
         });
 
@@ -96,6 +107,7 @@ void Spy::glProgramBinary(CallObserver* observer, uint32_t program, uint32_t bin
         observer->observePending();
 
         observer->encodeAndDelete(new api::CmdCall);
+        observer->exit();
     } else {
         GlesSpy::glProgramBinary(observer, program, binary_format, binary, binary_size);
     }
@@ -115,7 +127,7 @@ void Spy::glProgramBinaryOES(CallObserver* observer, uint32_t program, uint32_t 
             setFakeGlError(observer, GL_INVALID_ENUM);
         }
 
-        observer->encode(cmd::glProgramBinaryOES{
+        observer->enter(cmd::glProgramBinaryOES{
             observer->getCurrentThread(), program, binary_format, binary, binary_size
         });
 
@@ -123,6 +135,7 @@ void Spy::glProgramBinaryOES(CallObserver* observer, uint32_t program, uint32_t 
         observer->observePending();
 
         observer->encodeAndDelete(new api::CmdCall);
+        observer->exit();
     } else {
         GlesSpy::glProgramBinaryOES(observer, program, binary_format, binary, binary_size);
     }
@@ -139,7 +152,7 @@ void Spy::glShaderBinary(CallObserver* observer, int32_t count,
         // GL_INVALID_ENUM is generated if binaryFormat is not a value recognized by the implementation.
         setFakeGlError(observer, GL_INVALID_ENUM);
 
-        observer->encode(cmd::glShaderBinary{
+        observer->enter(cmd::glShaderBinary{
             observer->getCurrentThread(), count, shaders, binary_format, binary, binary_size
         });
 
@@ -148,6 +161,7 @@ void Spy::glShaderBinary(CallObserver* observer, int32_t count,
         observer->observePending();
 
         observer->encodeAndDelete(new api::CmdCall);
+        observer->exit();
     } else {
         GlesSpy::glShaderBinary(observer, count, shaders, binary_format, binary, binary_size);
     }
@@ -158,7 +172,7 @@ void Spy::glGetInteger64v(CallObserver* observer, uint32_t param, int64_t* value
         (param == GL_NUM_SHADER_BINARY_FORMATS || param == GL_NUM_PROGRAM_BINARY_FORMATS)) {
         values[0] = 0;
 
-        observer->encode(cmd::glGetInteger64v{
+        observer->enter(cmd::glGetInteger64v{
             observer->getCurrentThread(), param, values
         });
 
@@ -166,6 +180,7 @@ void Spy::glGetInteger64v(CallObserver* observer, uint32_t param, int64_t* value
 
         observer->write(slice(values, 0, 1));
         observer->observePending();
+        observer->exit();
     } else {
         GlesSpy::glGetInteger64v(observer, param, values);
     }
@@ -176,7 +191,7 @@ void Spy::glGetIntegerv(CallObserver* observer, uint32_t param, int32_t* values)
         (param == GL_NUM_SHADER_BINARY_FORMATS || param == GL_NUM_PROGRAM_BINARY_FORMATS)) {
         values[0] = 0;
 
-        observer->encode(cmd::glGetIntegerv{
+        observer->enter(cmd::glGetIntegerv{
             observer->getCurrentThread(), param, values
         });
 
@@ -184,6 +199,7 @@ void Spy::glGetIntegerv(CallObserver* observer, uint32_t param, int32_t* values)
 
         observer->write(slice(values, 0, 1));
         observer->observePending();
+        observer->exit();
     } else {
         GlesSpy::glGetIntegerv(observer, param, values);
     }
@@ -193,12 +209,15 @@ const GLubyte* Spy::glGetString(CallObserver* observer, uint32_t name) {
     if (mDisablePrecompiledShaders && name == GL_EXTENSIONS) {
         if (auto exts = reinterpret_cast<const char*>(GlesSpy::mImports.glGetString(name))) {
             std::string list = reinterpret_cast<const char*>(exts);
-            size_t start = list.find(kOESGetProgramBinary);
-            if (start != std::string::npos) {
-                static std::string copy = list;
-                copy.replace(start, strlen(kOESGetProgramBinary), kReplacementExtension);
-                // TODO: write command.
-                return reinterpret_cast<GLubyte*>(const_cast<char*>(copy.c_str()));
+            for (int i = 0; i < NELEM(kProgramBinaryExtensions); i++) {
+                size_t start = list.find(kProgramBinaryExtensions[i]);
+                if (start != std::string::npos) {
+                    static std::string copy = list;
+                    copy.replace(start, strlen(kProgramBinaryExtensions[i]),
+                            kProgramBinaryReplacements[i]);
+                    // TODO: write command.
+                    return reinterpret_cast<GLubyte*>(const_cast<char*>(copy.c_str()));
+                }
             }
         }
     }
@@ -208,10 +227,13 @@ const GLubyte* Spy::glGetString(CallObserver* observer, uint32_t name) {
 const GLubyte* Spy::glGetStringi(CallObserver* observer, uint32_t name, GLuint index) {
     if (mDisablePrecompiledShaders && (name == GL_EXTENSIONS)) {
         const char* extension = reinterpret_cast<const char*>(GlesSpy::mImports.glGetStringi(name, index));
-        if (strcmp(extension, kOESGetProgramBinary) == 0) {
-            // TODO: write command.
-            return reinterpret_cast<GLubyte*>(const_cast<char*>(kReplacementExtension));
-        }
+            for (int i = 0; i < NELEM(kProgramBinaryExtensions); i++) {
+                if (strcmp(extension, kProgramBinaryExtensions[i]) == 0) {
+                    // TODO: write command.
+                    return reinterpret_cast<GLubyte*>(const_cast<char*>(
+                            kProgramBinaryReplacements[i]));
+                }
+            }
     }
     return GlesSpy::glGetStringi(observer, name, index);
 }


### PR DESCRIPTION
* Fix bad encoding of commands when PCS are diabled. Commands should be a group.
* Also handle `ARB_get_program_binary`
* Fix compiler warnings about missing brackets around program hashes.