### PR TITLE
Get "bazel run gapid" working.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -25,6 +25,11 @@ gazelle(
 
 # Alias meant to be used with 'bazel run <alias> -- <arguments>'.
 alias(
+    name = "gapid",
+    actual = "//cmd/gapid",
+)
+
+alias(
     name = "gapis",
     actual = "//cmd/gapis",
 )

--- a/cmd/gapid/BUILD.bazel
+++ b/cmd/gapid/BUILD.bazel
@@ -61,6 +61,16 @@ go_library(
 # BUG: This isn't go_stripped_binary due to issue #1753.
 go_binary(
     name = "gapid",
+    data = [
+        "//cmd/gapis",
+        "//cmd/gapit",
+        "//gapic:gapic_deploy.jar",
+        "//gapis/messages:stb",
+    ],
+    args = [
+        "--jar",
+        "$(location //gapic:gapic_deploy.jar)"
+    ],
     embed = [":go_default_library"],
     gc_linkopts = select({
         "//tools/build:windows": [

--- a/cmd/gapid/main.go
+++ b/cmd/gapid/main.go
@@ -66,6 +66,7 @@ func run() int {
 		defer func() {
 			fmt.Println()
 			fmt.Println("Launcher Flags:")
+			fmt.Println(" --jar             Path to the gapic JAR to use")
 			fmt.Println(" --vm              Path to the JVM to use")
 			fmt.Println(" --vmarg           Extra argument for the JVM (repeatable)")
 			fmt.Println(" --console         Run GAPID inside a terminal console")
@@ -117,6 +118,9 @@ func newConfig() *config {
 	args := os.Args[1:]
 	for i := 0; i < len(args); i++ {
 		switch {
+		case args[i] == "--jar" && i < len(args)-1:
+			i++
+			c.gapic = args[i]
 		case args[i] == "--vm" && i < len(args)-1:
 			i++
 			c.vm = args[i]
@@ -240,23 +244,12 @@ func checkVM(java string, checkVersion bool) bool {
 }
 
 func (c *config) locateGAPIC() error {
-	gapic := filepath.Join(c.cwd, "lib", "gapic.jar")
+	gapic := c.gapic
+	if gapic == "" {
+		gapic = filepath.Join(c.cwd, "lib", "gapic.jar")
+	}
 	if _, err := os.Stat(gapic); !os.IsNotExist(err) {
 		c.gapic = gapic
-		return nil
-	}
-
-	jar := "gapic.jar"
-	switch runtime.GOOS {
-	case "linux", "windows":
-		jar = "gapic-" + runtime.GOOS + ".jar"
-	case "darwin":
-		jar = "gapic-osx.jar"
-	}
-
-	buildGapic := filepath.Join(c.cwd, "..", "java", jar)
-	if _, err := os.Stat(buildGapic); !os.IsNotExist(err) {
-		c.gapic = buildGapic
 		return nil
 	}
 

--- a/gapic/src/main/com/google/gapid/server/GapisProcess.java
+++ b/gapic/src/main/com/google/gapid/server/GapisProcess.java
@@ -138,6 +138,8 @@ public class GapisProcess extends ChildProcess<Integer> {
       args.add(gapisArgs.get());
     }
 
+    GapiPaths.get().addRunfilesFlag(args);
+
     pb.command(args);
     return null;
   }

--- a/gapic/src/main/com/google/gapid/server/GapisProcess.java
+++ b/gapic/src/main/com/google/gapid/server/GapisProcess.java
@@ -78,14 +78,9 @@ public class GapisProcess extends ChildProcess<Integer> {
   }
 
   @Override
-  protected Exception prepare(ProcessBuilder pb) {
-    if (!GapiPaths.isValid()) {
-      LOG.log(WARNING, "Could not find gapis, but needed to start the server.");
-      return new Exception("Could not find the gapis executable.");
-    }
-
+  protected Exception prepare(ProcessBuilder pb) throws GapiPaths.MissingToolsException {
     List<String> args = Lists.newArrayList();
-    args.add(GapiPaths.gapis().getAbsolutePath());
+    args.add(GapiPaths.get().gapis().getAbsolutePath());
 
     String gapirFlags = "";
 
@@ -119,8 +114,8 @@ public class GapisProcess extends ChildProcess<Integer> {
       args.add(gapirFlags);
     }
 
-    File strings = GapiPaths.strings();
-    if (strings.exists()) {
+    File strings = GapiPaths.get().strings();
+    if (strings != null && strings.exists()) {
       args.add("--strings");
       args.add(strings.getAbsolutePath());
     }

--- a/gapic/src/main/com/google/gapid/server/GapitPkgInfoProcess.java
+++ b/gapic/src/main/com/google/gapid/server/GapitPkgInfoProcess.java
@@ -55,6 +55,8 @@ public class GapitPkgInfoProcess extends ChildProcess<PkgInfo.PackageList> {
       args.add(settings.analyticsClientId);
     }
 
+    GapiPaths.get().addRunfilesFlag(args);
+
     args.add("packages");
 
     args.add("--format");

--- a/gapic/src/main/com/google/gapid/server/GapitPkgInfoProcess.java
+++ b/gapic/src/main/com/google/gapid/server/GapitPkgInfoProcess.java
@@ -15,8 +15,6 @@
  */
 package com.google.gapid.server;
 
-import static java.util.logging.Level.WARNING;
-
 import com.google.common.collect.Lists;
 import com.google.common.io.ByteStreams;
 import com.google.common.util.concurrent.SettableFuture;
@@ -24,7 +22,6 @@ import com.google.gapid.models.Settings;
 import com.google.gapid.proto.pkginfo.PkgInfo;
 
 import java.io.BufferedInputStream;
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Arrays;
@@ -49,15 +46,9 @@ public class GapitPkgInfoProcess extends ChildProcess<PkgInfo.PackageList> {
   }
 
   @Override
-  protected Exception prepare(ProcessBuilder pb) {
-    File gapit = GapiPaths.gapit();
-    if (gapit == null || !gapit.exists()) {
-      LOG.log(WARNING, "Could not find gapit for package info.");
-      return new Exception("Could not find the gapit executable.");
-    }
-
+  protected Exception prepare(ProcessBuilder pb) throws GapiPaths.MissingToolsException {
     List<String> args = Lists.newArrayList();
-    args.add(gapit.getAbsolutePath());
+    args.add(GapiPaths.get().gapit().getAbsolutePath());
 
     if (settings.analyticsEnabled()) {
       args.add("-analytics");

--- a/gapic/src/main/com/google/gapid/server/GapitTraceProcess.java
+++ b/gapic/src/main/com/google/gapid/server/GapitTraceProcess.java
@@ -23,7 +23,6 @@ import com.google.common.collect.Lists;
 import com.google.gapid.models.Settings;
 import com.google.gapid.server.Tracer.TraceRequest;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.List;
@@ -48,15 +47,9 @@ public class GapitTraceProcess extends ChildProcess<Boolean> {
   }
 
   @Override
-  protected Exception prepare(ProcessBuilder pb) {
-    File gapit = GapiPaths.gapit();
-    if (gapit == null || !gapit.exists()) {
-      LOG.log(WARNING, "Could not find gapit for tracing.");
-      return new Exception("Could not find the gapit executable.");
-    }
-
+  protected Exception prepare(ProcessBuilder pb) throws GapiPaths.MissingToolsException {
     List<String> args = Lists.newArrayList();
-    args.add(gapit.getAbsolutePath());
+    args.add(GapiPaths.get().gapit().getAbsolutePath());
 
     if (settings.analyticsEnabled()) {
       args.add("-analytics");

--- a/gapic/src/main/com/google/gapid/server/GapitTraceProcess.java
+++ b/gapic/src/main/com/google/gapid/server/GapitTraceProcess.java
@@ -59,6 +59,8 @@ public class GapitTraceProcess extends ChildProcess<Boolean> {
     args.add("-log-level");
     args.add(logLevel.get().gapisLevel);
 
+    GapiPaths.get().addRunfilesFlag(args);
+
     args.add("trace");
 
     String adb = GapiPaths.adb(settings);


### PR DESCRIPTION
 - Adds a new `--jar` flag that can be used to specify the gapic JAR file location, overriding the default `$PWD/lib/gapic.jar`.
 - Removes old cmake based gapic.jar finding logic.
 - Removes the side effects of the static `GapiPaths.findTools` function.
 - Adds runfiles support to the client.
 - `baze run gapid` now runs the client.