### PR TITLE
Fix tests.

### DIFF
--- a/core/os/android/adb/commands_test.go
+++ b/core/os/android/adb/commands_test.go
@@ -142,5 +142,5 @@ func TestStartActivity(t_ *testing.T) {
 		Activity: "FooBarActivity",
 	}
 	err := d.StartActivity(ctx, a)
-	expectedCommand(ctx, adbPath.System()+` -s run_device shell am start -S -a android.intent.action.MAIN -n com.google.test.AnApp/.FooBarActivity`, err)
+	expectedCommand(ctx, adbPath.System()+` -s run_device shell am start -S -W -a android.intent.action.MAIN -n com.google.test.AnApp/.FooBarActivity`, err)
 }

--- a/gapis/api/test/BUILD.bazel
+++ b/gapis/api/test/BUILD.bazel
@@ -75,6 +75,7 @@ go_test(
         "//core/log:go_default_library",
         "//core/os/device:go_default_library",
         "//gapil/constset:go_default_library",  # keep
+        "//gapir/client:go_default_library",
         "//gapis/api:go_default_library",
         "//gapis/api/test/test_pb:go_default_library",  #keep
         "//gapis/database:go_default_library",

--- a/gapis/api/test/mutate_test.go
+++ b/gapis/api/test/mutate_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/google/gapid/core/data/id"
 	"github.com/google/gapid/core/log"
 	"github.com/google/gapid/core/os/device"
+	"github.com/google/gapid/gapir/client"
 	"github.com/google/gapid/gapis/api"
 	"github.com/google/gapid/gapis/database"
 	"github.com/google/gapid/gapis/memory"
@@ -75,13 +76,13 @@ func (test test) check(ctx context.Context, ca, ra *device.MemoryLayout) {
 	assert.For(ctx, "Constants").ThatSlice(payload.Constants).Equals(test.expected.constants)
 }
 
-func checkResource(ctx context.Context, gotInfos []protocol.ResourceInfo, expectedIDs []id.ID) {
+func checkResource(ctx context.Context, gotInfos []*client.ResourceInfo, expectedIDs []id.ID) {
 	var err error
 
 	got := make([]interface{}, len(gotInfos))
 	for i, g := range gotInfos {
-		ctx := log.V{"id": g.ID}.Bind(ctx)
-		id, err := id.Parse(g.ID)
+		ctx := log.V{"id": g.Id}.Bind(ctx)
+		id, err := id.Parse(g.Id)
 		assert.For(ctx, "Parse resource ID").ThatError(err).Succeeded()
 		got[i], err = database.Resolve(ctx, id)
 		assert.For(ctx, "Get resource").ThatError(err).Succeeded()

--- a/gapis/replay/builder/builder_test.go
+++ b/gapis/replay/builder/builder_test.go
@@ -212,10 +212,9 @@ func TestRevertPostbackCommand(t *testing.T) {
 	ctx := log.Testing(t)
 	const expectedErr = fault.Const("Oh noes!")
 	postbackErr := error(nil)
-	postback := Postback(func(r binary.Reader, err error) error {
+	postback := Postback(func(r binary.Reader, err error) {
 		assert.For(ctx, "Postback reader").That(r).IsNil()
 		postbackErr = err
-		return nil
 	})
 
 	for _, test := range []struct {

--- a/test/integration/gles/replay/gles_test.go
+++ b/test/integration/gles/replay/gles_test.go
@@ -287,7 +287,7 @@ func TestNewContextUndefined(t *testing.T) {
 	c := buildAndMaybeExportCapture(ctx, b, "new-context-undefined")
 
 	checkReplay(ctx, c, d, 1, func() { // expect a single replay batch.
-		checkColorBuffer(ctx, c, d, 64, 64, 0.0, "undef-fb", makeCurrent, nil)
+		checkColorBuffer(ctx, c, d, 64, 64, 0.01, "undef-fb", makeCurrent, nil)
 	})
 }
 

--- a/test/integration/replay/postback_test.go
+++ b/test/integration/replay/postback_test.go
@@ -86,23 +86,22 @@ func TestPostbackString(t *testing.T) {
 
 	if doReplay(t, func(b *builder.Builder) {
 		ptr := b.String(expected)
-		b.Post(ptr, uint64(len(expected)), func(r binary.Reader, err error) error {
+		b.Post(ptr, uint64(len(expected)), func(r binary.Reader, err error) {
 			defer close(done)
 			if err != nil {
 				t.Errorf("Postback returned error: %v", err)
-				return err
+				return
 			}
 			data := make([]byte, len(expected))
 			r.Data(data)
 			err = r.Error()
 			if err != nil {
 				t.Errorf("Postback returned error: %v", err)
-				return err
+				return
 			}
 			if expected != string(data) {
 				t.Errorf("Postback data was not as expected. Expected: %v. Got: %v", expected, data)
 			}
-			return err
 		})
 	}) == nil {
 		<-done
@@ -116,63 +115,60 @@ func TestMultiPostback(t *testing.T) {
 		ptr := b.AllocateTemporaryMemory(8)
 		b.Push(value.Bool(false))
 		b.Store(ptr)
-		b.Post(ptr, 1, func(r binary.Reader, err error) error {
+		b.Post(ptr, 1, func(r binary.Reader, err error) {
 			expected := false
 			if err != nil {
 				t.Errorf("Postback returned error: %v", err)
-				return err
+				return
 			}
 			data := r.Bool()
 			err = r.Error()
 			if err != nil {
 				t.Errorf("Postback returned error: %v", err)
-				return err
+				return
 			}
 			if !reflect.DeepEqual(expected, data) {
 				t.Errorf("Postback data was not as expected. Expected: %v. Got: %v", expected, data)
 			}
-			return err
 		})
 
 		b.Push(value.Bool(true))
 		b.Store(ptr)
-		b.Post(ptr, 1, func(r binary.Reader, err error) error {
+		b.Post(ptr, 1, func(r binary.Reader, err error) {
 			expected := true
 			if err != nil {
 				t.Errorf("Postback returned error: %v", err)
-				return err
+				return
 			}
 			data := r.Bool()
 			err = r.Error()
 			if err != nil {
 				t.Errorf("Postback returned error: %v", err)
-				return err
+				return
 			}
 			if !reflect.DeepEqual(expected, data) {
 				t.Errorf("Postback data was not as expected. Expected: %v. Got: %v", expected, data)
 			}
-			return err
 		})
 
 		b.Push(value.F64(123.456))
 		b.Store(ptr)
-		b.Post(ptr, 8, func(r binary.Reader, err error) error {
+		b.Post(ptr, 8, func(r binary.Reader, err error) {
 			expected := float64(123.456)
 			if err != nil {
 				t.Errorf("Postback returned error: %v", err)
-				return err
+				return
 			}
 			data := r.Float64()
 			err = r.Error()
 			if err != nil {
 				t.Errorf("Postback returned error: %v", err)
-				return err
+				return
 			}
 			if !reflect.DeepEqual(expected, data) {
 				t.Errorf("Postback data was not as expected. Expected: %v. Got: %v", expected, data)
 			}
 			close(done)
-			return err
 		})
 	}) == nil {
 		<-done


### PR DESCRIPTION
Most were broken by the new gRPC replay changes.
`TestNewContextUndefined` gives slightly different results on different GPUs, so I've bumped the threshold a little.