### PR TITLE
cmd/gapit: Allow 'none' to be an option for --gapir-device.

### DIFF
--- a/cmd/gapit/common.go
+++ b/cmd/gapit/common.go
@@ -107,6 +107,9 @@ func getGapis(ctx context.Context, gapisFlags GapisFlags, gapirFlags GapirFlags)
 }
 
 func getDevice(ctx context.Context, client client.Client, capture *path.Capture, flags GapirFlags) (*path.Device, error) {
+	if flags.Device == "none" {
+		return nil, nil
+	}
 	ctx = log.V{"device": flags.Device}.Bind(ctx)
 	paths, err := client.GetDevicesForReplay(ctx, capture)
 	if err != nil {

--- a/cmd/gapit/flags.go
+++ b/cmd/gapit/flags.go
@@ -76,7 +76,7 @@ type (
 		Data   bool `help:"if true then display the bytes read and written by each command. Implies Ranges."`
 	}
 	DeviceFlags struct {
-		Device string `help:"Device to spawn on. One of: 'host', 'android' or <device-serial>"`
+		Device string `help:"Device to spawn on. One of: 'none', 'host', 'android' or <device-serial>"`
 	}
 	DevicesFlags struct {
 		Gapis GapisFlags


### PR DESCRIPTION
Sometimes you don't want to replay for a report.