### PR TITLE
Small fix and warnings from the trace UI changes.

### DIFF
--- a/gapic/src/main/com/google/gapid/models/Settings.java
+++ b/gapic/src/main/com/google/gapid/models/Settings.java
@@ -165,8 +165,12 @@ public class Settings {
   }
 
   public String[] getRecent() {
-    return stream(recentFiles).map(file -> new File(file)).filter(File::exists)
-        .filter(File::canRead).map(File::getAbsolutePath).toArray(l -> new String[l]);
+    return stream(recentFiles)
+        .map(file -> new File(file))
+        .filter(File::exists)
+        .filter(File::canRead)
+        .map(File::getAbsolutePath)
+        .toArray(String[]::new);
   }
 
   public boolean analyticsEnabled() {
@@ -313,7 +317,8 @@ public class Settings {
     }
 
     try {
-      return stream(Splitter.on(',').split(value).spliterator(), false).mapToInt(Integer::parseInt)
+      return stream(Splitter.on(',').split(value).spliterator(), false)
+          .mapToInt(Integer::parseInt)
           .toArray();
     } catch (NumberFormatException e) {
       return dflt;
@@ -328,7 +333,8 @@ public class Settings {
 
     try {
       return stream(Splitter.on(',').split(value).spliterator(), false)
-          .mapToDouble(Double::parseDouble).toArray();
+          .mapToDouble(Double::parseDouble)
+          .toArray();
     } catch (NumberFormatException e) {
       return dflt;
     }
@@ -341,7 +347,7 @@ public class Settings {
     }
     return stream(
         Splitter.on(',').trimResults().omitEmptyStrings().split(value).spliterator(), false)
-        .toArray(l -> new String[l]);
+        .toArray(String[]::new);
   }
 
   private static void setPoint(Properties properties, String name, Point point) {

--- a/gapic/src/main/com/google/gapid/server/Tracer.java
+++ b/gapic/src/main/com/google/gapid/server/Tracer.java
@@ -122,7 +122,8 @@ public class Tracer {
     public final boolean midExecution;
     public final boolean disableBuffering;
 
-    public TraceRequest(Api api, File output, int frameCount, boolean midExecution, boolean disableBuffering) {
+    public TraceRequest(
+        Api api, File output, int frameCount, boolean midExecution, boolean disableBuffering) {
       this.api = api;
       this.output = output;
       this.frameCount = frameCount;
@@ -174,10 +175,10 @@ public class Tracer {
     public final String intentArgs;
     public final boolean clearCache;
     public final boolean disablePcs;
-    public final boolean disableBuffering;
 
     public AndroidTraceRequest(Api api, Device.Instance device, String action, String intentArgs,
-        File output, int frameCount, boolean midExecution, boolean disableBuffering, boolean clearCache, boolean disablePcs) {
+        File output, int frameCount, boolean midExecution, boolean disableBuffering,
+        boolean clearCache, boolean disablePcs) {
       this(api, device, null, null, action, intentArgs, output, frameCount, midExecution,
           disableBuffering, clearCache, disablePcs);
     }
@@ -193,7 +194,6 @@ public class Tracer {
       this.intentArgs = intentArgs;
       this.clearCache = clearCache;
       this.disablePcs = disablePcs;
-      this.disableBuffering = disableBuffering;
     }
 
     @Override

--- a/gapic/src/main/com/google/gapid/views/TracerDialog.java
+++ b/gapic/src/main/com/google/gapid/views/TracerDialog.java
@@ -264,7 +264,7 @@ public class TracerDialog {
       protected final Text file;
       protected final Spinner frameCount;
       protected final Button fromBeginning;
-      protected final Button traceWithoutBuffering;
+      protected final Button withoutBuffering;
       protected boolean userHasChangedOutputFile = false;
 
       public SharedTraceInput(Composite parent, Models models, Widgets widgets) {
@@ -306,7 +306,7 @@ public class TracerDialog {
             new GridData(SWT.FILL, SWT.FILL, true, false));
 
         createLabel(this, "");
-        traceWithoutBuffering = withLayoutData(
+        withoutBuffering = withLayoutData(
             createCheckbox(this, "Disable Buffering", models.settings.traceWithoutBuffering),
             new GridData(SWT.FILL, SWT.FILL, true, false));
 
@@ -351,15 +351,16 @@ public class TracerDialog {
         settings.traceOutDir = directory.getText();
         settings.traceFrameCount = frameCount.getSelection();
         settings.traceMidExecution = !fromBeginning.getSelection();
-        settings.traceWithoutBuffering = traceWithoutBuffering.getSelection();
+        settings.traceWithoutBuffering = withoutBuffering.getSelection();
 
         return getTraceRequest(settings, getSelectedApi(), getOutputFile(),
-            frameCount.getSelection(), !fromBeginning.getSelection(), traceWithoutBuffering.getSelection());
+            frameCount.getSelection(), !fromBeginning.getSelection(),
+            withoutBuffering.getSelection());
       }
 
       protected abstract TraceRequest getTraceRequest(
           Settings settings, Tracer.Api traceApi, File output, int frames, boolean midExecution,
-          boolean traceWithoutBuffering);
+          boolean disableBuffering);
 
       protected Tracer.Api getSelectedApi() {
         return (Tracer.Api)api.getStructuredSelection().getFirstElement();
@@ -557,7 +558,7 @@ public class TracerDialog {
 
       @Override
       protected TraceRequest getTraceRequest(Settings settings, Tracer.Api traceApi, File output,
-          int frames, boolean midExecution, boolean traceWithoutBuffering) {
+          int frames, boolean midExecution, boolean disableBuffering) {
         String target = traceTarget.getText();
         int actionSep = target.indexOf(":");
         int pkgSep = target.indexOf("/");
@@ -573,11 +574,12 @@ public class TracerDialog {
           String pkg = target.substring(actionSep + 1, pkgSep);
           String activity = target.substring(pkgSep + 1);
           return new AndroidTraceRequest(traceApi, getSelectedDevice(), pkg, activity, action,
-              arguments.getText(), output, frames, midExecution, traceWithoutBuffering, clearCache.getSelection(),
-              disablePcs.getSelection());
+              arguments.getText(), output, frames, midExecution, disableBuffering,
+              clearCache.getSelection(), disablePcs.getSelection());
         } else {
           return new AndroidTraceRequest(traceApi, getSelectedDevice(), target, arguments.getText(),
-              output, frames, midExecution, traceWithoutBuffering, clearCache.getSelection(), disablePcs.getSelection());
+              output, frames, midExecution, disableBuffering, clearCache.getSelection(),
+              disablePcs.getSelection());
         }
       }
 
@@ -677,7 +679,7 @@ public class TracerDialog {
 
       @Override
       protected TraceRequest getTraceRequest(Settings settings, Tracer.Api traceApi, File output,
-          int frames, boolean midExecution, boolean traceWithoutBuffering) {
+          int frames, boolean midExecution, boolean disableBuffering) {
         settings.traceExecutable = executable.getText();
         settings.traceArgs = arguments.getText();
         settings.traceCwd = cwd.getText();
@@ -685,7 +687,7 @@ public class TracerDialog {
         return new DesktopTraceRequest(
             new File(executable.getText()), arguments.getText(),
             cwd.getText().isEmpty() ? null : new File(cwd.getText()), output, frames,
-            midExecution, traceWithoutBuffering);
+            midExecution, disableBuffering);
       }
     }
   }


### PR DESCRIPTION
Removes the duplicate field from the `AndroidTraceRequest` class that is already present in its base class. Sorry I missed this during the review. The rename in the `TracerDialog` is to silence a name-shadowing warning. I know in this case it is annoying, having to come up with two names for the same thing, however, the warning has saved me a bunch from silly mistakes (like spelling errors) other times, so I put up with it.