### PR TITLE
gapis/api: Fix struct encoding / decoding

### DIFF
--- a/gapis/api/templates/api.go.tmpl
+++ b/gapis/api/templates/api.go.tmpl
@@ -903,15 +903,18 @@ import (
     func (c {{$name}}) Encode(ϟe *ϟmem.Encoder) {
       alignment := {{$name}}Alignment(ϟe.MemoryLayout())
       ϟe.Align(alignment)
+      base := ϟe.Offset();
       {{range $f := $.Fields}}
         {{Template "Go.Encode" "Type" $f.Type "Value" (print "c." ($f.Name | GoPublicName))}}
       {{end}}
-      ϟe.Align(alignment)
+      bytes := ϟe.Offset() - base
+      ϟe.Pad({{$name}}Size(ϟe.MemoryLayout()) - bytes)
     }
 
     // Decode decodes this class from the decoder.
     func (c *{{$name}}) Decode(ϟd *ϟmem.Decoder) {
       ϟd.Align({{$name}}Alignment(ϟd.MemoryLayout()))
+      base := ϟd.Offset();
       {{range $f := $.Fields}}
         {{if IsClass $f.Type}}
           c.{{$f.Name | GoPublicName}}.Decode(ϟd)
@@ -919,7 +922,8 @@ import (
           c.{{$f.Name | GoPublicName}} = {{Template "Go.Decode" $f.Type}}
         {{end}}
       {{end}}
-      ϟd.Align({{$name}}Size(ϟd.MemoryLayout()))
+      bytes := ϟd.Offset() - base
+      ϟd.Skip({{$name}}Size(ϟd.MemoryLayout()) - bytes)
     }
   {{end}}
 {{end}}

--- a/gapis/memory/encoder.go
+++ b/gapis/memory/encoder.go
@@ -43,6 +43,12 @@ func (e *Encoder) MemoryLayout() *device.MemoryLayout {
 	return e.m
 }
 
+// Offset returns the byte offset of the writer from the initial Encoder
+// creation.
+func (e *Encoder) Offset() uint64 {
+	return e.o
+}
+
 // Align writes zero bytes until the write position is a multiple of to.
 func (e *Encoder) Align(to uint64) {
 	alignment := u64.AlignUp(e.o, to)


### PR DESCRIPTION
The tail alignment logic was wrong.