### PR TITLE
api.go.tmpl: Fix for bad initialization of state.

### DIFF
--- a/gapis/api/templates/api.go.tmpl
+++ b/gapis/api/templates/api.go.tmpl
@@ -1074,7 +1074,11 @@ import (
   func (g *State) Init() {
     {{range $g := $.Globals}}
       {{if IsNil $g.Default}}
-        g.{{$g.Name | GoPublicName}} = {{Template "Go.Null" $g.Type}}
+        {{if $init := Macro "Go.DefaultInitialValue" $g.Type}}
+          g.{{$g.Name | GoPublicName}} = {{$init}}
+        {{else}}
+          g.{{$g.Name | GoPublicName}} = {{Template "Go.Null" $g.Type}}
+        {{end}}
       {{else}}
         g.{{$g.Name | GoPublicName}} = {{Template "Go.Read" $g.Default}}
       {{end}}


### PR DESCRIPTION
I mistakenly dropped the use of `Go.DefaultInitialValue` in 8dd34eef13d87f1c4da55348c04bfef49c0146ad.