### PR TITLE
Vulkan DCE: Track the use of immutable samplers

### DIFF
--- a/gapis/api/vulkan/footprint_builder.go
+++ b/gapis/api/vulkan/footprint_builder.go
@@ -1922,6 +1922,16 @@ func (vb *FootprintBuilder) BuildFootprint(ctx context.Context,
 	// descriptor set
 	case *VkCreateDescriptorSetLayout:
 		write(ctx, bh, vkHandle(cmd.PSetLayout.MustRead(ctx, cmd, s, nil)))
+		info := cmd.PCreateInfo.MustRead(ctx, cmd, s, nil)
+		bindings := info.PBindings.Slice(0, uint64(info.BindingCount), l).MustRead(ctx, cmd, s, nil)
+		for _, b := range bindings {
+			if b.PImmutableSamplers != memory.Nullptr {
+				samplers := b.PImmutableSamplers.Slice(0, uint64(b.DescriptorCount), l).MustRead(ctx, cmd, s, nil)
+				for _, sam := range samplers {
+					read(ctx, bh, vkHandle(sam))
+				}
+			}
+		}
 	case *VkDestroyDescriptorSetLayout:
 		read(ctx, bh, vkHandle(cmd.DescriptorSetLayout))
 		bh.Alive = true


### PR DESCRIPTION
The read of immutable samplers should be tracked at
vkCreateDescriptorSetLayout, so that later use of a descriptor allocated
based on the descriptor set layout will keep the samplers alive.

It is more correct to have the samplers filling in the descriptor slots
in the corresponding binding/array elements of the descriptor sets
allocated based on the layout. But this is not necessary, as the
dependency has already be tracked by the chain of desscriptor set ->
descriptor layout -> immmutable samplers.