### PR TITLE
Remove pool identifiers from pointers.

### DIFF
--- a/cmd/gapit/common.go
+++ b/cmd/gapit/common.go
@@ -295,16 +295,16 @@ func printCommand(ctx context.Context, client service.Service, p *path.Command, 
 		m := boxedMemory.(*service.Memory)
 		for _, read := range m.Reads {
 			fmt.Printf("   R: [%v - %v]\n",
-				memory.BytePtr(read.Base, 0),
-				memory.BytePtr(read.Base+read.Size-1, 0))
+				memory.BytePtr(read.Base),
+				memory.BytePtr(read.Base+read.Size-1))
 			if of.Data {
 				printMemoryData(ctx, client, p, read)
 			}
 		}
 		for _, write := range m.Writes {
 			fmt.Printf("   W: [%v - %v]\n",
-				memory.BytePtr(write.Base, 0),
-				memory.BytePtr(write.Base+write.Size-1, 0))
+				memory.BytePtr(write.Base),
+				memory.BytePtr(write.Base+write.Size-1))
 			if of.Data {
 				printMemoryData(ctx, client, p, write)
 			}

--- a/gapic/src/main/com/google/gapid/views/Formatter.java
+++ b/gapic/src/main/com/google/gapid/views/Formatter.java
@@ -336,14 +336,7 @@ public class Formatter {
   }
 
   private static void format(Box.Pointer pointer, StylingString string, Style style) {
-    if (Memory.PoolNames.Application_VALUE != pointer.getPool()) {
-      string.append("*", string.structureStyle());
-      if (pointer.getAddress() != 0) {
-        string.append(toPointerString(pointer.getAddress()) + " ", style);
-      }
-      string.append("Pool: ", style);
-      string.append(uint32ToString(pointer.getPool()), style);
-    } else if (pointer.getAddress() == 0) {
+    if (pointer.getAddress() == 0) {
       string.append("(nil)", string.structureStyle());
     } else {
       string.append("*", string.structureStyle());
@@ -366,7 +359,7 @@ public class Formatter {
     string.append(String.valueOf(slice.getCount()), style);
     string.append("]", string.structureStyle());
 
-    if (slice.getBase().getPool() != Memory.PoolNames.Application_VALUE ||
+    if (slice.getPool() != Memory.PoolNames.Application_VALUE ||
         slice.getBase().getAddress() != 0) {
       string.append(" (", string.structureStyle());
       format(slice.getBase(), string, style);

--- a/gapis/api/gles/compat.go
+++ b/gapis/api/gles/compat.go
@@ -1092,7 +1092,7 @@ func compat(ctx context.Context, device *device.Instance, onError onCompatError)
 						out.MutateAndWrite(ctx, dID, cb.Custom(func(ctx context.Context, s *api.GlobalState, b *builder.Builder) error {
 							eglImage.Context = eglContextHandle[c]
 							eglImage.Target = EGLenum_EGL_GL_TEXTURE_2D
-							eglImage.Buffer = EGLClientBuffer{uint64(texID), memory.ApplicationPool}
+							eglImage.Buffer = EGLClientBuffer(texID)
 							return nil
 						}))
 						t.revert(ctx)

--- a/gapis/api/gles/compat_test.go
+++ b/gapis/api/gles/compat_test.go
@@ -33,9 +33,7 @@ var compat = gles.VisibleForTestingCompat
 
 const OpenGL_3_0 = "3.0"
 
-func p(addr uint64) memory.Pointer {
-	return memory.BytePtr(addr, memory.ApplicationPool)
-}
+var p = memory.BytePtr
 
 func newState(ctx context.Context) *api.GlobalState {
 	s, err := capture.NewState(ctx)
@@ -76,9 +74,7 @@ func TestGlVertexAttribPointerCompatTest(t *testing.T) {
 	positions := []float32{-1., -1., 1., -1., -1., 1., 1., 1.}
 	indices := []uint16{0, 1, 2, 1, 2, 3}
 	mw := &testcmd.Writer{S: newState(ctx)}
-	ctxHandle := memory.BytePtr(1, memory.ApplicationPool)
-	displayHandle := memory.BytePtr(2, memory.ApplicationPool)
-	surfaceHandle := memory.BytePtr(3, memory.ApplicationPool)
+	ctxHandle, displayHandle, surfaceHandle := p(1), p(2), p(3)
 	cb := gles.CommandBuilder{Thread: 0}
 	eglMakeCurrent := cb.EglMakeCurrent(displayHandle, surfaceHandle, surfaceHandle, ctxHandle, 0)
 	eglMakeCurrent.Extras().Add(gles.NewStaticContextStateForTest(), gles.NewDynamicContextStateForTest(64, 64, true))

--- a/gapis/api/gles/dead_code_elimination_test.go
+++ b/gapis/api/gles/dead_code_elimination_test.go
@@ -72,10 +72,10 @@ func TestDeadCommandRemoval(t *testing.T) {
 		},
 	}
 
-	ctxHandle1 := memory.BytePtr(1, memory.ApplicationPool)
-	ctxHandle2 := memory.BytePtr(2, memory.ApplicationPool)
-	displayHandle := memory.BytePtr(3, memory.ApplicationPool)
-	surfaceHandle := memory.BytePtr(4, memory.ApplicationPool)
+	ctxHandle1 := memory.BytePtr(1)
+	ctxHandle2 := memory.BytePtr(2)
+	displayHandle := memory.BytePtr(3)
+	surfaceHandle := memory.BytePtr(4)
 	cb := gles.CommandBuilder{Thread: 0}
 	prologue := []api.Cmd{
 		cb.EglCreateContext(displayHandle, surfaceHandle, surfaceHandle, memory.Nullptr, ctxHandle1),

--- a/gapis/api/gles/draw_call.go
+++ b/gapis/api/gles/draw_call.go
@@ -70,7 +70,7 @@ func getIndices(
 		reader = ptr.Slice(offset, size, s.MemoryLayout).Reader(ctx, s)
 	} else {
 		// Get the index buffer data from buffer, offset by the 'indices' pointer.
-		offset += ptr.addr
+		offset += uint64(ptr)
 		start := u64.Min(offset, indexBuffer.Data.count)
 		end := u64.Min(offset+size, indexBuffer.Data.count)
 		reader = indexBuffer.Data.Slice(start, end).Reader(ctx, s)

--- a/gapis/api/gles/texture_compat.go
+++ b/gapis/api/gles/texture_compat.go
@@ -217,10 +217,10 @@ func decompressTexImage2D(ctx context.Context, i api.CmdID, a *GlCompressedTexIm
 	dID := i.Derived()
 	c := GetContext(s, a.thread)
 	cb := CommandBuilder{Thread: a.thread}
-	data := a.Data
+	data := AsU8ˢ(a.Data.Slice(0, uint64(a.ImageSize), s.MemoryLayout), s.MemoryLayout)
 	if pb := c.Bound.PixelUnpackBuffer; pb != nil {
-		base := a.Data.addr
-		data = NewTexturePointer(pb.Data.Index(base))
+		offset := a.Data.Address()
+		data = pb.Data.Slice(offset, offset+uint64(a.ImageSize))
 		out.MutateAndWrite(ctx, dID, cb.GlBindBuffer(GLenum_GL_PIXEL_UNPACK_BUFFER, 0))
 		defer out.MutateAndWrite(ctx, dID, cb.GlBindBuffer(GLenum_GL_PIXEL_UNPACK_BUFFER, pb.ID))
 	} else {
@@ -233,7 +233,7 @@ func decompressTexImage2D(ctx context.Context, i api.CmdID, a *GlCompressedTexIm
 	}
 
 	src := image.Info{
-		Bytes:  image.NewID(data.Slice(0, uint64(a.ImageSize), s.MemoryLayout).ResourceID(ctx, s)),
+		Bytes:  image.NewID(data.ResourceID(ctx, s)),
 		Width:  uint32(a.Width),
 		Height: uint32(a.Height),
 		Depth:  1,
@@ -270,10 +270,10 @@ func decompressTexSubImage2D(ctx context.Context, i api.CmdID, a *GlCompressedTe
 	dID := i.Derived()
 	c := GetContext(s, a.thread)
 	cb := CommandBuilder{Thread: a.thread}
-	data := a.Data
+	data := AsU8ˢ(a.Data.Slice(0, uint64(a.ImageSize), s.MemoryLayout), s.MemoryLayout)
 	if pb := c.Bound.PixelUnpackBuffer; pb != nil {
-		base := a.Data.addr
-		data = TexturePointer(pb.Data.Index(base))
+		offset := a.Data.Address()
+		data = pb.Data.Slice(offset, offset+uint64(a.ImageSize))
 		out.MutateAndWrite(ctx, dID, cb.GlBindBuffer(GLenum_GL_PIXEL_UNPACK_BUFFER, 0))
 		defer out.MutateAndWrite(ctx, dID, cb.GlBindBuffer(GLenum_GL_PIXEL_UNPACK_BUFFER, pb.ID))
 	} else {
@@ -286,7 +286,7 @@ func decompressTexSubImage2D(ctx context.Context, i api.CmdID, a *GlCompressedTe
 	}
 
 	src := image.Info{
-		Bytes:  image.NewID(data.Slice(0, uint64(a.ImageSize), s.MemoryLayout).ResourceID(ctx, s)),
+		Bytes:  image.NewID(data.ResourceID(ctx, s)),
 		Width:  uint32(a.Width),
 		Height: uint32(a.Height),
 		Depth:  1,

--- a/gapis/api/state.go
+++ b/gapis/api/state.go
@@ -219,14 +219,14 @@ func (r AllocResult) Range() memory.Range {
 	return r.rng
 }
 
-// Ptr returns the beginning of the range as an application pool pointer.
+// Ptr returns a pointer to the beginning of the range.
 func (r AllocResult) Ptr() memory.Pointer {
-	return memory.BytePtr(r.rng.Base, memory.ApplicationPool)
+	return memory.BytePtr(r.rng.Base)
 }
 
 // Offset returns a pointer n bytes to the right of the associated range.
 func (r AllocResult) Offset(n uint64) memory.Pointer {
-	return memory.BytePtr(r.rng.Base+n, memory.ApplicationPool)
+	return memory.BytePtr(r.rng.Base + n)
 }
 
 // Address returns the beginning of the range.

--- a/gapis/api/templates/api.go.tmpl
+++ b/gapis/api/templates/api.go.tmpl
@@ -198,32 +198,26 @@
   {{$el_is_char := IsChar    ($p.To | Underlying | Unpack) }}
   {{$el_is_ptr  := IsPointer ($p.To | Underlying | Unpack) }}
 
-  var _ = ϟmem.Pointer({{$ptr_ty}}{})
-  var _ data.Assignable = &{{$ptr_ty}}{}
+  var (
+    _ ϟmem.Pointer = {{$ptr_ty}}(0)
+    _ path.Linker = {{$ptr_ty}}(0)
+    _ data.Assignable = (*{{$ptr_ty}})(nil)
+  )
 
   // {{$ptr_ty}} is a pointer to a {{$el_ty}} element.
-  {{if $el_is_ptr}}
-  // Note: Pointers are stored differently between the application pool and internal pools.
-  //  * The application pool stores pointers as an address of an architecture-dependant size.
-  //  * Internal pools store pointers as an 64-bit unsigned address and a 32-bit unsigned
-  //    pool identifier.
-  {{end}}
-  type {{$ptr_ty}} struct {
-    addr uint64
-    pool ϟmem.PoolID
-  }
+  type {{$ptr_ty}} uint64
 
   // New{{$ptr_ty}} returns a {{$ptr_ty}} that points to addr in the application pool.
   func New{{$ptr_ty}}(p ϟmem.Pointer) {{$ptr_ty}} {
     if p == nil {
-      return {{$ptr_ty}}{ 0, ϟmem.ApplicationPool }
+      return {{$ptr_ty}}(0)
     }
-    return {{$ptr_ty}}{ p.Address(), p.Pool() }
+    return {{$ptr_ty}}(p.Address())
   }
 
   func (p *{{$ptr_ty}}) Assign(o interface{}) bool {
     if o, ok := o.(ϟmem.Pointer); ok {
-      *p = {{$ptr_ty}}{o.Address(), o.Pool()}
+      *p = {{$ptr_ty}}(o.Address())
       return true
     }
     return false
@@ -231,20 +225,17 @@
 
   func (p {{$ptr_ty}}) String() string { return ϟmem.PointerToString(p) }
 
-  // IsNullptr returns true if the address is 0 and the pool is ϟmem.ApplicationPool.
-  func (p {{$ptr_ty}}) IsNullptr() bool { return p.addr == 0 && p.pool == ϟmem.ApplicationPool }
+  // IsNullptr returns true if the pointer address is 0.
+  func (p {{$ptr_ty}}) IsNullptr() bool { return p == 0 }
 
   // APointer implements the ReflectPointer interface
   func (p {{$ptr_ty}}) APointer() { return }
 
   // Address returns the pointer's memory address.
-  func (p {{$ptr_ty}}) Address() uint64 { return p.addr }
-
-  // Pool returns the memory pool.
-  func (p {{$ptr_ty}}) Pool() ϟmem.PoolID { return p.pool }
+  func (p {{$ptr_ty}}) Address() uint64 { return uint64(p) }
 
   // Offset returns the pointer offset by n bytes.
-  func (p {{$ptr_ty}}) Offset(n uint64) ϟmem.Pointer { return {{$ptr_ty}}{ p.addr + n, p.pool } }
+  func (p {{$ptr_ty}}) Offset(n uint64) ϟmem.Pointer { return {{$ptr_ty}}(uint64(p) + n) }
 
   // ElementType returns the reflect.Type of the element that {{$ptr_ty}} points to.
   func (p {{$ptr_ty}}) ElementType() reflect.Type {
@@ -290,12 +281,12 @@
     // StringSlice returns a slice starting at p and ending at the first 0 byte null-terminator.
     func (p {{$ptr_ty}}) StringSlice(ϟctx context.Context, ϟs *api.GlobalState) Charˢ {
       numBytes := uint64(2^6)
-      i, d := uint64(0), ϟs.MemoryDecoder(ϟctx, ϟs.Memory.MustGet(p.pool).TempSlice(ϟmem.Range{Base: p.addr, Size: p.addr + numBytes}))
+      i, d := uint64(0), ϟs.MemoryDecoder(ϟctx, ϟs.Memory.MustGet(ϟmem.ApplicationPool).TempSlice(ϟmem.Range{Base: uint64(p), Size: uint64(p) + numBytes}))
 
       for {
         if i >= numBytes {
           numBytes <<= 1
-          d = ϟs.MemoryDecoder(ϟctx, ϟs.Memory.MustGet(p.pool).TempSlice(ϟmem.Range{Base: p.addr + i, Size: p.addr + i + numBytes}))
+          d = ϟs.MemoryDecoder(ϟctx, ϟs.Memory.MustGet(ϟmem.ApplicationPool).TempSlice(ϟmem.Range{Base: uint64(p) + i, Size: numBytes - i}))
         }
 
         i++
@@ -314,19 +305,16 @@
     elSize := p.ElementSize(ϟl)
     count := end-start
     return {{$slice_ty}}{
-      root:  p.addr,
-      base:  p.addr + start * elSize,
+      root:  uint64(p),
+      base:  uint64(p) + start * elSize,
       size:  count * elSize,
       count: count,
-      pool:  p.pool,
+      pool:  ϟmem.ApplicationPool,
     }
   }
 
   // ISlice returns a new Slice from the pointer using start and end indices.
   func (p {{$ptr_ty}}) ISlice(start, end uint64, ϟl *device.MemoryLayout) ϟmem.Slice { return p.Slice(start, end, ϟl) }
-
-  // Check interface conformance
-  var _ path.Linker = {{$ptr_ty}}{}
 
   // Link returns a path to the object that this is a link to, or error
   // if you can not follow this path. Typically the incoming path ϟp
@@ -335,18 +323,18 @@
   // of the value of the instance after the command has executed.
   func (p {{$ptr_ty}}) Link(ϟctx context.Context, ϟp path.Node) (path.Node, error) {
     if cmd := path.FindCommand(ϟp); cmd != nil {
-      return cmd.MemoryAfter(uint32(p.pool), p.addr, 0), nil
+      return cmd.MemoryAfter(uint32(ϟmem.ApplicationPool), uint64(p), 0), nil
     }
     return nil, nil
   }
 
   {{if not (GetAnnotation $ "replay_custom_value")}}
     func (p {{$ptr_ty}}) value(ϟb *builder.Builder, ϟa api.Cmd, ϟs *api.GlobalState) value.Pointer {
-      if p.addr != 0 {
+      if p != 0 {
         {{if $el_is_ptr}}
-          return value.PointerIndex(p.addr / uint64(ϟs.MemoryLayout.GetPointer().GetSize()))
+          return value.PointerIndex(uint64(p) / uint64(ϟs.MemoryLayout.GetPointer().GetSize()))
         {{else}}
-          return value.ObservedPointer(p.addr)
+          return value.ObservedPointer(uint64(p))
         {{end}}
       } else {
         return value.AbsolutePointer(0)
@@ -391,7 +379,7 @@
       { // {{$.Name}}.{{$name}}
         d.Align({{Template "Go.AlignOf" (TypeOf $f)}})
         addr := value.ObservedPointer(s.base + d.Offset())
-        ϟb.Push({{Macro "Go.Type" $f}}{d.Pointer(), ϟmem.ApplicationPool}.value(ϟb, ϟa, ϟs))
+        ϟb.Push({{Macro "Go.Type" $f}}(d.Pointer()).value(ϟb, ϟa, ϟs))
         ϟb.Store(addr)
       }
     {{else if IsClass ($f.Type | Underlying)}}
@@ -653,8 +641,7 @@
         d, dst := s.Decoder(ϟctx, ϟs), value.PointerIndex(s.base / uint64(ϟl.GetPointer().GetSize()))
         for i := uint64(0); i < s.count; i++ {
           {{if (GetAnnotation $s.To "replay_remap")}}{{Error "Remappings of pointers not implemented"}}{{end}}
-          ptr := {{$el_ty}}{d.Pointer(), ϟmem.ApplicationPool}.value(ϟb, ϟa, ϟs)
-          ϟb.StorePointer(dst, ptr)
+          ϟb.StorePointer(dst, {{$el_ty}}(d.Pointer()).value(ϟb, ϟa, ϟs))
           dst++
         }
         panicOnError(d.Error())
@@ -725,15 +712,9 @@
     return s
   }
 
-  // Index returns a {{$ptr_ty}} to the i'th element in this {{$slice_ty}}.
-  func (s {{$slice_ty}}) Index(i uint64) {{$ptr_ty}} {
-    elSize := s.size / s.count
-    return {{$ptr_ty}}{ s.base + i * elSize, s.pool }
-  }
-
-  // IIndex returns a pointer to the i'th element in the slice.
-  func (s {{$slice_ty}}) IIndex(i uint64) ϟmem.Pointer {
-    return s.Index(i)
+  // Index returns a sub-slice to the i'th element in this {{$slice_ty}}.
+  func (s {{$slice_ty}}) Index(i uint64) {{$slice_ty}} {
+    return s.Slice(i, i+1)
   }
 
   // Slice returns a sub-slice from the {{$slice_ty}} using start and end indices.
@@ -762,7 +743,7 @@
 
   // String returns a string description of the {{$slice_ty}} slice.
   func (s {{$slice_ty}}) String() string {
-    return fmt.Sprintf("{{$el_ty}}(%v@%v)[%d]", s.base, s.pool, s.count)
+    return fmt.Sprintf("{{$el_ty}}(0x%x@%v)[%d]", s.base, s.pool, s.count)
   }
 
   // Check interface conformance

--- a/gapis/api/templates/go_common.tmpl
+++ b/gapis/api/templates/go_common.tmpl
@@ -91,7 +91,7 @@
 */}}
 {{define "Go.Null"}}
   {{AssertType $ "Type"}}
-  {{     if IsPointer       $}}{{Template "Go.Type" $}}{}
+  {{     if IsPointer       $}}{{Template "Go.Type" $}}(0)
   {{else if IsSlice         $}}{{Template "Go.Type" $}}{}
   {{else if IsReference     $}}{{Template "Go.Type" $}}(nil)
   {{else if IsMap           $}}New{{Template "Go.Type" $}}()
@@ -490,7 +490,7 @@
   {{else if IsNull             $}}{{Template "Go.Null" $.Type}}
   {{else if IsNew              $}}new {{Template "Go.Type" $.Type}}
   {{else if IsSliceContains    $}}{{Template "Go.Read" $.Slice  }}.Contains(ϟctx, {{Template "Go.Read" $.Value}}, ϟa, ϟs, ϟb)
-  {{else if IsSliceIndex       $}}{{Template "Go.Read" $.Slice  }}.Index({{Template "Go.Read" $.Index}}).{{Macro "Go.MemoryRead"}}
+  {{else if IsSliceIndex       $}}{{Template "Go.Read" $.Slice  }}.Index({{Template "Go.Read" $.Index}}).{{Macro "Go.MemoryRead"}}[0]
   {{else if IsSliceRange       $}}{{Template "Go.Read" $.Slice  }}.Slice({{Template "Go.Read" $.Range.LHS}}, {{Template "Go.Read" $.Range.RHS}})
   {{else if IsPointerRange     $}}{{Template "Go.Read" $.Pointer}}.Slice({{Template "Go.Read" $.Range.LHS}}, {{Template "Go.Read" $.Range.RHS}}, ϟl)
   {{else if IsClone            $}}{{Template "Go.Read" $.Slice  }}.Clone(ϟctx, ϟa, ϟs, ϟb)
@@ -576,7 +576,7 @@
   {{$src    := Macro "Go.Read" $.Object}}
 
   {{/* T* -> number */}}{{if and (IsPointer $src_ty) (IsNumericType $dst_ty)}}
-    {{Template "Go.Type" $.Type}}({{$src}}.addr)
+    {{Template "Go.Type" $.Type}}({{$src}})
   {{/* A[] -> B[] */}}{{else if and (IsSlice $src_ty) (IsSlice $dst_ty)}}
     As{{Template "Go.Type" $.Type}}({{$src}}, ϟl)
   {{/* T[] -> T* */}}{{else if and (IsSlice $src_ty) (IsPointer $dst_ty)}}

--- a/gapis/api/templates/go_convert_common.tmpl
+++ b/gapis/api/templates/go_convert_common.tmpl
@@ -297,7 +297,7 @@
         «}¶
         return ϟobj¶
       «} ()
-    {{else if IsPointer $truetype}}{{$target}}({{$.Value}}.addr)
+    {{else if IsPointer $truetype}}{{$target}}({{$.Value}})
     {{else if IsSlice $truetype}}&{{$target}}{»¶
       Root:  {{$.Value}}.root,¶
       Base:  {{$.Value}}.base,¶
@@ -329,7 +329,7 @@
         ϟobj := &{{Template "Convert.LiveType" $.Type.To}}{}¶
         return ϟobj, func() { *ϟobj ={{Template "Convert.FromProto" "Type" $.Type.To "Value" $value}} }¶
       «}).({{$target}})
-    {{else if IsPointer $truetype}}{{$target}}{addr: uint64({{$.Value}}), pool: memory.ApplicationPool}
+    {{else if IsPointer $truetype}}{{$target}}({{$.Value}})
     {{else if IsSlice $truetype}}{{$target}}{»¶
       root:  {{$.Value}}.Root,¶
       base:  {{$.Value}}.Base,¶

--- a/gapis/api/templates/mutate.go.tmpl
+++ b/gapis/api/templates/mutate.go.tmpl
@@ -592,7 +592,7 @@
   {{AssertType $ "SliceAssign"}}
 
   {{if ne $.Operator "="}}{{Error "Compound assignments to pointers are not supported (%s)" $.Operator}}{{end}}
-  {{Template "Go.Read" $.To.Slice}}.Index({{Template "Go.Read" $.To.Index}}).MustWrite(ϟctx, {{Template "Go.Read" $.Value}}, ϟa, ϟs, ϟb)
+  {{Template "Go.Read" $.To.Slice}}.Index({{Template "Go.Read" $.To.Index}}).MustWrite(ϟctx, []{{Template "Go.Type" $.To}}{ {{Template "Go.Read" $.Value}} }, ϟa, ϟs, ϟb)
 {{end}}
 
 

--- a/gapis/api/test/intrinsics_test.go
+++ b/gapis/api/test/intrinsics_test.go
@@ -25,9 +25,7 @@ import (
 	"github.com/google/gapid/gapis/memory"
 )
 
-func p(addr uint64) memory.Pointer {
-	return memory.BytePtr(addr, memory.ApplicationPool)
-}
+var p = memory.BytePtr
 
 func TestClone(t *testing.T) {
 	ctx := log.Testing(t)
@@ -115,8 +113,8 @@ func TestSliceCasts(t *testing.T) {
 	api.MutateCmds(ctx, s, nil,
 		cb.CmdSliceCasts(p(0x1234), 10),
 	)
-	assert.For(ctx, "U16[] -> U8[]").That(GetState(s).U8s).Equals(U8ᵖ{0x1234, 0}.Slice(0, 20, l))
-	assert.For(ctx, "U16[] -> U16[]").That(GetState(s).U16s).Equals(U16ᵖ{0x1234, 0}.Slice(0, 10, l))
-	assert.For(ctx, "U16[] -> U32[]").That(GetState(s).U32s).Equals(U32ᵖ{0x1234, 0}.Slice(0, 5, l))
-	assert.For(ctx, "U16[] -> int[]").That(GetState(s).Ints).Equals(Intᵖ{0x1234, 0}.Slice(0, 3, l))
+	assert.For(ctx, "U16[] -> U8[]").That(GetState(s).U8s).Equals(U8ᵖ(0x1234).Slice(0, 20, l))
+	assert.For(ctx, "U16[] -> U16[]").That(GetState(s).U16s).Equals(U16ᵖ(0x1234).Slice(0, 10, l))
+	assert.For(ctx, "U16[] -> U32[]").That(GetState(s).U32s).Equals(U32ᵖ(0x1234).Slice(0, 5, l))
+	assert.For(ctx, "U16[] -> int[]").That(GetState(s).Ints).Equals(Intᵖ(0x1234).Slice(0, 3, l))
 }

--- a/gapis/api/test/mutate_test.go
+++ b/gapis/api/test/mutate_test.go
@@ -1207,11 +1207,11 @@ func TestOperationsOpCall_ReadPointerStruct(t *testing.T) {
 	a := device.Little32
 	aRng, aID := memory.Store(
 		ctx, a, p(0x100000),
-		PointerStruct{F2: 0x23, F1: 0x01, Pointer: U32ᵖ{0x200000, 0}})
+		PointerStruct{F2: 0x23, F1: 0x01, Pointer: U32ᵖ(0x200000)})
 	bRng, bID := memory.Store(ctx, a, p(0x200000), uint32(0x45))
 	cRng, cID := memory.Store(
 		ctx, a, p(0x300000),
-		PointerStruct{F2: 0x89, F1: 0x67, Pointer: U32ᵖ{0x200000, 0}})
+		PointerStruct{F2: 0x89, F1: 0x67, Pointer: U32ᵖ(0x200000)})
 
 	test{
 		cmds: []api.Cmd{
@@ -1292,13 +1292,13 @@ func TestOperationsOpCall_ReadNestedStruct(t *testing.T) {
 	a := device.Little32
 	nestedRng, nestedID := memory.Store(
 		ctx, a, p(0x100000),
-		NestedStruct{RS: RemappedStructᵖ{0x200000, 0}, PS: PointerStructᵖ{0x300000, 0}})
+		NestedStruct{RS: RemappedStructᵖ(0x200000), PS: PointerStructᵖ(0x300000)})
 	rsRng, rsID := memory.Store(
 		ctx, a, p(0x200000),
 		RemappedStruct{F1: 0x01, Handle: 0x23, F3: 0x45})
 	psRng, psID := memory.Store(
 		ctx, a, p(0x300000),
-		PointerStruct{F1: 0x67, F2: 0x89, Pointer: U32ᵖ{0x400000, 0}})
+		PointerStruct{F1: 0x67, F2: 0x89, Pointer: U32ᵖ(0x400000)})
 	pRng, pID := memory.Store(ctx, a, p(0x400000), uint32(0xab))
 
 	test{
@@ -1415,7 +1415,7 @@ func TestOperationsOpCall_ReadStringStruct(t *testing.T) {
 	})
 
 	ssRng, ssID := memory.Store(ctx, a, p(0x500000),
-		StringStruct{Count: 5, Strings: Charᵖᵖ{0x400000, 0}})
+		StringStruct{Count: 5, Strings: Charᵖᵖ(0x400000)})
 
 	test{
 		cmds: []api.Cmd{

--- a/gapis/api/vulkan/draw_call_mesh.go
+++ b/gapis/api/vulkan/draw_call_mesh.go
@@ -190,7 +190,7 @@ func getIndicesData(ctx context.Context, s *api.GlobalState, boundIndexBuffer *B
 				if err != nil {
 					return nil, err
 				}
-				index += int32(oneByte) << (8 * j)
+				index += int32(oneByte[0]) << (8 * j)
 			}
 			index += vertexOffset
 			if index < 0 {

--- a/gapis/api/vulkan/externs.go
+++ b/gapis/api/vulkan/externs.go
@@ -38,12 +38,12 @@ type externs struct {
 
 func (e externs) hasDynamicProperty(info VkPipelineDynamicStateCreateInfoᶜᵖ,
 	state VkDynamicState) bool {
-	if (info) == (VkPipelineDynamicStateCreateInfoᶜᵖ{}) {
+	if info == 0 {
 		return false
 	}
 	l := e.s.MemoryLayout
-	dynamic_state_info := info.Slice(0, 1, l).Index(0).MustRead(e.ctx, e.cmd, e.s, e.b)
-	states := dynamic_state_info.PDynamicStates.Slice(0, uint64(dynamic_state_info.DynamicStateCount), l).MustRead(e.ctx, e.cmd, e.s, e.b)
+	dynamicStateInfo := info.Slice(0, 1, l).MustRead(e.ctx, e.cmd, e.s, e.b)[0]
+	states := dynamicStateInfo.PDynamicStates.Slice(0, uint64(dynamicStateInfo.DynamicStateCount), l).MustRead(e.ctx, e.cmd, e.s, e.b)
 	for _, s := range states {
 		if s == state {
 			return true
@@ -124,7 +124,7 @@ func (e externs) leaveSubcontext() {
 
 func (e externs) nextSubcontext() {
 	o := GetState(e.s)
-	o.SubCmdIdx[len(o.SubCmdIdx)-1] += 1
+	o.SubCmdIdx[len(o.SubCmdIdx)-1]++
 }
 
 func (e externs) onPreSubcommand(ref *CommandReference) {
@@ -170,15 +170,15 @@ func (e externs) unmapMemory(slice memory.Slice) {
 }
 
 func (e externs) trackMappedCoherentMemory(start uint64, size memory.Size) {}
-func (e externs) readMappedCoherentMemory(memory_handle VkDeviceMemory, offset_in_mapped uint64, read_size memory.Size) {
+func (e externs) readMappedCoherentMemory(memoryHandle VkDeviceMemory, offsetInMapped uint64, readSize memory.Size) {
 	l := e.s.MemoryLayout
-	mem := GetState(e.s).DeviceMemories.Get(memory_handle)
-	mapped_offset := uint64(mem.MappedOffset)
-	dstStart := mapped_offset + offset_in_mapped
-	srcStart := offset_in_mapped
+	mem := GetState(e.s).DeviceMemories.Get(memoryHandle)
+	mappedOffset := uint64(mem.MappedOffset)
+	dstStart := mappedOffset + offsetInMapped
+	srcStart := offsetInMapped
 
-	absSrcStart := mem.MappedLocation.Address() + offset_in_mapped
-	absSrcMemRng := memory.Range{Base: absSrcStart, Size: uint64(read_size)}
+	absSrcStart := mem.MappedLocation.Address() + offsetInMapped
+	absSrcMemRng := memory.Range{Base: absSrcStart, Size: uint64(readSize)}
 
 	writeRngList := e.s.Memory.ApplicationPool().Slice(absSrcMemRng).ValidRanges()
 	for _, r := range writeRngList {
@@ -191,9 +191,9 @@ func (e externs) untrackMappedCoherentMemory(start uint64, size memory.Size) {}
 func (e externs) numberOfPNext(pNext Voidᶜᵖ) uint32 {
 	l := e.s.MemoryLayout
 	counter := uint32(0)
-	for (pNext) != (Voidᶜᵖ{}) {
+	for pNext != 0 {
 		counter++
-		pNext = Voidᶜᵖᵖ(pNext).Slice(0, 2, l).Index(1).MustRead(e.ctx, e.cmd, e.s, e.b)
+		pNext = Voidᶜᵖᵖ(pNext).Slice(1, 2, l).MustRead(e.ctx, e.cmd, e.s, e.b)[0]
 	}
 	return counter
 }

--- a/gapis/api/vulkan/footprint_builder.go
+++ b/gapis/api/vulkan/footprint_builder.go
@@ -1808,7 +1808,7 @@ func (vb *FootprintBuilder) BuildFootprint(ctx context.Context,
 
 	case *VkGetSwapchainImagesKHR:
 		read(ctx, bh, vkHandle(cmd.Swapchain))
-		if (cmd.PSwapchainImages == VkImageᵖ{}) {
+		if cmd.PSwapchainImages == 0 {
 			modify(ctx, bh, vkHandle(cmd.Swapchain))
 		} else {
 			count := uint64(cmd.PSwapchainImageCount.MustRead(ctx, cmd, s, nil))
@@ -1861,7 +1861,7 @@ func (vb *FootprintBuilder) BuildFootprint(ctx context.Context,
 		imgIds := info.PImageIndices.Slice(0, swCount, l)
 		for swi, vkSw := range info.PSwapchains.Slice(0, swCount, l).MustRead(ctx, cmd, s, nil) {
 			read(ctx, bh, vkHandle(vkSw))
-			imgID := imgIds.Index(uint64(swi)).MustRead(ctx, cmd, s, nil)
+			imgID := imgIds.Index(uint64(swi)).MustRead(ctx, cmd, s, nil)[0]
 			vkImg := GetState(s).Swapchains.Get(vkSw).SwapchainImages.Get(imgID).VulkanHandle
 			imgLayout, imgData := vb.getImageLayoutAndData(ctx, bh, vkImg)
 			read(ctx, bh, imgLayout)
@@ -1924,7 +1924,7 @@ func (vb *FootprintBuilder) BuildFootprint(ctx context.Context,
 		setCount := uint64(info.DescriptorSetCount)
 		vkLayouts := info.PSetLayouts.Slice(0, setCount, l)
 		for i, vkSet := range cmd.PDescriptorSets.Slice(0, setCount, l).MustRead(ctx, cmd, s, nil) {
-			vkLayout := vkLayouts.Index(uint64(i)).MustRead(ctx, cmd, s, nil)
+			vkLayout := vkLayouts.Index(uint64(i)).MustRead(ctx, cmd, s, nil)[0]
 			read(ctx, bh, vkHandle(vkLayout))
 			layoutObj := GetState(s).DescriptorSetLayouts.Get(vkLayout)
 			write(ctx, bh, vkHandle(vkSet))

--- a/gapis/api/vulkan/read_framebuffer.go
+++ b/gapis/api/vulkan/read_framebuffer.go
@@ -443,7 +443,7 @@ func postImageData(ctx context.Context,
 	if err != nil {
 		res(nil, &service.ErrDataUnavailable{Reason: messages.ErrMessage("Device Memory -> Host mapping failed")})
 	}
-	mappedPointer := MustAllocData(ctx, s, Voidᶜᵖ{at, memory.ApplicationPool})
+	mappedPointer := MustAllocData(ctx, s, Voidᶜᵖ(at))
 
 	// Barrier data for layout transitions of staging image
 	stagingImageToDstBarrier := VkImageMemoryBarrier{

--- a/gapis/api/vulkan/replay.go
+++ b/gapis/api/vulkan/replay.go
@@ -278,7 +278,7 @@ func (t *makeAttachementReadable) Transform(ctx context.Context, id api.CmdID, c
 		//   https://github.com/google/gapid/issues/1766
 		l := s.MemoryLayout
 		cmd.Extras().Observations().ApplyWrites(s.Memory.ApplicationPool())
-		t.NumPhysicalDevicesLeft = uint32(e.PPhysicalDeviceCount.Slice(0, 1, l).Index(0).MustRead(ctx, cmd, s, nil))
+		t.NumPhysicalDevicesLeft = uint32(e.PPhysicalDeviceCount.Slice(0, 1, l).MustRead(ctx, cmd, s, nil)[0])
 		// Do not mutate the second call to vkEnumeratePhysicalDevices, all the following vkGetPhysicalDeviceProperties belong to this
 		// physical device enumeration.
 		t.InPhysicalDeviceEnumerate = true

--- a/gapis/api/vulkan/wireframe.go
+++ b/gapis/api/vulkan/wireframe.go
@@ -39,7 +39,7 @@ func wireframe(ctx context.Context) transform.Transformer {
 			newInfos := make([]VkGraphicsPipelineCreateInfo, count)
 			newRasterStateDatas := make([]api.AllocResult, count)
 			for i := uint64(0); i < count; i++ {
-				info := infos.Index(i).MustRead(ctx, cmd, s, nil)
+				info := infos.Index(i).MustRead(ctx, cmd, s, nil)[0]
 				rasterState := info.PRasterizationState.MustRead(ctx, cmd, s, nil)
 				rasterState.PolygonMode = VkPolygonMode_VK_POLYGON_MODE_LINE
 				newRasterStateDatas[i] = s.AllocDataOrPanic(ctx, rasterState)

--- a/gapis/memory/load.go
+++ b/gapis/memory/load.go
@@ -41,8 +41,7 @@ func LoadSlice(ctx context.Context, s Slice, pools Pools, l *device.MemoryLayout
 
 // LoadPointer loads the element from p.
 func LoadPointer(ctx context.Context, p Pointer, pools Pools, l *device.MemoryLayout) (interface{}, error) {
-	pool := pools.MustGet(p.Pool())
-	ioR := pool.At(p.Address()).NewReader(ctx)
+	ioR := pools.ApplicationPool().At(p.Address()).NewReader(ctx)
 	binR := endian.Reader(ioR, l.GetEndian())
 	d := NewDecoder(binR, l)
 	elPtr := reflect.New(p.ElementType())

--- a/gapis/memory/slice.go
+++ b/gapis/memory/slice.go
@@ -17,8 +17,6 @@ package memory
 import (
 	"fmt"
 	"reflect"
-
-	"github.com/google/gapid/core/os/device"
 )
 
 // Slice is the interface implemented by types that represent a slice on
@@ -85,12 +83,4 @@ func (s sli) ISlice(start, end uint64) Slice {
 		pool:  s.pool,
 		elTy:  s.elTy,
 	}
-}
-
-func (s sli) IIndex(i uint64, m *device.MemoryLayout) Pointer {
-	if count := s.Count(); i >= count {
-		panic(fmt.Errorf("%v.IIndex(%d) is out of bounds [0 - %d]", s, i, count-1))
-	}
-	elSize := s.ElementSize()
-	return ptr{s.base + i*elSize, s.pool, s.elTy}
 }

--- a/gapis/memory/types.go
+++ b/gapis/memory/types.go
@@ -14,14 +14,18 @@
 
 package memory
 
-import "reflect"
+import (
+	"reflect"
+)
 
 var (
-	tyPointer = reflect.TypeOf((*ReflectPointer)(nil)).Elem()
-	tyCharTy  = reflect.TypeOf((*CharTy)(nil)).Elem()
-	tyIntTy   = reflect.TypeOf((*IntTy)(nil)).Elem()
-	tyUintTy  = reflect.TypeOf((*UintTy)(nil)).Elem()
-	tySizeTy  = reflect.TypeOf((*SizeTy)(nil)).Elem()
+	tyPointer   = reflect.TypeOf((*ReflectPointer)(nil)).Elem()
+	tyCharTy    = reflect.TypeOf((*CharTy)(nil)).Elem()
+	tyIntTy     = reflect.TypeOf((*IntTy)(nil)).Elem()
+	tyUintTy    = reflect.TypeOf((*UintTy)(nil)).Elem()
+	tySizeTy    = reflect.TypeOf((*SizeTy)(nil)).Elem()
+	tyEncodable = reflect.TypeOf((*Encodable)(nil)).Elem()
+	tyDecodable = reflect.TypeOf((*Decodable)(nil)).Elem()
 )
 
 // Int is a signed integer type.
@@ -32,7 +36,7 @@ type IntTy interface {
 	IsInt()
 }
 
-// Dummy function to make Int implement IntTy interface
+// IsInt is a dummy function to make Int implement IntTy interface
 func (Int) IsInt() {}
 
 // Uint is an unsigned integer type.
@@ -43,7 +47,7 @@ type UintTy interface {
 	IsUint()
 }
 
-// Dummy function to make Uint implement UintTy interface
+// IsUint is a dummy function to make Uint implement UintTy interface
 func (Uint) IsUint() {}
 
 // Char is the possibly signed but maybe unsigned C/C++ char.
@@ -54,7 +58,7 @@ type CharTy interface {
 	IsChar()
 }
 
-// Dummy function to make Char implement CharTy interface
+// IsChar is a dummy function to make Char implement CharTy interface
 func (Char) IsChar() {}
 
 // CharToBytes changes the Char values to their byte[] representation.
@@ -74,11 +78,25 @@ type SizeTy interface {
 	IsMemorySize()
 }
 
-// Dummy function to make Size implement SizeTy interface
+// IsMemorySize is a dummy function to make Size implement SizeTy interface
 func (Size) IsMemorySize() {}
 
 // IsSize returns true if v is a Size or alias to a Size.
 func IsSize(v interface{}) bool {
 	_, ok := v.(SizeTy)
 	return ok
+}
+
+// Encodable is the interface implemented by types that can encode themselves to
+// an encoder.
+type Encodable interface {
+	// Encode encodes this object to the encoder.
+	Encode(*Encoder)
+}
+
+// Decodable is the interface implemented by types that can decode themselves
+// from an encoder.
+type Decodable interface {
+	// Decode decodes this object from the decoder.
+	Decode(*Decoder)
 }

--- a/gapis/memory/write_test.go
+++ b/gapis/memory/write_test.go
@@ -28,7 +28,7 @@ func TestWriteOn32bitArch(t *testing.T) {
 		uint8(0x12), int8(0x12),
 		uint16(0x1234), int16(0x1234),
 		uint32(0x12345678), int32(0x12345678),
-		BytePtr(0x87654321, 0),
+		BytePtr(0x87654321),
 		[]uint8{0x10, 0x20, 0x30},
 		[]uint16{0x10, 0x20, 0x30},
 		[]uint32{0x10, 0x20, 0x30},
@@ -67,7 +67,7 @@ func TestWriteStructOn32bitArch(t *testing.T) {
 		Y Pointer
 		Z int16
 		W uint64
-	}{0x12, BytePtr(0xdeadbeef, 0), 0x3456, 0x8888888899999999}
+	}{0x12, BytePtr(0xdeadbeef), 0x3456, 0x8888888899999999}
 
 	buf := &bytes.Buffer{}
 	e := NewEncoder(endian.Writer(buf, arch.GetEndian()), arch)
@@ -95,9 +95,9 @@ func TestWriteOn64bitArch(t *testing.T) {
 		uint8(0x12), int8(0x12),
 		uint16(0x1234), int16(0x1234),
 		uint32(0x12345678), int32(0x12345678),
-		BytePtr(0x87654321, 0),
+		BytePtr(0x87654321),
 		[]uint8{0x10, 0x20, 0x30},
-		BytePtr(0x1234567890abcdef, 0),
+		BytePtr(0x1234567890abcdef),
 		"hello",
 		uint64(0xfedcba0987654321), // Mock size_t type
 	}
@@ -134,7 +134,7 @@ func TestWriteStructOn64bitArch(t *testing.T) {
 		Y Pointer
 		Z int16
 		W uint64
-	}{0x12, BytePtr(0xbeefdeaddeadbeef, 0), 0x3456, 0x8888888899999999}
+	}{0x12, BytePtr(0xbeefdeaddeadbeef), 0x3456, 0x8888888899999999}
 
 	buf := &bytes.Buffer{}
 	e := NewEncoder(endian.Writer(buf, arch.GetEndian()), arch)

--- a/gapis/resolve/state_tree_test.go
+++ b/gapis/resolve/state_tree_test.go
@@ -73,7 +73,7 @@ var testState = TestState{
 		Map:       map[int]string{1: "one", 5: "five", 9: "nine"},
 		Array:     []int{0, 10, 20, 30, 40},
 		Slice:     memory.NewSlice(0x1000, 0x1000, 5*intSize, 5, memory.ApplicationPool, intType),
-		Pointer:   memory.NewPtr(0x1010, memory.ApplicationPool, reflect.TypeOf(memory.Size(0))),
+		Pointer:   memory.NewPtr(0x1010, reflect.TypeOf(memory.Size(0))),
 		Interface: &TestStruct{},
 	},
 	ReferenceB: &TestStruct{
@@ -387,7 +387,7 @@ func TestStateTreeNode(t *testing.T) {
 				NumChildren:    0,
 				Name:           "Pointer",
 				ValuePath:      rootPath.Field("ReferenceA").Field("Pointer").Path(),
-				Preview:        box.NewValue(memory.NewPtr(0x1010, memory.ApplicationPool, intType)),
+				Preview:        box.NewValue(memory.NewPtr(0x1010, intType)),
 				PreviewIsValue: true,
 			},
 		}, {

--- a/gapis/service/box/box.go
+++ b/gapis/service/box/box.go
@@ -107,7 +107,7 @@ func (b *boxer) val(v reflect.Value) *Value {
 	switch {
 	case IsMemoryPointer(t):
 		p := AsMemoryPointer(v)
-		return &Value{0, &Value_Pointer{&Pointer{p.Address(), uint32(p.Pool())}}}
+		return &Value{0, &Value_Pointer{&Pointer{p.Address()}}}
 	case IsMemorySlice(t):
 		s := v.Interface().(memory.Slice)
 		elTy, ok := pod.TypeOf(s.ElementType())
@@ -116,7 +116,8 @@ func (b *boxer) val(v reflect.Value) *Value {
 		}
 		return &Value{0, &Value_Slice{&Slice{
 			Type:  elTy,
-			Base:  &Pointer{s.Base(), uint32(s.Pool())},
+			Pool:  uint64(s.Pool()),
+			Base:  &Pointer{s.Base()},
 			Size:  s.Size(),
 			Count: s.Count(),
 			Root:  s.Root(),
@@ -271,7 +272,7 @@ func (b *unboxer) val(v *Value) (out reflect.Value) {
 		}
 		panic(fmt.Errorf("Unsupported POD Value %+v", v))
 	case *Value_Pointer:
-		p := memory.BytePtr(v.Pointer.Address, memory.PoolID(v.Pointer.Pool))
+		p := memory.BytePtr(v.Pointer.Address)
 		return reflect.ValueOf(p)
 	case *Value_Slice:
 		p := memory.NewSlice(
@@ -279,7 +280,7 @@ func (b *unboxer) val(v *Value) (out reflect.Value) {
 			v.Slice.Base.Address,
 			v.Slice.Size,
 			v.Slice.Count,
-			memory.PoolID(v.Slice.Base.Pool),
+			memory.PoolID(v.Slice.Pool),
 			v.Slice.Type.Get(),
 		)
 		return reflect.ValueOf(p)

--- a/gapis/service/box/box.proto
+++ b/gapis/service/box/box.proto
@@ -40,25 +40,25 @@ message Value {
   }
 }
 
+
 message Pointer {
   // base address of the pointer.
   uint64 address = 1;
-  // the pool identifier.
-  uint32 pool = 2;
 }
-
 message Slice {
   // the type of the slice data.
   pod.Type type = 1;
+  // the pool identifier of the slice.
+  uint64 pool = 2;
   // the base address of the slice.
-  Pointer base = 2;
+  Pointer base = 3;
   // the number of elements in the slice.
-  uint64 count = 3;
+  uint64 count = 4;
   // the total size of the slice in bytes.
-  uint64 size = 4;
+  uint64 size = 5;
   // the original pointer this slice derives from.
   // Is constant even after sub-slicing.
-  uint64 root = 5;
+  uint64 root = 6;
 }
 
 message Reference {

--- a/gapis/service/box/box_test.go
+++ b/gapis/service/box/box_test.go
@@ -359,7 +359,7 @@ func TestBoxMemoryType(t *testing.T) {
 
 func TestBoxUnboxMemory(t *testing.T) {
 	val := Memory{
-		P: memory.BytePtr(1234, 555),
+		P: memory.BytePtr(1234),
 		S: memory.NewSlice(1234, 1256, 42, 42, 333, reflect.TypeOf(byte(0))),
 	}
 	boxed := box.NewValue(val)

--- a/test/integration/replay/gles/gles_test.go
+++ b/test/integration/replay/gles/gles_test.go
@@ -165,7 +165,7 @@ type Fixture struct {
 func (f *Fixture) p(ctx context.Context) memory.Pointer {
 	base, err := f.s.Allocator.Alloc(8, 8)
 	assert.With(ctx).ThatError(err).Succeeded()
-	return memory.BytePtr(base, memory.ApplicationPool)
+	return memory.BytePtr(base)
 }
 
 func newFixture(ctx context.Context) (context.Context, *Fixture) {
@@ -199,7 +199,7 @@ func TestMain(m *testing.M) {
 }
 
 func p(addr uint64) memory.Pointer {
-	return memory.BytePtr(addr, memory.ApplicationPool)
+	return memory.BytePtr(addr)
 }
 
 func checkImage(ctx context.Context, name string, got *image.Data, threshold float64) {

--- a/test/integration/replay/gles/samples/builder.go
+++ b/test/integration/replay/gles/samples/builder.go
@@ -52,7 +52,7 @@ func (b *builder) p() memory.Pointer {
 	if err != nil {
 		panic(err)
 	}
-	return memory.BytePtr(base, memory.ApplicationPool)
+	return memory.BytePtr(base)
 }
 
 func (b *builder) data(ctx context.Context, v ...interface{}) api.AllocResult {


### PR DESCRIPTION
The API language allows you to convert a pointer into a slice, not the other way around. Because the only way to create a non-app pool is to create a slice, there is no possibility of having a pointer in anything but the application pool.

This has a number of knock on effects for the API, including how slices are read / written.