### PR TITLE
Encode physical device properties in extra

### DIFF
--- a/gapii/cc/vulkan_extras.cpp
+++ b/gapii/cc/vulkan_extras.cpp
@@ -455,6 +455,18 @@ void VulkanSpy::pushRenderPassMarker(CallObserver*, VkRenderPass) {}
 void VulkanSpy::popRenderPassMarker(CallObserver*) {}
 void VulkanSpy::popAndPushMarkerForNextSubpass(CallObserver*, uint32_t) {}
 
+void VulkanSpy::fetchPhysicalDeviceProperties(
+    CallObserver* observer, VkInstance instance, VkPhysicalDevice* devs,
+    uint32_t count, gapil::Ref<PhyDevProperties> props) {
+  for (uint32_t i = 0; i < count; i++) {
+    VkPhysicalDevice dev = devs[i];
+    props->mPhyDevToProperties[dev] = VkPhysicalDeviceProperties(arena());
+    mImports.mVkInstanceFunctions[instance].vkGetPhysicalDeviceProperties(
+        dev, &props->mPhyDevToProperties[dev]);
+  }
+  observer->encode(*props.get());
+}
+
 // Override API functions
 // SpyOverride_vkGetInstanceProcAddr(), SpyOverride_vkGetDeviceProcAddr(),
 // SpyOverride_vkCreateInstance() and SpyOverride_vkCreateDevice() require
@@ -693,33 +705,6 @@ uint32_t VulkanSpy::CreateBufferAndGetMemoryRequirements(
   if (result == gapii::VkResult::VK_SUCCESS) {
     gapii::VkMemoryRequirements mem_req{&arena};
     gapii::vkGetBufferMemoryRequirements(device, *pBuffer, &mem_req);
-  }
-  return result;
-}
-
-uint32_t VulkanSpy::EnumeratePhysicalDevicesAndCacheProperties(
-    VkInstance instance, uint32_t* pPhysicalDeviceCount,
-    VkPhysicalDevice* pPhysicalDevices) {
-
-  core::Arena arena;
-  uint32_t result = gapii::vkEnumeratePhysicalDevices(
-      instance, pPhysicalDeviceCount, pPhysicalDevices);
-  if ((result == gapii::VkResult::VK_SUCCESS) &&
-      (pPhysicalDevices != nullptr)) {
-    uint32_t dev_count = *pPhysicalDeviceCount;
-    std::vector<VkPhysicalDevice> devs(pPhysicalDevices,
-                                       pPhysicalDevices + dev_count);
-    for (VkPhysicalDevice dev : devs) {
-      gapii::VkPhysicalDeviceProperties dev_prop{&arena};
-      gapii::vkGetPhysicalDeviceProperties(dev, &dev_prop);
-      uint32_t queue_family_count = 0;
-      gapii::vkGetPhysicalDeviceQueueFamilyProperties(dev, &queue_family_count,
-                                                      nullptr);
-      std::vector<VkQueueFamilyProperties> queue_family_props(
-          queue_family_count, VkQueueFamilyProperties{&arena});
-      gapii::vkGetPhysicalDeviceQueueFamilyProperties(
-          dev, &queue_family_count, queue_family_props.data());
-    }
   }
   return result;
 }

--- a/gapii/cc/vulkan_extras.cpp
+++ b/gapii/cc/vulkan_extras.cpp
@@ -455,15 +455,16 @@ void VulkanSpy::pushRenderPassMarker(CallObserver*, VkRenderPass) {}
 void VulkanSpy::popRenderPassMarker(CallObserver*) {}
 void VulkanSpy::popAndPushMarkerForNextSubpass(CallObserver*, uint32_t) {}
 
