### PR TITLE
Turn --direct_run on by default.

### DIFF
--- a/tools/bazel.rc
+++ b/tools/bazel.rc
@@ -2,6 +2,7 @@
 build --verbose_failures
 test --test_output=errors
 query --nohost_deps --noimplicit_deps
+run --direct_run
 
 # Adding in c11 compiling, this really should be done in the android toolchains
 build --cxxopt="-std=c++11"


### PR DESCRIPTION
Now that we're requiring a new enough bazel, make --direct_run the default for `bazel run`. This will cause any `bazel run ...` to 1) not hold on to the bazel lock, allowing other concurrent `bazel run`s and 2) use the console stdin, so that `bazel run gapit trace ...` actually works.