### PR TITLE
Elide ALL commands that we are not trying to trace.

### DIFF
--- a/gapii/cc/call_observer.h
+++ b/gapii/cc/call_observer.h
@@ -220,6 +220,9 @@ private:
     // The current API that this call-observer is observing.
     uint8_t mApi;
 
+    // Whether or not we should be tracing with this call observer
+    bool mShouldTrace;
+
     // The current thread id.
     uint64_t mCurrentThread;
 

--- a/gapii/cc/spy_base.h
+++ b/gapii/cc/spy_base.h
@@ -89,6 +89,10 @@ public:
         return should_trace(api) ? mEncoder : mNullEncoder;
     }
 
+    std::shared_ptr<gapii::PackEncoder> nullEncoder() {
+        return mNullEncoder;
+    }
+
     // Returns true if we should observe application pool.
     bool shouldObserveApplicationPool() { return mObserveApplicationPool; }
 


### PR DESCRIPTION
We were ignoring some of the data, but not all of it. We would
end up adding the commands to the tree, but no observations,
this caused havok with the new memory work, since replaying
those commands would cause OOB memory accesses.