### PR TITLE
Add a workaround for some Linux drivers.

### DIFF
--- a/gapir/cc/linux/vulkan_renderer.cpp
+++ b/gapir/cc/linux/vulkan_renderer.cpp
@@ -34,6 +34,21 @@ private:
 
 VulkanRendererImpl::VulkanRendererImpl() {
     mApi.resolve();
+    // Create a dummy instance renderer that never gets cleaned up.
+    // This works around some driver bugs.
+    // See https://github.com/google/gapid/issues/1899
+    auto create_info = Vulkan::VkInstanceCreateInfo{
+        Vulkan::VkStructureType::VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO,
+        nullptr,
+        0,
+        nullptr,
+        0,
+        nullptr,
+        0,
+        nullptr
+    };
+    Vulkan::VkInstance inst;
+    mApi.mFunctionStubs.vkCreateInstance(&create_info, nullptr, &inst);
 }
 
 VulkanRendererImpl::~VulkanRendererImpl() {


### PR DESCRIPTION
We can get a crash when cleaning an instance in some
circumstances with Vulkan drivers on Linux.

If we force the Loader to keep an instance alive, then
we won't run into this problem. The downside is that we
leak a single instance.