### PR TITLE
More robot fixes to get buildbot uploads working

### DIFF
--- a/cmd/robot/upload.go
+++ b/cmd/robot/upload.go
@@ -42,9 +42,9 @@ func (p path) upload(ctx context.Context, client *stash.Client) (string, error) 
 }
 
 func paths(paths []string) []uploadable {
-	r := make([]uploadable, len(paths), 0)
-	for _, p := range paths {
-		r = append(r, path(p))
+	r := make([]uploadable, len(paths))
+	for i, p := range paths {
+		r[i] = path(p)
 	}
 	return r
 }

--- a/core/git/log.go
+++ b/core/git/log.go
@@ -53,9 +53,12 @@ func (g Git) Parent(ctx context.Context, cl ChangeList) (ChangeList, error) {
 	return cls[0], nil
 }
 
-// HeadCL returns the ChangeList at HEAD.
-func (g Git) HeadCL(ctx context.Context) (ChangeList, error) {
-	cls, err := g.Log(ctx, 1)
+// HeadCL returns the HEAD ChangeList at the given commit/tag/branch.
+func (g Git) HeadCL(ctx context.Context, at string) (ChangeList, error) {
+	if at == "" {
+		at = "HEAD"
+	}
+	cls, err := g.LogFrom(ctx, at, 1)
 	if err != nil {
 		return ChangeList{}, err
 	}

--- a/test/robot/build/build.proto
+++ b/test/robot/build/build.proto
@@ -25,14 +25,11 @@ enum Type {
   // UnknownType is the default (invalid) type.
   UnknownType = 0;
   // BuildBot is the type for builds from the official build bots.
-  // For these kinds of builds, the tag must be set and can be used for merging.
+  // For these types of builds, the cl must be set and will be used for merging.
   BuildBot = 1;
   // User is the type for a user built build but without local modifications.
-  // For these types of builds, the cl must be set and can be used for merging.
   User = 2;
   // Local is the type for local modified source builds.
-  // For these kinds of builds, the tag may be set, and if it is, it will be used
-  // for merging.
   Local = 3;
 }
 

--- a/test/robot/build/package.go
+++ b/test/robot/build/package.go
@@ -137,14 +137,10 @@ func (p *packages) findArtifactPackage(ctx context.Context, a *Artifact, info *I
 			}
 		}
 	}
-	// if we don't have a tag, local builds never merge
-	if info.Type == Local {
-		return nil
-	}
-	if info.Cl != "" {
-		// non local builds with a matching cl can be merged
+	// Only BuildBot packages can be merged based on CL.
+	if info.Type == BuildBot && info.Cl != "" {
 		for _, pkg := range p.entries {
-			if pkg.Information.Cl == info.Cl {
+			if pkg.Information.Type == BuildBot && pkg.Information.Cl == info.Cl {
 				return pkg
 			}
 		}

--- a/tools/build/rules/lingo.bzl
+++ b/tools/build/rules/lingo.bzl
@@ -41,4 +41,5 @@ lingo = rule(
             default = Label("//cmd/lingo:lingo"),
         ),
     },
+    output_to_genfiles = True,
 )


### PR DESCRIPTION
- allow querying on enums by representing their names as strings (e.g. `struct.EnumField == "EnumName"`)
- don't require unique tags for every build bot package
- only merge build bot packages based on CL (and fix the test to check for type of both the merger and the mergee)
- allow a `robot upload build` to specify that it is a build bot build and clean up how things are inferred from the local git. 