### PR TITLE
Actually construct the final command if it failed in the middle.

### DIFF
--- a/gapis/capture/capture.go
+++ b/gapis/capture/capture.go
@@ -339,6 +339,7 @@ func fromProto(ctx context.Context, r *Record) (out *Capture, err error) {
 		}
 		return nil, err
 	}
+	d.flush(ctx)
 	if d.header == nil {
 		return nil, log.Err(ctx, nil, "Capture was missing header chunk")
 	}

--- a/gapis/capture/decoder.go
+++ b/gapis/capture/decoder.go
@@ -72,6 +72,7 @@ func (d *decoder) EndGroup(ctx context.Context, id uint64) error {
 
 	switch obj := obj.(type) {
 	case *cmdGroup:
+		obj.invoked = true
 		id := d.builder.addCmd(ctx, obj.cmd)
 		for _, c := range obj.children {
 			c.SetCaller(id)
@@ -183,4 +184,10 @@ func (d *decoder) decode(ctx context.Context, in proto.Message) (interface{}, er
 	}
 
 	return obj, nil
+}
+
+func (d *decoder) flush(ctx context.Context) {
+	for k := range d.groups {
+		d.EndGroup(ctx, k)
+	}
 }


### PR DESCRIPTION
We actually add partial commands to the command list.
This means we can actually display the command that caused a crash.