### PR TITLE
Vulkan: Fix the hang at tracing due to a bug in memory tracker

### DIFF
--- a/core/memory_tracker/cc/memory_tracker.h
+++ b/core/memory_tracker/cc/memory_tracker.h
@@ -115,11 +115,11 @@ inline bool IsInRanges(uintptr_t addr, std::map<uintptr_t, size_t>& ranges,
       }
     }
   }
-  // Check the previous range
-  auto pit = std::prev(it, 1);
-  if (pit == ranges.end()) {
+  if (it == ranges.begin()) {
     return false;
   }
+  // Check the previous range
+  auto pit = std::prev(it, 1);
   uintptr_t range_start =
       page_aligned_ranges ? get_aligned_addr(pit->first) : pit->first;
   uintptr_t range_size = page_aligned_ranges


### PR DESCRIPTION
std::prev(some_container.begin(), 1) is an undefined behavior, should
not rely on it.