-void VulkanSpy::fetchPhysicalDeviceProperties(
-    CallObserver* observer, VkInstance instance, gapil::Slice<VkPhysicalDevice> devs,
-    gapil::Ref<PhyDevProperties> props) {
+gapil::Ref<PhyDevProperties> VulkanSpy::fetchPhysicalDeviceProperties(
+    CallObserver* observer, VkInstance instance, gapil::Slice<VkPhysicalDevice> devs) {
+  auto props = gapil::Ref<PhyDevProperties>::create(arena());
   for (VkPhysicalDevice dev : devs) {
     props->mPhyDevToProperties[dev] = VkPhysicalDeviceProperties(arena());
     mImports.mVkInstanceFunctions[instance].vkGetPhysicalDeviceProperties(
         dev, &props->mPhyDevToProperties[dev]);
   }
   observer->encode(*props.get());
+  return props;
 }
 
 // Override API functions

--- a/gapii/cc/vulkan_extras.cpp
+++ b/gapii/cc/vulkan_extras.cpp
@@ -455,9 +455,9 @@ void VulkanSpy::pushRenderPassMarker(CallObserver*, VkRenderPass) {}
 void VulkanSpy::popRenderPassMarker(CallObserver*) {}
 void VulkanSpy::popAndPushMarkerForNextSubpass(CallObserver*, uint32_t) {}
 
-gapil::Ref<PhyDevProperties> VulkanSpy::fetchPhysicalDeviceProperties(
+gapil::Ref<PhysicalDevicesAndProperties> VulkanSpy::fetchPhysicalDeviceProperties(
     CallObserver* observer, VkInstance instance, gapil::Slice<VkPhysicalDevice> devs) {
-  auto props = gapil::Ref<PhyDevProperties>::create(arena());
+  auto props = gapil::Ref<PhysicalDevicesAndProperties>::create(arena());
   for (VkPhysicalDevice dev : devs) {
     props->mPhyDevToProperties[dev] = VkPhysicalDeviceProperties(arena());
     mImports.mVkInstanceFunctions[instance].vkGetPhysicalDeviceProperties(

--- a/gapii/cc/vulkan_extras.cpp
+++ b/gapii/cc/vulkan_extras.cpp
@@ -456,10 +456,9 @@ void VulkanSpy::popRenderPassMarker(CallObserver*) {}
 void VulkanSpy::popAndPushMarkerForNextSubpass(CallObserver*, uint32_t) {}
 
 void VulkanSpy::fetchPhysicalDeviceProperties(
-    CallObserver* observer, VkInstance instance, VkPhysicalDevice* devs,
-    uint32_t count, gapil::Ref<PhyDevProperties> props) {
-  for (uint32_t i = 0; i < count; i++) {
-    VkPhysicalDevice dev = devs[i];
+    CallObserver* observer, VkInstance instance, gapil::Slice<VkPhysicalDevice> devs,
+    gapil::Ref<PhyDevProperties> props) {
+  for (VkPhysicalDevice dev : devs) {
     props->mPhyDevToProperties[dev] = VkPhysicalDeviceProperties(arena());
     mImports.mVkInstanceFunctions[instance].vkGetPhysicalDeviceProperties(
         dev, &props->mPhyDevToProperties[dev]);

--- a/gapii/cc/vulkan_extras.inc
+++ b/gapii/cc/vulkan_extras.inc
@@ -96,10 +96,6 @@ static uint32_t CreateBufferAndGetMemoryRequirements(VkDevice,
                                                      const VkAllocationCallbacks*,
                                                      VkBuffer*);
 
-static uint32_t EnumeratePhysicalDevicesAndCacheProperties(
-    VkInstance, uint32_t* pPhysicalDeviceCount,
-    VkPhysicalDevice* pPhysicalDevices);
-
 bool m_coherent_memory_tracking_enabled = false;
 
 void SpyOverride_cacheImageSparseMemoryRequirements(

--- a/gapis/api/vulkan/api/physical_device.api
+++ b/gapis/api/vulkan/api/physical_device.api
@@ -72,8 +72,7 @@ cmd VkResult vkEnumeratePhysicalDevices(
       devices[i] = device
     }
     pPhysicalDeviceCount[0] = count
-    props := new!PhyDevProperties()
-    fetchPhysicalDeviceProperties(instance, devices, props)
+    props := fetchPhysicalDeviceProperties(instance, devices)
     for i in (0 .. count) {
       if (PhysicalDevices[devices[i]] == null) {
         object := new!PhysicalDeviceObject()

--- a/gapis/api/vulkan/api/physical_device.api
+++ b/gapis/api/vulkan/api/physical_device.api
@@ -73,7 +73,7 @@ cmd VkResult vkEnumeratePhysicalDevices(
     }
     pPhysicalDeviceCount[0] = count
     props := new!PhyDevProperties()
-    fetchPhysicalDeviceProperties(instance, pPhysicalDevices, count, props)
+    fetchPhysicalDeviceProperties(instance, devices, props)
     for i in (0 .. count) {
       if (PhysicalDevices[devices[i]] == null) {
         object := new!PhysicalDeviceObject()

--- a/gapis/api/vulkan/api/physical_device.api
+++ b/gapis/api/vulkan/api/physical_device.api
@@ -47,7 +47,7 @@
   @unused VkPhysicalDeviceProperties         PhysicalDeviceProperties
 }
 
-@internal class PhyDevProperties{
+@internal class PhysicalDevicesAndProperties{
   map!(VkPhysicalDevice, VkPhysicalDeviceProperties) PhyDevToProperties
 }
 

--- a/gapis/api/vulkan/api/physical_device.api
+++ b/gapis/api/vulkan/api/physical_device.api
@@ -47,6 +47,10 @@
   @unused VkPhysicalDeviceProperties         PhysicalDeviceProperties
 }
 
+@internal class PhyDevProperties{
+  map!(VkPhysicalDevice, VkPhysicalDeviceProperties) PhyDevToProperties
+}
+
 @threadSafety("system")
 @indirect("VkInstance")
 cmd VkResult vkEnumeratePhysicalDevices(
@@ -68,13 +72,15 @@ cmd VkResult vkEnumeratePhysicalDevices(
       devices[i] = device
     }
     pPhysicalDeviceCount[0] = count
-
+    props := new!PhyDevProperties()
+    fetchPhysicalDeviceProperties(instance, pPhysicalDevices, count, props)
     for i in (0 .. count) {
       if (PhysicalDevices[devices[i]] == null) {
         object := new!PhysicalDeviceObject()
         object.Instance = instance
         object.Index = i
         object.VulkanHandle = devices[i]
+        object.PhysicalDeviceProperties = props.PhyDevToProperties[devices[i]]
         PhysicalDevices[devices[i]] = object
       }
     }

--- a/gapis/api/vulkan/externs.go
+++ b/gapis/api/vulkan/externs.go
@@ -318,12 +318,13 @@ func bindSparse(ctx context.Context, a api.Cmd, id api.CmdID, s *api.GlobalState
 	}
 }
 
-func (e externs) fetchPhysicalDeviceProperties(inst VkInstance, devs VkPhysicalDeviceˢ, props PhyDevPropertiesʳ) {
+func (e externs) fetchPhysicalDeviceProperties(inst VkInstance, devs VkPhysicalDeviceˢ) PhyDevPropertiesʳ {
 	for _, ee := range e.cmd.Extras().All() {
 		if p, ok := ee.(PhyDevProperties); ok {
-			props.Set(p)
+			return MakePhyDevPropertiesʳ().Set(p)
 		}
 	}
+	return NilPhyDevPropertiesʳ
 }
 
 func (e externs) vkErrInvalidHandle(handleType string, handle uint64) {

--- a/gapis/api/vulkan/externs.go
+++ b/gapis/api/vulkan/externs.go
@@ -318,6 +318,14 @@ func bindSparse(ctx context.Context, a api.Cmd, id api.CmdID, s *api.GlobalState
 	}
 }
 
+func (e externs) fetchPhysicalDeviceProperties(inst VkInstance, devs VkPhysicalDeviceᵖ, count uint32, props PhyDevPropertiesʳ) {
+	for _, ee := range e.cmd.Extras().All() {
+		if p, ok := ee.(PhyDevProperties); ok {
+			props.Set(p)
+		}
+	}
+}
+
 func (e externs) vkErrInvalidHandle(handleType string, handle uint64) {
 	var issue replay.Issue
 	issue.Command = e.cmdID

--- a/gapis/api/vulkan/externs.go
+++ b/gapis/api/vulkan/externs.go
@@ -318,7 +318,7 @@ func bindSparse(ctx context.Context, a api.Cmd, id api.CmdID, s *api.GlobalState
 	}
 }
 
-func (e externs) fetchPhysicalDeviceProperties(inst VkInstance, devs VkPhysicalDeviceᵖ, count uint32, props PhyDevPropertiesʳ) {
+func (e externs) fetchPhysicalDeviceProperties(inst VkInstance, devs VkPhysicalDeviceˢ, props PhyDevPropertiesʳ) {
 	for _, ee := range e.cmd.Extras().All() {
 		if p, ok := ee.(PhyDevProperties); ok {
 			props.Set(p)

--- a/gapis/api/vulkan/externs.go
+++ b/gapis/api/vulkan/externs.go
@@ -318,13 +318,13 @@ func bindSparse(ctx context.Context, a api.Cmd, id api.CmdID, s *api.GlobalState
 	}
 }
 
-func (e externs) fetchPhysicalDeviceProperties(inst VkInstance, devs VkPhysicalDeviceˢ) PhyDevPropertiesʳ {
+func (e externs) fetchPhysicalDeviceProperties(inst VkInstance, devs VkPhysicalDeviceˢ) PhysicalDevicesAndPropertiesʳ {
 	for _, ee := range e.cmd.Extras().All() {
-		if p, ok := ee.(PhyDevProperties); ok {
-			return MakePhyDevPropertiesʳ().Set(p)
+		if p, ok := ee.(PhysicalDevicesAndProperties); ok {
+			return MakePhysicalDevicesAndPropertiesʳ().Set(p)
 		}
 	}
-	return NilPhyDevPropertiesʳ
+	return NilPhysicalDevicesAndPropertiesʳ
 }
 
 func (e externs) vkErrInvalidHandle(handleType string, handle uint64) {

--- a/gapis/api/vulkan/replay.go
+++ b/gapis/api/vulkan/replay.go
@@ -95,13 +95,7 @@ func (a API) GetReplayPriority(ctx context.Context, i *device.Instance, h *captu
 // makeAttachementReadable is a transformation marking all color/depth/stencil
 // attachment images created via vkCreateImage commands as readable (by patching
 // the transfer src bit).
-type makeAttachementReadable struct {
-	instance                  VkInstance
-	enumeratedPhysicalDevices []VkPhysicalDevice
-	properties                []VkPhysicalDeviceProperties
-	inPhysicalDeviceEnumerate bool
-	numPhysicalDevicesLeft    uint32
-}
+type makeAttachementReadable struct{}
 
 // drawConfig is a replay.Config used by colorBufferRequest and
 // depthBufferRequests.
@@ -462,13 +456,7 @@ func (a API) Replay(
 	cmds := capture.Commands
 
 	transforms := transform.Transforms{}
-	transforms.Add(&makeAttachementReadable{
-		VkInstance(0),
-		make([]VkPhysicalDevice, 0),
-		make([]VkPhysicalDeviceProperties, 0),
-		false,
-		0,
-	})
+	transforms.Add(&makeAttachementReadable{})
 
 	readFramebuffer := newReadFramebuffer(ctx)
 	injector := &transform.Injector{}

--- a/gapis/api/vulkan/templates/vk_spy_helpers.cpp.tmpl
+++ b/gapis/api/vulkan/templates/vk_spy_helpers.cpp.tmpl
@@ -87,11 +87,7 @@ PFN_vkVoidFunction VulkanSpy::SpyOverride_vkGetInstanceProcAddr(VkInstance insta
         {{if (Macro "IsIndirected" "Command" $c "IndirectOn" "VkInstance")}}
             {{$name := Macro "CmdName" $c}}
             if(!strcmp(pName, "{{$name}}"))
-            {{if eq $name "vkEnumeratePhysicalDevices"}}
-              return reinterpret_cast<PFN_vkVoidFunction>(VulkanSpy::EnumeratePhysicalDevicesAndCacheProperties);
-            {{else}}
               return reinterpret_cast<PFN_vkVoidFunction>(gapii::{{$name}});
-            {{end}}
         {{end}}
     {{end}}
 

--- a/gapis/api/vulkan/vulkan.api
+++ b/gapis/api/vulkan/vulkan.api
@@ -111,7 +111,7 @@ extern void onDeferSubcommand(ref!CommandReference ref)
 extern void onCommandAdded(VkCommandBuffer buffer)
 extern void resetCmd(VkCommandBuffer buffer)
 extern void validate(string layerName, bool condition, string message)
-extern void fetchPhysicalDeviceProperties(VkInstance instance, VkPhysicalDevice[] devs, ref!PhyDevProperties props)
+extern ref!PhyDevProperties fetchPhysicalDeviceProperties(VkInstance instance, VkPhysicalDevice[] devs)
 
 ///////////////////////
 // Function pointers //

--- a/gapis/api/vulkan/vulkan.api
+++ b/gapis/api/vulkan/vulkan.api
@@ -111,7 +111,7 @@ extern void onDeferSubcommand(ref!CommandReference ref)
 extern void onCommandAdded(VkCommandBuffer buffer)
 extern void resetCmd(VkCommandBuffer buffer)
 extern void validate(string layerName, bool condition, string message)
-extern ref!PhyDevProperties fetchPhysicalDeviceProperties(VkInstance instance, VkPhysicalDevice[] devs)
+extern ref!PhysicalDevicesAndProperties fetchPhysicalDeviceProperties(VkInstance instance, VkPhysicalDevice[] devs)
 
 ///////////////////////
 // Function pointers //

--- a/gapis/api/vulkan/vulkan.api
+++ b/gapis/api/vulkan/vulkan.api
@@ -111,7 +111,7 @@ extern void onDeferSubcommand(ref!CommandReference ref)
 extern void onCommandAdded(VkCommandBuffer buffer)
 extern void resetCmd(VkCommandBuffer buffer)
 extern void validate(string layerName, bool condition, string message)
-extern void fetchPhysicalDeviceProperties(VkInstance instance, VkPhysicalDevice* devs, u32 count, ref!PhyDevProperties props)
+extern void fetchPhysicalDeviceProperties(VkInstance instance, VkPhysicalDevice[] devs, ref!PhyDevProperties props)
 
 ///////////////////////
 // Function pointers //

--- a/gapis/api/vulkan/vulkan.api
+++ b/gapis/api/vulkan/vulkan.api
@@ -111,6 +111,7 @@ extern void onDeferSubcommand(ref!CommandReference ref)
 extern void onCommandAdded(VkCommandBuffer buffer)
 extern void resetCmd(VkCommandBuffer buffer)
 extern void validate(string layerName, bool condition, string message)
+extern void fetchPhysicalDeviceProperties(VkInstance instance, VkPhysicalDevice* devs, u32 count, ref!PhyDevProperties props)
 
 ///////////////////////
 // Function pointers //


### PR DESCRIPTION
Fixes #1766 

So that we won't insert extra `vkGetPhysicalDeviceProperties` after `vkEnumeratePhysicalDevices`.