### PR TITLE
Rename template map.Range() to All()

### DIFF
--- a/gapis/api/gles/compat.go
+++ b/gapis/api/gles/compat.go
@@ -62,7 +62,7 @@ func listToExtensions(list []string) extensions {
 
 func translateExtensions(in U32ːstringᵐ) extensions {
 	out := make(extensions, in.Len())
-	for _, s := range in.Range() {
+	for _, s := range in.All() {
 		out[s] = struct{}{}
 	}
 	return out
@@ -1308,7 +1308,7 @@ func compatMultiviewDraw(ctx context.Context, id api.CmdID, cmd api.Cmd, out tra
 }
 
 func (fb Framebufferʳ) ForEachAttachment(action func(GLenum, FramebufferAttachment)) {
-	for i, a := range fb.ColorAttachments().Range() {
+	for i, a := range fb.ColorAttachments().All() {
 		action(GLenum_GL_COLOR_ATTACHMENT0+GLenum(i), a)
 	}
 	action(GLenum_GL_DEPTH_ATTACHMENT, fb.DepthAttachment())
@@ -1333,15 +1333,15 @@ func disableUnusedAttribArrays(ctx context.Context, t *tweaker) {
 	}
 	inputs := p.ActiveResources().ProgramInputs()
 	used := make([]bool, t.c.Constants().MaxVertexAttribBindings())
-	for _, input := range inputs.Range() {
-		for _, l := range input.Locations().Range() {
+	for _, input := range inputs.All() {
+		for _, l := range input.Locations().All() {
 			if l >= 0 && l < GLint(len(used)) {
 				used[l] = true
 			}
 		}
 	}
 
-	for l, arr := range t.c.Bound().VertexArray().VertexAttributeArrays().Range() {
+	for l, arr := range t.c.Bound().VertexArray().VertexAttributeArrays().All() {
 		if arr.Enabled() == GLboolean_GL_TRUE && l < AttributeLocation(len(used)) && !used[l] {
 			t.glDisableVertexAttribArray(ctx, l)
 		}

--- a/gapis/api/gles/compat_buffers.go
+++ b/gapis/api/gles/compat_buffers.go
@@ -91,7 +91,7 @@ func (m *bufferCompat) modifyBufferData(ctx context.Context, out transform.Write
 	}
 
 	rebind := []binding{}
-	for i, b := range c.Bound().UniformBuffers().Range() {
+	for i, b := range c.Bound().UniformBuffers().All() {
 		if b.Binding().IsNil() || m.unaligned[b.Binding().ID()] != unaligned {
 			continue
 		}

--- a/gapis/api/gles/compat_client.go
+++ b/gapis/api/gles/compat_client.go
@@ -131,7 +131,7 @@ func compatDrawElements(
 // clientVAsBound returns true if there are any vertex attribute arrays enabled
 // with pointers to client-side memory.
 func clientVAsBound(c Contextʳ, clientVAs map[VertexAttributeArrayʳ]*GlVertexAttribPointer) bool {
-	for _, arr := range c.Bound().VertexArray().VertexAttributeArrays().Range() {
+	for _, arr := range c.Bound().VertexArray().VertexAttributeArrays().All() {
 		if arr.Enabled() == GLboolean_GL_TRUE {
 			if _, ok := clientVAs[arr]; ok {
 				return true
@@ -164,7 +164,7 @@ func moveClientVBsToVAs(
 	// Gather together all the client-buffers in use by the vertex-attribs.
 	// Merge together all the memory intervals that these use.
 	va := c.Bound().VertexArray()
-	for _, arr := range va.VertexAttributeArrays().Range() {
+	for _, arr := range va.VertexAttributeArrays().All() {
 		if arr.Enabled() == GLboolean_GL_TRUE {
 			vb := arr.Binding()
 			if cmd, ok := clientVAs[arr]; ok {

--- a/gapis/api/gles/custom_replay.go
+++ b/gapis/api/gles/custom_replay.go
@@ -398,7 +398,7 @@ func bindAttribLocations(ctx context.Context, cmd api.Cmd, id api.CmdID, s *api.
 	pi := FindLinkProgramExtra(cmd.Extras())
 	if !pi.IsNil() && b != nil && !pi.ActiveResources().IsNil() {
 		cb := CommandBuilder{Thread: cmd.Thread()}
-		for _, attr := range pi.ActiveResources().ProgramInputs().Range() {
+		for _, attr := range pi.ActiveResources().ProgramInputs().All() {
 			if int32(attr.Locations().Get(0)) != -1 {
 				tmp := s.AllocDataOrPanic(ctx, attr.Name())
 				cmd := cb.GlBindAttribLocation(pid, AttributeLocation(attr.Locations().Get(0)), tmp.Ptr()).
@@ -423,7 +423,7 @@ func bindUniformBlocks(ctx context.Context, cmd api.Cmd, id api.CmdID, s *api.Gl
 	pi := FindLinkProgramExtra(cmd.Extras())
 	if !pi.IsNil() && b != nil && !pi.ActiveResources().IsNil() {
 		cb := CommandBuilder{Thread: cmd.Thread()}
-		for i, ub := range pi.ActiveResources().UniformBlocks().Range() {
+		for i, ub := range pi.ActiveResources().UniformBlocks().All() {
 			// Query replay-time uniform block index so that the remapping is established
 			tmp := s.AllocDataOrPanic(ctx, ub.Name())
 			defer tmp.Free()

--- a/gapis/api/gles/dependency_graph_behaviour_provider.go
+++ b/gapis/api/gles/dependency_graph_behaviour_provider.go
@@ -180,7 +180,7 @@ func (*GlesDependencyGraphBehaviourProvider) GetBehaviourForAtom(
 				clearBuffer(g, &b, cmd.Buffer(), cmd.Drawbuffer(), c)
 			case *GlClear:
 				if (cmd.Mask() & GLbitfield_GL_COLOR_BUFFER_BIT) != 0 {
-					for i := range c.Bound().DrawFramebuffer().ColorAttachments().Range() {
+					for i := range c.Bound().DrawFramebuffer().ColorAttachments().All() {
 						clearBuffer(g, &b, GLenum_GL_COLOR, i, c)
 					}
 				}
@@ -236,7 +236,7 @@ func (*GlesDependencyGraphBehaviourProvider) GetBehaviourForAtom(
 					log.E(ctx, "Can not find bound texture %v", cmd.Target())
 				}
 				if baseLevel, ok := tex.Levels().Lookup(0); ok {
-					for layerIndex := range baseLevel.Layers().Range() {
+					for layerIndex := range baseLevel.Layers().All() {
 						data, size := tex.dataAndSize(0, layerIndex)
 						b.Read(g, data)
 						b.Read(g, size)
@@ -295,7 +295,7 @@ func getAllUsedTextureData(ctx context.Context, cmd api.Cmd, id api.CmdID, s *ap
 	if c.Bound().Program().IsNil() {
 		return
 	}
-	for _, uniform := range c.Bound().Program().UniformLocations().Range() {
+	for _, uniform := range c.Bound().Program().UniformLocations().All() {
 		if uniform.Type() == GLenum_GL_FLOAT_VEC4 || uniform.Type() == GLenum_GL_FLOAT_MAT4 {
 			continue // Optimization - skip the two most common types which we know are not samplers.
 		}

--- a/gapis/api/gles/draw_call_mesh.go
+++ b/gapis/api/gles/draw_call_mesh.go
@@ -91,7 +91,7 @@ func drawCallMesh(ctx context.Context, dc drawCall, p *path.Mesh) (*api.Mesh, er
 
 	vb := &vertex.Buffer{}
 	va := c.Bound().VertexArray()
-	for _, attr := range program.ActiveResources().ProgramInputs().Range() {
+	for _, attr := range program.ActiveResources().ProgramInputs().All() {
 		vaa := va.VertexAttributeArrays().Get(AttributeLocation(attr.Locations().Get(0)))
 		if vaa.IsNil() || vaa.Enabled() == GLboolean_GL_FALSE {
 			continue

--- a/gapis/api/gles/externs.go
+++ b/gapis/api/gles/externs.go
@@ -76,7 +76,7 @@ func (e externs) GetEGLImageData(id EGLImageKHR, _ GLsizei, _ GLsizei) {
 	if d := FindEGLImageData(e.cmd.Extras()); d != nil {
 		if GetState(e.s).EGLImages().Contains(id) {
 			ei := GetState(e.s).EGLImages().Get(id)
-			for _, img := range ei.Images().Range() {
+			for _, img := range ei.Images().All() {
 				poolID, pool := e.s.Memory.New()
 				pool.Write(0, memory.Resource(d.ID, d.Size))
 				data := NewU8ˢ(0, 0, d.Size, d.Size, poolID)

--- a/gapis/api/gles/gles.go
+++ b/gapis/api/gles/gles.go
@@ -49,7 +49,7 @@ func (s *State) Root(ctx context.Context, p *path.State) (path.Node, error) {
 	if err != nil {
 		return nil, err
 	}
-	for thread, context := range s.Contexts().Range() {
+	for thread, context := range s.Contexts().All() {
 		if c.ID == context.ID() {
 			return s.contextRoot(p.After, thread), nil
 		}
@@ -64,7 +64,7 @@ func (s *State) SetupInitialState(ctx context.Context, g *api.GlobalState) {
 	s.SetGLXContexts(NewGLXContextːContextʳᵐ())
 	s.SetWGLContexts(NewHGLRCːContextʳᵐ())
 	s.SetCGLContexts(NewCGLContextObjːContextʳᵐ())
-	for _, c := range s.EGLContexts().Range() {
+	for _, c := range s.EGLContexts().All() {
 		if t := c.Other().BoundOnThread(); t != 0 {
 			s.Contexts().Add(t, c) // Current thread bindings.
 		}

--- a/gapis/api/gles/replay.go
+++ b/gapis/api/gles/replay.go
@@ -300,7 +300,7 @@ func (t *destroyResourcesAtEOS) Flush(ctx context.Context, out transform.Writer)
 	cmds := []api.Cmd{}
 
 	// Start by unbinding all the contexts from all the threads.
-	for t, c := range GetState(s).Contexts().Range() {
+	for t, c := range GetState(s).Contexts().All() {
 		if c.IsNil() {
 			continue
 		}
@@ -310,7 +310,7 @@ func (t *destroyResourcesAtEOS) Flush(ctx context.Context, out transform.Writer)
 
 	// Now using a single thread, bind each context and delete all objects.
 	cb := CommandBuilder{Thread: 0}
-	for i, c := range GetState(s).EGLContexts().Range() {
+	for i, c := range GetState(s).EGLContexts().All() {
 		if !c.Other().Initialized() {
 			// This context was never bound. Skip it.
 			continue
@@ -320,7 +320,7 @@ func (t *destroyResourcesAtEOS) Flush(ctx context.Context, out transform.Writer)
 
 		// Delete all Renderbuffers.
 		renderbuffers := make([]RenderbufferId, 0, c.Objects().Renderbuffers().Len())
-		for renderbufferID := range c.Objects().Renderbuffers().Range() {
+		for renderbufferID := range c.Objects().Renderbuffers().All() {
 			// Skip virtual renderbuffers: backbuffer_color(-1), backbuffer_depth(-2), backbuffer_stencil(-3).
 			if renderbufferID < 0xf0000000 {
 				renderbuffers = append(renderbuffers, renderbufferID)
@@ -333,7 +333,7 @@ func (t *destroyResourcesAtEOS) Flush(ctx context.Context, out transform.Writer)
 
 		// Delete all Textures.
 		textures := make([]TextureId, 0, c.Objects().Textures().Len())
-		for textureID := range c.Objects().Textures().Range() {
+		for textureID := range c.Objects().Textures().All() {
 			textures = append(textures, textureID)
 		}
 		if len(textures) > 0 {
@@ -343,7 +343,7 @@ func (t *destroyResourcesAtEOS) Flush(ctx context.Context, out transform.Writer)
 
 		// Delete all Framebuffers.
 		framebuffers := make([]FramebufferId, 0, c.Objects().Framebuffers().Len())
-		for framebufferID := range c.Objects().Framebuffers().Range() {
+		for framebufferID := range c.Objects().Framebuffers().All() {
 			framebuffers = append(framebuffers, framebufferID)
 		}
 		if len(framebuffers) > 0 {
@@ -353,7 +353,7 @@ func (t *destroyResourcesAtEOS) Flush(ctx context.Context, out transform.Writer)
 
 		// Delete all Buffers.
 		buffers := make([]BufferId, 0, c.Objects().Buffers().Len())
-		for bufferID := range c.Objects().Buffers().Range() {
+		for bufferID := range c.Objects().Buffers().All() {
 			buffers = append(buffers, bufferID)
 		}
 		if len(buffers) > 0 {
@@ -363,7 +363,7 @@ func (t *destroyResourcesAtEOS) Flush(ctx context.Context, out transform.Writer)
 
 		// Delete all VertexArrays.
 		vertexArrays := make([]VertexArrayId, 0, c.Objects().VertexArrays().Len())
-		for vertexArrayID := range c.Objects().VertexArrays().Range() {
+		for vertexArrayID := range c.Objects().VertexArrays().All() {
 			vertexArrays = append(vertexArrays, vertexArrayID)
 		}
 		if len(vertexArrays) > 0 {
@@ -383,7 +383,7 @@ func (t *destroyResourcesAtEOS) Flush(ctx context.Context, out transform.Writer)
 
 		// Delete all Queries.
 		queries := make([]QueryId, 0, c.Objects().Queries().Len())
-		for queryID := range c.Objects().Queries().Range() {
+		for queryID := range c.Objects().Queries().All() {
 			queries = append(queries, queryID)
 		}
 		if len(queries) > 0 {

--- a/gapis/api/gles/resources.go
+++ b/gapis/api/gles/resources.go
@@ -64,14 +64,14 @@ func (t Textureʳ) ResourceData(ctx context.Context, s *api.GlobalState) (*api.R
 	switch t.Kind() {
 	case GLenum_GL_TEXTURE_1D, GLenum_GL_TEXTURE_2D, GLenum_GL_TEXTURE_2D_MULTISAMPLE:
 		count := GLint(0)
-		for i := range t.Levels().Range() {
+		for i := range t.Levels().All() {
 			if i >= count {
 				count = i + 1
 			}
 		}
 
 		levels := make([]*image.Info, count)
-		for i, level := range t.Levels().Range() {
+		for i, level := range t.Levels().All() {
 			img, err := level.Layers().Get(0).ImageInfo(ctx, s)
 			if err != nil {
 				return nil, err
@@ -95,7 +95,7 @@ func (t Textureʳ) ResourceData(ctx context.Context, s *api.GlobalState) (*api.R
 			return api.NewResourceData(api.NewTexture(&api.Texture2D{})), nil
 		}
 		levels := make([]*image.Info, ei.Images().Len())
-		for i, img := range ei.Images().Range() {
+		for i, img := range ei.Images().All() {
 			ii, err := img.ImageInfo(ctx, s)
 			if err != nil {
 				return nil, err
@@ -145,7 +145,7 @@ func (t Textureʳ) ResourceData(ctx context.Context, s *api.GlobalState) (*api.R
 
 	case GLenum_GL_TEXTURE_3D:
 		levels := make([]*image.Info, t.Levels().Len())
-		for i, level := range t.Levels().Range() {
+		for i, level := range t.Levels().All() {
 			img := level.Layers().Get(0)
 			l := &image.Info{
 				Width:  uint32(img.Width()),
@@ -188,9 +188,9 @@ func (t Textureʳ) ResourceData(ctx context.Context, s *api.GlobalState) (*api.R
 
 	case GLenum_GL_TEXTURE_CUBE_MAP:
 		levels := make([]*api.CubemapLevel, t.Levels().Len())
-		for i, level := range t.Levels().Range() {
+		for i, level := range t.Levels().All() {
 			levels[i] = &api.CubemapLevel{}
-			for j, face := range level.Layers().Range() {
+			for j, face := range level.Layers().All() {
 				img, err := face.ImageInfo(ctx, s)
 				if err != nil {
 					return nil, err
@@ -244,7 +244,7 @@ func (i Imageʳ) ImageInfo(ctx context.Context, s *api.GlobalState) (*image.Info
 // LayerCount returns the maximum number of layers across all levels.
 func (t Textureʳ) LayerCount() int {
 	max := 0
-	for _, l := range t.Levels().Range() {
+	for _, l := range t.Levels().All() {
 		if l.Layers().Len() > max {
 			max = l.Layers().Len()
 		}
@@ -391,7 +391,7 @@ func (p Programʳ) ResourceData(ctx context.Context, s *api.GlobalState) (*api.R
 	ctx = log.Enter(ctx, "Program.ResourceData()")
 
 	shaders := make([]*api.Shader, 0, p.Shaders().Len())
-	for shaderType, shader := range p.Shaders().Range() {
+	for shaderType, shader := range p.Shaders().All() {
 		var ty api.ShaderType
 		switch shaderType {
 		case GLenum_GL_VERTEX_SHADER:
@@ -415,7 +415,7 @@ func (p Programʳ) ResourceData(ctx context.Context, s *api.GlobalState) (*api.R
 
 	uniforms := []*api.Uniform{}
 	if res := p.ActiveResources(); !res.IsNil() {
-		for _, activeUniform := range res.DefaultUniformBlock().Range() {
+		for _, activeUniform := range res.DefaultUniformBlock().All() {
 			var uniformFormat api.UniformFormat
 			var uniformType api.UniformType
 

--- a/gapis/api/gles/stub_program.go
+++ b/gapis/api/gles/stub_program.go
@@ -58,7 +58,7 @@ func stubShaderSource(pi LinkProgramExtraʳ) (vertexShaderSource, fragmentShader
 	vsDecls, fsDecls := []string{}, []string{}
 	vsTickles, fsTickles := []string{}, []string{}
 	if !pi.IsNil() && !pi.ActiveResources().IsNil() {
-		for _, u := range pi.ActiveResources().DefaultUniformBlock().Range() {
+		for _, u := range pi.ActiveResources().DefaultUniformBlock().All() {
 			var decls, tickles *[]string
 			if isSampler(u.Type()) {
 				decls, tickles = &fsDecls, &fsTickles

--- a/gapis/api/gles/tweaker.go
+++ b/gapis/api/gles/tweaker.go
@@ -174,7 +174,7 @@ func (t *tweaker) makeVertexArray(ctx context.Context, enabledLocations ...Attri
 		// GLES 2.0 does not have Vertex Array Objects, but the state is fairly simple.
 		vao := t.c.Bound().VertexArray()
 		// Disable all vertex attribute arrays
-		for location, origVertexAttrib := range vao.VertexAttributeArrays().Range() {
+		for location, origVertexAttrib := range vao.VertexAttributeArrays().All() {
 			if origVertexAttrib.Enabled() == GLboolean_GL_TRUE {
 				t.doAndUndo(ctx,
 					t.cb.GlDisableVertexAttribArray(location),

--- a/gapis/api/templates/api.go.tmpl
+++ b/gapis/api/templates/api.go.tmpl
@@ -293,8 +293,8 @@ import (
     return 0
   }
 
-  // Returns an object which can be used for interation in a range-based loop.
-  func (m {{$name}}) Range() map[{{$key}}]{{$value}} {
+  // All returns this {{$name}} as a Go map.
+  func (m {{$name}}) All() map[{{$key}}]{{$value}} {
     if m.Map != nil {
       return *m.Map
     }

--- a/gapis/api/templates/mutate.go.tmpl
+++ b/gapis/api/templates/mutate.go.tmpl
@@ -436,7 +436,7 @@
 
   {
     {{if ne $.IndexIterator.Name "_"}}{{$.IndexIterator.Name}} := int32(0){{end}}
-    for {{$.KeyIterator.Name}}, {{$.ValueIterator.Name}} := range {{Template "Go.Read" $.Map}}.Range() {
+    for {{$.KeyIterator.Name}}, {{$.ValueIterator.Name}} := range {{Template "Go.Read" $.Map}}.All() {
       {{Template "Block" $.Block}}
       {{if ne $.IndexIterator.Name "_"}}{{$.IndexIterator.Name}}++{{end}}
     }

--- a/gapis/api/vulkan/externs.go
+++ b/gapis/api/vulkan/externs.go
@@ -248,13 +248,13 @@ func bindSparse(ctx context.Context, a api.Cmd, id api.CmdID, s *api.GlobalState
 		return (dividend + divisor - 1) / divisor
 	}
 	st := GetState(s)
-	for buffer, binds := range binds.BufferBinds().Range() {
+	for buffer, binds := range binds.BufferBinds().All() {
 		if !st.Buffers().Contains(buffer) {
 			subVkErrorInvalidBuffer(ctx, a, id, nil, s, nil, a.Thread(), nil, buffer)
 		}
 		bufObj := st.Buffers().Get(buffer)
 		blockSize := bufObj.MemoryRequirements().Alignment()
-		for _, bind := range binds.SparseMemoryBinds().Range() {
+		for _, bind := range binds.SparseMemoryBinds().All() {
 			// TODO: assert bind.Size and bind.MemoryOffset must be multiple times of
 			// block size.
 			numBlocks := roundUpTo(bind.Size(), blockSize)
@@ -275,13 +275,13 @@ func bindSparse(ctx context.Context, a api.Cmd, id api.CmdID, s *api.GlobalState
 			}
 		}
 	}
-	for image, binds := range binds.OpaqueImageBinds().Range() {
+	for image, binds := range binds.OpaqueImageBinds().All() {
 		if !st.Images().Contains(image) {
 			subVkErrorInvalidImage(ctx, a, id, nil, s, nil, a.Thread(), nil, image)
 		}
 		imgObj := st.Images().Get(image)
 		blockSize := imgObj.MemoryRequirements().Alignment()
-		for _, bind := range binds.SparseMemoryBinds().Range() {
+		for _, bind := range binds.SparseMemoryBinds().All() {
 			// TODO: assert bind.Size and bind.MemoryOffset must be multiple times of
 			// block size.
 			numBlocks := roundUpTo(bind.Size(), blockSize)
@@ -302,12 +302,12 @@ func bindSparse(ctx context.Context, a api.Cmd, id api.CmdID, s *api.GlobalState
 			}
 		}
 	}
-	for image, binds := range binds.ImageBinds().Range() {
+	for image, binds := range binds.ImageBinds().All() {
 		if !st.Images().Contains(image) {
 			subVkErrorInvalidImage(ctx, a, id, nil, s, nil, a.Thread(), nil, image)
 		}
 		imgObj := st.Images().Get(image)
-		for _, bind := range binds.SparseImageMemoryBinds().Range() {
+		for _, bind := range binds.SparseImageMemoryBinds().All() {
 			if !imgObj.IsNil() {
 				err := subAddSparseImageMemoryBinding(ctx, a, id, nil, s, nil, a.Thread(), nil, image, bind)
 				if err != nil {

--- a/gapis/api/vulkan/footprint_builder.go
+++ b/gapis/api/vulkan/footprint_builder.go
@@ -643,24 +643,24 @@ func (qei *queueExecutionState) beginRenderPass(ctx context.Context,
 		resolveAs := map[uint32]struct{}{}
 		inputAs := map[uint32]struct{}{}
 
-		for _, ref := range desc.ColorAttachments().Range() {
+		for _, ref := range desc.ColorAttachments().All() {
 			if ref.Attachment() != vkAttachmentUnused {
 				colorAs[ref.Attachment()] = struct{}{}
 			}
 		}
-		for _, ref := range desc.ResolveAttachments().Range() {
+		for _, ref := range desc.ResolveAttachments().All() {
 			if ref.Attachment() != vkAttachmentUnused {
 				resolveAs[ref.Attachment()] = struct{}{}
 			}
 		}
-		for _, ref := range desc.InputAttachments().Range() {
+		for _, ref := range desc.InputAttachments().All() {
 			if ref.Attachment() != vkAttachmentUnused {
 				inputAs[ref.Attachment()] = struct{}{}
 			}
 		}
 		// TODO: handle preserveAttachments
 
-		for _, viewObj := range fb.ImageAttachments().Range() {
+		for _, viewObj := range fb.ImageAttachments().All() {
 			if read(ctx, bh, vkHandle(viewObj.VulkanHandle())) {
 				read(ctx, bh, vkHandle(viewObj.Image().VulkanHandle()))
 			}
@@ -1646,7 +1646,7 @@ func (vb *FootprintBuilder) BuildFootprint(ctx context.Context,
 			if GetState(s).LastDrawInfos().Contains(lastBoundQueue.VulkanHandle()) {
 				lastDrawInfo := GetState(s).LastDrawInfos().Get(lastBoundQueue.VulkanHandle())
 				if !lastDrawInfo.Framebuffer().IsNil() {
-					for _, view := range lastDrawInfo.Framebuffer().ImageAttachments().Range() {
+					for _, view := range lastDrawInfo.Framebuffer().ImageAttachments().All() {
 						if view.IsNil() || view.Image().IsNil() {
 							continue
 						}
@@ -1939,7 +1939,7 @@ func (vb *FootprintBuilder) BuildFootprint(ctx context.Context,
 			layoutObj := GetState(s).DescriptorSetLayouts().Get(vkLayout)
 			write(ctx, bh, vkHandle(vkSet))
 			vb.descriptorSets[vkSet] = newDescriptorSet()
-			for bi, bindingInfo := range layoutObj.Bindings().Range() {
+			for bi, bindingInfo := range layoutObj.Bindings().All() {
 				for di := uint32(0); di < bindingInfo.Count(); di++ {
 					vb.descriptorSets[vkSet].reserveDescriptor(uint64(bi), uint64(di))
 				}
@@ -2251,7 +2251,7 @@ func (vb *FootprintBuilder) BuildFootprint(ctx context.Context,
 		rp := GetState(s).RenderPasses().Get(vkRp)
 		fb := GetState(s).Framebuffers().Get(vkFb)
 		read(ctx, bh, vkHandle(fb.RenderPass().VulkanHandle()))
-		for _, ia := range fb.ImageAttachments().Range() {
+		for _, ia := range fb.ImageAttachments().All() {
 			if read(ctx, bh, vkHandle(ia.VulkanHandle())) {
 				read(ctx, bh, vkHandle(ia.Image().VulkanHandle()))
 			}
@@ -3166,7 +3166,7 @@ func getSubBufferData(bufData memorySpan, offset, size uint64) memorySpan {
 
 func sparseImageMemoryBindGranularity(ctx context.Context, imgObj ImageObjectʳ,
 	bind VkSparseImageMemoryBind) (VkExtent3D, bool) {
-	for _, r := range imgObj.SparseMemoryRequirements().Range() {
+	for _, r := range imgObj.SparseMemoryRequirements().All() {
 		if r.FormatProperties().AspectMask() == bind.Subresource().AspectMask() {
 			return r.FormatProperties().ImageGranularity(), true
 		}

--- a/gapis/api/vulkan/image_primer.go
+++ b/gapis/api/vulkan/image_primer.go
@@ -2347,20 +2347,20 @@ func vkCreateImage(sb *stateBuilder, dev VkDevice, info ImageInfo, handle VkImag
 		dev, sb.MustAllocReadData(
 			NewVkImageCreateInfo(
 				VkStructureType_VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO, // sType
-				pNext,                                                                   // pNext
-				info.Flags(),                                                            // flags
-				info.ImageType(),                                                        // imageType
-				info.Fmt(),                                                              // format
-				info.Extent(),                                                           // extent
-				info.MipLevels(),                                                        // mipLevels
-				info.ArrayLayers(),                                                      // arrayLayers
-				info.Samples(),                                                          // samples
-				info.Tiling(),                                                           // tiling
-				info.Usage(),                                                            // usage
-				info.SharingMode(),                                                      // sharingMode
-				uint32(info.QueueFamilyIndices().Len()),                                 // queueFamilyIndexCount
-				NewU32ᶜᵖ(sb.MustUnpackReadMap(info.QueueFamilyIndices().Range()).Ptr()), // pQueueFamilyIndices
-				VkImageLayout_VK_IMAGE_LAYOUT_UNDEFINED,                                 // initialLayout
+				pNext,                                                                 // pNext
+				info.Flags(),                                                          // flags
+				info.ImageType(),                                                      // imageType
+				info.Fmt(),                                                            // format
+				info.Extent(),                                                         // extent
+				info.MipLevels(),                                                      // mipLevels
+				info.ArrayLayers(),                                                    // arrayLayers
+				info.Samples(),                                                        // samples
+				info.Tiling(),                                                         // tiling
+				info.Usage(),                                                          // usage
+				info.SharingMode(),                                                    // sharingMode
+				uint32(info.QueueFamilyIndices().Len()),                               // queueFamilyIndexCount
+				NewU32ᶜᵖ(sb.MustUnpackReadMap(info.QueueFamilyIndices().All()).Ptr()), // pQueueFamilyIndices
+				VkImageLayout_VK_IMAGE_LAYOUT_UNDEFINED,                               // initialLayout
 			)).Ptr(),
 		memory.Nullptr,
 		sb.MustAllocWriteData(handle).Ptr(),
@@ -2517,10 +2517,10 @@ func walkImageSubresourceRange(sb *stateBuilder, img ImageObjectʳ, rng VkImageS
 }
 
 func walkSparseImageMemoryBindings(sb *stateBuilder, img ImageObjectʳ, f func(aspect VkImageAspectFlagBits, layer, level uint32, blockData SparseBoundImageBlockInfoʳ)) {
-	for aspect, aspectData := range img.SparseImageMemoryBindings().Range() {
-		for layer, layerData := range aspectData.Layers().Range() {
-			for level, levelData := range layerData.Levels().Range() {
-				for _, blockData := range levelData.Blocks().Range() {
+	for aspect, aspectData := range img.SparseImageMemoryBindings().All() {
+		for layer, layerData := range aspectData.Layers().All() {
+			for level, levelData := range layerData.Levels().All() {
+				for _, blockData := range levelData.Blocks().All() {
 					f(VkImageAspectFlagBits(aspect), layer, level, blockData)
 				}
 			}

--- a/gapis/api/vulkan/replay.go
+++ b/gapis/api/vulkan/replay.go
@@ -346,111 +346,111 @@ func (t *destroyResourcesAtEOS) Flush(ctx context.Context, out transform.Writer)
 	p := memory.Nullptr
 
 	// Wait all queues in all devices to finish their jobs first.
-	for handle := range so.Devices().Range() {
+	for handle := range so.Devices().All() {
 		out.MutateAndWrite(ctx, id, cb.VkDeviceWaitIdle(handle, VkResult_VK_SUCCESS))
 	}
 
 	// Synchronization primitives.
-	for handle, object := range so.Events().Range() {
+	for handle, object := range so.Events().All() {
 		out.MutateAndWrite(ctx, id, cb.VkDestroyEvent(object.Device(), handle, p))
 	}
-	for handle, object := range so.Fences().Range() {
+	for handle, object := range so.Fences().All() {
 		out.MutateAndWrite(ctx, id, cb.VkDestroyFence(object.Device(), handle, p))
 	}
-	for handle, object := range so.Semaphores().Range() {
+	for handle, object := range so.Semaphores().All() {
 		out.MutateAndWrite(ctx, id, cb.VkDestroySemaphore(object.Device(), handle, p))
 	}
 
 	// Framebuffers, samplers.
-	for handle, object := range so.Framebuffers().Range() {
+	for handle, object := range so.Framebuffers().All() {
 		out.MutateAndWrite(ctx, id, cb.VkDestroyFramebuffer(object.Device(), handle, p))
 	}
-	for handle, object := range so.Samplers().Range() {
+	for handle, object := range so.Samplers().All() {
 		out.MutateAndWrite(ctx, id, cb.VkDestroySampler(object.Device(), handle, p))
 	}
 
-	for handle, object := range so.ImageViews().Range() {
+	for handle, object := range so.ImageViews().All() {
 		out.MutateAndWrite(ctx, id, cb.VkDestroyImageView(object.Device(), handle, p))
 	}
 
 	// Buffers.
-	for handle, object := range so.BufferViews().Range() {
+	for handle, object := range so.BufferViews().All() {
 		out.MutateAndWrite(ctx, id, cb.VkDestroyBufferView(object.Device(), handle, p))
 	}
-	for handle, object := range so.Buffers().Range() {
+	for handle, object := range so.Buffers().All() {
 		out.MutateAndWrite(ctx, id, cb.VkDestroyBuffer(object.Device(), handle, p))
 	}
 
 	// Descriptor sets.
-	for handle, object := range so.DescriptorPools().Range() {
+	for handle, object := range so.DescriptorPools().All() {
 		out.MutateAndWrite(ctx, id, cb.VkDestroyDescriptorPool(object.Device(), handle, p))
 	}
-	for handle, object := range so.DescriptorSetLayouts().Range() {
+	for handle, object := range so.DescriptorSetLayouts().All() {
 		out.MutateAndWrite(ctx, id, cb.VkDestroyDescriptorSetLayout(object.Device(), handle, p))
 	}
 
 	// Shader modules.
-	for handle, object := range so.ShaderModules().Range() {
+	for handle, object := range so.ShaderModules().All() {
 		out.MutateAndWrite(ctx, id, cb.VkDestroyShaderModule(object.Device(), handle, p))
 	}
 
 	// Pipelines.
-	for handle, object := range so.GraphicsPipelines().Range() {
+	for handle, object := range so.GraphicsPipelines().All() {
 		out.MutateAndWrite(ctx, id, cb.VkDestroyPipeline(object.Device(), handle, p))
 	}
-	for handle, object := range so.ComputePipelines().Range() {
+	for handle, object := range so.ComputePipelines().All() {
 		out.MutateAndWrite(ctx, id, cb.VkDestroyPipeline(object.Device(), handle, p))
 	}
-	for handle, object := range so.PipelineLayouts().Range() {
+	for handle, object := range so.PipelineLayouts().All() {
 		out.MutateAndWrite(ctx, id, cb.VkDestroyPipelineLayout(object.Device(), handle, p))
 	}
-	for handle, object := range so.PipelineCaches().Range() {
+	for handle, object := range so.PipelineCaches().All() {
 		out.MutateAndWrite(ctx, id, cb.VkDestroyPipelineCache(object.Device(), handle, p))
 	}
 
 	// Render passes.
-	for handle, object := range so.RenderPasses().Range() {
+	for handle, object := range so.RenderPasses().All() {
 		out.MutateAndWrite(ctx, id, cb.VkDestroyRenderPass(object.Device(), handle, p))
 	}
 
-	for handle, object := range so.QueryPools().Range() {
+	for handle, object := range so.QueryPools().All() {
 		out.MutateAndWrite(ctx, id, cb.VkDestroyQueryPool(object.Device(), handle, p))
 	}
 
 	// Command buffers.
-	for handle, object := range so.CommandPools().Range() {
+	for handle, object := range so.CommandPools().All() {
 		out.MutateAndWrite(ctx, id, cb.VkDestroyCommandPool(object.Device(), handle, p))
 	}
 
 	// Swapchains.
-	for handle, object := range so.Swapchains().Range() {
+	for handle, object := range so.Swapchains().All() {
 		out.MutateAndWrite(ctx, id, cb.VkDestroySwapchainKHR(object.Device(), handle, p))
 	}
 
 	// Memories.
-	for handle, object := range so.DeviceMemories().Range() {
+	for handle, object := range so.DeviceMemories().All() {
 		out.MutateAndWrite(ctx, id, cb.VkFreeMemory(object.Device(), handle, p))
 	}
 
 	// Note: so.Images also contains Swapchain images. We do not want
 	// to delete those, as that must be handled by VkDestroySwapchainKHR
-	for handle, object := range so.Images().Range() {
+	for handle, object := range so.Images().All() {
 		if !object.IsSwapchainImage() {
 			out.MutateAndWrite(ctx, id, cb.VkDestroyImage(object.Device(), handle, p))
 		}
 	}
 	// Devices.
-	for handle := range so.Devices().Range() {
+	for handle := range so.Devices().All() {
 		out.MutateAndWrite(ctx, id, cb.VkDestroyDevice(handle, p))
 	}
 
 	// Surfaces.
-	for handle, object := range so.Surfaces().Range() {
+	for handle, object := range so.Surfaces().All() {
 		out.MutateAndWrite(ctx, id, cb.VkDestroySurfaceKHR(object.Instance(), handle, p))
 	}
 
 	// Instances.
-	for handle := range so.Instances().Range() {
+	for handle := range so.Instances().All() {
 		out.MutateAndWrite(ctx, id, cb.VkDestroyInstance(handle, p))
 	}
 }


### PR DESCRIPTION
`Range` was seemingly named by the use of iteration over the map entries.
Having it called `Range` for getting a Go map (what it returns) is odd.

I've named this `All` as it will convert all the map elements from C. (in a future CL)