### PR TITLE
Vulkan: Fix trace crash with Vulkan loaders

### DIFF
--- a/core/vulkan/vk_virtual_swapchain/cc/layer.h
+++ b/core/vulkan/vk_virtual_swapchain/cc/layer.h
@@ -28,10 +28,10 @@ namespace swapchain {
 // Sets the key of the dispatch tables used in lower layers of the parent
 // dispatchable handle to the new child dispatchable handle. This is necessary
 // as lower layers may use that key to find the dispatch table, and a child
-// handles should share the same dispatch table key. E.g. VkCommandBuffer is a
+// handle should share the same dispatch table key. E.g. VkCommandBuffer is a
 // child dispatchable handle of VkDevice, all the VkCommandBuffer dispatching
 // functions are actually device functions (resolved by VkGetDeviceProcAddress).
-// ref: https://github.com/KhronosGroup/Vulkan-LoaderAndValidationLayers/blob/master/loader/LoaderAndLayerInterface.md#creating-new-dispatchable-objects,
+// Ref: https://github.com/KhronosGroup/Vulkan-LoaderAndValidationLayers/blob/master/loader/LoaderAndLayerInterface.md#creating-new-dispatchable-objects,
 static inline void set_dispatch_from_parent(void* child, void* parent) {
   *((const void**)child) = *((const void**)parent);
 }

--- a/gapii/cc/vulkan_mid_execution.cpp
+++ b/gapii/cc/vulkan_mid_execution.cpp
@@ -229,6 +229,12 @@ class StagingCommandBuffer {
 
     device_functions_.vkAllocateCommandBuffers(device, &allocate_info,
                                                &command_buffer_);
+    // Set the key of the dispatch tables used in lower layers of the parent
+    // dispatchable handle to the new child dispatchable handle. This is
+    // necessary as lower layers may use that key to find the dispatch table,
+    // and a child handle should share the same dispatch table key.
+    // Ref: https://github.com/KhronosGroup/Vulkan-LoaderAndValidationLayers/blob/master/loader/LoaderAndLayerInterface.md#creating-new-dispatchable-objects
+    *((const void**)command_buffer_) = *((const void**)device_);
 
     VkCommandBufferBeginInfo begin_info = {
         VkStructureType::VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO,  // sType


### PR DESCRIPTION
So that tracing with VulkanSDK loader won't crash.