### PR TITLE
Add frame range options to gapit stats

### DIFF
--- a/cmd/gapit/flags.go
+++ b/cmd/gapit/flags.go
@@ -245,4 +245,11 @@ type (
 	UnpackFlags struct {
 		Verbose bool `help:"if true, then output will not be truncated"`
 	}
+	StatsFlags struct {
+		Gapis  GapisFlags
+		Frames struct {
+			Start int `help:"frame to start stats from"`
+			Count int `help:"number of frames after Start to process: -1 for all frames"`
+		}
+	}
 )

--- a/cmd/gapit/stats.go
+++ b/cmd/gapit/stats.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"math"
 	"path/filepath"
 
 	"github.com/google/gapid/core/app"
@@ -27,10 +28,11 @@ import (
 	"github.com/google/gapid/gapis/service/path"
 )
 
-type infoVerb struct{ Gapis GapisFlags }
+type infoVerb struct{ StatsFlags }
 
 func init() {
 	verb := &infoVerb{}
+	verb.Frames.Count = -1
 	app.AddVerb(&app.Verb{
 		Name:      "stats",
 		ShortHelp: "Prints information about a capture file",
@@ -62,13 +64,7 @@ func loadCapture(ctx context.Context, flags flag.FlagSet, gapisFlags GapisFlags)
 	return client, capture, nil
 }
 
-func (verb *infoVerb) Run(ctx context.Context, flags flag.FlagSet) error {
-	client, capture, err := loadCapture(ctx, flags, verb.Gapis)
-	if err != nil {
-		return err
-	}
-	defer client.Close()
-
+func (verb *infoVerb) getEventsInRange(ctx context.Context, client service.Service, capture *path.Capture) ([]*service.Event, error) {
 	events, err := getEvents(ctx, client, &path.Events{
 		Capture:                 capture,
 		AllCommands:             true,
@@ -76,6 +72,54 @@ func (verb *infoVerb) Run(ctx context.Context, flags flag.FlagSet) error {
 		FirstInFrame:            true,
 		FramebufferObservations: true,
 	})
+	if err != nil {
+		return nil, err
+	}
+
+	if verb.Frames.Start == 0 && verb.Frames.Count == -1 {
+		return events, err
+	}
+
+	fifIndices := []uint64{}
+	for _, e := range events {
+		if e.Kind == service.EventKind_FirstInFrame {
+			fifIndices = append(fifIndices, e.Command.Indices[0])
+		}
+	}
+
+	if verb.Frames.Start > len(fifIndices) {
+		return nil, log.Errf(ctx, nil, "Captured only %v frames, less than start frame %v", len(fifIndices), verb.Frames.Start)
+	}
+
+	startIndex := fifIndices[verb.Frames.Start]
+	endIndex := uint64(math.MaxUint64)
+	if verb.Frames.Count >= 0 &&
+		verb.Frames.Start+verb.Frames.Count < len(fifIndices) {
+
+		endIndex = fifIndices[verb.Frames.Start+verb.Frames.Count]
+	}
+
+	begin, end := len(events), len(events)
+	for i, e := range events {
+		if i < begin && e.Command.Indices[0] >= startIndex {
+			begin = i
+		}
+		if i < end && e.Command.Indices[0] >= endIndex {
+			end = i
+		}
+	}
+	fmt.Println(startIndex, endIndex, begin, end)
+	return events[begin:end], nil
+}
+
+func (verb *infoVerb) Run(ctx context.Context, flags flag.FlagSet) error {
+	client, capture, err := loadCapture(ctx, flags, verb.Gapis)
+	if err != nil {
+		return err
+	}
+	defer client.Close()
+
+	events, err := verb.GetEventsInRange(ctx, client, capture)
 
 	if err != nil {
 		return log.Err(ctx, err, "Couldn't get events")

--- a/cmd/gapit/stats.go
+++ b/cmd/gapit/stats.go
@@ -108,7 +108,6 @@ func (verb *infoVerb) getEventsInRange(ctx context.Context, client service.Servi
 			end = i
 		}
 	}
-	fmt.Println(startIndex, endIndex, begin, end)
 	return events[begin:end], nil
 }
 


### PR DESCRIPTION
Options emulate those of gapit video:
  - frame-start is the frame to start at
  - frame-count is the number of frames to consider after the start