### PR TITLE
Add Size field to Slices.

### DIFF
--- a/gapii/cc/spy_base.cpp
+++ b/gapii/cc/spy_base.cpp
@@ -23,7 +23,7 @@
 
 // CurrentCaptureVersion is incremented on breaking changes to the capture format.
 // NB: Also update equally named field in capture.go
-static const int CurrentCaptureVersion = 2;
+static const int CurrentCaptureVersion = 3;
 
 using core::Interval;
 

--- a/gapii/cc/vulkan_mid_execution.cpp
+++ b/gapii/cc/vulkan_mid_execution.cpp
@@ -344,7 +344,7 @@ void VulkanSpy::prepareGPUBuffers(CallObserver *observer, PackEncoder *group,
   for (auto &mem : mState.DeviceMemories) {
     auto &memory = mem.second;
     memory->mData = gapil::Slice<uint8_t>::create(
-        create_virtual_pool(memory->mAllocationSize));
+        create_virtual_pool(memory->mAllocationSize), false);
     gpu_pools->insert(memory->mData.pool_id());
     if (memory->mMappedLocation != nullptr) {
       if (subIsMemoryCoherent(nullptr, nullptr, memory)) {
@@ -587,7 +587,7 @@ void VulkanSpy::prepareGPUBuffers(CallObserver *observer, PackEncoder *group,
               level_size(image_info.mExtent, image_info.mFormat, lev.first,
                          a.first);
           level->mData = gapil::Slice<uint8_t>::create(
-              create_virtual_pool(e.level_size));
+              create_virtual_pool(e.level_size), false);
           gpu_pools->insert(level->mData.pool_id());
         }
       }

--- a/gapil/compiler/builtins.go
+++ b/gapil/compiler/builtins.go
@@ -52,10 +52,11 @@ const (
 
 // Field names for the slice_t runtime type.
 const (
-	SlicePool = "pool"
-	SliceRoot = "root"
-	SliceBase = "base"
-	SliceSize = "size"
+	SlicePool  = "pool"
+	SliceRoot  = "root"
+	SliceBase  = "base"
+	SliceSize  = "size"
+	SliceCount = "count"
 )
 
 // Field names for the pool_t runtime type.

--- a/gapil/compiler/cast.go
+++ b/gapil/compiler/cast.go
@@ -50,7 +50,7 @@ func (c *C) doCast(s *S, dstTy, srcTy semantic.Type, v *codegen.Value) *codegen.
 		pool := v.Extract(SlicePool)
 		count := s.Div(size, s.SizeOf(c.T.Storage(srcSliceTy.To)))
 		size = s.Mul(count, s.SizeOf(c.T.Storage(dstSliceTy.To)))
-		return c.buildSlice(s, root, base, size, pool)
+		return c.buildSlice(s, root, base, size, count, pool)
 	default:
 		return v.Cast(c.T.Target(dstTy)) // TODO: storage vs memory.
 	}

--- a/gapil/compiler/plugins/encoder/entities.go
+++ b/gapil/compiler/plugins/encoder/entities.go
@@ -229,10 +229,11 @@ func (e *entities) declSlices(c *compiler.C) {
 		desc: &descriptor.DescriptorProto{
 			Name: proto.String("Slice"),
 			Field: []*descriptor.FieldDescriptorProto{
-				u64.protoDescField("Root", 1),
-				u64.protoDescField("Base", 2),
-				u64.protoDescField("Count", 3),
-				u32.protoDescField("Pool", 4),
+				u64.protoDescField("root", 1),
+				u64.protoDescField("base", 2),
+				u64.protoDescField("size", 3),
+				u64.protoDescField("count", 4),
+				u32.protoDescField("pool", 5),
 			},
 		},
 		protoTy: descriptor.FieldDescriptorProto_TYPE_MESSAGE,

--- a/gapil/compiler/plugins/encoder/test/cgo.go
+++ b/gapil/compiler/plugins/encoder/test/cgo.go
@@ -314,19 +314,20 @@ func encodeRefTypes(refs *pb.RefTypes, isGroup bool) callbacks {
 	})
 }
 
