### PR TITLE
Minor bazel workspace changes

### DIFF
--- a/tools/build/workspace.bzl
+++ b/tools/build/workspace.bzl
@@ -49,15 +49,6 @@ def gapid_dependencies(android = True, java_client = True, mingw = True):
         build_file = "@gapid//tools/build/third_party:protobuf.BUILD",
     )
 
-    # rules_go has a second copy of the protobuf repo. Add it here, so we can override the BUILD file.
-    _maybe(github_repository,
-        name = "com_github_google_protobuf",
-        organization = "google",
-        project = "protobuf",
-        commit = "f08e4dd9845c5ba121b402f8768f3d2617191bbe",
-        build_file = "@gapid//tools/build/third_party:protobuf.BUILD",
-    )
-
     _maybe(github_repository,
         name = "com_github_grpc_grpc",
         organization = "grpc",

--- a/tools/build/workspace.bzl
+++ b/tools/build/workspace.bzl
@@ -22,12 +22,18 @@ load("@gapid//tools/build/third_party:breakpad.bzl", "breakpad")
 
 # Defines the repositories for GAPID's dependencies, excluding the
 # go dependencies, which require @io_bazel_rules_go to be setup.
-def gapid_dependencies(android = True, java_client = True, mingw = True):
+#  android - if false, the Android NDK/SDK are not initialized.
+#  java_client - if false, the Java deps used by the client are not initialized.
+#  mingw - if false, our cc toolchain, which uses MinGW on Windows is not initialized.
+#  locals - can be used to provide local path overrides for repos:
+#     {"foo": "/path/to/foo"} would cause @foo to be a local repo based on /path/to/foo.
+def gapid_dependencies(android = True, java_client = True, mingw = True, locals = {}):
     #####################################################
     # Get repositories with workspace rules we need first
 
     _maybe(github_repository,
         name = "io_bazel_rules_go",
+        locals = locals,
         organization = "bazelbuild",
         project = "rules_go",
         commit = "2d3336269eab48bac7adcaff03e7232e14463619",
@@ -35,6 +41,7 @@ def gapid_dependencies(android = True, java_client = True, mingw = True):
 
     _maybe(github_repository,
         name = "bazel_gazelle",
+        locals = locals,
         organization = "bazelbuild",
         project = "bazel-gazelle",
         commit = "f4ae892927eeabd060c59693c38e82303f41558d",
@@ -42,6 +49,7 @@ def gapid_dependencies(android = True, java_client = True, mingw = True):
 
     _maybe(github_repository,
         name = "com_google_protobuf",
+        locals = locals,
         organization = "google",
         project = "protobuf",
         commit = "f08e4dd9845c5ba121b402f8768f3d2617191bbe",
@@ -51,6 +59,7 @@ def gapid_dependencies(android = True, java_client = True, mingw = True):
 
     _maybe(github_repository,
         name = "com_github_grpc_grpc",
+        locals = locals,
         organization = "grpc",
         project = "grpc",
         commit = "fa301e3674a1cc786eb4dd4253a0e677f2eb68e3",
@@ -61,6 +70,7 @@ def gapid_dependencies(android = True, java_client = True, mingw = True):
 
     _maybe(github_repository,
         name = "com_google_googletest",
+        locals = locals,
         organization = "google",
         project = "googletest",
         commit = "62dbaa2947f7d058ea7e16703faea69b1134b024",
@@ -68,6 +78,7 @@ def gapid_dependencies(android = True, java_client = True, mingw = True):
 
     _maybe(github_repository,
         name = "astc-encoder",
+        locals = locals,
         organization = "ARM-software",
         project = "astc-encoder",
         commit = "b6bf6e7a523ddafdb8cfdc84b068d8fe70ffb45e",
@@ -76,11 +87,13 @@ def gapid_dependencies(android = True, java_client = True, mingw = True):
 
     _maybe(breakpad,
         name = "breakpad",
+        locals = locals,
         commit = "a61afe7a3e865f1da7ff7185184fe23977c2adca",
     )
 
     _maybe(github_repository,
         name = "cityhash",
+        locals = locals,
         organization = "google",
         project = "cityhash",
         commit = "8af9b8c2b889d80c22d6bc26ba0df1afb79a30db",
@@ -89,6 +102,7 @@ def gapid_dependencies(android = True, java_client = True, mingw = True):
 
     _maybe(github_repository,
         name = "glslang",
+        locals = locals,
         organization = "KhronosGroup",
         project = "glslang",
         commit = "56e8056582c92e0226d87418171d06f4e74ff29b",
@@ -97,6 +111,7 @@ def gapid_dependencies(android = True, java_client = True, mingw = True):
 
     _maybe(github_repository,
         name = "llvm",
+        locals = locals,
         organization = "ben-clayton",
         project = "llvm",
         commit = "4c7186401413dad4dc7d6923b69b05554e762cff",
@@ -105,6 +120,7 @@ def gapid_dependencies(android = True, java_client = True, mingw = True):
 
     _maybe(native.new_git_repository,
         name = "lss",
+        locals = locals,
         remote = "https://chromium.googlesource.com/linux-syscall-support",
         commit = "e6527b0cd469e3ff5764785dadcb39bf7d787154",
         build_file = "@gapid//tools/build/third_party:lss.BUILD",
@@ -112,6 +128,7 @@ def gapid_dependencies(android = True, java_client = True, mingw = True):
 
     _maybe(github_repository,
         name = "spirv-headers",
+        locals = locals,
         organization = "KhronosGroup",
         project = "SPIRV-Headers",
         commit = "9f6846f973a1ef53790e75b9190820ab1557434f",
@@ -120,6 +137,7 @@ def gapid_dependencies(android = True, java_client = True, mingw = True):
 
     _maybe(github_repository,
         name = "spirv-cross",
+        locals = locals,
         organization = "KhronosGroup",
         project = "SPIRV-Cross",
         commit = "29315f3b3fd6dcafab0075e1a3d898c3ff995fed",
@@ -128,6 +146,7 @@ def gapid_dependencies(android = True, java_client = True, mingw = True):
 
     _maybe(github_repository,
         name = "spirv-tools",
+        locals = locals,
         organization = "KhronosGroup",
         project = "SPIRV-Tools",
         commit = "8d8a71278bf9e83dd0fb30d5474386d30870b74d",
@@ -137,6 +156,7 @@ def gapid_dependencies(android = True, java_client = True, mingw = True):
     if java_client:
         _maybe(github_repository,
             name = "com_github_grpc_java",
+            locals = locals,
             organization = "grpc",
             project = "grpc-java",
             commit = "009c51f2f793aabf516db90a14a52da2b613aa21",
@@ -146,21 +166,41 @@ def gapid_dependencies(android = True, java_client = True, mingw = True):
     if android:
         _maybe(native.android_sdk_repository,
             name = "androidsdk",
+            locals = locals,
             api_level = 21,
         )
 
         _maybe(native.android_ndk_repository,
             name = "androidndk",
+            locals = locals,
             api_level = 21,
         )
 
         _maybe(android_native_app_glue,
             name = "android_native_app_glue",
+            locals = locals,
         )
 
     if mingw:
         cc_configure()
 
-def _maybe(repo_rule, name, **kwargs):
-    if name not in native.existing_rules():
+def _maybe(repo_rule, name, locals, **kwargs):
+    if name in native.existing_rules():
+        return
+
+    if name not in locals:
         repo_rule(name = name, **kwargs)
+        return
+
+    build_file = kwargs.get("build_file")
+    if build_file == None:
+        native.local_repository(
+            name = name,
+            path = locals.get(name)
+        )
+    else:
+        native.new_local_repository(
+            name = name,
+            path = locals.get(name),
+            build_file = build_file
+        )


### PR DESCRIPTION
- remove `com_github_google_protobuf` again. First removed in f37a0edb, accidentally re-added in 6b16e36f.
- allow dependencies to be local, but still use our build files.