### PR TITLE
Vulkan on Android: Keep VkGraphicsSpy layer around after VkCreateInstance

### DIFF
--- a/gapii/cc/vulkan_extras.inc
+++ b/gapii/cc/vulkan_extras.inc
@@ -102,10 +102,6 @@ static uint32_t EnumeratePhysicalDevicesAndCacheProperties(
 
 bool m_coherent_memory_tracking_enabled = false;
 
-#if TARGET_OS == GAPID_OS_ANDROID
-bool m_should_unset_debug_vulkan_layers = true;
-#endif // TARGET_OS == GAPID_OS_ANDROID
-
 void SpyOverride_cacheImageSparseMemoryRequirements(
     VkDevice device, VkImage image, uint32_t count,
     VkSparseImageMemoryRequirements* pSparseMemoryRequirements);

--- a/gapis/api/vulkan/templates/vk_spy_helpers.cpp.tmpl
+++ b/gapis/api/vulkan/templates/vk_spy_helpers.cpp.tmpl
@@ -32,10 +32,6 @@
 #include "gapii/cc/vulkan_imports.h"
 #include "gapii/cc/vulkan_spy.h"
 ¶
-#if TARGET_OS == GAPID_OS_ANDROID
-#include "gapii/cc/connection_stream.h"
-#endif
-¶
 #include "core/os/device/deviceinfo/cc/query.h"
 ¶
 extern "C" {«
@@ -314,21 +310,6 @@ uint32_t VulkanSpy::SpyOverride_vkCreateInstance(
             {{end}}
         {{end}}
     }
-    // On Android once the loader finishes loadinging layers, unset the system
-    // property: debug.vulkan.layers, to minimize the potential possibility to
-    // affect other processes.
-#if TARGET_OS == GAPID_OS_ANDROID
-    if (m_should_unset_debug_vulkan_layers) {
-        const char* unset_pipe = "unset-debug-vulkan-layers";
-        GAPID_INFO("Waiting for connection from host on %s", unset_pipe);
-        auto connForUnset = ConnectionStream::listenPipe(unset_pipe, true);
-        const char* msg = "Drop VkGraphicsSpy";
-        GAPID_INFO("Sending message: \"%s\" to host", msg);
-        connForUnset->write(msg, sizeof(msg));
-        connForUnset->close();
-        m_should_unset_debug_vulkan_layers = false;
-    }
-#endif // TARGET_OS == GAPID_OS_ANDROID
     return result;
 }
 


### PR DESCRIPTION
Fix #1793 