### PR TITLE
Remove the manifest_merger rule attribute.

### DIFF
--- a/gapidapk/android/apk/rules.bzl
+++ b/gapidapk/android/apk/rules.bzl
@@ -87,7 +87,6 @@ def gapid_apk(name = "", abi = "", pkg = "", libs = {}):
         },
         custom_package = "com.google.android.gapid",
         manifest = ":"+name+"_manifest",
-        manifest_merger = "android",
         deps = [
             "//gapidapk/android/app/src/main:gapid",
             ":" + name + "_native",


### PR DESCRIPTION
It's been removed in bazel 13.