### PR TITLE
WIP: GLES on-device replay

### DIFF
--- a/gapis/api/gles/compat.go
+++ b/gapis/api/gles/compat.go
@@ -396,6 +396,10 @@ func compat(ctx context.Context, device *device.Instance, onError onCompatError)
 			return
 
 		case *GlShaderSource:
+			if version.IsES { // No compat required.
+				out.MutateAndWrite(ctx, id, cmd)
+				return
+			}
 			// Apply the state mutation of the unmodified glShaderSource
 			// command.
 			// This is so we can grab the source string from the Shader object.
@@ -404,6 +408,10 @@ func compat(ctx context.Context, device *device.Instance, onError onCompatError)
 			return
 
 		case *GlCompileShader:
+			if version.IsES { // No compat required.
+				out.MutateAndWrite(ctx, id, cmd)
+				return
+			}
 			shader := c.Objects.Shaders.Get(cmd.Shader)
 			src := ""
 

--- a/gapis/api/gles/find_issues.go
+++ b/gapis/api/gles/find_issues.go
@@ -39,17 +39,20 @@ import (
 // the slice out. Once the last issue is sent (if any) all the chans in out are
 // closed.
 type findIssues struct {
-	state       *api.GlobalState
-	device      *device.Instance
-	issues      []replay.Issue
-	res         []replay.Result
-	lastGlError GLenum
+	state         *api.GlobalState
+	device        *device.Instance
+	targetVersion *Version
+	issues        []replay.Issue
+	res           []replay.Result
+	lastGlError   GLenum
 }
 
 func newFindIssues(ctx context.Context, c *capture.Capture, device *device.Instance) *findIssues {
+	targetVersion, _ := ParseVersion(device.Configuration.Drivers.OpenGL.Version)
 	transform := &findIssues{
-		state:  c.NewState(ctx),
-		device: device,
+		state:         c.NewState(ctx),
+		device:        device,
+		targetVersion: targetVersion,
 	}
 	transform.state.OnError = func(err interface{}) {
 		if glenum, ok := err.(GLenum); ok {
@@ -166,15 +169,19 @@ func (t *findIssues) Transform(ctx context.Context, id api.CmdID, cmd api.Cmd, o
 			t.onIssue(cmd, id, service.Severity_ErrorLevel, err)
 			return
 		}
-		opts := shadertools.ConvertOptions{
-			ShaderType:        st,
-			CheckAfterChanges: true,
-			Disassemble:       true,
-			TargetGLSLVersion: 430,
-		}
 
-		if _, err := shadertools.ConvertGlsl(shader.Source, &opts); err != nil {
-			t.onIssue(cmd, id, service.Severity_ErrorLevel, err)
+		if t.targetVersion.IsES {
+			// Check we are able to convert this GLES shader to desktop GL.
+			opts := shadertools.ConvertOptions{
+				ShaderType:        st,
+				CheckAfterChanges: true,
+				Disassemble:       true,
+				TargetGLSLVersion: 430,
+			}
+
+			if _, err := shadertools.ConvertGlsl(shader.Source, &opts); err != nil {
+				t.onIssue(cmd, id, service.Severity_ErrorLevel, err)
+			}
 		}
 
 		const buflen = 8192

--- a/gapis/api/gles/read_framebuffer.go
+++ b/gapis/api/gles/read_framebuffer.go
@@ -22,6 +22,7 @@ import (
 	"github.com/google/gapid/core/data/binary"
 	"github.com/google/gapid/core/image"
 	"github.com/google/gapid/core/log"
+	"github.com/google/gapid/core/os/device"
 	"github.com/google/gapid/core/stream"
 	"github.com/google/gapid/gapis/api"
 	"github.com/google/gapid/gapis/api/transform"
@@ -32,10 +33,14 @@ import (
 	"github.com/google/gapid/gapis/service"
 )
 
-type readFramebuffer struct{ transform.Tasks }
+type readFramebuffer struct {
+	transform.Tasks
+	targetVersion *Version
+}
 
-func newReadFramebuffer(ctx context.Context) *readFramebuffer {
-	return &readFramebuffer{}
+func newReadFramebuffer(ctx context.Context, device *device.Instance) *readFramebuffer {
+	targetVersion, _ := ParseVersion(device.Configuration.Drivers.OpenGL.Version)
+	return &readFramebuffer{targetVersion: targetVersion}
 }
 
 func getBoundFramebufferID(thread uint64, s *api.GlobalState) (FramebufferId, error) {
@@ -56,7 +61,7 @@ func (t *readFramebuffer) depth(
 	res replay.Result) {
 
 	t.Add(id, func(ctx context.Context, out transform.Writer) {
-		postFBData(ctx, id, thread, 0, 0, fb, GLenum_GL_DEPTH_ATTACHMENT, out, res)
+		postFBData(ctx, id, thread, 0, 0, fb, GLenum_GL_DEPTH_ATTACHMENT, t.targetVersion, out, res)
 	})
 }
 
@@ -70,7 +75,7 @@ func (t *readFramebuffer) color(
 
 	t.Add(id, func(ctx context.Context, out transform.Writer) {
 		attachment := GLenum_GL_COLOR_ATTACHMENT0 + GLenum(bufferIdx)
-		postFBData(ctx, id, thread, width, height, fb, attachment, out, res)
+		postFBData(ctx, id, thread, width, height, fb, attachment, t.targetVersion, out, res)
 	})
 }
 
@@ -80,6 +85,7 @@ func postFBData(ctx context.Context,
 	width, height uint32,
 	fb FramebufferId,
 	attachment GLenum,
+	version *Version,
 	out transform.Writer,
 	res replay.Result) {
 
@@ -180,15 +186,18 @@ func postFBData(ctx context.Context,
 	}
 
 	if hasColor {
-		// TODO: These glReadBuffer calls need to be changed for on-device
-		//       replay. Note that glReadBuffer was only introduced in
-		//       OpenGL ES 3.0, and that GL_FRONT is not a legal enum value.
 		if c.Bound.DrawFramebuffer == c.Objects.Default.Framebuffer {
 			out.MutateAndWrite(ctx, dID, cb.Custom(func(ctx context.Context, s *api.GlobalState, b *builder.Builder) error {
 				// TODO: We assume here that the default framebuffer is
 				//       single-buffered. Once we support double-buffering we
 				//       need to decide whether to read from GL_FRONT or GL_BACK.
-				cb.GlReadBuffer(GLenum_GL_FRONT).Call(ctx, s, b)
+				buf := GLenum_GL_BACK
+				if !version.IsES {
+					// OpenGL expects GL_FRONT for single-buffered
+					// configurations. Note this is not a legal value for GLES.
+					buf = GLenum_GL_FRONT
+				}
+				cb.GlReadBuffer(buf).Call(ctx, s, b)
 				return nil
 			}))
 		} else {
@@ -227,6 +236,21 @@ func postFBData(ctx context.Context,
 			cb.GlBlitFramebuffer(0, 0, GLint(inW), GLint(inH), 0, 0, GLint(outW), GLint(outH), bufferBits, GLenum_GL_LINEAR),
 		)
 		t.glBindFramebuffer_Read(ctx, framebufferID)
+	}
+
+	if u, t := getReadPixelsFormat(version, unsizedFormat, ty); unsizedFormat != u || ty != t {
+		// glReadPixels() cannot be called with the natural unsized-format and
+		// type of the framebuffer. Instead, fetch the framebuffer in a format
+		// that can be read, and then convert the result to the expected format.
+		f, err := getImageFormat(u, t)
+		if err != nil {
+			res(nil, err)
+			return
+		}
+		res = res.Transform(func(in interface{}) (interface{}, error) {
+			return in.(*image.Data).Convert(imgFmt)
+		})
+		imgFmt, unsizedFormat, ty = f, u, t
 	}
 
 	t.setPackStorage(ctx, PixelStorageState{Alignment: 1}, 0)
@@ -270,6 +294,38 @@ func postFBData(ctx context.Context,
 	}))
 
 	out.MutateAndWrite(ctx, dID, cb.GlGetError(0)) // Check for errors.
+}
+
+// getReadPixelsFormat returns a unsized-format and type that is compatible with
+// glReadPixels() for the given framebuffer unsized-format and type.
+// See the GLES spec: 4.3.2 Reading Pixels
+func getReadPixelsFormat(version *Version, uf GLenum, ty GLenum) (GLenum, GLenum) {
+	if version.IsES {
+		switch uf {
+		case GLenum_GL_RED_INTEGER, GLenum_GL_RG_INTEGER, GLenum_GL_RGB_INTEGER, GLenum_GL_RGBA_INTEGER:
+			uf = GLenum_GL_RGBA_INTEGER
+		default:
+			uf = GLenum_GL_RGBA
+		}
+		switch ty {
+		case GLenum_GL_UNSIGNED_BYTE,
+			GLenum_GL_UNSIGNED_SHORT_4_4_4_4,
+			GLenum_GL_UNSIGNED_SHORT_5_5_5_1,
+			GLenum_GL_UNSIGNED_SHORT_5_6_5:
+			ty = GLenum_GL_UNSIGNED_BYTE
+		case GLenum_GL_UNSIGNED_INT,
+			GLenum_GL_UNSIGNED_INT_10F_11F_11F_REV,
+			GLenum_GL_UNSIGNED_INT_2_10_10_10_REV,
+			GLenum_GL_UNSIGNED_INT_5_9_9_9_REV,
+			GLenum_GL_UNSIGNED_SHORT:
+			ty = GLenum_GL_UNSIGNED_INT
+		case GLenum_GL_BYTE, GLenum_GL_INT, GLenum_GL_SHORT:
+			ty = GLenum_GL_INT
+		default:
+			ty = GLenum_GL_FLOAT
+		}
+	}
+	return uf, ty
 }
 
 func mutateAndWriteEach(ctx context.Context, out transform.Writer, id api.CmdID, cmds ...api.Cmd) {

--- a/gapis/api/gles/read_texture.go
+++ b/gapis/api/gles/read_texture.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/google/gapid/core/image"
 	"github.com/google/gapid/core/log"
+	"github.com/google/gapid/core/os/device"
 	"github.com/google/gapid/gapis/api"
 	"github.com/google/gapid/gapis/api/transform"
 	"github.com/google/gapid/gapis/replay"
@@ -30,7 +31,15 @@ type textureRequest struct {
 	data *ReadGPUTextureDataResolveable
 }
 
-type readTexture struct{ transform.Tasks }
+type readTexture struct {
+	transform.Tasks
+	targetVersion *Version
+}
+
+func newReadTexture(ctx context.Context, device *device.Instance) *readTexture {
+	targetVersion, _ := ParseVersion(device.Configuration.Drivers.OpenGL.Version)
+	return &readTexture{targetVersion: targetVersion}
+}
 
 func (t *readTexture) add(ctx context.Context, r *ReadGPUTextureDataResolveable, res replay.Result) {
 	id := api.CmdID(r.After)
@@ -69,11 +78,11 @@ func (t *readTexture) add(ctx context.Context, r *ReadGPUTextureDataResolveable,
 			return
 		}
 
-		t := newTweaker(out, dID, cb)
-		defer t.revert(ctx)
+		tw := newTweaker(out, dID, cb)
+		defer tw.revert(ctx)
 
-		framebufferID := t.glGenFramebuffer(ctx)
-		t.glBindFramebuffer_Draw(ctx, framebufferID)
+		framebufferID := tw.glGenFramebuffer(ctx)
+		tw.glBindFramebuffer_Draw(ctx, framebufferID)
 
 		streamFmt, err := getUncompressedStreamFormat(getUnsizedFormatAndType(layer.SizedFormat))
 		if err != nil {
@@ -126,7 +135,7 @@ func (t *readTexture) add(ctx context.Context, r *ReadGPUTextureDataResolveable,
 			return in.(*image.Data).Convert(f)
 		})
 
-		postFBData(ctx, dID, r.Thread, uint32(layer.Width), uint32(layer.Height), framebufferID, attachment, out, res)
+		postFBData(ctx, dID, r.Thread, uint32(layer.Width), uint32(layer.Height), framebufferID, attachment, t.targetVersion, out, res)
 	})
 }
 


### PR DESCRIPTION
Simple GLES apps will now replay on the connected device.
Reading depth / stencil buffers does not currently work.
More complex GLES apps can crash GAPIR.