### PR TITLE
Remove the runtime dependency on libGL again.

### DIFF
--- a/core/os/device/deviceinfo/cc/linux/query.cpp
+++ b/core/os/device/deviceinfo/cc/linux/query.cpp
@@ -75,6 +75,10 @@ void destroyContext() {
         return;
     }
 
+    if (!core::hasGLorGLES()) {
+        return;
+    }
+
     core::DlLoader libX("libX11.so");
     pfn_XFree fn_XFree = (pfn_XFree)libX.lookup("XFree");
     pfn_XCloseDisplay fn_XCloseDisplay = (pfn_XCloseDisplay)libX.lookup("XCloseDisplay");
@@ -101,6 +105,9 @@ void destroyContext() {
 }
 
 void createGlContext() {
+    if (!core::hasGLorGLES()) {
+        return;
+    }
     auto fn_glXChooseFBConfig= (pfn_glXChooseFBConfig)core::GetGlesProcAddress("glXChooseFBConfig", true);
     auto fn_glXCreateNewContext = (pfn_glXCreateNewContext)core::GetGlesProcAddress("glXCreateNewContext", true);
     auto fn_glXCreatePbuffer = (pfn_glXCreatePbuffer)core::GetGlesProcAddress("glXCreatePbuffer", true);

--- a/gapis/api/gles/templates/api_imports.cpp.tmpl
+++ b/gapis/api/gles/templates/api_imports.cpp.tmpl
@@ -44,6 +44,9 @@ namespace gapii {
   }
 ¶
   void {{$name}}::resolve() {
+    if (!core::hasGLorGLES()) {
+      return;
+    }
     using namespace core;
     {{range $c := AllCommands $}}
       {{if not (GetAnnotation $c "synthetic")}}


### PR DESCRIPTION
If libGL.so can not be found, continue to be able to trace
and replay vulkan applications.