### PR TITLE
Rework API encode / decode

### DIFF
--- a/gapis/api/templates/api.go.tmpl
+++ b/gapis/api/templates/api.go.tmpl
@@ -146,7 +146,7 @@
       // Dummy function to make {{$name}} implement UintTy interface
       func ({{$name}}) IsUint() {}
     {{end}}
-    func Decode{{$name}}(d *ϟmem.Decoder) {{$name}} {
+    func Decode{{$name}}(ϟd *ϟmem.Decoder) {{$name}} {
       return {{$name}}({{Template "Go.Decode" $u}})
     }
   {{end}}
@@ -173,9 +173,17 @@
     }
   {{end}}
 
-  func Decode{{$ty | Title}}(d *ϟmem.Decoder) {{$ty}} {
+  // Encode encodes this static array to the encoder.
+  func (a {{$ty}}) Encode(ϟe *ϟmem.Encoder) {
+    for i, c := 0, {{$.Size}}; i < c; i++ {
+      {{Template "Go.Encode" "Type" $.ValueType "Value" "a[i]"}}
+    }
+  }
+
+  // Decode decodes this static array from the decoder.
+  func Decode{{$ty | Title}}(ϟd *ϟmem.Decoder) {{$ty}} {
     out := {{$ty}}{}
-    ϟmem.Read(d, &out)
+    ϟmem.Read(ϟd, &out)
     return out
   }
 {{end}}
@@ -281,16 +289,15 @@
     // StringSlice returns a slice starting at p and ending at the first 0 byte null-terminator.
     func (p {{$ptr_ty}}) StringSlice(ϟctx context.Context, ϟs *api.GlobalState) Charˢ {
       numBytes := uint64(2^6)
-      i, d := uint64(0), ϟs.MemoryDecoder(ϟctx, ϟs.Memory.MustGet(ϟmem.ApplicationPool).TempSlice(ϟmem.Range{Base: uint64(p), Size: uint64(p) + numBytes}))
+      i, ϟd := uint64(0), ϟs.MemoryDecoder(ϟctx, ϟs.Memory.MustGet(ϟmem.ApplicationPool).TempSlice(ϟmem.Range{Base: uint64(p), Size: numBytes}))
 
       for {
         if i >= numBytes {
-          numBytes <<= 1
-          d = ϟs.MemoryDecoder(ϟctx, ϟs.Memory.MustGet(ϟmem.ApplicationPool).TempSlice(ϟmem.Range{Base: uint64(p) + i, Size: numBytes - i}))
+          ϟd = ϟs.MemoryDecoder(ϟctx, ϟs.Memory.MustGet(ϟmem.ApplicationPool).TempSlice(ϟmem.Range{Base: uint64(p) + i, Size: numBytes}))
         }
 
         i++
-        if b := d.U8(); b == 0 {
+        if b := ϟd.U8(); b == 0 {
           return Charˢ(p.Slice(0, i, ϟs.MemoryLayout))
         }
       }
@@ -358,11 +365,11 @@
     // Write out the entire structure, then over-write
     // any pointer fields.
     ϟb.Write(s.Range(), s.ResourceID(ϟctx, ϟs))
-    d := s.Decoder(ϟctx, ϟs)
+    ϟd := s.Decoder(ϟctx, ϟs)
     for i := uint64(0); i < s.count; i++ {
       {{Template "ReadStructFieldsWithRemapping" $}}
     }
-    panicOnError(d.Error())
+    panicOnError(ϟd.Error())
   {{end}}
 {{end}}
 
@@ -377,19 +384,19 @@
     {{$name := $f.Name | GoPublicName}}
     {{if IsPointer ($f.Type | Underlying)}}
       { // {{$.Name}}.{{$name}}
-        d.Align({{Template "Go.AlignOf" (TypeOf $f)}})
-        addr := value.ObservedPointer(s.base + d.Offset())
-        ϟb.Push({{Macro "Go.Type" $f}}(d.Pointer()).value(ϟb, ϟa, ϟs))
+        ϟd.Align({{Template "Go.AlignOf" (TypeOf $f)}})
+        addr := value.ObservedPointer(s.base + ϟd.Offset())
+        ϟb.Push({{Macro "Go.Type" $f}}(ϟd.Pointer()).value(ϟb, ϟa, ϟs))
         ϟb.Store(addr)
       }
     {{else if IsClass ($f.Type | Underlying)}}
-      d.Align({{Template "Go.AlignOf" (TypeOf $f)}})
+      ϟd.Align({{Template "Go.AlignOf" (TypeOf $f)}})
       {{Template "ReadStructFieldsWithRemapping" $f.Type}}
     {{else}}
       {{if GetAnnotation $f.Type "replay_remap"}}
         {
-          d.Align({{Template "Go.AlignOf" (TypeOf $f)}})
-          addr := value.ObservedPointer(s.base + d.Offset())
+          ϟd.Align({{Template "Go.AlignOf" (TypeOf $f)}})
+          addr := value.ObservedPointer(s.base + ϟd.Offset())
           v := {{Template "Go.Decode" $f.Type}}
           if key, remap := v.remap(ϟa, ϟs); remap {
             loadRemap(ϟb, key, {{Template "Go.Replay.Type" $f.Type}}, {{Template "Go.Replay.Value" "Type" $f.Type "Name" "v"}})
@@ -397,7 +404,7 @@
           }
         }
       {{else}}
-        {{Template "Go.Decode" $f.Type}} // {{$.Name}}.{{$name}}
+        _ = {{Template "Go.Decode" $f.Type}} // {{$.Name}}.{{$name}}
       {{end}}
     {{end}}
   {{end}}
@@ -558,9 +565,9 @@
     func (s {{$slice_ty}}) Read(ϟctx context.Context, ϟa api.Cmd, ϟs *api.GlobalState, ϟb *builder.Builder) ([]{{$el_ty}}, error) {
       s.OnRead(ϟctx, ϟa, ϟs, ϟb)
       res := make([]{{$el_ty}}, s.count)
-      d := s.Decoder(ϟctx, ϟs)
-      ϟmem.Read(d, &res)
-      if err := d.Error(); err != nil {
+      ϟd := s.Decoder(ϟctx, ϟs)
+      ϟmem.Read(ϟd, &res)
+      if err := ϟd.Error(); err != nil {
         return nil, err
       }
       return res, nil
@@ -638,20 +645,20 @@
              To handle this, we store pointers in a separate table and refer to
              these using pointer indices.
         */}}
-        d, dst := s.Decoder(ϟctx, ϟs), value.PointerIndex(s.base / uint64(ϟl.GetPointer().GetSize()))
+        ϟd, dst := s.Decoder(ϟctx, ϟs), value.PointerIndex(s.base / uint64(ϟl.GetPointer().GetSize()))
         for i := uint64(0); i < s.count; i++ {
           {{if (GetAnnotation $s.To "replay_remap")}}{{Error "Remappings of pointers not implemented"}}{{end}}
-          ϟb.StorePointer(dst, {{$el_ty}}(d.Pointer()).value(ϟb, ϟa, ϟs))
+          ϟb.StorePointer(dst, {{$el_ty}}(ϟd.Pointer()).value(ϟb, ϟa, ϟs))
           dst++
         }
-        panicOnError(d.Error())
+        panicOnError(ϟd.Error())
       {{else if IsClass ($s.To | Underlying)}}
         {{Template "ReadStructWithRemapping" $s.To}}
       {{else}}
         s.ReserveMemory(ϟctx, ϟa, ϟs, ϟb)
         {{if (GetAnnotation $s.To "replay_remap")}}
           {{/* Element type has explicitly stated it needs custom remapping */}}
-          ptr, step, d := value.ObservedPointer(s.base), value.ObservedPointer(s.ElementSize(ϟl)), s.Decoder(ϟctx, ϟs)
+          ptr, step, ϟd := value.ObservedPointer(s.base), value.ObservedPointer(s.ElementSize(ϟl)), s.Decoder(ϟctx, ϟs)
           for i := uint64(0); i < s.count; i++ {
             v := {{Template "Go.Decode" $s.To}}
             if key, remap := v.remap(ϟa, ϟs); remap {
@@ -662,7 +669,7 @@
             ϟb.Store(ptr)
             ptr += step
           }
-          panicOnError(d.Error())
+          panicOnError(ϟd.Error())
         {{else}}
           ϟb.Write(s.Range(), s.ResourceID(ϟctx, ϟs))
         {{end}}
@@ -684,7 +691,7 @@
       {{if (GetAnnotation $s.To "replay_remap")}}
         {{/* Element type has explicitly stated it needs custom remapping */}}
         size := s.ElementSize(ϟl)
-        ptr, step, d := value.ObservedPointer(s.base), value.ObservedPointer(size), s.Decoder(ϟctx, ϟs)
+        ptr, step, ϟd := value.ObservedPointer(s.base), value.ObservedPointer(size), s.Decoder(ϟctx, ϟs)
         for i := uint64(0); i < s.count; i++ {
           v := {{Template "Go.Decode" $s.To}}
           if key, remap := v.remap(ϟa, ϟs); remap {
@@ -698,7 +705,7 @@
           }
           ptr += step
         }
-        panicOnError(d.Error())
+        panicOnError(ϟd.Error())
       {{end}}
     }
     return s
@@ -1086,6 +1093,59 @@
       return c
     }
   {{end}}
+
+  {{if IsStorageType $}}
+    // {{$name}}Size returns the size of the class in bytes.
+    func {{$name}}Size(ϟl *device.MemoryLayout) uint64 {
+      var size, align uint64
+      {{range $f := $.Fields}}
+        {{$a := print $f.Name "Alignment"}}
+        {{$a}} := {{Template "Go.AlignOf" $f.Type}}
+        size = u64.AlignUp(size, {{$a}})
+        size += {{Template "Go.SizeOf" $f.Type}}
+        align = u64.Max(align, {{$a}})
+      {{end}}
+      return u64.AlignUp(size, align)
+    }
+
+    // TypeSize returns the size of the class in bytes.
+    func ({{$name}}) TypeSize(ϟl *device.MemoryLayout) uint64 { return {{$name}}Size(ϟl) }
+
+    // {{$name}}Alignment returns the alignment of the class in bytes.
+    func {{$name}}Alignment(ϟl *device.MemoryLayout) uint64 {
+      alignment := uint64(1)
+      {{range $f := $.Fields}}
+        alignment = u64.Max(alignment, {{Template "Go.AlignOf" $f.Type}})
+      {{end}}
+      return alignment
+    }
+
+    // TypeAlignment returns the alignment of the class in bytes.
+    func ({{$name}}) TypeAlignment(ϟl *device.MemoryLayout) uint64 { return {{$name}}Alignment(ϟl) }
+
+    // Encode encodes this class to the encoder.
+    func (c {{$name}}) Encode(ϟe *ϟmem.Encoder) {
+      alignment := {{$name}}Alignment(ϟe.MemoryLayout())
+      ϟe.Align(alignment)
+      {{range $f := $.Fields}}
+        {{Template "Go.Encode" "Type" $f.Type "Value" (print "c." ($f.Name | GoPublicName))}}
+      {{end}}
+      ϟe.Align(alignment)
+    }
+
+    // Decode decodes this class from the decoder.
+    func (c *{{$name}}) Decode(ϟd *ϟmem.Decoder) {
+      ϟd.Align({{$name}}Alignment(ϟd.MemoryLayout()))
+      {{range $f := $.Fields}}
+        {{if IsClass $f.Type}}
+          c.{{$f.Name | GoPublicName}}.Decode(ϟd)
+        {{else}}
+          c.{{$f.Name | GoPublicName}} = {{Template "Go.Decode" $f.Type}}
+        {{end}}
+      {{end}}
+      ϟd.Align({{$name}}Size(ϟd.MemoryLayout()))
+    }
+  {{end}}
 {{end}}
 
 
@@ -1155,8 +1215,8 @@
     return fmt.Sprintf("{{$.Name}}(%d)", e)
   }
 
-  func Decode{{$.Name | Title}}(d *ϟmem.Decoder) {{$.Name}} {
-    return {{$.Name}}(d.U32())
+  func Decode{{$.Name | Title}}(ϟd *ϟmem.Decoder) {{$.Name}} {
+    return {{$.Name}}(ϟd.U32())
   }
 {{end}}
 

--- a/gapis/api/templates/go_common.tmpl
+++ b/gapis/api/templates/go_common.tmpl
@@ -122,31 +122,68 @@
 
 {{/*
 -------------------------------------------------------------------------------
+  Emits the logic to encode the specified value to the encoder ϟe.
+-------------------------------------------------------------------------------
+*/}}
+{{define "Go.Encode"}}
+  {{AssertType $.Type "Type"}}
+
+  {{     if IsPseudonym   $.Type}}{{Template "Go.Encode" "Type" $.Type.To "Value" (print (Macro "Go.Type" $.Type.To) "(" $.Value ")")}}
+  {{else if IsVoid        $.Type}}ϟe.I8({{$.Value}})
+  {{else if IsBool        $.Type}}ϟe.Bool({{$.Value}})
+  {{else if IsChar        $.Type}}ϟe.Char({{$.Value}})
+  {{else if IsU8          $.Type}}ϟe.U8({{$.Value}})
+  {{else if IsS8          $.Type}}ϟe.I8({{$.Value}})
+  {{else if IsU16         $.Type}}ϟe.U16({{$.Value}})
+  {{else if IsS16         $.Type}}ϟe.I16({{$.Value}})
+  {{else if IsF32         $.Type}}ϟe.F32({{$.Value}})
+  {{else if IsU32         $.Type}}ϟe.U32({{$.Value}})
+  {{else if IsS32         $.Type}}ϟe.I32({{$.Value}})
+  {{else if IsF64         $.Type}}ϟe.F64({{$.Value}})
+  {{else if IsU64         $.Type}}ϟe.U64({{$.Value}})
+  {{else if IsS64         $.Type}}ϟe.I64({{$.Value}})
+  {{else if IsEnum        $.Type}}{{Template "Go.Encode" "Type" $.Type.NumberType "Value" (print (Macro "Go.Type" $.Type.NumberType) "(" $.Value ")")}}
+  {{else if IsString      $.Type}}ϟe.String({{$.Value}})
+  {{else if IsPointer     $.Type}}ϟe.Pointer({{$.Value}}.Address())
+  {{else if IsInt         $.Type}}ϟe.Int({{$.Value}})
+  {{else if IsUint        $.Type}}ϟe.Uint({{$.Value}})
+  {{else if IsSize        $.Type}}ϟe.Size({{$.Value}})
+  {{else if IsStaticArray $.Type}}{{$.Value}}.Encode(ϟe)
+  {{else if IsClass       $.Type}}{{$.Value}}.Encode(ϟe)
+  {{else                        }}{{Error "macro Go.Encode called with unsupported type: %v" $.Type}}
+  {{end}}
+{{end}}
+
+
+{{/*
+-------------------------------------------------------------------------------
   Emits the logic to decode the specified type from the decoder d.
 -------------------------------------------------------------------------------
 */}}
 {{define "Go.Decode"}}
   {{AssertType $ "Type"}}
 
-  {{     if IsStaticArray $}}Decode{{Macro "Go.Type" $ | Title}}(d)
-  {{else if IsPseudonym   $}}Decode{{Macro "Go.Type" $ | Title}}(d)
-  {{else if IsEnum        $}}Decode{{Macro "Go.Type" $ | Title}}(d)
-  {{else if IsBool        $}}d.Bool()
-  {{else if IsU8          $}}d.U8()
-  {{else if IsS8          $}}d.I8()
-  {{else if IsU16         $}}d.U16()
-  {{else if IsS16         $}}d.I16()
-  {{else if IsF32         $}}d.F32()
-  {{else if IsU32         $}}d.U32()
-  {{else if IsS32         $}}d.I32()
-  {{else if IsF64         $}}d.F64()
-  {{else if IsU64         $}}d.U64()
-  {{else if IsS64         $}}d.I64()
-  {{else if IsString      $}}d.String()
-  {{else if IsChar        $}}d.Char()
-  {{else if IsInt         $}}d.Int()
-  {{else if IsUint        $}}d.Uint()
-  {{else if IsSize        $}}d.Size()
+  {{     if IsStaticArray $}}Decode{{Macro "Go.Type" $ | Title}}(ϟd)
+  {{else if IsPseudonym   $}}{{Template "Go.Type" $}}({{Template "Go.Decode" ($ | Underlying)}})
+  {{else if IsEnum        $}}Decode{{Macro "Go.Type" $ | Title}}(ϟd)
+  {{else if IsClass       $}}Decode{{Macro "Go.Type" $ | Title}}(ϟd)
+  {{else if IsBool        $}}ϟd.Bool()
+  {{else if IsU8          $}}ϟd.U8()
+  {{else if IsS8          $}}ϟd.I8()
+  {{else if IsU16         $}}ϟd.U16()
+  {{else if IsS16         $}}ϟd.I16()
+  {{else if IsF32         $}}ϟd.F32()
+  {{else if IsU32         $}}ϟd.U32()
+  {{else if IsS32         $}}ϟd.I32()
+  {{else if IsF64         $}}ϟd.F64()
+  {{else if IsU64         $}}ϟd.U64()
+  {{else if IsS64         $}}ϟd.I64()
+  {{else if IsString      $}}ϟd.String()
+  {{else if IsPointer     $}}{{Template "Go.Type" $}}(ϟd.Pointer())
+  {{else if IsChar        $}}ϟd.Char()
+  {{else if IsInt         $}}ϟd.Int()
+  {{else if IsUint        $}}ϟd.Uint()
+  {{else if IsSize        $}}ϟd.Size()
   {{else}}{{Error "macro Go.Decode called with unsupported type: %v" $}}
   {{end}}
 {{end}}
@@ -181,7 +218,7 @@
   {{else if IsUint        $}}uint64(ϟl.GetInteger().GetSize())
   {{else if IsSize        $}}uint64(ϟl.GetSize().GetSize())
   {{else if IsStaticArray $}}{{Template "Go.SizeOf" $.ValueType}}*{{$.Size}}
-  {{else if IsClass       $}}ϟmem.SizeOf(reflect.TypeOf({{Template "Go.Type" $}}{}), ϟl)
+  {{else if IsClass       $}}{{Template "Go.Type" $}}Size(ϟl)
   {{else                   }}{{Error "macro Go.SizeOf called with unsupported type: %v" $}}
   {{end}}
 {{end}}
@@ -216,7 +253,7 @@
   {{else if IsUint        $}}uint64(ϟl.GetInteger().GetSize())
   {{else if IsSize        $}}uint64(ϟl.GetSize().GetSize())
   {{else if IsStaticArray $}}{{Template "Go.AlignOf" $.ValueType}}
-  {{else if IsClass       $}}ϟmem.AlignOf(reflect.TypeOf({{$.Name}}{}), ϟl)
+  {{else if IsClass       $}}{{Template "Go.Type" $}}Alignment(ϟl)
   {{else                   }}{{Error "macro Go.AlignOf called with unsupported type: %v" $}}
   {{end}}
 {{end}}

--- a/gapis/memory/decoder.go
+++ b/gapis/memory/decoder.go
@@ -40,6 +40,11 @@ func (d *Decoder) alignAndOffset(l *device.DataTypeLayout) {
 	d.o += uint64(l.GetSize())
 }
 
+// MemoryLayout returns the MemoryLayout used by the decoder.
+func (d *Decoder) MemoryLayout() *device.MemoryLayout {
+	return d.m
+}
+
 // Offset returns the byte offset of the reader from the initial Decoder
 // creation.
 func (d *Decoder) Offset() uint64 {

--- a/gapis/memory/encoder.go
+++ b/gapis/memory/encoder.go
@@ -38,6 +38,11 @@ func (e *Encoder) alignAndOffset(d *device.DataTypeLayout) {
 	e.o += uint64(d.GetSize())
 }
 
+// MemoryLayout returns the MemoryLayout used by the encoder.
+func (e *Encoder) MemoryLayout() *device.MemoryLayout {
+	return e.m
+}
+
 // Align writes zero bytes until the write position is a multiple of to.
 func (e *Encoder) Align(to uint64) {
 	alignment := u64.AlignUp(e.o, to)

--- a/gapis/memory/types.go
+++ b/gapis/memory/types.go
@@ -16,6 +16,8 @@ package memory
 
 import (
 	"reflect"
+
+	"github.com/google/gapid/core/os/device"
 )
 
 var (
@@ -24,6 +26,8 @@ var (
 	tyIntTy     = reflect.TypeOf((*IntTy)(nil)).Elem()
 	tyUintTy    = reflect.TypeOf((*UintTy)(nil)).Elem()
 	tySizeTy    = reflect.TypeOf((*SizeTy)(nil)).Elem()
+	tySizedTy   = reflect.TypeOf((*SizedTy)(nil)).Elem()
+	tyAlignedTy = reflect.TypeOf((*AlignedTy)(nil)).Elem()
 	tyEncodable = reflect.TypeOf((*Encodable)(nil)).Elem()
 	tyDecodable = reflect.TypeOf((*Decodable)(nil)).Elem()
 )
@@ -85,6 +89,18 @@ func (Size) IsMemorySize() {}
 func IsSize(v interface{}) bool {
 	_, ok := v.(SizeTy)
 	return ok
+}
+
+// SizedTy is the interface implemented by types that can calculate their size.
+type SizedTy interface {
+	// Size returns the size of the type in bytes.
+	TypeSize(*device.MemoryLayout) uint64
+}
+
+// AlignedTy is the interface implemented by types that can calculate their size.
+type AlignedTy interface {
+	// Alignment returns the alignment of the type in bytes.
+	TypeAlignment(*device.MemoryLayout) uint64
 }
 
 // Encodable is the interface implemented by types that can encode themselves to

--- a/gapis/memory/write_test.go
+++ b/gapis/memory/write_test.go
@@ -60,14 +60,25 @@ func TestWriteOn32bitArch(t *testing.T) {
 	}
 }
 
+type encodableStruct struct {
+	X uint8
+	Y Pointer
+	Z int16
+	W uint64
+}
+
+var _ Encodable = encodableStruct{}
+
+func (s encodableStruct) Encode(e *Encoder) {
+	e.U8(s.X)
+	e.Pointer(s.Y.Address())
+	e.I16(s.Z)
+	e.U64(s.W)
+}
+
 func TestWriteStructOn32bitArch(t *testing.T) {
 	arch := device.Big32
-	values := struct {
-		X uint8
-		Y Pointer
-		Z int16
-		W uint64
-	}{0x12, BytePtr(0xdeadbeef), 0x3456, 0x8888888899999999}
+	values := encodableStruct{0x12, BytePtr(0xdeadbeef), 0x3456, 0x8888888899999999}
 
 	buf := &bytes.Buffer{}
 	e := NewEncoder(endian.Writer(buf, arch.GetEndian()), arch)
@@ -129,12 +140,7 @@ func TestWriteOn64bitArch(t *testing.T) {
 
 func TestWriteStructOn64bitArch(t *testing.T) {
 	arch := device.Big64
-	values := struct {
-		X uint8
-		Y Pointer
-		Z int16
-		W uint64
-	}{0x12, BytePtr(0xbeefdeaddeadbeef), 0x3456, 0x8888888899999999}
+	values := encodableStruct{0x12, BytePtr(0xbeefdeaddeadbeef), 0x3456, 0x8888888899999999}
 
 	buf := &bytes.Buffer{}
 	e := NewEncoder(endian.Writer(buf, arch.GetEndian()), arch)


### PR DESCRIPTION
Move away from reflection based encoding & decoding for a more explicit template generated implementation.

This is required as the compiler will implement this for us, and in the interim, the reflection based approach will not work using cgo wrappers.