### PR TITLE
Read coherent SSBOs.

### DIFF
--- a/gapis/api/vulkan/api/coherent_memory.api
+++ b/gapis/api/vulkan/api/coherent_memory.api
@@ -67,6 +67,50 @@ sub void readCoherentMemoryInBuffer(ref!BufferObject buffer, VkDeviceSize readOf
   }
 }
 
+sub void readCoherentMemoryInBufferBindings(map!(u32, ref!VkDescriptorBufferInfo) bufferBindings) {
+  for _, _, v in bufferBindings {
+    if v.Buffer != as!VkBuffer(0) {
+      if (v.Buffer in Buffers) {
+        readCoherentMemoryInBuffer(Buffers[v.Buffer], v.Offset, v.Range)
+      }
+    }
+  }
+}
+
+sub void readCoherentMemoryBufferViewBindings(map!(u32, VkBufferView) bufferViews) {
+  for _, _, v in bufferViews {
+    if v in BufferViews {
+      view := BufferViews[v]
+      if (view.Buffer.VulkanHandle in Buffers) {
+        readCoherentMemoryInBuffer(view.Buffer, view.Offset, view.Range)
+      }
+    }
+  }
+}
+
+sub void readCoherentMemoryInDescriptorSet(ref!DescriptorSetObject descriptor_set) {
+  for _, _, v in descriptor_set.Bindings {
+    switch v.BindingType {
+      case
+        VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
+        VK_DESCRIPTOR_TYPE_STORAGE_BUFFER,
+        VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC,
+        VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC:
+          readCoherentMemoryInBufferBindings(v.BufferBinding)
+      case VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER,
+        VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER:
+          readCoherentMemoryBufferViewBindings(v.BufferViewBindings)
+      default: {}
+    }
+  }
+}
+
+sub void readCoherentMemoryInBoundDescriptorSets() {
+  for _, _, s in lastDrawInfo().DescriptorSets {
+    readCoherentMemoryInDescriptorSet(s)
+  }
+}
+
 sub void readCoherentMemoryInImage(ref!ImageObject image) {
   mem := image.BoundMemory
   if mem != null {

--- a/gapis/api/vulkan/api/draw_commands.api
+++ b/gapis/api/vulkan/api/draw_commands.api
@@ -138,6 +138,7 @@ cmd void vkCmdBindVertexBuffers(
 
 
 sub void dovkCmdDraw(ref!vkCmdDrawArgs draw) {
+  readCoherentMemoryInBoundDescriptorSets()
   readCoherentMemoryInCurrentPipelineBoundVertexBuffers(draw.VertexCount, draw.InstanceCount, draw.FirstVertex, draw.FirstInstance)
   clearLastDrawInfoDrawCommandParameters()
   lastDrawInfo().CommandParameters.Draw = draw
@@ -189,6 +190,7 @@ sub void dovkCmdDrawIndexed(ref!vkCmdDrawIndexedArgs draw) {
   readCoherentMemoryInBuffer(indexBuffer, startOffset, numBytes)
   // Read the whole vertex buffer if a buffer is backed with coherent memory.
   readCoherentMemoryInCurrentPipelineBoundVertexBuffers(0xFFFFFFFF, draw.InstanceCount, 0, draw.FirstInstance)
+  readCoherentMemoryInBoundDescriptorSets()
   clearLastDrawInfoDrawCommandParameters()
   lastDrawInfo().CommandParameters.DrawIndexed = draw
 }
@@ -227,6 +229,7 @@ cmd void vkCmdDrawIndexed(
 
 sub void dovkCmdDrawIndirect(ref!vkCmdDrawIndirectArgs draw) {
   if draw.DrawCount > 0 {
+    readCoherentMemoryInBoundDescriptorSets()
     command_size := as!VkDeviceSize(16)
     indirect_buffer_read_size := as!VkDeviceSize((draw.DrawCount - 1) * draw.Stride) + command_size
     readCoherentMemoryInBuffer(Buffers[draw.Buffer], draw.Offset, indirect_buffer_read_size)
@@ -265,6 +268,7 @@ cmd void vkCmdDrawIndirect(
 
 sub void dovkCmdDrawIndexedIndirect(ref!vkCmdDrawIndexedIndirectArgs draw) {
   if draw.DrawCount > 0 {
+    readCoherentMemoryInBoundDescriptorSets()
     command_size := as!VkDeviceSize(16)
     indirect_buffer_read_size := as!VkDeviceSize((draw.DrawCount - 1) * draw.Stride) + command_size
     readCoherentMemoryInBuffer(Buffers[draw.Buffer], draw.Offset, indirect_buffer_read_size)
@@ -304,6 +308,7 @@ cmd void vkCmdDrawIndexedIndirect(
 }
 
 sub void dovkCmdDispatch(ref!vkCmdDispatchArgs args) {
+  readCoherentMemoryInBoundDescriptorSets()
 }
 
 @threadSafety("app")
@@ -333,6 +338,7 @@ class vkCmdDispatchIndirectArgs {
 sub void dovkCmdDispatchIndirect(ref!vkCmdDispatchIndirectArgs dispatch) {
   command_size := as!VkDeviceSize(12)
   readCoherentMemoryInBuffer(Buffers[dispatch.Buffer], dispatch.Offset, command_size)
+  readCoherentMemoryInBoundDescriptorSets()
 }
 
 @threadSafety("app")


### PR DESCRIPTION
We were not doing this, meaning some data was not getting captured
correctly.