### PR TITLE
WIP: Replace memory ranges with actual byte slices.

### DIFF
--- a/gapii/cc/vulkan_mid_execution.cpp
+++ b/gapii/cc/vulkan_mid_execution.cpp
@@ -293,7 +293,7 @@ void VulkanSpy::prepareGPUBuffers(CallObserver *observer, PackEncoder *group,
     pool->buffer = nullptr;
 
     memory::Observation observation;
-    observation.set_base(0);
+    observation.set_base(pool->size - 1);
     observation.set_size(0);
     observation.set_resindex(empty_index);
     observation.set_pool(pool->id);

--- a/gapis/api/cmd_observations.go
+++ b/gapis/api/cmd_observations.go
@@ -49,20 +49,20 @@ func (o *CmdObservations) AddWrite(rng memory.Range, id id.ID) {
 
 // ApplyReads applies all the observed reads to memory pool p.
 // This is a no-op when called when o is nil.
-func (o *CmdObservations) ApplyReads(p *memory.Pool) {
+func (o *CmdObservations) ApplyReads(ctx context.Context, p *memory.Pool) {
 	if o != nil {
 		for _, r := range o.Reads {
-			p.Write(r.Range.Base, memory.Resource(r.ID, r.Range.Size))
+			p.Write(ctx, r.Range.Base, memory.Resource(r.ID, r.Range.Size))
 		}
 	}
 }
 
 // ApplyWrites applies all the observed writes to the memory pool p.
 // This is a no-op when called when o is nil.
-func (o *CmdObservations) ApplyWrites(p *memory.Pool) {
+func (o *CmdObservations) ApplyWrites(ctx context.Context, p *memory.Pool) {
 	if o != nil {
 		for _, w := range o.Writes {
-			p.Write(w.Range.Base, memory.Resource(w.ID, w.Range.Size))
+			p.Write(ctx, w.Range.Base, memory.Resource(w.ID, w.Range.Size))
 		}
 	}
 }

--- a/gapis/api/gles/compat.go
+++ b/gapis/api/gles/compat.go
@@ -470,7 +470,7 @@ func compat(ctx context.Context, device *device.Instance, onError onCompatError)
 		case *GlDrawBuffers:
 			// Currently the default framebuffer for replay is single-buffered
 			// and so we need to transform any usage of GL_BACK to GL_FRONT.
-			cmd.Extras().Observations().ApplyReads(s.Memory.ApplicationPool())
+			cmd.Extras().Observations().ApplyReads(ctx, s.Memory.ApplicationPool())
 			bufs := cmd.Bufs().Slice(0, uint64(cmd.N()), s.MemoryLayout).MustRead(ctx, cmd, s, nil)
 			for i, buf := range bufs {
 				if buf == GLenum_GL_BACK {
@@ -947,7 +947,7 @@ func compat(ctx context.Context, device *device.Instance, onError onCompatError)
 			}
 
 		case *GlDeleteBuffers:
-			cmd.Extras().Observations().ApplyReads(s.Memory.ApplicationPool())
+			cmd.Extras().Observations().ApplyReads(ctx, s.Memory.ApplicationPool())
 			ids, err := cmd.Buffers().Slice(0, uint64(cmd.Count()), s.MemoryLayout).Read(ctx, cmd, s, nil)
 			if err == nil {
 				deleteCompat(ctx, ids, dID, dictionary.From(c.Objects().Buffers()), s, out,
@@ -961,7 +961,7 @@ func compat(ctx context.Context, device *device.Instance, onError onCompatError)
 			// (0). As we do compat for glBindFramebuffer(), scan the list of
 			// framebuffers that are being deleted, and forward them to a fake
 			// call to glBindFramebuffer(XXX, 0) if we find any.
-			cmd.Extras().Observations().ApplyReads(s.Memory.ApplicationPool())
+			cmd.Extras().Observations().ApplyReads(ctx, s.Memory.ApplicationPool())
 			fbs, err := cmd.Framebuffers().Slice(0, uint64(cmd.Count()), s.MemoryLayout).Read(ctx, cmd, s, nil)
 			if err == nil {
 				for _, fb := range fbs {
@@ -979,8 +979,9 @@ func compat(ctx context.Context, device *device.Instance, onError onCompatError)
 			}
 
 		case *GlDeleteProgramPipelines:
-			cmd.Extras().Observations().ApplyReads(s.Memory.ApplicationPool())
+			cmd.Extras().Observations().ApplyReads(ctx, s.Memory.ApplicationPool())
 			ids, err := cmd.Pipelines().Slice(0, uint64(cmd.N()), s.MemoryLayout).Read(ctx, cmd, s, nil)
+
 			if err == nil {
 				deleteCompat(ctx, ids, dID, dictionary.From(c.Objects().Pipelines()), s, out,
 					func(cnt GLsizei, buf memory.Pointer) api.Cmd { return cb.GlDeleteProgramPipelines(cnt, buf) })
@@ -988,7 +989,7 @@ func compat(ctx context.Context, device *device.Instance, onError onCompatError)
 			}
 
 		case *GlDeleteQueries:
-			cmd.Extras().Observations().ApplyReads(s.Memory.ApplicationPool())
+			cmd.Extras().Observations().ApplyReads(ctx, s.Memory.ApplicationPool())
 			ids, err := cmd.Queries().Slice(0, uint64(cmd.Count()), s.MemoryLayout).Read(ctx, cmd, s, nil)
 			if err == nil {
 				deleteCompat(ctx, ids, dID, dictionary.From(c.Objects().Queries()), s, out,
@@ -997,7 +998,7 @@ func compat(ctx context.Context, device *device.Instance, onError onCompatError)
 			}
 
 		case *GlDeleteRenderbuffers:
-			cmd.Extras().Observations().ApplyReads(s.Memory.ApplicationPool())
+			cmd.Extras().Observations().ApplyReads(ctx, s.Memory.ApplicationPool())
 			ids, err := cmd.Renderbuffers().Slice(0, uint64(cmd.Count()), s.MemoryLayout).Read(ctx, cmd, s, nil)
 			if err == nil {
 				deleteCompat(ctx, ids, dID, dictionary.From(c.Objects().Renderbuffers()), s, out,
@@ -1006,7 +1007,7 @@ func compat(ctx context.Context, device *device.Instance, onError onCompatError)
 			}
 
 		case *GlDeleteSamplers:
-			cmd.Extras().Observations().ApplyReads(s.Memory.ApplicationPool())
+			cmd.Extras().Observations().ApplyReads(ctx, s.Memory.ApplicationPool())
 			ids, err := cmd.Samplers().Slice(0, uint64(cmd.Count()), s.MemoryLayout).Read(ctx, cmd, s, nil)
 			if err == nil {
 				deleteCompat(ctx, ids, dID, dictionary.From(c.Objects().Samplers()), s, out,
@@ -1015,7 +1016,7 @@ func compat(ctx context.Context, device *device.Instance, onError onCompatError)
 			}
 
 		case *GlDeleteTextures:
-			cmd.Extras().Observations().ApplyReads(s.Memory.ApplicationPool())
+			cmd.Extras().Observations().ApplyReads(ctx, s.Memory.ApplicationPool())
 			ids, err := cmd.Textures().Slice(0, uint64(cmd.Count()), s.MemoryLayout).Read(ctx, cmd, s, nil)
 			if err == nil {
 				deleteCompat(ctx, ids, dID, dictionary.From(c.Objects().Textures()), s, out,
@@ -1024,7 +1025,7 @@ func compat(ctx context.Context, device *device.Instance, onError onCompatError)
 			}
 
 		case *GlDeleteTransformFeedbacks:
-			cmd.Extras().Observations().ApplyReads(s.Memory.ApplicationPool())
+			cmd.Extras().Observations().ApplyReads(ctx, s.Memory.ApplicationPool())
 			ids, err := cmd.Ids().Slice(0, uint64(cmd.Count()), s.MemoryLayout).Read(ctx, cmd, s, nil)
 			if err == nil {
 				deleteCompat(ctx, ids, dID, dictionary.From(c.Objects().TransformFeedbacks()), s, out,
@@ -1033,7 +1034,7 @@ func compat(ctx context.Context, device *device.Instance, onError onCompatError)
 			}
 
 		case *GlDeleteVertexArrays:
-			cmd.Extras().Observations().ApplyReads(s.Memory.ApplicationPool())
+			cmd.Extras().Observations().ApplyReads(ctx, s.Memory.ApplicationPool())
 			ids, err := cmd.Arrays().Slice(0, uint64(cmd.Count()), s.MemoryLayout).Read(ctx, cmd, s, nil)
 			if err == nil {
 				deleteCompat(ctx, ids, dID, dictionary.From(c.Objects().VertexArrays()), s, out,

--- a/gapis/api/gles/compat_client.go
+++ b/gapis/api/gles/compat_client.go
@@ -96,7 +96,7 @@ func compatDrawElements(
 			// The indices are also in client memory, so we need to apply the
 			// command's reads now so that the indices can be read from the
 			// application pool.
-			cmd.Extras().Observations().ApplyReads(s.Memory.ApplicationPool())
+			cmd.Extras().Observations().ApplyReads(ctx, s.Memory.ApplicationPool())
 			indexSize := DataTypeSize(cmd.IndicesType())
 			data := U8ᵖ(cmd.Indices()).Slice(0, uint64(indexSize*int(cmd.IndicesCount())), s.MemoryLayout)
 			limits, ok := cmd.indexLimits()
@@ -200,7 +200,7 @@ func moveClientVBsToVAs(
 	// We need to do this as the glBufferData calls below will require the data.
 	dID := id.Derived()
 	out.MutateAndWrite(ctx, dID, cb.Custom(func(ctx context.Context, s *api.GlobalState, b *builder.Builder) error {
-		cmd.Extras().Observations().ApplyReads(s.Memory.ApplicationPool())
+		cmd.Extras().Observations().ApplyReads(ctx, s.Memory.ApplicationPool())
 		return nil
 	}))
 

--- a/gapis/api/gles/find_issues.go
+++ b/gapis/api/gles/find_issues.go
@@ -46,9 +46,9 @@ type findIssues struct {
 	lastGlError GLenum
 }
 
-func newFindIssues(ctx context.Context, c *capture.Capture, device *device.Instance) *findIssues {
+func newFindIssues(ctx context.Context, c *capture.Capture, oldState *api.GlobalState, device *device.Instance) *findIssues {
 	transform := &findIssues{
-		state:  c.NewState(ctx),
+		state: c.NewUninitializedStateWithAllocator(ctx, oldState.Allocator),
 		device: device,
 	}
 	transform.state.OnError = func(err interface{}) {

--- a/gapis/api/gles/replay.go
+++ b/gapis/api/gles/replay.go
@@ -129,7 +129,7 @@ func (a API) Replay(
 		case issuesRequest:
 			deadCodeElimination.KeepAllAlive = true
 			if issues == nil {
-				issues = newFindIssues(ctx, capture, device)
+				issues = newFindIssues(ctx, capture, out.State(), device)
 			}
 			issues.reportTo(rr.Result)
 			onCompatError = func(ctx context.Context, id api.CmdID, cmd api.Cmd, err error) {

--- a/gapis/api/gles/resources.go
+++ b/gapis/api/gles/resources.go
@@ -166,7 +166,7 @@ func (t Textureʳ) ResourceData(ctx context.Context, s *api.GlobalState) (*api.R
 				if err != nil {
 					return nil, err
 				}
-				data := pool.Slice(l.Data().Range())
+				data := pool.Slice(ctx, l.Data().Range())
 				buf := make([]byte, data.Size())
 				if err := data.Get(ctx, 0, buf); err != nil {
 					return nil, err

--- a/gapis/api/gles/state_builder.go
+++ b/gapis/api/gles/state_builder.go
@@ -57,7 +57,7 @@ func (s *State) RebuildState(ctx context.Context, oldState *api.GlobalState) ([]
 	// Ensure that all pool IDs are distinct between the old state and new state.
 	// This helps with verification at the end by ensuring that diffing algorithm
 	// will not miss diffs just because the pool IDs happen to be same by chance.
-	sb.newState.Memory.NewAt(sb.oldState.Memory.NextPoolID())
+	sb.newState.Memory.NewAt(sb.oldState.Memory.NextPoolID(), 0, newState.Arena)
 
 	// Create EGL contexts (possibly shared)
 	representative := map[ShareListʳ]EGLContext{}

--- a/gapis/api/gles/texture_compat.go
+++ b/gapis/api/gles/texture_compat.go
@@ -229,7 +229,7 @@ func decompressTexImage2D(ctx context.Context, i api.CmdID, a *GlCompressedTexIm
 		out.MutateAndWrite(ctx, dID, cb.GlBindBuffer(GLenum_GL_PIXEL_UNPACK_BUFFER, 0))
 		defer out.MutateAndWrite(ctx, dID, cb.GlBindBuffer(GLenum_GL_PIXEL_UNPACK_BUFFER, pb.ID()))
 	} else {
-		a.Extras().Observations().ApplyReads(s.Memory.ApplicationPool())
+		a.Extras().Observations().ApplyReads(ctx, s.Memory.ApplicationPool())
 	}
 
 	format, err := getCompressedImageFormat(a.Internalformat())
@@ -282,7 +282,7 @@ func decompressTexSubImage2D(ctx context.Context, i api.CmdID, a *GlCompressedTe
 		out.MutateAndWrite(ctx, dID, cb.GlBindBuffer(GLenum_GL_PIXEL_UNPACK_BUFFER, 0))
 		defer out.MutateAndWrite(ctx, dID, cb.GlBindBuffer(GLenum_GL_PIXEL_UNPACK_BUFFER, pb.ID()))
 	} else {
-		a.Extras().Observations().ApplyReads(s.Memory.ApplicationPool())
+		a.Extras().Observations().ApplyReads(ctx, s.Memory.ApplicationPool())
 	}
 
 	format, err := getCompressedImageFormat(a.Internalformat())

--- a/gapis/api/gles/undefined_framebuffer.go
+++ b/gapis/api/gles/undefined_framebuffer.go
@@ -110,8 +110,7 @@ func drawUndefinedFramebuffer(ctx context.Context, id api.CmdID, cmd api.Cmd, de
 	tmp0 := t.AllocData(ctx, aScreenCoords)
 	out.MutateAndWrite(ctx, dID, cb.GlBindAttribLocation(programID, aScreenCoordsLocation, tmp0.Ptr()).
 		AddRead(tmp0.Data()))
-	tmp0.Free()
-
+		
 	attrib := MakeProgramResourceʳ(s.Arena)
 	attrib.SetType(GLenum_GL_FLOAT_VEC2)
 	attrib.SetName(aScreenCoords)

--- a/gapis/api/gvr/framebindings.go
+++ b/gapis/api/gvr/framebindings.go
@@ -79,7 +79,7 @@ func (r *FrameBindingsResolvable) Resolve(ctx context.Context) (interface{}, err
 			// Annoyingly gvr_frame_submit takes a pointer to the frame pointer,
 			// just so it can be nullified before returning. To avoid another
 			// state mutation just to get the pointer, cache them here.
-			cmd.extras.Observations().ApplyReads(s.Memory.ApplicationPool())
+			cmd.extras.Observations().ApplyReads(ctx, s.Memory.ApplicationPool())
 			frame, err := cmd.Frame().Read(ctx, cmd, s, nil)
 			if err != nil {
 				return err

--- a/gapis/api/templates/api.go.tmpl
+++ b/gapis/api/templates/api.go.tmpl
@@ -492,9 +492,9 @@ import (
   {{if $el_is_char}}
     // Make{{$slice_ty}}FromString returns a {{$slice_ty}} backed by a new
     // memory pool containing a copy of str.
-    func Make{{$slice_ty}}FromString(str string, ϟg *ϟapi.GlobalState) {{$slice_ty}} {
-      id, pool := ϟg.Memory.New()
-      pool.Write(0, ϟmem.Blob([]byte(str)))
+    func Make{{$slice_ty}}FromString(ϟctx context.Context, str string, ϟg *ϟapi.GlobalState) {{$slice_ty}} {
+      id, pool := ϟg.Memory.New(uint64(len(str)), ϟg.Arena)
+      pool.Write(ϟctx, 0, ϟmem.Blob([]byte(str)))
       return {{$slice_ty}}{
         size:  uint64(len(str)),
         count: uint64(len(str)),
@@ -527,7 +527,7 @@ import (
   // Make{{$slice_ty}} returns a {{$slice_ty}} backed by a new memory pool.
   func Make{{$slice_ty}}(count uint64, ϟg *ϟapi.GlobalState) {{$slice_ty}} {
     ϟl, ϟa := ϟg.MemoryLayout, ϟg.Arena; _, _ = ϟl, ϟa
-    id, _ := ϟg.Memory.New()
+    id, _ := ϟg.Memory.New({{Template "Go.SizeOf" $s.To}} * count, ϟg.Arena)
     return {{$slice_ty}}{
       size:  count * {{Template "Go.SizeOf" $s.To}},
       count: count,
@@ -537,9 +537,10 @@ import (
 
   // Clone returns a copy of the {{$slice_ty}} in a new memory pool.
   func (s {{$slice_ty}}) Clone(ϟctx context.Context, ϟc ϟapi.Cmd, ϟg *ϟapi.GlobalState, ϟb *builder.Builder) {{$slice_ty}} {
+    ϟl := ϟg.MemoryLayout; _ = ϟl
     s.OnRead(ϟctx, ϟc, ϟg, ϟb)
-    id, dst := ϟg.Memory.New()
-    dst.Write(0, ϟg.Memory.MustGet(s.pool).Slice(s.Range()))
+    id, dst := ϟg.Memory.New({{Template "Go.SizeOf" $s.To}} * s.count, ϟg.Arena)
+    dst.Write(ϟctx, 0, ϟg.Memory.MustGet(s.pool).Slice(ϟctx, s.Range()))
     return {{$slice_ty}}{
       size:  s.size,
       count: s.count,
@@ -580,7 +581,7 @@ import (
   // ResourceID returns an identifier to a resource representing the data of
   // this slice.
   func (s {{$slice_ty}}) ResourceID(ϟctx context.Context, ϟg *ϟapi.GlobalState) id.ID {
-    id, err := ϟg.Memory.MustGet(s.Pool()).Slice(s.Range()).ResourceID(ϟctx)
+    id, err := ϟg.Memory.MustGet(s.Pool()).Slice(ϟctx, s.Range()).ResourceID(ϟctx)
     if err != nil {
       panic(err)
     }
@@ -589,22 +590,22 @@ import (
 
   // Reader returns a binary reader for the slice.
   func (s {{$slice_ty}}) Reader(ϟctx context.Context, ϟg *ϟapi.GlobalState) binary.Reader {
-    return ϟg.MemoryReader(ϟctx, ϟg.Memory.MustGet(s.Pool()).Slice(s.Range()))
+    return ϟg.MemoryReader(ϟctx, ϟg.Memory.MustGet(s.Pool()).Slice(ϟctx, s.Range()))
   }
 
   // Writer returns a binary writer for the slice.
-  func (s {{$slice_ty}}) Writer(ϟg *ϟapi.GlobalState) binary.Writer {
-    return ϟg.MemoryWriter(s.Pool(), s.Range())
+  func (s {{$slice_ty}}) Writer(ϟctx context.Context, ϟg *ϟapi.GlobalState) binary.Writer {
+    return ϟg.MemoryWriter(ϟctx, s.Pool(), s.Range())
   }
 
   // Decoder returns a memory decoder for the slice.
   func (s {{$slice_ty}}) Decoder(ϟctx context.Context, ϟg *ϟapi.GlobalState) *ϟmem.Decoder {
-    return ϟg.MemoryDecoder(ϟctx, ϟg.Memory.MustGet(s.Pool()).Slice(s.Range()))
+    return ϟg.MemoryDecoder(ϟctx, ϟg.Memory.MustGet(s.Pool()).Slice(ϟctx, s.Range()))
   }
 
   // Encoder returns a memory encoder for the slice.
-  func (s {{$slice_ty}}) Encoder(ϟg *ϟapi.GlobalState) *ϟmem.Encoder {
-    return ϟg.MemoryEncoder(s.Pool(), s.Range())
+  func (s {{$slice_ty}}) Encoder(ϟctx context.Context, ϟg *ϟapi.GlobalState) *ϟmem.Encoder {
+    return ϟg.MemoryEncoder(ϟctx, s.Pool(), s.Range())
   }
 
   {{if not $el_is_void}}
@@ -655,7 +656,7 @@ import (
     func (s {{$slice_ty}}) Write(ϟctx context.Context, src []{{$el_ty}}, ϟc ϟapi.Cmd, ϟg *ϟapi.GlobalState, ϟb *builder.Builder) (uint64, error) {
       ϟa := ϟg.Arena; _ = ϟa
       count := u64.Min(s.Count(), uint64(len(src)))
-      e := s.Slice(0, count).Encoder(ϟg)
+      e := s.Slice(0, count).Encoder(ϟctx, ϟg)
       ϟmem.Write(e, src[:count])
       s.OnWrite(ϟctx, ϟc, ϟg, ϟb)
       if err := e.Error(); err != nil {
@@ -683,7 +684,7 @@ import (
       } else {
     {{end}}
       src.OnRead(ϟctx, ϟc, ϟg, ϟb)
-      ϟg.Memory.MustGet(dst.Pool()).Write(dst.Base(), ϟg.Memory.MustGet(src.Pool()).Slice(src.Range()))
+      ϟg.Memory.MustGet(dst.Pool()).Write(ϟctx, dst.Base(), ϟg.Memory.MustGet(src.Pool()).Slice(ϟctx, src.Range()))
       dst.OnWrite(ϟctx, ϟc, ϟg, ϟb)
     {{if $el_is_ptr}} } {{end}}
       return dst, src
@@ -942,19 +943,8 @@ import (
   {{if $el_is_char}}
     // StringSlice returns a slice starting at p and ending at the first 0 byte null-terminator.
     func (p {{$ptr_ty}}) StringSlice(ϟctx context.Context, ϟg *ϟapi.GlobalState) Charˢ {
-      numBytes := uint64(2^6)
-      i, ϟd := uint64(0), ϟg.MemoryDecoder(ϟctx, ϟg.Memory.MustGet(ϟmem.ApplicationPool).TempSlice(ϟmem.Range{Base: uint64(p), Size: numBytes}))
-
-      for {
-        if i >= numBytes {
-          ϟd = ϟg.MemoryDecoder(ϟctx, ϟg.Memory.MustGet(ϟmem.ApplicationPool).TempSlice(ϟmem.Range{Base: uint64(p) + i, Size: numBytes}))
-        }
-
-        i++
-        if b := ϟd.U8(); b == 0 {
-          return Charˢ(p.Slice(0, i, ϟg.MemoryLayout))
-        }
-      }
+      strlen := uint64(ϟg.Memory.MustGet(ϟmem.ApplicationPool).StringSize(uint64(p)))
+      return Charˢ(p.Slice(0, strlen, ϟg.MemoryLayout))
     }
   {{end}}
 

--- a/gapis/api/templates/convert.go.tmpl
+++ b/gapis/api/templates/convert.go.tmpl
@@ -143,7 +143,7 @@
   ¶
   // {{$name}}From builds a {{$name}} from the storage form.¶
   func {{$name}}From(ctx context.Context, from *{{$p}}, ϟrefs *protoconv.FromProtoContext) *{{$name}} {»¶
-    ϟa := arena.Get(ctx)¶
+    ϟa := *arena.Get(ctx)¶
     cb := CommandBuilder{uint64(from.GetThread()), ϟa}¶
     {{range $p := $.CallParameters}}
       {{$proto := $p.Name | ProtoGoName}}
@@ -214,7 +214,7 @@
   ¶
   // {{$name}}From builds a {{$name}} from the storage form.¶
   func {{$name}}From(ctx context.Context, from *{{$proto}}, ϟrefs *protoconv.FromProtoContext) {{$name}} {»¶
-    ϟa := arena.Get(ctx)¶
+    ϟa := *arena.Get(ctx)¶
     ϟc := Make{{$name}}(ϟa)¶
     {{range $v := $.Fields}}
       {{Template "Convert.From" "Field" $v}}
@@ -250,7 +250,7 @@
   // {{$name}}From builds a {{$name}} from the storage form.¶
   func {{$name}}From(ctx context.Context, from *{{$proto}}, ϟrefs *protoconv.FromProtoContext) {{$name}} {»¶
     return ϟrefs.GetReferencedObject(from.GetReferenceID(), Nil{{$name}}, func() (interface{}, func()) {»¶
-      ϟa := arena.Get(ctx)¶
+      ϟa := *arena.Get(ctx)¶
       ϟobj := Make{{$name}}(ϟa)¶
       return ϟobj, func() {
         ϟobj.Set({{Template "Convert.FromProto" "Type" $.To "Value" "from.Value"}})¶
@@ -293,7 +293,7 @@
   ¶
   // {{$name}}From builds a {{$name}} from the storage form.¶
   func {{$name}}From(ctx context.Context, from *{{$proto}}, ϟrefs *protoconv.FromProtoContext) {{$name}} {»¶
-    ϟa := arena.Get(ctx)¶
+    ϟa := *arena.Get(ctx)¶
     ϟobj := New{{$name}}(ϟa)¶
     if from.GetReferenceID() == 0 {»¶
       return ϟobj¶

--- a/gapis/api/templates/mutate.go.tmpl
+++ b/gapis/api/templates/mutate.go.tmpl
@@ -164,7 +164,7 @@
       {{Global "CurrentFunction" $}}
 
       {{/* simulate the call */}}
-      ϟo.ApplyReads(ϟg.Memory.ApplicationPool())
+      ϟo.ApplyReads(ϟctx, ϟg.Memory.ApplicationPool())
       {{Template "Block" $.Block}}
 
       return task.StopReason(ϟctx)
@@ -664,7 +664,7 @@
   {{end}}
 
   {{/* Merge the observed writes into the application pool */}}
-  ϟo.ApplyWrites(ϟg.Memory.ApplicationPool())
+  ϟo.ApplyWrites(ϟctx, ϟg.Memory.ApplicationPool())
 {{end}}
 
 

--- a/gapis/api/templates/state_serialize.go.tmpl
+++ b/gapis/api/templates/state_serialize.go.tmpl
@@ -69,7 +69,7 @@
   ¶
   // StateFrom builds a State from the storage form.¶
   func StateFrom(ctx context.Context, from *{{$p}}, ϟrefs *protoconv.FromProtoContext) *State {»¶
-    ϟc := NewState(arena.Get(ctx))¶
+    ϟc := NewState(*arena.Get(ctx))¶
     ϟa := ϟc.Arena(); _ = ϟa¶
     {{range $g := $.Globals}}
       {{if $init := Macro "Go.DefaultInitialValue" $g.Type}}

--- a/gapis/api/vulkan/api/memory.api
+++ b/gapis/api/vulkan/api/memory.api
@@ -50,7 +50,7 @@
   void*                   MappedLocation
   u32                     MemoryTypeIndex
   @spy_disabled
-  @hidden @nobox @internal u8[]     Data
+  @nobox @internal u8[]     Data
   @unused ref!VulkanDebugMarkerInfo DebugInfo
   ref!MemoryDedicatedAllocationInfo DedicatedAllocationNV
   ref!MemoryDedicatedAllocationInfo DedicatedAllocationKHR

--- a/gapis/api/vulkan/custom_replay.go
+++ b/gapis/api/vulkan/custom_replay.go
@@ -282,7 +282,7 @@ func (a *VkCreateDevice) Mutate(ctx context.Context, id api.CmdID, s *api.Global
 	createInfoPtr := a.PCreateInfo()
 	allocated := []*api.AllocResult{}
 	if b != nil {
-		a.Extras().Observations().ApplyReads(s.Memory.ApplicationPool())
+		a.Extras().Observations().ApplyReads(ctx, s.Memory.ApplicationPool())
 		createInfo := a.PCreateInfo().MustRead(ctx, a, s, nil)
 		defer func() {
 			for _, d := range allocated {
@@ -379,10 +379,10 @@ func (a *VkCreateSwapchainKHR) Mutate(ctx context.Context, id api.CmdID, s *api.
 func (a *VkAcquireNextImageKHR) Mutate(ctx context.Context, id api.CmdID, s *api.GlobalState, b *builder.Builder) error {
 	l := s.MemoryLayout
 	o := a.Extras().Observations()
-	o.ApplyReads(s.Memory.ApplicationPool())
+	o.ApplyReads(ctx, s.Memory.ApplicationPool())
 	// Apply the write observation before having the replay device calling the vkAcquireNextImageKHR() command.
 	// This is to pass the returned image index value captured in the trace, into the replay device to acquire for the specific image.
-	o.ApplyWrites(s.Memory.ApplicationPool())
+	o.ApplyWrites(ctx, s.Memory.ApplicationPool())
 	_ = a.PImageIndex().Slice(0, 1, l).MustRead(ctx, a, s, b)
 	if b != nil {
 		a.Call(ctx, s, b)

--- a/gapis/api/vulkan/externs.go
+++ b/gapis/api/vulkan/externs.go
@@ -180,10 +180,11 @@ func (e externs) readMappedCoherentMemory(memoryHandle VkDeviceMemory, offsetInM
 	absSrcStart := mem.MappedLocation().Address() + offsetInMapped
 	absSrcMemRng := memory.Range{Base: absSrcStart, Size: uint64(readSize)}
 
-	writeRngList := e.s.Memory.ApplicationPool().Slice(absSrcMemRng).ValidRanges()
+	writeRngList := e.s.Memory.ApplicationPool().ValidRanges(e.ctx, absSrcMemRng)
 	for _, r := range writeRngList {
-		mem.Data().Slice(dstStart+r.Base, dstStart+r.Base+r.Size).
-			Copy(e.ctx, U8ᵖ(mem.MappedLocation()).Slice(srcStart+r.Base, srcStart+r.Base+r.Size, l), e.cmd, e.s, e.b)
+		rangeBase := r.Base - absSrcMemRng.Base
+		mem.Data().Slice(dstStart+rangeBase, dstStart+rangeBase+r.Size).
+			Copy(e.ctx, U8ᵖ(mem.MappedLocation()).Slice(srcStart+rangeBase, srcStart+rangeBase+r.Size, l), e.cmd, e.s, e.b)
 	}
 }
 func (e externs) untrackMappedCoherentMemory(start uint64, size memory.Size) {}

--- a/gapis/api/vulkan/find_issues.go
+++ b/gapis/api/vulkan/find_issues.go
@@ -38,9 +38,9 @@ type findIssues struct {
 	res    []replay.Result
 }
 
-func newFindIssues(ctx context.Context, c *capture.Capture) *findIssues {
+func newFindIssues(ctx context.Context, c *capture.Capture, oldState *api.GlobalState) *findIssues {
 	t := &findIssues{
-		state: c.NewState(ctx),
+		state: c.NewUninitializedStateWithAllocator(ctx, oldState.Allocator),
 	}
 	t.state.OnError = func(err interface{}) {
 		if issue, ok := err.(replay.Issue); ok {

--- a/gapis/api/vulkan/vulkan.go
+++ b/gapis/api/vulkan/vulkan.go
@@ -142,6 +142,7 @@ type markerInfo struct {
 
 func (API) ResolveSynchronization(ctx context.Context, d *sync.Data, c *path.Capture) error {
 	ctx = capture.Put(ctx, c)
+	
 	st, err := capture.NewState(ctx)
 	if err != nil {
 		return err

--- a/gapis/api/vulkan/vulkan_terminator.go
+++ b/gapis/api/vulkan/vulkan_terminator.go
@@ -317,7 +317,7 @@ func cutCommandBuffer(ctx context.Context, id api.CmdID,
 	c := GetState(s)
 	l := s.MemoryLayout
 	o := a.Extras().Observations()
-	o.ApplyReads(s.Memory.ApplicationPool())
+	o.ApplyReads(ctx, s.Memory.ApplicationPool())
 	submitInfo := a.PSubmits().Slice(0, uint64(a.SubmitCount()), l)
 	skipAll := len(idx) == 0
 

--- a/gapis/api/vulkan/wireframe.go
+++ b/gapis/api/vulkan/wireframe.go
@@ -31,7 +31,8 @@ func wireframe(ctx context.Context) transform.Transformer {
 		s := out.State()
 		l := s.MemoryLayout
 		cb := CommandBuilder{Thread: cmd.Thread(), Arena: s.Arena}
-		cmd.Extras().Observations().ApplyReads(s.Memory.ApplicationPool())
+		cmd.Extras().Observations().ApplyReads(ctx, s.Memory.ApplicationPool())
+		
 		switch cmd := cmd.(type) {
 		case *VkCreateGraphicsPipelines:
 			count := uint64(cmd.CreateInfoCount())

--- a/gapis/memory/BUILD.bazel
+++ b/gapis/memory/BUILD.bazel
@@ -50,8 +50,11 @@ go_library(
         "//core/data/endian:go_default_library",
         "//core/data/id:go_default_library",
         "//core/data/slice:go_default_library",
+# Remove this before checking in
+        "//core/log:go_default_library",
         "//core/math/interval:go_default_library",
         "//core/math/u64:go_default_library",
+        "//core/memory/arena:go_default_library",
         "//core/os/device:go_default_library",
         "//gapis/database:go_default_library",
         "@com_github_pkg_errors//:go_default_library",

--- a/gapis/memory/load.go
+++ b/gapis/memory/load.go
@@ -27,7 +27,7 @@ import (
 func LoadSlice(ctx context.Context, s Slice, pools Pools, l *device.MemoryLayout) (interface{}, error) {
 	pool := pools.MustGet(s.Pool())
 	rng := Range{s.Base(), s.Size()}
-	ioR := pool.Slice(rng).NewReader(ctx)
+	ioR := pool.Slice(ctx, rng).NewReader(ctx)
 	binR := endian.Reader(ioR, l.GetEndian())
 	d := NewDecoder(binR, l)
 	count := int(s.Count())
@@ -41,7 +41,7 @@ func LoadSlice(ctx context.Context, s Slice, pools Pools, l *device.MemoryLayout
 
 // LoadPointer loads the element from p.
 func LoadPointer(ctx context.Context, p Pointer, pools Pools, l *device.MemoryLayout) (interface{}, error) {
-	ioR := pools.ApplicationPool().At(p.Address()).NewReader(ctx)
+	ioR := pools.ApplicationPool().Slice(ctx, Range{p.Address(), p.ElementSize(l)}).NewReader(ctx)
 	binR := endian.Reader(ioR, l.GetEndian())
 	d := NewDecoder(binR, l)
 	elPtr := reflect.New(p.ElementType())

--- a/gapis/memory/pool.go
+++ b/gapis/memory/pool.go
@@ -18,11 +18,15 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"runtime"
+	"sort"
 	"strings"
+	"unsafe"
 
 	"github.com/google/gapid/core/data/id"
 	"github.com/google/gapid/core/math/interval"
 	"github.com/google/gapid/core/math/u64"
+	"github.com/google/gapid/core/memory/arena"
 	"github.com/google/gapid/gapis/database"
 	"github.com/pkg/errors"
 )
@@ -36,9 +40,12 @@ import (
 // Pool slice has Get called will any resolving, loading or copying of binary
 // data occur.
 type Pool struct {
-	writes  poolWriteList
-	OnRead  func(Range)
-	OnWrite func(Range)
+	id          PoolID
+	writes      poolWriteList
+	allocations []allocation
+	arena       arena.Arena
+	OnRead      func(Range)
+	OnWrite     func(Range)
 }
 
 // PoolID is an identifier of a Pool.
@@ -62,65 +69,224 @@ const (
 	ApplicationPool = PoolID(PoolNames_Application)
 )
 
+// byteSlice returns a slice into an unsafe pointer
+func byteSlice(ptr unsafe.Pointer) []byte {
+	return ((*[1 << 30]byte)(ptr))[:]
+}
+
+type allocation struct {
+	offset uint64
+	size   uint64
+	data   unsafe.Pointer
+}
+
+func insertAllocation(allocations []allocation, a allocation) []allocation {
+	index := sort.Search(len(allocations), func(i int) bool { return allocations[i].offset > a.offset })
+	allocations = append(allocations, allocation{})
+	copy(allocations[index+1:], allocations[index:])
+	allocations[index] = a
+	return allocations
+}
+
 // NewPools creates and returns a new Pools instance.
-func NewPools() Pools {
+func NewPools(ranges interval.U64RangeList, arena arena.Arena) Pools {
+	memPools := map[PoolID]*Pool{ApplicationPool: {
+		id:          ApplicationPool,
+		writes:      poolWriteList{},
+		allocations: make([]allocation, 0, ranges.Length()),
+		arena:       arena,
+	}}
+	memPools[ApplicationPool].ReserveRanges(ranges)
+	runtime.SetFinalizer(memPools[ApplicationPool], func(p *Pool) {
+		for _, v := range p.allocations {
+			arena.Free(v.data)
+		}
+	})
+
 	return Pools{
-		pools:      map[PoolID]*Pool{ApplicationPool: {}},
+		pools:      memPools,
 		nextPoolID: ApplicationPool + 1,
 	}
 }
 
-// Slice returns a Data referencing the subset of the Pool range.
-func (m *Pool) Slice(rng Range) Data {
-	i, c := interval.Intersect(&m.writes, rng.Span())
-	if c == 1 {
-		w := m.writes[i]
-		if rng == w.dst {
-			// Exact hit
-			return w.src
-		}
-		if rng.First() >= w.dst.First() && rng.Last() <= w.dst.Last() {
-			// Subset of a write.
-			rng.Base -= w.dst.First()
-			return w.src.Slice(rng)
-		}
+// ReserveRanges makes a set of ranges available in the
+// application pool.
+func (m *Pool) ReserveRanges(ranges interval.U64RangeList) {
+	if m.id != ApplicationPool {
+		panic("You can only reserve ranges in the application pool")
 	}
-	writes := make(poolWriteList, c)
-	copy(writes, m.writes[i:i+c])
-	return poolSlice{rng: rng, writes: writes}
+	for idx := range ranges {
+		alloc := allocation{
+			ranges[idx].First,
+			ranges[idx].Count,
+			m.arena.Allocate(uint32(ranges[idx].Count), 1),
+		}
+		m.allocations = insertAllocation(m.allocations, alloc)
+	}
 }
 
-// TempSlice returns a slice that is only valid until the next
+// AddRange makes a single allocation available to the application
+// pool
+func (m *Pool) AddRange(offset, count uint64) {
+	if m.id != ApplicationPool {
+		panic("You can only reserve ranges in the application pool")
+	}
+
+	alloc := allocation{
+		offset,
+		count,
+		m.arena.Allocate(uint32(count), 1),
+	}
+	m.allocations = insertAllocation(m.allocations, alloc)
+}
+
+// RemoveRange removes a single allocation from the application pool.
+// It is invalid to remove an allocation that was never added
+func (m *Pool) RemoveRange(offset uint64) {
+	if m.id != ApplicationPool {
+		panic("You can only remove ranges from the application pool")
+	}
+	i := sort.Search(len(m.allocations), func(i int) bool { return m.allocations[i].offset >= offset })
+	if i >= len(m.allocations) || m.allocations[i].offset != offset {
+		msg := fmt.Sprintf("Removed allocation [%d] was not found in arena %+v", offset, m.allocations)
+		panic(msg)
+	}
+	m.arena.Free(m.allocations[i].data)
+	copy(m.allocations[i:], m.allocations[i+1:])
+	m.allocations = m.allocations[:len(m.allocations)-1]
+}
+
+func (m *Pool) tryGetAllocation(base uint64) int {
+	i := sort.Search(len(m.allocations), func(i int) bool { return m.allocations[i].offset > base })
+	if i == 0 {
+		return len(m.allocations) + 1
+	}
+
+	if i >= len(m.allocations) && 0 != len(m.allocations) {
+		i = len(m.allocations)
+	}
+
+	return i - 1
+}
+
+func (m *Pool) mustGetAllocation(base uint64) int {
+	i := sort.Search(len(m.allocations), func(i int) bool { return m.allocations[i].offset > base })
+	if i == 0 {
+		panic(fmt.Sprintf("Could not find allocation in pool: %+v, %+v", base, m.allocations))
+	}
+
+	if i >= len(m.allocations) && 0 != len(m.allocations) {
+		i = len(m.allocations)
+	}
+
+	i--
+	allocation := m.allocations[i]
+	if base > allocation.offset+allocation.size {
+		panic(fmt.Sprintf("Could not find allocation in pool: %+v, %+v, %+v", base, allocation, m.allocations))
+	}
+	return i
+}
+
+func (m *Pool) mustGetOffsetAndAllocation(rng Range) (int, uint64) {
+	i := m.mustGetAllocation(rng.Base)
+	allocation := m.allocations[i]
+	if allocation.offset+allocation.size < rng.Base+rng.Size {
+		panic(fmt.Sprintf("Slicing outside of range %+v %+v %+v \n\n---------------------------\n%+v\n----------------------\n", rng, rng.Size, allocation, m.allocations))
+	}
+	offsetInAlloc := rng.Base - allocation.offset
+	return i, offsetInAlloc
+}
+
+func (m *Pool) StringSize(base uint64) int {
+	i := m.mustGetAllocation(base)
+	size := 0
+	alloc := m.allocations[i]
+	pos := base - alloc.offset
+	data := byteSlice(alloc.data)
+	for pos < alloc.size {
+		size++
+		if data[pos] == 0 {
+			break
+		}
+		pos++
+	}
+	return size
+}
+
+var panicRead = 2
+
+// ValidRanges returns all valid ranges in this pool that fall within
+// the given range
+func (m *Pool) ValidRanges(ctx context.Context, rng Range) RangeList {
+	last := rng.Base + rng.Size - 1
+	valid := make(RangeList, 0)
+	i := m.tryGetAllocation(last)
+	for last >= rng.Base {
+		if i >= len(m.allocations) || i < 0 {
+			break
+		}
+		alloc := m.allocations[i]
+
+		begin := u64.Max(rng.Base, alloc.offset)
+		end := u64.Min(rng.Base+rng.Size, alloc.offset+alloc.size)
+		if end <= begin {
+			break
+		}
+
+		valid = append([]Range{Range{begin, end - begin}}, valid...)
+		last = begin - 1
+
+		i--
+	}
+
+	return valid
+}
+
+// Slice returns a Data referencing the subset of the Pool range.
+func (m *Pool) Slice(ctx context.Context, rng Range) Data {
+	panicRead--
+	if m.id == ApplicationPool {
+
+		alloc, offsetInAlloc := m.mustGetOffsetAndAllocation(rng)
+		data := make([]byte, rng.Size)
+		copy(data, byteSlice(m.allocations[alloc].data)[offsetInAlloc:offsetInAlloc+rng.Size])
+		b := Blob(data)
+		return b
+	}
+	data := make([]byte, rng.Size)
+	copy(data, byteSlice(m.allocations[0].data)[rng.Base:rng.Base+rng.Size])
+
+	return Blob(data)
+}
+
+// WriteableSlice returns a slice that is only valid until the next
 // Read/Write operation on this pool.
 // This puts much less pressure on the garbage collector since we don't
 // have to make a copy of the range.
-func (m *Pool) TempSlice(rng Range) Data {
-	i, c := interval.Intersect(&m.writes, rng.Span())
-	if c == 1 {
-		w := m.writes[i]
-		if rng == w.dst {
-			// Exact hit
-			return w.src
-		}
-		if rng.First() >= w.dst.First() && rng.Last() <= w.dst.Last() {
-			// Subset of a write.
-			rng.Base -= w.dst.First()
-			return w.src.Slice(rng)
-		}
+func (m *Pool) WriteableSlice(rng Range) []byte {
+	if m.id == ApplicationPool {
+		alloc, offsetInAlloc := m.mustGetOffsetAndAllocation(rng)
+		return byteSlice(m.allocations[alloc].data)[offsetInAlloc : offsetInAlloc+rng.Size]
+	} else {
+		return byteSlice(m.allocations[0].data)[rng.Base : rng.Base+rng.Size]
 	}
-	return poolSlice{rng: rng, writes: m.writes[i : i+c]}
 }
 
-// At returns an unbounded Data starting at p.
-func (m *Pool) At(addr uint64) Data {
-	return m.Slice(Range{Base: addr, Size: ^uint64(0) - addr})
-}
+var panicWrites = 2
 
 // Write copies the data src to the address dst.
-func (m *Pool) Write(dst uint64, src Data) {
-	rng := Range{Base: dst, Size: src.Size()}
-	i := interval.Replace(&m.writes, rng.Span())
-	m.writes[i].src = src
+func (m *Pool) Write(ctx context.Context, dst uint64, src Data) {
+	panicWrites--
+	if m.id == ApplicationPool {
+		alloc, offsetInAlloc := m.mustGetOffsetAndAllocation(Range{dst, src.Size()})
+		src.Get(ctx, 0, byteSlice(m.allocations[alloc].data)[offsetInAlloc:offsetInAlloc+src.Size()])
+		return
+	}
+	if m.allocations[0].size < dst+src.Size() {
+		panic(fmt.Sprintf("Cannot write [ %v bytes ] %p, at offset %v in pool %+v", src.Size(), src, dst, *m))
+	}
+
+	src.Get(ctx, 0, byteSlice(m.allocations[0].data)[dst:dst+src.Size()])
 }
 
 // String returns the full history of writes performed to this pool.
@@ -140,23 +306,39 @@ func (m *Pools) NextPoolID() PoolID {
 }
 
 // New creates and returns a new Pool and its id.
-func (m *Pools) New() (id PoolID, p *Pool) {
-	id, p = m.nextPoolID, &Pool{}
+func (m *Pools) New(size uint64, arena arena.Arena) (id PoolID, p *Pool) {
+	id, p = m.nextPoolID, &Pool{
+		id:     m.nextPoolID,
+		writes: poolWriteList{},
+		// DONT CHECK THIS IN YET: We should probably plumb uint64 all the way through
+		allocations: []allocation{allocation{0, size, arena.Allocate(uint32(size), 1)}},
+		arena:       arena,
+	}
 	m.pools[id] = p
 	m.nextPoolID++
 
 	if m.OnCreate != nil {
 		m.OnCreate(id, p)
 	}
+	runtime.SetFinalizer(p, func(p *Pool) {
+		for _, v := range p.allocations {
+			arena.Free(v.data)
+		}
+	})
 	return
 }
 
-// NewAt creates and returns a new Pool with a specific ID, fails if it cannot
-func (m *Pools) NewAt(id PoolID) *Pool {
+// NewAt creates and returns a new Pool with a specific ID, panics if it cannot
+func (m *Pools) NewAt(id PoolID, size uint64, arena arena.Arena) *Pool {
 	if _, ok := m.pools[id]; ok {
 		panic("Could not create given pool")
 	}
-	p := &Pool{}
+	p := &Pool{
+		id:          id,
+		writes:      poolWriteList{},
+		allocations: []allocation{allocation{uint64(0), size, arena.Allocate(uint32(size), 1)}},
+		arena:       arena,
+	}
 	m.pools[id] = p
 	if id >= m.nextPoolID {
 		m.nextPoolID = id + 1

--- a/gapis/memory/read.go
+++ b/gapis/memory/read.go
@@ -93,6 +93,10 @@ func decode(d *Decoder, v reflect.Value) {
 			}
 		}
 	case reflect.Struct:
+		if t.Implements(tyDecodable) {
+			v.Interface().(Decodable).Decode(d)
+			return
+		}
 		d.Align(AlignOf(v.Type(), d.m))
 		base := d.o
 		for i, c := 0, v.NumField(); i < c; i++ {

--- a/gapis/memory/write.go
+++ b/gapis/memory/write.go
@@ -89,14 +89,18 @@ func encode(e *Encoder, v reflect.Value) {
 			}
 		}
 	case reflect.Struct:
-		e.Align(AlignOf(v.Type(), e.m))
-		base := e.o
-		for i, c := 0, v.NumField(); i < c; i++ {
-			encode(e, v.Field(i))
+		if t.Implements(tyEncodable) {
+			v.Interface().(Encodable).Encode(e)
+		} else {
+			e.Align(AlignOf(v.Type(), e.m))
+			base := e.o
+			for i, c := 0, v.NumField(); i < c; i++ {
+				encode(e, v.Field(i))
+			}
+			written := e.o - base
+			padding := SizeOf(v.Type(), e.m) - written
+			e.Pad(padding)
 		}
-		written := e.o - base
-		padding := SizeOf(v.Type(), e.m) - written
-		e.Pad(padding)
 	case reflect.String:
 		e.String(v.String())
 	case reflect.Bool:

--- a/gapis/memory/writer.go
+++ b/gapis/memory/writer.go
@@ -15,15 +15,14 @@
 package memory
 
 import (
+	"context"
 	"fmt"
 	"io"
 )
 
 // Writer returns a binary writer for the specified memory pool and range.
-func Writer(p *Pool, rng Range) io.Writer {
-	b := make([]byte, rng.Size)
-	p.Write(rng.Base, Blob(b))
-	w := writer(b)
+func Writer(ctx context.Context, p *Pool, rng Range) io.Writer {
+	w := writer(p.WriteableSlice(rng))
 	return &w
 }
 

--- a/gapis/resolve/state.go
+++ b/gapis/resolve/state.go
@@ -21,7 +21,6 @@ import (
 	"github.com/google/gapid/gapis/api"
 	"github.com/google/gapid/gapis/api/sync"
 	"github.com/google/gapid/gapis/capture"
-	"github.com/google/gapid/gapis/database"
 	"github.com/google/gapid/gapis/messages"
 	"github.com/google/gapid/gapis/service"
 	"github.com/google/gapid/gapis/service/path"
@@ -30,7 +29,9 @@ import (
 // GlobalState resolves the global *api.GlobalState at a requested point in a
 // capture.
 func GlobalState(ctx context.Context, p *path.GlobalState) (*api.GlobalState, error) {
-	obj, err := database.Build(ctx, &GlobalStateResolvable{p})
+// DO NOT CHECK THIS IN.
+// Implement a "proper" way to ge the database to not hold onto objects
+	obj, err := (&GlobalStateResolvable{p}).Resolve(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -39,7 +40,7 @@ func GlobalState(ctx context.Context, p *path.GlobalState) (*api.GlobalState, er
 
 // State resolves the specific API state at a requested point in a capture.
 func State(ctx context.Context, p *path.State) (interface{}, error) {
-	return database.Build(ctx, &StateResolvable{p})
+	return (&StateResolvable{p}).Resolve(ctx)
 }
 
 // Resolve implements the database.Resolver interface.


### PR DESCRIPTION
This has one major piece of work left to do, which is to handle
OOB reads, and "virtual" writes, as in writes that require
replays to read.

They should not be a significant amount of extra work, but will
at least be some.

I also intend on fixing all of the DO NOT CHECK THIS IN, and re-enabling all of the tests before even trying to check this in.


Preliminary performance numbers vs master:
```
report-time                 | 35.665628305    | 22.059362156  (-38.1%)
linearize-time              | 51.404897128    | 34.734433885  (-32.4%)
```