### PR TITLE
On starting a queue-submit, clear the last draw info.

### DIFF
--- a/gapis/api/vulkan/vulkan.api
+++ b/gapis/api/vulkan/vulkan.api
@@ -3953,6 +3953,9 @@ cmd VkResult vkQueueSubmit(
   LastSubmission = SUBMIT
   submitInfo := pSubmits[0:submitCount]
   LastBoundQueue = Queues[queue]
+  if (LastBoundQueue.VulkanHandle in LastDrawInfos) {
+    LastDrawInfos[LastBoundQueue.VulkanHandle] = new!DrawInfo()
+  }
 
   enterSubcontext()
   for i in (0 .. submitCount) {


### PR DESCRIPTION
During this submission, we have no valid draw info at the
start of the submission, don't try and use it.