-func convSlice(in *memory_pb.Slice, out *C.slice, elSize uintptr) {
-	out.pool = nil
+func convSlice(in *memory_pb.Slice, out *C.slice) {
 	out.root = (unsafe.Pointer)(uintptr(in.Root))
 	out.base = (unsafe.Pointer)(uintptr(in.Base))
-	out.size = (C.uint64_t)(in.Count * uint64(elSize))
+	out.size = (C.uint64_t)(in.Size)
+	out.count = (C.uint64_t)(in.Count)
+	out.pool = nil
 }
 
 func encodeSliceTypes(slices *pb.SliceTypes, isGroup bool) callbacks {
 	s := C.slice_types{}
 
-	convSlice(slices.A, &s.a, 1 /* uint8_t */)
-	convSlice(slices.B, &s.b, 4 /* float */)
-	convSlice(slices.C, &s.c, C.INT_TYPES_SIZE /* int_types */)
+	convSlice(slices.A, &s.a)
+	convSlice(slices.B, &s.b)
+	convSlice(slices.C, &s.c)
 
 	return withEncoder(func(ctx *C.context) {
 		C.slice_types__encode(&s, ctx, toUint8(isGroup))

--- a/gapil/compiler/plugins/encoder/test/encoder_test.go
+++ b/gapil/compiler/plugins/encoder/test/encoder_test.go
@@ -274,18 +274,21 @@ func TestSliceTypes(t *testing.T) {
 		A: &memory_pb.Slice{
 			Root:  0x1000,
 			Base:  0x2000,
+			Size:  0x10,
 			Count: 0x10,
 			Pool:  0,
 		},
 		B: &memory_pb.Slice{
 			Root:  0x2000,
 			Base:  0x3000,
+			Size:  0x80,
 			Count: 0x20,
 			Pool:  0,
 		},
 		C: &memory_pb.Slice{
 			Root:  0x3000,
 			Base:  0x4000,
+			Size:  0xc0,
 			Count: 0x30,
 			Pool:  0,
 		},
@@ -293,9 +296,9 @@ func TestSliceTypes(t *testing.T) {
 	checkCallbacks(ctx, "slice_types", encodeSliceTypes(&class, false), callbacks{
 		expectedType(&pb.SliceTypes{}),
 		expectedType(&memory_pb.Slice{}),
-		cbSliceEncoded{Size: 0x10},
-		cbSliceEncoded{Size: 0x20 * 4},
-		cbSliceEncoded{Size: 0x30 * 16},
+		cbSliceEncoded{int(class.A.Size)},
+		cbSliceEncoded{int(class.B.Size)},
+		cbSliceEncoded{int(class.C.Size)},
 		cbEncodeObject{Type: 1, IsGroup: false, Data: encodeProto(&class)},
 	})
 }

--- a/gapil/compiler/type.go
+++ b/gapil/compiler/type.go
@@ -518,11 +518,11 @@ func (c *C) initialValue(s *S, t semantic.Type) *codegen.Value {
 	}
 }
 
-func (c *C) buildSlice(s *S, root, base, size, pool *codegen.Value) *codegen.Value {
-	slice := s.Undef(c.T.Sli)
-	slice = slice.Insert(SliceRoot, root)
-	slice = slice.Insert(SliceBase, base)
-	slice = slice.Insert(SliceSize, size)
-	slice = slice.Insert(SlicePool, pool)
-	return slice
+func (c *C) buildSlice(s *S, root, base, size, count, pool *codegen.Value) *codegen.Value {
+	return s.Undef(c.T.Sli).
+		Insert(SliceRoot, root).
+		Insert(SliceBase, base).
+		Insert(SliceSize, size).
+		Insert(SliceCount, count).
+		Insert(SlicePool, pool)
 }

--- a/gapil/runtime/cc/runtime.h
+++ b/gapil/runtime/cc/runtime.h
@@ -59,10 +59,11 @@ typedef struct pool_t {
 
 // slice is the data of a gapil slice type (elty foo[]).
 typedef struct slice_t {
-	pool*    pool; // the underlying pool. nullptr represents the application pool.
-	void*    root; // original pointer this slice derives from.
-	void*    base; // address of first element.
-	uint64_t size; // size in bytes of the slice.
+	pool*    pool;  // the underlying pool. nullptr represents the application pool.
+	void*    root;  // original pointer this slice derives from.
+	void*    base;  // address of first element.
+	uint64_t size;  // size in bytes of the slice.
+	uint64_t count; // total number of elements in the slice.
 } slice;
 
 // string is the shared data of a gapil string type.
@@ -143,15 +144,12 @@ DECL_GAPIL_CB(void, gapil_free, arena*, void* ptr);
 // allocates a new slice and underlying pool with the given size.
 DECL_GAPIL_CB(pool*, gapil_make_pool, context* ctx, uint64_t size);
 
-// allocates a new slice and underlying pool with the given size.
-DECL_GAPIL_CB(void, gapil_make_slice, context* ctx, uint64_t size, slice* out);
-
 // allocates a new slice and underlying pool filled with data from the given
 // base pointer, offset and size.
-DECL_GAPIL_CB(void, gapil_pointer_to_slice, context* ctx, uintptr_t ptr, uint64_t offset, uint64_t size, slice* out);
+DECL_GAPIL_CB(void, gapil_pointer_to_slice, context* ctx, uintptr_t ptr, uint64_t offset, uint64_t size, uint64_t count, slice* out);
 
-// frees a pool previously allocated with gapil_make_pool, gapil_make_slice,
-// gapil_string_to_slice or gapil_pointer_to_slice.
+// frees a pool previously allocated with gapil_make_pool, gapil_string_to_slice
+// or gapil_pointer_to_slice.
 DECL_GAPIL_CB(void, gapil_free_pool, pool*);
 
 // copies N bytes of data from src to dst, where N is min(dst.size, src.size).

--- a/gapil/runtime/cc/slice.h
+++ b/gapil/runtime/cc/slice.h
@@ -41,8 +41,12 @@ public:
     // Constructs a new slice and pool sized to the given number of elements.
     inline Slice(T* base, uint64_t count);
 
+    // Constructs a new slice given the full explicit parameters.
+    inline Slice(pool_t* pool, void* root, void* base, uint64_t size, uint64_t count, bool add_ref = true);
+
     // Creates and returns a new slice wrapping the given pool.
-    inline static Slice create(pool_t* pool);
+    // If add_ref is true then the pool's reference count will be incremented.
+    inline static Slice create(pool_t* pool, bool add_ref);
 
     // Creates and returns a new slice and pool sized to the given number of
     // elements.
@@ -96,6 +100,8 @@ public:
     inline T* end() const;
 
 private:
+    void init(pool_t* pool, void* root, void* base, uint64_t size, uint64_t count, bool add_ref = true);
+
     void reference() const;
     void release();
 

--- a/gapil/runtime/cc/slice.inc
+++ b/gapil/runtime/cc/slice.inc
@@ -22,41 +22,55 @@
 namespace gapil {
 
 template <typename T>
-Slice<T>::Slice() {
-    data.pool = nullptr;
-    data.root = 0;
-    data.base = 0;
-    data.size = 0;
-}
+void Slice<T>::init(pool_t* pool, void* root, void* base, uint64_t size, uint64_t count, bool add_ref /* = true */) {
+    data.pool = pool;
+    data.root = root;
+    data.base = base;
+    data.size = size;
+    data.count = count;
 
-template <typename T>
-Slice<T>::Slice(const Slice<T>& other) {
-    data.pool = other.data.pool;
-    data.root = other.data.root;
-    data.base = other.data.base;
-    data.size = other.data.size;
-
-    if (data.pool != nullptr) {
+    if (add_ref && pool != nullptr) {
         reference();
     }
 }
 
 template <typename T>
+Slice<T>::Slice() {
+    init(nullptr, 0, 0, 0, 0);
+}
+
+template <typename T>
+Slice<T>::Slice(const Slice<T>& other) {
+    init(other.data.pool,
+         other.data.root,
+         other.data.base,
+         other.data.size,
+         other.data.count);
+}
+
+template <typename T>
 Slice<T>::Slice(Slice<T>&& other) {
-    data.pool = other.data.pool;
-    data.root = other.data.root;
-    data.base = other.data.base;
-    data.size = other.data.size;
+    init(other.data.pool,
+         other.data.root,
+         other.data.base,
+         other.data.size,
+         other.data.count);
 
     other.data.pool = nullptr;
 }
 
 template <typename T>
 Slice<T>::Slice(T* base, uint64_t count) {
-    data.pool = nullptr;
-    data.root = base;
-    data.base = base;
-    data.size = count * sizeof(T);
+    init(/* pool */  nullptr,
+         /* root */  base,
+         /* base */  base,
+         /* size */  count * sizeof(T),
+         /* count */ count);
+}
+
+template <typename T>
+Slice<T>::Slice(pool_t* pool, void* root, void* base, uint64_t size, uint64_t count, bool add_ref /* = true */) {
+    init(pool, root, base, size, count, add_ref);
 }
 
 template <typename T>
@@ -67,20 +81,25 @@ Slice<T>::~Slice() {
 }
 
 template <typename T>
-Slice<T> Slice<T>::create(pool_t* pool) {
-    Slice<T> out;
-    out.data.pool = pool;
-    out.data.root = pool->buffer;
-    out.data.base = pool->buffer;
-    out.data.size = pool->size;
-    return out;
+Slice<T> Slice<T>::create(pool_t* pool, bool add_ref) {
+    return Slice<T>(/* pool */ pool,
+                    /* root */ pool->buffer,
+                    /* base */ pool->buffer,
+                    /* size */ pool->size,
+                    /* count */ pool->size / sizeof(T),
+                    /* add_ref */ add_ref);
 }
 
 template <typename T>
 Slice<T> Slice<T>::create(context_t* ctx, uint64_t count) {
-    Slice<T> out;
-    gapil_make_slice(ctx, count * sizeof(T), &out.data);
-    return out;
+    auto size = count * sizeof(T);
+    auto pool = gapil_make_pool(ctx, size);
+    return Slice<T>(/* pool */ pool,
+                    /* root */ pool->buffer,
+                    /* base */ pool->buffer,
+                    /* size */ pool->size,
+                    /* count */ count,
+                    /* add_ref */ false);
 }
 
 template <typename T>
@@ -88,13 +107,11 @@ Slice<T>& Slice<T>::operator = (const Slice<T>& other) {
     if (data.pool != nullptr) {
         release();
     }
-    data.pool = other.data.pool;
-    data.root = other.data.root;
-    data.base = other.data.base;
-    data.size = other.data.size;
-    if (data.pool != nullptr) {
-        reference();
-    }
+    init(other.data.pool,
+         other.data.root,
+         other.data.base,
+         other.data.size,
+         other.data.count);
     return *this;
 }
 
@@ -103,12 +120,13 @@ bool Slice<T>::operator == (const Slice<T>& other) const {
     return data.pool == other.data.pool &&
            data.root == other.data.root &&
            data.base == other.data.base &&
-           data.size == other.data.size;
+           data.size == other.data.size &&
+           data.count == other.data.count;
 }
 
 template <typename T>
 uint64_t Slice<T>::count() const {
-    return data.size / sizeof(T);
+    return data.count;
 }
 
 template <typename T>
@@ -146,11 +164,13 @@ Slice<T> Slice<T>::operator()(uint64_t start, uint64_t end) const {
     GAPID_ASSERT_MSG(start <= end, "slice start is after end");
     GAPID_ASSERT_MSG(end <= count(), "slice index out of bounds");
     GAPID_ASSERT_MSG(data.base != nullptr || (start == end), "slice of null slice");
+    auto count = end - start;
     Slice<T> out;
     out.data.pool = data.pool;
     out.data.root = data.root;
     out.data.base = reinterpret_cast<uint8_t*>(data.base) + start * sizeof(T);
-    out.data.size = (end - start) * sizeof(T);
+    out.data.size = count * sizeof(T);
+    out.data.count = count;
     if (data.pool != nullptr) {
         reference();
     }
@@ -177,7 +197,12 @@ void Slice<T>::copy(const Slice<T>& dst, uint64_t start, uint64_t count, uint64_
 template <typename T>
 template <typename U>
 Slice<U> Slice<T>::as() const {
-    return *reinterpret_cast<const Slice<U>*>(this);
+    auto count = data.size / sizeof(U);
+    return Slice<U>(/* pool */  data.pool,
+                    /* root */  data.root,
+                    /* base */  data.base,
+                    /* size */  count * sizeof(U),
+                    /* count */ count);
 }
 
 template <typename T>

--- a/gapil/serialization/serialization.go
+++ b/gapil/serialization/serialization.go
@@ -39,8 +39,9 @@ const (
 	RefVal          = ProtoFieldID(2)
 	SliceRoot       = ProtoFieldID(1)
 	SliceBase       = ProtoFieldID(2)
-	SliceCount      = ProtoFieldID(3)
-	SlicePool       = ProtoFieldID(4)
+	SliceSize       = ProtoFieldID(3)
+	SliceCount      = ProtoFieldID(4)
+	SlicePool       = ProtoFieldID(5)
 )
 
 // IsEncodable returns true if the node is encodable.

--- a/gapis/api/gles/compat_client.go
+++ b/gapis/api/gles/compat_client.go
@@ -131,7 +131,7 @@ func compatDrawElements(
 		end := u64.Min(start+uint64(indexSize)*uint64(cmd.indicesCount()), data.count) // Clamp
 		limits, ok := cmd.indexLimits()
 		if !ok {
-			limits = e.calcIndexLimits(data.Slice(start, end, s.MemoryLayout), indexSize)
+			limits = e.calcIndexLimits(data.Slice(start, end), indexSize)
 		}
 		moveClientVBsToVAs(ctx, t, clientVAs, limits.First, limits.Count, id, cmd, s, c, out)
 	}

--- a/gapis/api/gles/draw_call.go
+++ b/gapis/api/gles/draw_call.go
@@ -73,7 +73,7 @@ func getIndices(
 		offset += ptr.addr
 		start := u64.Min(offset, indexBuffer.Data.count)
 		end := u64.Min(offset+size, indexBuffer.Data.count)
-		reader = indexBuffer.Data.Slice(start, end, s.MemoryLayout).Reader(ctx, s)
+		reader = indexBuffer.Data.Slice(start, end).Reader(ctx, s)
 	}
 
 	indices, err := decodeIndices(reader, ty)

--- a/gapis/api/gles/draw_call_mesh.go
+++ b/gapis/api/gles/draw_call_mesh.go
@@ -177,7 +177,7 @@ func vertexStreamData(
 
 	// Only read as much data as we actually have.
 	size := u64.Min(uint64(compactSize+ /* total size of gaps */ gap*(vectorCount-1)), slice.count-base)
-	data, err := slice.Slice(base, base+size, s.MemoryLayout).Read(ctx, nil, s, nil)
+	data, err := slice.Slice(base, base+size).Read(ctx, nil, s, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/gapis/api/gles/externs.go
+++ b/gapis/api/gles/externs.go
@@ -46,7 +46,7 @@ func (e externs) mapMemory(slice memory.Slice) {
 		switch e.cmd.(type) {
 		case *GlMapBufferRange, *GlMapBufferRangeEXT, *GlMapBufferOES, *GlMapBuffer:
 			// Base address is on the stack.
-			b.MapMemory(slice.Range(e.s.MemoryLayout))
+			b.MapMemory(memory.Range{Base: slice.Base(), Size: slice.Size()})
 
 		default:
 			log.E(ctx, "mapBuffer extern called for unsupported command: %v", e.cmd)
@@ -56,7 +56,7 @@ func (e externs) mapMemory(slice memory.Slice) {
 
 func (e externs) unmapMemory(slice memory.Slice) {
 	if b := e.b; b != nil {
-		b.UnmapMemory(slice.Range(e.s.MemoryLayout))
+		b.UnmapMemory(memory.Range{Base: slice.Base(), Size: slice.Size()})
 	}
 }
 

--- a/gapis/api/gles/resources.go
+++ b/gapis/api/gles/resources.go
@@ -164,7 +164,7 @@ func (t *Texture) ResourceData(ctx context.Context, s *api.GlobalState) (*api.Re
 				if err != nil {
 					return nil, err
 				}
-				data := pool.Slice(l.Data.Range(s.MemoryLayout))
+				data := pool.Slice(l.Data.Range())
 				buf := make([]byte, data.Size())
 				if err := data.Get(ctx, 0, buf); err != nil {
 					return nil, err

--- a/gapis/api/gles/texture_compat.go
+++ b/gapis/api/gles/texture_compat.go
@@ -220,7 +220,7 @@ func decompressTexImage2D(ctx context.Context, i api.CmdID, a *GlCompressedTexIm
 	data := a.Data
 	if pb := c.Bound.PixelUnpackBuffer; pb != nil {
 		base := a.Data.addr
-		data = NewTexturePointer(pb.Data.Index(base, s.MemoryLayout))
+		data = NewTexturePointer(pb.Data.Index(base))
 		out.MutateAndWrite(ctx, dID, cb.GlBindBuffer(GLenum_GL_PIXEL_UNPACK_BUFFER, 0))
 		defer out.MutateAndWrite(ctx, dID, cb.GlBindBuffer(GLenum_GL_PIXEL_UNPACK_BUFFER, pb.ID))
 	} else {
@@ -273,7 +273,7 @@ func decompressTexSubImage2D(ctx context.Context, i api.CmdID, a *GlCompressedTe
 	data := a.Data
 	if pb := c.Bound.PixelUnpackBuffer; pb != nil {
 		base := a.Data.addr
-		data = TexturePointer(pb.Data.Index(base, s.MemoryLayout))
+		data = TexturePointer(pb.Data.Index(base))
 		out.MutateAndWrite(ctx, dID, cb.GlBindBuffer(GLenum_GL_PIXEL_UNPACK_BUFFER, 0))
 		defer out.MutateAndWrite(ctx, dID, cb.GlBindBuffer(GLenum_GL_PIXEL_UNPACK_BUFFER, pb.ID))
 	} else {

--- a/gapis/api/templates/api.go.tmpl
+++ b/gapis/api/templates/api.go.tmpl
@@ -311,7 +311,15 @@
     if start > end {
       panic(fmt.Errorf("Slice start (%d) is greater than the end (%d)", start, end))
     }
-    return {{$slice_ty}}{root: p.addr, base: p.addr + start * p.ElementSize(ϟl), count: end-start, pool: p.pool}
+    elSize := p.ElementSize(ϟl)
+    count := end-start
+    return {{$slice_ty}}{
+      root:  p.addr,
+      base:  p.addr + start * elSize,
+      size:  count * elSize,
+      count: count,
+      pool:  p.pool,
+    }
   }
 
   // ISlice returns a new Slice from the pointer using start and end indices.
@@ -361,7 +369,7 @@
     s.ReserveMemory(ϟctx, ϟa, ϟs, ϟb)
     // Write out the entire structure, then over-write
     // any pointer fields.
-    ϟb.Write(s.Range(ϟs.MemoryLayout), s.ResourceID(ϟctx, ϟs))
+    ϟb.Write(s.Range(), s.ResourceID(ϟctx, ϟs))
     d := s.Decoder(ϟctx, ϟs)
     for i := uint64(0); i < s.count; i++ {
       {{Template "ReadStructFieldsWithRemapping" $}}
@@ -430,6 +438,7 @@
   type {{$slice_ty}} struct {
     root  uint64        // Original pointer this slice derives from.
     base  uint64        // Address of first element.
+    size  uint64        // Total size of the slice in bytes.
     count uint64        // Number of elements in the slice.
     pool  ϟmem.PoolID // The pool identifier.
   }
@@ -440,7 +449,11 @@
     func Make{{$slice_ty}}FromString(str string, ϟs *api.GlobalState) {{$slice_ty}} {
       id, pool := ϟs.Memory.New()
       pool.Write(0, ϟmem.Blob([]byte(str)))
-      return {{$slice_ty}}{ count: uint64(len(str)), pool: id }
+      return {{$slice_ty}}{
+        size:  uint64(len(str)),
+        count: uint64(len(str)),
+        pool:  id,
+      }
     }
   {{end}}
 
@@ -455,16 +468,25 @@
 
   // Make{{$slice_ty}} returns a {{$slice_ty}} backed by a new memory pool.
   func Make{{$slice_ty}}(count uint64, ϟs *api.GlobalState) {{$slice_ty}} {
+    ϟl := ϟs.MemoryLayout; _ = ϟl
     id, _ := ϟs.Memory.New()
-    return {{$slice_ty}}{ count: count, pool: id }
+    return {{$slice_ty}}{
+      size:  count * {{Template "Go.SizeOf" $s.To}},
+      count: count,
+      pool:  id,
+    }
   }
 
   // Clone returns a copy of the {{$slice_ty}} in a new memory pool.
   func (s {{$slice_ty}}) Clone(ϟctx context.Context, ϟa api.Cmd, ϟs *api.GlobalState, ϟb *builder.Builder) {{$slice_ty}} {
     s.OnRead(ϟctx, ϟa, ϟs, ϟb)
     id, dst := ϟs.Memory.New()
-    dst.Write(0, ϟs.Memory.MustGet(s.pool).Slice(s.Range(ϟs.MemoryLayout)))
-    return {{$slice_ty}}{ count: s.count, pool: id }
+    dst.Write(0, ϟs.Memory.MustGet(s.pool).Slice(s.Range()))
+    return {{$slice_ty}}{
+      size:  s.size,
+      count: s.count,
+      pool: id,
+    }
   }
 
   // Root returns the original pointer this slice derives from.
@@ -475,6 +497,9 @@
 
   // Count returns the number of elements in the slice.
   func (s {{$slice_ty}}) Count() uint64 { return s.count }
+
+  // Size returns the size of the slice in bytes.
+  func (s {{$slice_ty}}) Size() uint64 { return s.size }
 
   // Pool returns the the pool identifier.
   func (s {{$slice_ty}}) Pool() ϟmem.PoolID { return s.pool }
@@ -489,16 +514,15 @@
   func (s {{$slice_ty}}) ElementSize(ϟl *device.MemoryLayout) uint64 {
     return {{Template "Go.SizeOf" $s.To}}
   }
-
   // Range returns the memory range this slice represents in the underlying pool.
-  func (s {{$slice_ty}}) Range(ϟl *device.MemoryLayout) ϟmem.Range {
-    return ϟmem.Range{Base: s.base, Size: s.count * s.ElementSize(ϟl) }
+  func (s {{$slice_ty}}) Range() ϟmem.Range {
+    return ϟmem.Range{Base: s.base, Size: s.size }
   }
 
   // ResourceID returns an identifier to a resource representing the data of
   // this slice.
   func (s {{$slice_ty}}) ResourceID(ϟctx context.Context, ϟs *api.GlobalState) id.ID {
-    id, err := ϟs.Memory.MustGet(s.pool).Slice(s.Range(ϟs.MemoryLayout)).ResourceID(ϟctx)
+    id, err := ϟs.Memory.MustGet(s.pool).Slice(s.Range()).ResourceID(ϟctx)
     if err != nil {
       panic(err)
     }
@@ -507,22 +531,22 @@
 
   // Reader returns a binary reader for the slice.
   func (s {{$slice_ty}}) Reader(ϟctx context.Context, ϟs *api.GlobalState) binary.Reader {
-    return ϟs.MemoryReader(ϟctx, ϟs.Memory.MustGet(s.pool).Slice(s.Range(ϟs.MemoryLayout)))
+    return ϟs.MemoryReader(ϟctx, ϟs.Memory.MustGet(s.pool).Slice(s.Range()))
   }
 
   // Writer returns a binary writer for the slice.
   func (s {{$slice_ty}}) Writer(ϟs *api.GlobalState) binary.Writer {
-    return ϟs.MemoryWriter(s.pool, s.Range(ϟs.MemoryLayout))
+    return ϟs.MemoryWriter(s.pool, s.Range())
   }
 
   // Decoder returns a memory decoder for the slice.
   func (s {{$slice_ty}}) Decoder(ϟctx context.Context, ϟs *api.GlobalState) *ϟmem.Decoder {
-    return ϟs.MemoryDecoder(ϟctx, ϟs.Memory.MustGet(s.pool).Slice(s.Range(ϟs.MemoryLayout)))
+    return ϟs.MemoryDecoder(ϟctx, ϟs.Memory.MustGet(s.pool).Slice(s.Range()))
   }
 
   // Encoder returns a memory encoder for the slice.
   func (s {{$slice_ty}}) Encoder(ϟs *api.GlobalState) *ϟmem.Encoder {
-    return ϟs.MemoryEncoder(s.pool, s.Range(ϟs.MemoryLayout))
+    return ϟs.MemoryEncoder(s.pool, s.Range())
   }
 
   {{if not $el_is_void}}
@@ -530,13 +554,16 @@
     // The returned slice length will be calculated so that the returned slice is
     // no longer (in bytes) than s.
     func As{{$slice_ty}}(s ϟmem.Slice, ϟl *device.MemoryLayout) {{$slice_ty}} {
-      out := {{$slice_ty}}{
-        root: s.Root(),
-        base: s.Base(),
-        pool: s.Pool(),
+      elSize := {{Template "Go.SizeOf" $s.To}}
+      newCount := s.Size() / elSize
+      newSize := newCount * elSize
+      return {{$slice_ty}}{
+        root:  s.Root(),
+        base:  s.Base(),
+        pool:  s.Pool(),
+        size:  newSize,
+        count: newCount,
       }
-      out.count = (s.Count() * s.ElementSize(ϟl)) / out.ElementSize(ϟl)
-      return out
     }
 
     // Read reads and returns all the {{$el_ty}} elements in this {{$slice_ty}}.
@@ -562,7 +589,7 @@
     // which is the minimum of s.count and len(src).
     func (s {{$slice_ty}}) Write(ϟctx context.Context, src []{{$el_ty}}, ϟa api.Cmd, ϟs *api.GlobalState, ϟb *builder.Builder) (uint64, error) {
       count := u64.Min(s.count, uint64(len(src)))
-      e := s.Slice(0, count, ϟs.MemoryLayout).Encoder(ϟs)
+      e := s.Slice(0, count).Encoder(ϟs)
       ϟmem.Write(e, src[:count])
       s.OnWrite(ϟctx, ϟa, ϟs, ϟb)
       if err := e.Error(); err != nil {
@@ -583,14 +610,14 @@
     // The slices of this and dst to the copied elements is returned.
     func (dst {{$slice_ty}}) Copy(ϟctx context.Context, src {{$slice_ty}}, ϟa api.Cmd, ϟs *api.GlobalState, ϟb *builder.Builder) (d, s {{$slice_ty}}) {
       count := u64.Min(dst.count, src.count)
-      dst, src = dst.Slice(0, count, ϟs.MemoryLayout), src.Slice(0, count, ϟs.MemoryLayout)
+      dst, src = dst.Slice(0, count), src.Slice(0, count)
     {{if $el_is_ptr}}
       if (dst.pool == ϟmem.ApplicationPool) != (src.pool == ϟmem.ApplicationPool) {
         dst.MustWrite(ϟctx, src.MustRead(ϟctx, ϟa, ϟs, ϟb), ϟa, ϟs, ϟb) // Element-wise copy so we can convert u64 <-> {{$ptr_ty}}
       } else {
     {{end}}
       src.OnRead(ϟctx, ϟa, ϟs, ϟb)
-      ϟs.Memory.MustGet(dst.pool).Write(dst.base, ϟs.Memory.MustGet(src.pool).Slice(src.Range(ϟs.MemoryLayout)))
+      ϟs.Memory.MustGet(dst.pool).Write(dst.base, ϟs.Memory.MustGet(src.pool).Slice(src.Range()))
       dst.OnWrite(ϟctx, ϟa, ϟs, ϟb)
     {{if $el_is_ptr}} } {{end}}
       return dst, src
@@ -610,10 +637,10 @@
 
   // OnRead calls the backing pool's OnRead callback. s is returned so calls can be chained.
   func (s {{$slice_ty}}) OnRead(ϟctx context.Context, ϟa api.Cmd, ϟs *api.GlobalState, ϟb *builder.Builder) {{$slice_ty}} {
-    ϟl := ϟs.MemoryLayout
+    ϟl := ϟs.MemoryLayout; _ = ϟl
     if pool, err := ϟs.Memory.Get(s.pool); err == nil {
       if f := pool.OnRead; f != nil {
-        f(s.Range(ϟl))
+        f(s.Range())
       }
     }
     if ϟb != nil && s.pool == ϟmem.ApplicationPool {
@@ -650,7 +677,7 @@
           }
           panicOnError(d.Error())
         {{else}}
-          ϟb.Write(s.Range(ϟl), s.ResourceID(ϟctx, ϟs))
+          ϟb.Write(s.Range(), s.ResourceID(ϟctx, ϟs))
         {{end}}
       {{end}}
     }
@@ -659,14 +686,14 @@
 
   // OnWrite calls the backing pool's OnWrite callback. s is returned so calls can be chained.
   func (s {{$slice_ty}}) OnWrite(ϟctx context.Context, ϟa api.Cmd, ϟs *api.GlobalState, ϟb *builder.Builder) {{$slice_ty}} {
-    ϟl := ϟs.MemoryLayout
+    ϟl := ϟs.MemoryLayout; _ = ϟl
     if pool, err := ϟs.Memory.Get(s.pool); err == nil {
       if f := pool.OnWrite; f != nil {
-        f(s.Range(ϟl))
+        f(s.Range())
       }
     }
     if ϟb != nil && s.pool == ϟmem.ApplicationPool {
-      ϟb.ReserveMemory(ϟmem.Range{Base: s.root, Size: uint64(s.Range(ϟl).End() - s.root)})
+      ϟb.ReserveMemory(ϟmem.Range{Base: s.root, Size: uint64(s.Range().End() - s.root)})
       {{if (GetAnnotation $s.To "replay_remap")}}
         {{/* Element type has explicitly stated it needs custom remapping */}}
         size := s.ElementSize(ϟl)
@@ -692,36 +719,45 @@
 
   func (s {{$slice_ty}}) ReserveMemory(ϟctx context.Context, ϟa api.Cmd, ϟs *api.GlobalState, ϟb *builder.Builder) {{$slice_ty}} {
     if ϟb != nil && s.pool == ϟmem.ApplicationPool {
-      rng := s.Range(ϟs.MemoryLayout)
+      rng := s.Range()
       ϟb.ReserveMemory(ϟmem.Range{Base: s.root, Size: uint64(rng.End() - s.root)})
     }
     return s
   }
 
   // Index returns a {{$ptr_ty}} to the i'th element in this {{$slice_ty}}.
-  func (s {{$slice_ty}}) Index(i uint64, ϟl *device.MemoryLayout) {{$ptr_ty}} {
-    return {{$ptr_ty}}{ s.base + i * s.ElementSize(ϟl), s.pool }
+  func (s {{$slice_ty}}) Index(i uint64) {{$ptr_ty}} {
+    elSize := s.size / s.count
+    return {{$ptr_ty}}{ s.base + i * elSize, s.pool }
   }
 
   // IIndex returns a pointer to the i'th element in the slice.
-  func (s {{$slice_ty}}) IIndex(i uint64, ϟl *device.MemoryLayout) ϟmem.Pointer {
-    return s.Index(i, ϟl)
+  func (s {{$slice_ty}}) IIndex(i uint64) ϟmem.Pointer {
+    return s.Index(i)
   }
 
   // Slice returns a sub-slice from the {{$slice_ty}} using start and end indices.
-  func (s {{$slice_ty}}) Slice(start, end uint64, ϟl *device.MemoryLayout) {{$slice_ty}} {
+  func (s {{$slice_ty}}) Slice(start, end uint64) {{$slice_ty}} {
     if start > end {
       panic(fmt.Errorf("%v.Slice start (%d) is greater than the end (%d)", s, start, end))
     }
     if end > s.count {
       panic(fmt.Errorf("%v.Slice(%d, %d) - out of bounds", s, start, end))
     }
-    return {{$slice_ty}}{root: s.root, base: s.base + start * s.ElementSize(ϟl), count: end-start, pool: s.pool}
+    newCount := end-start
+    elSize := s.size / s.count
+    return {{$slice_ty}}{
+      root:  s.root,
+      base:  s.base + start * elSize,
+      size:  newCount * elSize,
+      count: newCount,
+      pool:  s.pool,
+    }
   }
 
   // ISlice returns a sub-slice from this slice using start and end indices.
-  func (s {{$slice_ty}}) ISlice(start, end uint64, ϟl *device.MemoryLayout) ϟmem.Slice {
-    return s.Slice(start, end, ϟl)
+  func (s {{$slice_ty}}) ISlice(start, end uint64) ϟmem.Slice {
+    return s.Slice(start, end)
   }
 
   // String returns a string description of the {{$slice_ty}} slice.

--- a/gapis/api/templates/go_common.tmpl
+++ b/gapis/api/templates/go_common.tmpl
@@ -490,8 +490,8 @@
   {{else if IsNull             $}}{{Template "Go.Null" $.Type}}
   {{else if IsNew              $}}new {{Template "Go.Type" $.Type}}
   {{else if IsSliceContains    $}}{{Template "Go.Read" $.Slice  }}.Contains(ϟctx, {{Template "Go.Read" $.Value}}, ϟa, ϟs, ϟb)
-  {{else if IsSliceIndex       $}}{{Template "Go.Read" $.Slice  }}.Index({{Template "Go.Read" $.Index}}, ϟl).{{Macro "Go.MemoryRead"}}
-  {{else if IsSliceRange       $}}{{Template "Go.Read" $.Slice  }}.Slice({{Template "Go.Read" $.Range.LHS}}, {{Template "Go.Read" $.Range.RHS}}, ϟl)
+  {{else if IsSliceIndex       $}}{{Template "Go.Read" $.Slice  }}.Index({{Template "Go.Read" $.Index}}).{{Macro "Go.MemoryRead"}}
+  {{else if IsSliceRange       $}}{{Template "Go.Read" $.Slice  }}.Slice({{Template "Go.Read" $.Range.LHS}}, {{Template "Go.Read" $.Range.RHS}})
   {{else if IsPointerRange     $}}{{Template "Go.Read" $.Pointer}}.Slice({{Template "Go.Read" $.Range.LHS}}, {{Template "Go.Read" $.Range.RHS}}, ϟl)
   {{else if IsClone            $}}{{Template "Go.Read" $.Slice  }}.Clone(ϟctx, ϟa, ϟs, ϟb)
   {{else if IsMake             $}}Make{{Template "Go.Type" $.Type}}({{Template "Go.Read" $.Size}}, ϟs)
@@ -580,7 +580,7 @@
   {{/* A[] -> B[] */}}{{else if and (IsSlice $src_ty) (IsSlice $dst_ty)}}
     As{{Template "Go.Type" $.Type}}({{$src}}, ϟl)
   {{/* T[] -> T* */}}{{else if and (IsSlice $src_ty) (IsPointer $dst_ty)}}
-    {{Template "Go.Type" $.Type}}({{$src}}.Index(0, ϟl))
+    {{Template "Go.Type" $.Type}}({{$src}}.Index(0))
   {{/* char* -> string */}}{{else if and (IsPointer $src_ty) (IsString $dst_ty)}}
     strings.TrimRight(string(ϟmem.CharToBytes({{$src}}.StringSlice(ϟctx, ϟs).{{Macro "Go.MemoryRead"}})), "\x00")
   {{/* char[] -> string */}}{{else if and (IsSlice $src_ty) (IsString $dst_ty)}}

--- a/gapis/api/templates/go_convert_common.tmpl
+++ b/gapis/api/templates/go_convert_common.tmpl
@@ -299,10 +299,11 @@
       «} ()
     {{else if IsPointer $truetype}}{{$target}}({{$.Value}}.addr)
     {{else if IsSlice $truetype}}&{{$target}}{»¶
-      Root: {{$.Value}}.root,¶
-      Base: {{$.Value}}.base,¶
+      Root:  {{$.Value}}.root,¶
+      Base:  {{$.Value}}.base,¶
+      Size:  {{$.Value}}.size,¶
       Count: {{$.Value}}.count,¶
-      Pool: uint32({{$.Value}}.pool),¶
+      Pool:  uint32({{$.Value}}.pool),¶
     «}
     {{else if IsBool $truetype}}func(v bool) {{$target}}  { if v { return 1 } else { return 0 } } ({{$.Value}})
     {{else if eq $source $target}}{{$.Value}}
@@ -332,6 +333,7 @@
     {{else if IsSlice $truetype}}{{$target}}{»¶
       root:  {{$.Value}}.Root,¶
       base:  {{$.Value}}.Base,¶
+      size:  {{$.Value}}.Size,¶
       count: {{$.Value}}.Count,¶
       pool:  memory.PoolID({{$.Value}}.Pool),¶
     «}

--- a/gapis/api/templates/mutate.go.tmpl
+++ b/gapis/api/templates/mutate.go.tmpl
@@ -592,7 +592,7 @@
   {{AssertType $ "SliceAssign"}}
 
   {{if ne $.Operator "="}}{{Error "Compound assignments to pointers are not supported (%s)" $.Operator}}{{end}}
-  {{Template "Go.Read" $.To.Slice}}.Index({{Template "Go.Read" $.To.Index}}, ϟl).MustWrite(ϟctx, {{Template "Go.Read" $.Value}}, ϟa, ϟs, ϟb)
+  {{Template "Go.Read" $.To.Slice}}.Index({{Template "Go.Read" $.To.Index}}).MustWrite(ϟctx, {{Template "Go.Read" $.Value}}, ϟa, ϟs, ϟb)
 {{end}}
 
 
@@ -624,7 +624,7 @@
         {{/* TODO: Unlike Slice.Copy, this does not optimise for non-pointer copies. */}}
         ϟdst, ϟsrc := {{Template "Go.Read" $.Statement.Dst}}, {{Template "Go.Read" $.Statement.Src}}
         ϟcount := u64.Min(ϟdst.Count(), ϟsrc.Count())
-        ϟdst, ϟsrc = ϟdst.Slice(0, ϟcount, ϟl), ϟsrc.Slice(0, ϟcount, ϟl)
+        ϟdst, ϟsrc = ϟdst.Slice(0, ϟcount), ϟsrc.Slice(0, ϟcount)
         ϟsrcElems := ϟsrc.MustRead(ϟctx, ϟa, ϟs, ϟb)
       {{end}}
 

--- a/gapis/api/vulkan/custom_replay.go
+++ b/gapis/api/vulkan/custom_replay.go
@@ -382,11 +382,11 @@ func (a *VkAcquireNextImageKHR) Mutate(ctx context.Context, id api.CmdID, s *api
 	// Apply the write observation before having the replay device calling the vkAcquireNextImageKHR() command.
 	// This is to pass the returned image index value captured in the trace, into the replay device to acquire for the specific image.
 	o.ApplyWrites(s.Memory.ApplicationPool())
-	_ = a.PImageIndex.Slice(uint64(0), uint64(1), l).Index(uint64(0), l).MustRead(ctx, a, s, b)
+	_ = a.PImageIndex.Slice(0, 1, l).Index(0).MustRead(ctx, a, s, b)
 	if b != nil {
 		a.Call(ctx, s, b)
 	}
-	a.PImageIndex.Slice(uint64(0), uint64(1), l).Index(uint64(0), l).Write(ctx, a.PImageIndex.Slice(uint64(0), uint64(1), l).Index(uint64(0), l).MustRead(ctx, a, s, nil), a, s, b)
+	a.PImageIndex.Slice(0, 1, l).Index(0).Write(ctx, a.PImageIndex.Slice(0, 1, l).Index(0).MustRead(ctx, a, s, nil), a, s, b)
 	_ = a.Result
 	if a.Semaphore != VkSemaphore(0) {
 		GetState(s).Semaphores.Get(a.Semaphore).Signaled = true
@@ -432,7 +432,7 @@ func (a *ReplayAllocateImageMemory) Mutate(ctx context.Context, id api.CmdID, s 
 	}
 	l := s.MemoryLayout
 	c := GetState(s)
-	memory := a.PMemory.Slice(uint64(0), uint64(1), l).Index(uint64(0), l).MustRead(ctx, a, s, nil)
+	memory := a.PMemory.Slice(0, 1, l).Index(0).MustRead(ctx, a, s, nil)
 	imageObject := c.Images.Get(a.Image)
 	imageWidth := imageObject.Info.Extent.Width
 	imageHeight := imageObject.Info.Extent.Height
@@ -449,6 +449,6 @@ func (a *ReplayAllocateImageMemory) Mutate(ctx context.Context, id api.CmdID, s 
 		MemoryTypeIndex: 0,
 		Data:            MakeU8ˢ(uint64(imageSize), s)}
 	c.DeviceMemories.Set(memory, memoryObject)
-	a.PMemory.Slice(uint64(0), uint64(1), l).Index(uint64(0), l).Write(ctx, memory, a, s, b)
+	a.PMemory.Slice(0, 1, l).Index(0).Write(ctx, memory, a, s, b)
 	return err
 }

--- a/gapis/api/vulkan/draw_call_mesh.go
+++ b/gapis/api/vulkan/draw_call_mesh.go
@@ -182,11 +182,11 @@ func getIndicesData(ctx context.Context, s *api.GlobalState, boundIndexBuffer *B
 			log.E(ctx, "Shadow memory of index buffer is not big enough")
 			return []uint32{}, nil
 		}
-		indicesSlice := backingMem.Data.Slice(start, end, s.MemoryLayout)
+		indicesSlice := backingMem.Data.Slice(start, end)
 		for i := uint64(0); (i < size) && (i+sizeOfIndex-1 < size); i += sizeOfIndex {
 			index := int32(0)
 			for j := uint64(0); j < sizeOfIndex; j++ {
-				oneByte, err := indicesSlice.Index(i+j, s.MemoryLayout).Read(ctx, nil, s, nil)
+				oneByte, err := indicesSlice.Index(i+j).Read(ctx, nil, s, nil)
 				if err != nil {
 					return nil, err
 				}
@@ -292,7 +292,7 @@ func getVerticesData(ctx context.Context, s *api.GlobalState, thread uint64,
 	backingMemoryData := boundVertexBuffer.Buffer.Memory.Data
 	sliceOffset := uint64(boundVertexBuffer.Offset + boundVertexBuffer.Buffer.MemoryOffset)
 	sliceSize := uint64(boundVertexBuffer.Range)
-	vertexSlice := backingMemoryData.Slice(sliceOffset, sliceOffset+sliceSize, s.MemoryLayout)
+	vertexSlice := backingMemoryData.Slice(sliceOffset, sliceOffset+sliceSize)
 
 	formatElementAndTexelBlockSize, err :=
 		subGetElementAndTexelBlockSize(ctx, nil, api.CmdNoID, nil, s, nil, thread, nil, attribute.Format)
@@ -313,7 +313,7 @@ func getVerticesData(ctx context.Context, s *api.GlobalState, thread uint64,
 		// our zero-initialized buffer.
 		return out, fmt.Errorf("Vertex data is out of range")
 	}
-	data, err := vertexSlice.Slice(offset, offset+fullSize, s.MemoryLayout).Read(ctx, nil, s, nil)
+	data, err := vertexSlice.Slice(offset, offset+fullSize).Read(ctx, nil, s, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/gapis/api/vulkan/externs.go
+++ b/gapis/api/vulkan/externs.go
@@ -42,8 +42,8 @@ func (e externs) hasDynamicProperty(info VkPipelineDynamicStateCreateInfoᶜᵖ,
 		return false
 	}
 	l := e.s.MemoryLayout
-	dynamic_state_info := info.Slice(uint64(0), uint64(1), l).Index(uint64(0), l).MustRead(e.ctx, e.cmd, e.s, e.b)
-	states := dynamic_state_info.PDynamicStates.Slice(uint64(uint32(0)), uint64(dynamic_state_info.DynamicStateCount), l).MustRead(e.ctx, e.cmd, e.s, e.b)
+	dynamic_state_info := info.Slice(0, 1, l).Index(0).MustRead(e.ctx, e.cmd, e.s, e.b)
+	states := dynamic_state_info.PDynamicStates.Slice(0, uint64(dynamic_state_info.DynamicStateCount), l).MustRead(e.ctx, e.cmd, e.s, e.b)
 	for _, s := range states {
 		if s == state {
 			return true
@@ -58,7 +58,7 @@ func (e externs) mapMemory(value Voidᵖᵖ, slice memory.Slice) {
 		switch e.cmd.(type) {
 		case *VkMapMemory:
 			b.Load(protocol.Type_AbsolutePointer, value.value(e.b, e.cmd, e.s))
-			b.MapMemory(slice.Range(e.s.MemoryLayout))
+			b.MapMemory(memory.Range{Base: slice.Base(), Size: slice.Size()})
 		default:
 			log.E(ctx, "mapBuffer extern called for unsupported command: %v", e.cmd)
 		}
@@ -165,7 +165,7 @@ func (e externs) postBindSparse(binds *QueuedSparseBinds) {
 
 func (e externs) unmapMemory(slice memory.Slice) {
 	if b := e.b; b != nil {
-		b.UnmapMemory(slice.Range(e.s.MemoryLayout))
+		b.UnmapMemory(memory.Range{Base: slice.Base(), Size: slice.Size()})
 	}
 }
 
@@ -182,7 +182,7 @@ func (e externs) readMappedCoherentMemory(memory_handle VkDeviceMemory, offset_i
 
 	writeRngList := e.s.Memory.ApplicationPool().Slice(absSrcMemRng).ValidRanges()
 	for _, r := range writeRngList {
-		mem.Data.Slice(dstStart+r.Base, dstStart+r.Base+r.Size, l).Copy(
+		mem.Data.Slice(dstStart+r.Base, dstStart+r.Base+r.Size).Copy(
 			e.ctx, U8ᵖ(mem.MappedLocation).Slice(srcStart+r.Base, srcStart+r.Base+r.Size, l), e.cmd, e.s, e.b)
 	}
 }
@@ -193,7 +193,7 @@ func (e externs) numberOfPNext(pNext Voidᶜᵖ) uint32 {
 	counter := uint32(0)
 	for (pNext) != (Voidᶜᵖ{}) {
 		counter++
-		pNext = Voidᶜᵖᵖ(pNext).Slice(uint64(0), uint64(2), l).Index(uint64(1), l).MustRead(e.ctx, e.cmd, e.s, e.b)
+		pNext = Voidᶜᵖᵖ(pNext).Slice(0, 2, l).Index(1).MustRead(e.ctx, e.cmd, e.s, e.b)
 	}
 	return counter
 }

--- a/gapis/api/vulkan/footprint_builder.go
+++ b/gapis/api/vulkan/footprint_builder.go
@@ -1861,7 +1861,7 @@ func (vb *FootprintBuilder) BuildFootprint(ctx context.Context,
 		imgIds := info.PImageIndices.Slice(0, swCount, l)
 		for swi, vkSw := range info.PSwapchains.Slice(0, swCount, l).MustRead(ctx, cmd, s, nil) {
 			read(ctx, bh, vkHandle(vkSw))
-			imgID := imgIds.Index(uint64(swi), l).MustRead(ctx, cmd, s, nil)
+			imgID := imgIds.Index(uint64(swi)).MustRead(ctx, cmd, s, nil)
 			vkImg := GetState(s).Swapchains.Get(vkSw).SwapchainImages.Get(imgID).VulkanHandle
 			imgLayout, imgData := vb.getImageLayoutAndData(ctx, bh, vkImg)
 			read(ctx, bh, imgLayout)
@@ -1924,7 +1924,7 @@ func (vb *FootprintBuilder) BuildFootprint(ctx context.Context,
 		setCount := uint64(info.DescriptorSetCount)
 		vkLayouts := info.PSetLayouts.Slice(0, setCount, l)
 		for i, vkSet := range cmd.PDescriptorSets.Slice(0, setCount, l).MustRead(ctx, cmd, s, nil) {
-			vkLayout := vkLayouts.Index(uint64(i), l).MustRead(ctx, cmd, s, nil)
+			vkLayout := vkLayouts.Index(uint64(i)).MustRead(ctx, cmd, s, nil)
 			read(ctx, bh, vkHandle(vkLayout))
 			layoutObj := GetState(s).DescriptorSetLayouts.Get(vkLayout)
 			write(ctx, bh, vkHandle(vkSet))

--- a/gapis/api/vulkan/image_primer.go
+++ b/gapis/api/vulkan/image_primer.go
@@ -452,9 +452,10 @@ func (h *ipStoreHandler) store(job *ipStoreJob, queue *QueueObject) error {
 		job.opaqueBlockExtent,
 		job.storeTarget.Info.Format,
 		0, job.aspect).levelSize)
-	data := job.storeTarget.Aspects.Get(job.aspect).Layers.Get(job.layer).Levels.Get(
-		job.level).Data.Slice(opaqueDataOffset, opaqueDataSizeInBytes,
-		h.sb.oldState.MemoryLayout).MustRead(h.sb.ctx, nil, h.sb.oldState, nil)
+	data := job.storeTarget.Aspects.
+		Get(job.aspect).Layers.Get(job.layer).Levels.Get(job.level).Data.
+		Slice(opaqueDataOffset, opaqueDataSizeInBytes).
+		MustRead(h.sb.ctx, nil, h.sb.oldState, nil)
 
 	srcVkFmt := job.storeTarget.Info.Format
 	if srcVkFmt == VkFormat_VK_FORMAT_E5B9G9R9_UFLOAT_PACK32 {
@@ -2110,7 +2111,9 @@ func (h *ipBufferCopySession) getCopyAndData(dstImg *ImageObject, dstAspect VkIm
 		srcImg.Info.Format,
 		0, srcAspect).levelSize)
 
-	data := srcImg.Aspects.Get(srcAspect).Layers.Get(layer).Levels.Get(level).Data.Slice(srcImgDataOffset, srcImgDataOffset+srcImgDataSizeInBytes, h.sb.oldState.MemoryLayout).MustRead(h.sb.ctx, nil, h.sb.oldState, nil)
+	data := srcImg.Aspects.Get(srcAspect).Layers.Get(layer).Levels.Get(level).
+		Data.Slice(srcImgDataOffset, srcImgDataOffset+srcImgDataSizeInBytes).
+		MustRead(h.sb.ctx, nil, h.sb.oldState, nil)
 
 	unpacked := data
 	if dstImg.Info.Format != srcImg.Info.Format {

--- a/gapis/api/vulkan/replay.go
+++ b/gapis/api/vulkan/replay.go
@@ -99,7 +99,7 @@ type makeAttachementReadable struct {
 	EnumeratedPhysicalDevices []VkPhysicalDevice
 	Properties                []VkPhysicalDeviceProperties
 	InPhysicalDeviceEnumerate bool
-	NumPhysicalDevicesLeft 	  uint32
+	NumPhysicalDevicesLeft    uint32
 }
 
 // drawConfig is a replay.Config used by colorBufferRequest and
@@ -275,10 +275,10 @@ func (t *makeAttachementReadable) Transform(ctx context.Context, id api.CmdID, c
 		// We have inserted e.PPhysicalDeviceCount calls to VkGetPhysicalDeviceProperties
 		// after this command. Use those to get the physical device info.
 		// This is temporary, we need to switch this to use Extras.
-		//   https://github.com/google/gapid/issues/1766 
+		//   https://github.com/google/gapid/issues/1766
 		l := s.MemoryLayout
 		cmd.Extras().Observations().ApplyWrites(s.Memory.ApplicationPool())
-		t.NumPhysicalDevicesLeft = uint32(e.PPhysicalDeviceCount.Slice(uint64(0), uint64(1), l).Index(uint64(0), l).MustRead(ctx, cmd, s, nil))
+		t.NumPhysicalDevicesLeft = uint32(e.PPhysicalDeviceCount.Slice(0, 1, l).Index(0).MustRead(ctx, cmd, s, nil))
 		// Do not mutate the second call to vkEnumeratePhysicalDevices, all the following vkGetPhysicalDeviceProperties belong to this
 		// physical device enumeration.
 		t.InPhysicalDeviceEnumerate = true

--- a/gapis/api/vulkan/state_rebuilder.go
+++ b/gapis/api/vulkan/state_rebuilder.go
@@ -1081,7 +1081,6 @@ func (sb *stateBuilder) createBuffer(buffer *BufferObject) {
 				data := sb.s.DeviceMemories.Get(bind.Memory).Data.Slice(
 					uint64(bind.MemoryOffset),
 					uint64(bind.MemoryOffset+size),
-					sb.oldState.MemoryLayout,
 				).MustRead(sb.ctx, nil, sb.oldState, nil)
 				contents = append(contents, data...)
 				copies = append(copies, VkBufferCopy{
@@ -1109,7 +1108,6 @@ func (sb *stateBuilder) createBuffer(buffer *BufferObject) {
 		data := buffer.Memory.Data.Slice(
 			uint64(buffer.MemoryOffset),
 			uint64(buffer.MemoryOffset+size),
-			sb.oldState.MemoryLayout,
 		).MustRead(sb.ctx, nil, sb.oldState, nil)
 		contents = append(contents, data...)
 		copies = append(copies, VkBufferCopy{

--- a/gapis/api/vulkan/vulkan_terminator.go
+++ b/gapis/api/vulkan/vulkan_terminator.go
@@ -156,10 +156,10 @@ func resolveCurrentRenderPass(ctx context.Context, s *api.GlobalState, submit *V
 	submitInfo := submit.PSubmits.Slice(uint64(0), uint64(submit.SubmitCount), l)
 	loopLevel := 0
 	for sub := 0; sub < int(idx[0])+getExtra(idx, loopLevel); sub++ {
-		info := submitInfo.Index(uint64(sub), l).MustRead(ctx, a, s, nil)
+		info := submitInfo.Index(uint64(sub)).MustRead(ctx, a, s, nil)
 		buffers := info.PCommandBuffers.Slice(uint64(0), uint64(info.CommandBufferCount), l)
 		for cmd := 0; cmd < int(info.CommandBufferCount); cmd++ {
-			buffer := buffers.Index(uint64(cmd), l).MustRead(ctx, a, s, nil)
+			buffer := buffers.Index(uint64(cmd)).MustRead(ctx, a, s, nil)
 			bufferObject := c.CommandBuffers.Get(buffer)
 			walkCommands(c, &bufferObject.CommandReferences, f)
 		}
@@ -167,17 +167,17 @@ func resolveCurrentRenderPass(ctx context.Context, s *api.GlobalState, submit *V
 	if !incrementLoopLevel(idx, &loopLevel) {
 		return lrp, subpass
 	}
-	lastInfo := submitInfo.Index(uint64(idx[0]), l).MustRead(ctx, a, s, nil)
+	lastInfo := submitInfo.Index(uint64(idx[0])).MustRead(ctx, a, s, nil)
 	lastBuffers := lastInfo.PCommandBuffers.Slice(uint64(0), uint64(lastInfo.CommandBufferCount), l)
 	for cmdbuffer := 0; cmdbuffer < int(idx[1])+getExtra(idx, loopLevel); cmdbuffer++ {
-		buffer := lastBuffers.Index(uint64(cmdbuffer), l).MustRead(ctx, a, s, nil)
+		buffer := lastBuffers.Index(uint64(cmdbuffer)).MustRead(ctx, a, s, nil)
 		bufferObject := c.CommandBuffers.Get(buffer)
 		walkCommands(c, &bufferObject.CommandReferences, f)
 	}
 	if !incrementLoopLevel(idx, &loopLevel) {
 		return lrp, subpass
 	}
-	lastBuffer := lastBuffers.Index(uint64(idx[1]), l).MustRead(ctx, a, s, nil)
+	lastBuffer := lastBuffers.Index(uint64(idx[1])).MustRead(ctx, a, s, nil)
 	lastBufferObject := c.CommandBuffers.Get(lastBuffer)
 	for cmd := 0; cmd < int(idx[2])+getExtra(idx, loopLevel); cmd++ {
 		f(lastBufferObject.CommandReferences.Get(uint32(cmd)))
@@ -344,14 +344,14 @@ func cutCommandBuffer(ctx context.Context, id api.CmdID,
 	submitCopy.SubmitCount = uint32(lastSubmit + 1)
 	newSubmits := make([]VkSubmitInfo, lastSubmit+1)
 	for i := 0; i < int(lastSubmit)+1; i++ {
-		newSubmits[i] = submitInfo.Index(uint64(i), l).MustRead(ctx, a, s, nil)
+		newSubmits[i] = submitInfo.Index(uint64(i)).MustRead(ctx, a, s, nil)
 	}
 	newSubmits[lastSubmit].CommandBufferCount = uint32(lastCommandBuffer + 1)
 
 	newCommandBuffers = make([]VkCommandBuffer, lastCommandBuffer+1)
 	buffers := newSubmits[lastSubmit].PCommandBuffers.Slice(uint64(0), uint64(newSubmits[lastSubmit].CommandBufferCount), l)
 	for i := 0; i < int(lastCommandBuffer)+1; i++ {
-		newCommandBuffers[i] = buffers.Index(uint64(i), l).MustRead(ctx, a, s, nil)
+		newCommandBuffers[i] = buffers.Index(uint64(i)).MustRead(ctx, a, s, nil)
 	}
 
 	var lrp *RenderPassObject

--- a/gapis/api/vulkan/wireframe.go
+++ b/gapis/api/vulkan/wireframe.go
@@ -39,7 +39,7 @@ func wireframe(ctx context.Context) transform.Transformer {
 			newInfos := make([]VkGraphicsPipelineCreateInfo, count)
 			newRasterStateDatas := make([]api.AllocResult, count)
 			for i := uint64(0); i < count; i++ {
-				info := infos.Index(i, l).MustRead(ctx, cmd, s, nil)
+				info := infos.Index(i).MustRead(ctx, cmd, s, nil)
 				rasterState := info.PRasterizationState.MustRead(ctx, cmd, s, nil)
 				rasterState.PolygonMode = VkPolygonMode_VK_POLYGON_MODE_LINE
 				newRasterStateDatas[i] = s.AllocDataOrPanic(ctx, rasterState)

--- a/gapis/capture/capture.go
+++ b/gapis/capture/capture.go
@@ -48,7 +48,7 @@ var (
 const (
 	// CurrentCaptureVersion is incremented on breaking changes to the capture format.
 	// NB: Also update equally named field in spy_base.cpp
-	CurrentCaptureVersion int32 = 2
+	CurrentCaptureVersion int32 = 3
 )
 
 type ErrUnsupportedVersion struct{ Version int32 }

--- a/gapis/memory/load.go
+++ b/gapis/memory/load.go
@@ -26,7 +26,7 @@ import (
 // LoadSlice loads the slice elements from s into a go-slice of the slice type.
 func LoadSlice(ctx context.Context, s Slice, pools Pools, l *device.MemoryLayout) (interface{}, error) {
 	pool := pools.MustGet(s.Pool())
-	rng := s.Range(l)
+	rng := Range{s.Base(), s.Size()}
 	ioR := pool.Slice(rng).NewReader(ctx)
 	binR := endian.Reader(ioR, l.GetEndian())
 	d := NewDecoder(binR, l)

--- a/gapis/memory/memory_pb/memory.proto
+++ b/gapis/memory/memory_pb/memory.proto
@@ -33,11 +33,13 @@ message Observation {
 // Slice is the common data between all slice types.
 message Slice {
     // Original pointer this slice derives from.
-    uint64 Root = 1;
+    uint64 root = 1;
     // Address of first element.
-    uint64 Base = 2;
-    // Number of elements in the slice.
-    uint64 Count= 3;
+    uint64 base = 2;
+    // The size of the slice in bytes.
+    uint64 size = 3;
+    // The number of elements in the slice.
+    uint64 count = 4;
     // The pool identifier.
-    uint32 Pool = 4;
+    uint32 pool = 5;
 }

--- a/gapis/memory/pointer.go
+++ b/gapis/memory/pointer.go
@@ -94,7 +94,14 @@ func (p ptr) ISlice(start, end uint64, m *device.MemoryLayout) Slice {
 	if start > end {
 		panic(fmt.Errorf("%v.Slice start (%d) is greater than the end (%d)", p, start, end))
 	}
-	return sli{root: p.addr, base: p.addr + start*p.ElementSize(m), count: end - start, pool: p.pool, elTy: p.elTy}
+	elSize := p.ElementSize(m)
+	return sli{
+		root: p.addr,
+		base: p.addr + start*elSize,
+		size: (end - start) * elSize,
+		pool: p.pool,
+		elTy: p.elTy,
+	}
 }
 
 var _ data.Assignable = &ptr{}

--- a/gapis/memory/slice.go
+++ b/gapis/memory/slice.go
@@ -30,6 +30,9 @@ type Slice interface {
 	// Base returns the address of first element.
 	Base() uint64
 
+	// Size returns the size of the slice in bytes.
+	Size() uint64
+
 	// Count returns the number of elements in the slice.
 	Count() uint64
 
@@ -39,54 +42,55 @@ type Slice interface {
 	// ElementType returns the reflect.Type of the elements in the slice.
 	ElementType() reflect.Type
 
-	// ElementSize returns the size in bytes of a single element in the slice.
-	ElementSize(*device.MemoryLayout) uint64
-
-	// Range returns the memory range this slice represents in the underlying pool.
-	Range(*device.MemoryLayout) Range
-
 	// ISlice returns a sub-slice from this slice using start and end indices.
-	ISlice(start, end uint64, m *device.MemoryLayout) Slice
-
-	// IIndex returns a pointer to the i'th element in the slice.
-	IIndex(i uint64, m *device.MemoryLayout) Pointer
+	ISlice(start, end uint64) Slice
 }
 
 // NewSlice returns a new Slice.
-func NewSlice(root, base, count uint64, pool PoolID, elTy reflect.Type) Slice {
-	return &sli{root, base, count, pool, elTy}
+func NewSlice(root, base, size, count uint64, pool PoolID, elTy reflect.Type) Slice {
+	return &sli{root, base, size, count, pool, elTy}
 }
 
 // sli is a slice of a basic type.
 type sli struct {
 	root  uint64
 	base  uint64
+	size  uint64
 	count uint64
 	pool  PoolID
 	elTy  reflect.Type
 }
 
-func (s sli) Root() uint64                              { return s.root }
-func (s sli) Base() uint64                              { return s.base }
-func (s sli) Count() uint64                             { return s.count }
-func (s sli) Pool() PoolID                              { return s.pool }
-func (s sli) ElementType() reflect.Type                 { return s.elTy }
-func (s sli) ElementSize(m *device.MemoryLayout) uint64 { return SizeOf(s.elTy, m) }
-func (s sli) Range(m *device.MemoryLayout) Range {
-	return Range{s.base, s.ElementSize(m) * s.count}
-}
-func (s sli) ISlice(start, end uint64, m *device.MemoryLayout) Slice {
+func (s sli) Root() uint64              { return s.root }
+func (s sli) Base() uint64              { return s.base }
+func (s sli) Size() uint64              { return s.size }
+func (s sli) Count() uint64             { return s.count }
+func (s sli) Pool() PoolID              { return s.pool }
+func (s sli) ElementSize() uint64       { return s.Size() / s.Count() }
+func (s sli) ElementType() reflect.Type { return s.elTy }
+func (s sli) ISlice(start, end uint64) Slice {
 	if start > end {
 		panic(fmt.Errorf("%v.ISlice start (%d) is greater than the end (%d)", s, start, end))
 	}
-	if end > s.count {
+	if end > s.Count() {
 		panic(fmt.Errorf("%v.ISlice(%d, %d) - out of bounds", s, start, end))
 	}
-	return sli{s.root, s.base + start*s.ElementSize(m), end - start, s.pool, s.elTy}
-}
-func (s sli) IIndex(i uint64, m *device.MemoryLayout) Pointer {
-	if i >= s.count {
-		panic(fmt.Errorf("%v.IIndex(%d) is out of bounds [0 - %d]", s, i, s.count-1))
+	count := end - start
+	elSize := s.ElementSize()
+	return sli{
+		root:  s.root,
+		base:  s.base + start*elSize,
+		size:  count * elSize,
+		count: count,
+		pool:  s.pool,
+		elTy:  s.elTy,
 	}
-	return ptr{s.base + i*s.ElementSize(m), s.pool, s.elTy}
+}
+
+func (s sli) IIndex(i uint64, m *device.MemoryLayout) Pointer {
+	if count := s.Count(); i >= count {
+		panic(fmt.Errorf("%v.IIndex(%d) is out of bounds [0 - %d]", s, i, count-1))
+	}
+	elSize := s.ElementSize()
+	return ptr{s.base + i*elSize, s.pool, s.elTy}
 }

--- a/gapis/resolve/resolve.go
+++ b/gapis/resolve/resolve.go
@@ -128,16 +128,11 @@ func ArrayIndex(ctx context.Context, p *path.ArrayIndex) (interface{}, error) {
 	a := reflect.ValueOf(obj)
 	switch {
 	case box.IsMemorySlice(a.Type()):
-		ml, err := memoryLayout(ctx, p)
-		if err != nil {
-			return nil, err
-		}
-
 		slice := box.AsMemorySlice(a)
 		if count := slice.Count(); p.Index >= count {
 			return nil, errPathOOB(p.Index, "Index", 0, count-1, p)
 		}
-		return slice.IIndex(p.Index, ml), nil
+		return slice.ISlice(p.Index, p.Index+1), nil
 
 	default:
 		switch a.Kind() {
@@ -165,16 +160,11 @@ func Slice(ctx context.Context, p *path.Slice) (interface{}, error) {
 	a := reflect.ValueOf(obj)
 	switch {
 	case box.IsMemorySlice(a.Type()):
-		ml, err := memoryLayout(ctx, p)
-		if err != nil {
-			return nil, err
-		}
-
 		slice := box.AsMemorySlice(a)
-		if p.Start >= slice.Count() || p.End > slice.Count() {
-			return nil, errPathSliceOOB(p.Start, p.End, slice.Count(), p)
+		if count := slice.Count(); p.Start >= count || p.End > count {
+			return nil, errPathSliceOOB(p.Start, p.End, count, p)
 		}
-		return slice.ISlice(p.Start, p.End, ml), nil
+		return slice.ISlice(p.Start, p.End), nil
 
 	default:
 		switch a.Kind() {

--- a/gapis/resolve/state_tree_test.go
+++ b/gapis/resolve/state_tree_test.go
@@ -32,6 +32,10 @@ import (
 	"github.com/google/gapid/gapis/service/path"
 )
 
+var intType = reflect.TypeOf(memory.Int(0))
+
+const intSize = 8
+
 type TestStruct struct {
 	/* 0 */ Bool bool
 	/* 1 */ Int int
@@ -68,7 +72,7 @@ var testState = TestState{
 		Reference: nil,
 		Map:       map[int]string{1: "one", 5: "five", 9: "nine"},
 		Array:     []int{0, 10, 20, 30, 40},
-		Slice:     memory.NewSlice(0x1000, 0x1000, 5, memory.ApplicationPool, reflect.TypeOf(memory.Int(0))),
+		Slice:     memory.NewSlice(0x1000, 0x1000, 5*intSize, 5, memory.ApplicationPool, intType),
 		Pointer:   memory.NewPtr(0x1010, memory.ApplicationPool, reflect.TypeOf(memory.Size(0))),
 		Interface: &TestStruct{},
 	},
@@ -86,7 +90,7 @@ var testState = TestState{
 			20, 21, 22, 23, 24, 25, 26, 27, 28, 29,
 			30, 31, 32, 33,
 		},
-		Slice: memory.NewSlice(0x1000, 0x1000, 1005, memory.ApplicationPool, reflect.TypeOf(memory.Int(0))),
+		Slice: memory.NewSlice(0x1000, 0x1000, 1005*intSize, 1005, memory.ApplicationPool, intType),
 	},
 	ReferenceC: nil,
 }
@@ -347,7 +351,7 @@ func TestStateTreeNode(t *testing.T) {
 				NumChildren:    5,
 				Name:           "Slice",
 				ValuePath:      rootPath.Field("ReferenceA").Field("Slice").Path(),
-				Preview:        box.NewValue(memory.NewSlice(0x1000, 0x1000, 5, memory.ApplicationPool, reflect.TypeOf(memory.Int(0)))),
+				Preview:        box.NewValue(memory.NewSlice(0x1000, 0x1000, 5*intSize, 5, memory.ApplicationPool, intType)),
 				PreviewIsValue: true,
 			},
 		}, {
@@ -383,7 +387,7 @@ func TestStateTreeNode(t *testing.T) {
 				NumChildren:    0,
 				Name:           "Pointer",
 				ValuePath:      rootPath.Field("ReferenceA").Field("Pointer").Path(),
-				Preview:        box.NewValue(memory.NewPtr(0x1010, memory.ApplicationPool, reflect.TypeOf(memory.Int(0)))),
+				Preview:        box.NewValue(memory.NewPtr(0x1010, memory.ApplicationPool, intType)),
 				PreviewIsValue: true,
 			},
 		}, {
@@ -497,7 +501,7 @@ func TestStateTreeNode(t *testing.T) {
 				NumChildren:    2,
 				Name:           "Slice",
 				ValuePath:      rootPath.Field("ReferenceB").Field("Slice").Path(),
-				Preview:        box.NewValue(memory.NewSlice(0x1000, 0x1000, 1005, memory.ApplicationPool, reflect.TypeOf(memory.Int(0)))),
+				Preview:        box.NewValue(memory.NewSlice(0x1000, 0x1000, 1005*intSize, 1005, memory.ApplicationPool, intType)),
 				PreviewIsValue: true,
 			},
 		}, {
@@ -506,7 +510,7 @@ func TestStateTreeNode(t *testing.T) {
 				NumChildren:    10,
 				Name:           "[0 - 999]",
 				ValuePath:      rootPath.Field("ReferenceB").Field("Slice").Slice(0, 999).Path(),
-				Preview:        box.NewValue(memory.NewSlice(0x1000, 0x1000, 1000, memory.ApplicationPool, reflect.TypeOf(memory.Int(0)))),
+				Preview:        box.NewValue(memory.NewSlice(0x1000, 0x1000, 1000*intSize, 1000, memory.ApplicationPool, intType)),
 				PreviewIsValue: true,
 			},
 		}, {
@@ -515,7 +519,7 @@ func TestStateTreeNode(t *testing.T) {
 				NumChildren:    10,
 				Name:           "[400 - 499]",
 				ValuePath:      rootPath.Field("ReferenceB").Field("Slice").Slice(0, 999).Slice(400, 499).Path(),
-				Preview:        box.NewValue(memory.NewSlice(0x1000, 0x1C80, 100, memory.ApplicationPool, reflect.TypeOf(memory.Int(0)))),
+				Preview:        box.NewValue(memory.NewSlice(0x1000, 0x1C80, 100*intSize, 100, memory.ApplicationPool, intType)),
 				PreviewIsValue: true,
 			},
 		}, {
@@ -524,7 +528,7 @@ func TestStateTreeNode(t *testing.T) {
 				NumChildren:    10,
 				Name:           "[430 - 439]",
 				ValuePath:      rootPath.Field("ReferenceB").Field("Slice").Slice(0, 999).Slice(400, 499).Slice(30, 39).Path(),
-				Preview:        box.NewValue(memory.NewSlice(0x1000, 0x1D70, 10, memory.ApplicationPool, reflect.TypeOf(memory.Int(0)))),
+				Preview:        box.NewValue(memory.NewSlice(0x1000, 0x1D70, 10*intSize, 10, memory.ApplicationPool, intType)),
 				PreviewIsValue: true,
 			},
 		}, {
@@ -542,7 +546,7 @@ func TestStateTreeNode(t *testing.T) {
 				NumChildren:    5,
 				Name:           "[1000 - 1004]",
 				ValuePath:      rootPath.Field("ReferenceB").Field("Slice").Slice(1000, 1004).Path(),
-				Preview:        box.NewValue(memory.NewSlice(0x1000, 0x2F40, 5, memory.ApplicationPool, reflect.TypeOf(memory.Int(0)))),
+				Preview:        box.NewValue(memory.NewSlice(0x1000, 0x2F40, 5*intSize, 5, memory.ApplicationPool, intType)),
 				PreviewIsValue: true,
 			},
 		}, {

--- a/gapis/service/box/box.go
+++ b/gapis/service/box/box.go
@@ -117,6 +117,7 @@ func (b *boxer) val(v reflect.Value) *Value {
 		return &Value{0, &Value_Slice{&Slice{
 			Type:  elTy,
 			Base:  &Pointer{s.Base(), uint32(s.Pool())},
+			Size:  s.Size(),
 			Count: s.Count(),
 			Root:  s.Root(),
 		}}}
@@ -276,6 +277,7 @@ func (b *unboxer) val(v *Value) (out reflect.Value) {
 		p := memory.NewSlice(
 			v.Slice.Root,
 			v.Slice.Base.Address,
+			v.Slice.Size,
 			v.Slice.Count,
 			memory.PoolID(v.Slice.Base.Pool),
 			v.Slice.Type.Get(),

--- a/gapis/service/box/box.proto
+++ b/gapis/service/box/box.proto
@@ -54,9 +54,11 @@ message Slice {
   Pointer base = 2;
   // the number of elements in the slice.
   uint64 count = 3;
+  // the total size of the slice in bytes.
+  uint64 size = 4;
   // the original pointer this slice derives from.
   // Is constant even after sub-slicing.
-  uint64 root = 4;
+  uint64 root = 5;
 }
 
 message Reference {

--- a/gapis/service/box/box_test.go
+++ b/gapis/service/box/box_test.go
@@ -360,7 +360,7 @@ func TestBoxMemoryType(t *testing.T) {
 func TestBoxUnboxMemory(t *testing.T) {
 	val := Memory{
 		P: memory.BytePtr(1234, 555),
-		S: memory.NewSlice(1234, 1256, 42, 333, reflect.TypeOf(byte(0))),
+		S: memory.NewSlice(1234, 1256, 42, 42, 333, reflect.TypeOf(byte(0))),
 	}
 	boxed := box.NewValue(val)
 	var unboxed Memory


### PR DESCRIPTION
Note: This is a file format breaking change.

We've switched between using Size or Count a couple of times now, and we currently only serialize Count, however the new compiler relies on Size information. Converting between these two requires the memory layout with is awkward to get at when deserializing.

Given that we've already broken file formats between v0.1.3 and the next release, I've simply added the field and bumped the file format version again.