### PR TITLE
Add context destruction blacklist.

### DIFF
--- a/core/os/device/deviceinfo/cc/query.cpp
+++ b/core/os/device/deviceinfo/cc/query.cpp
@@ -160,7 +160,18 @@ void buildDeviceInstance(const query::Option& opt, void* platform_data,
   instance->set_allocated_configuration(configuration);
   deviceInstanceID(instance);
 
-  query::destroyContext();
+  // Blacklist of OS/Hardware version that means we cannot safely
+  // destroy the context.
+  // https://github.com/google/gapid/issues/1867
+  bool blacklist = false;
+  if (std::string(gpuName).find("Vega") != std::string::npos &&
+      std::string(query::osName()).find("Windows 10") != std::string::npos) {
+      blacklist = true;
+  }
+
+  if (!blacklist) {
+     query::destroyContext();
+  }
 
   *out = instance;
 }

--- a/core/os/device/deviceinfo/cc/windows/query.cpp
+++ b/core/os/device/deviceinfo/cc/windows/query.cpp
@@ -26,16 +26,19 @@ namespace {
 
 static const char* wndClassName = TEXT("opengl-dummy-window");
 
-WNDCLASS registerWindowClass() {
-    WNDCLASS wc;
+WNDCLASSEX registerWindowClass() {
+    WNDCLASSEX wc;
     memset(&wc, 0, sizeof(wc));
-    wc.style         = 0;
+    wc.cbSize        = sizeof(wc);
+// We must use CS_OWNDC here if we are to use this window with GL.
+// https://www.khronos.org/opengl/wiki/Creating_an_OpenGL_Context_(WGL)#The_Window_Itself
+    wc.style         = CS_OWNDC;
     wc.lpfnWndProc   = DefWindowProc;
     wc.hInstance     = GetModuleHandle(0);
     wc.hCursor       = LoadCursor(0, IDC_ARROW);
     wc.lpszMenuName  = TEXT("");
     wc.lpszClassName = wndClassName;
-    RegisterClass(&wc);
+    RegisterClassEx(&wc);
     return wc;
 }
 
@@ -91,7 +94,7 @@ void createGlContext() {
         return;
     }
 
-    WNDCLASS wc = registerWindowClass();
+    WNDCLASSEX wc = registerWindowClass();
     gContext.mWnd = CreateWindow(wndClassName, TEXT(""), WS_POPUP, 0, 0, 8, 8, 0, 0, GetModuleHandle(0), 0);
     if (gContext.mWnd == nullptr) {
         return;


### PR DESCRIPTION
This will cause a context and window leak, which is bad, but
only for certain hardware combinations.

We can remove once we figure out exactly waht is causing
this behavior.