### PR TITLE
 Remove inserted commands for fetching image/buffer memory requirements

### DIFF
--- a/gapii/cc/vulkan_extras.inc
+++ b/gapii/cc/vulkan_extras.inc
@@ -87,15 +87,6 @@ void SpyOverride_vkCmdDebugMarkerEndEXT(VkCommandBuffer commandBuffer) {}
 void SpyOverride_vkCmdDebugMarkerInsertEXT(
     VkCommandBuffer commandBuffer, VkDebugMarkerMarkerInfoEXT* pMarkerInfo) {}
 
-static uint32_t CreateImageAndGetMemoryRequirements(VkDevice,
-                                                    const VkImageCreateInfo*,
-                                                    const VkAllocationCallbacks*,
-                                                    VkImage*);
-static uint32_t CreateBufferAndGetMemoryRequirements(VkDevice,
-                                                     const VkBufferCreateInfo*,
-                                                     const VkAllocationCallbacks*,
-                                                     VkBuffer*);
-
 bool m_coherent_memory_tracking_enabled = false;
 
 void SpyOverride_cacheImageSparseMemoryRequirements(

--- a/gapis/api/vulkan/api/buffer.api
+++ b/gapis/api/vulkan/api/buffer.api
@@ -112,6 +112,11 @@ cmd VkResult vkCreateBuffer(
     VulkanHandle:  buffer,
     Info:          bufferInfo,
   )
+
+  // If the vkCreateBuffer is inserted by GAPID (e.g. the staging buffer for
+  // reading framebuffer), an empty memory requirement struct will be returned.
+  bufferObject.MemoryRequirements = fetchBufferMemoryRequirements(device, buffer)
+
   Buffers[buffer] = bufferObject
 
   return ?

--- a/gapis/api/vulkan/api/image.api
+++ b/gapis/api/vulkan/api/image.api
@@ -115,6 +115,11 @@
   VkSparseMemoryBindFlags Flags
 }
 
+@internal class ImageMemoryRequirements {
+  VkMemoryRequirements MemoryRequirements
+  map!(u32, VkSparseImageMemoryRequirements) AspectBitsToSparseMemoryRequirements
+}
+
 @threadSafety("system")
 @indirect("VkDevice")
 @override
@@ -167,6 +172,8 @@ cmd VkResult vkCreateImage(
         VK_IMAGE_ASPECT_COLOR_BIT
     })
 
+  hasSparseBit := (as!u32(info.flags) & as!u32(VK_IMAGE_CREATE_SPARSE_BINDING_BIT)) != 0
+
   // Handle pNext
   if info.pNext != null {
     numPNext := numberOfPNext(info.pNext)
@@ -210,6 +217,17 @@ cmd VkResult vkCreateImage(
       }
     }
   }
+
+  memRequirements := fetchImageMemoryRequirements(device, handle, hasSparseBit)
+  // If the vkCreateImage is inserted by GAPID (e.g. the staging image for
+  // reading framebuffer), NO memory requirements will be returned.
+  if memRequirements != null {
+    object.MemoryRequirements = memRequirements.MemoryRequirements
+    if (hasSparseBit) {
+      object.SparseMemoryRequirements = memRequirements.AspectBitsToSparseMemoryRequirements
+    }
+  }
+
   Images[handle] = object
 
   return ?

--- a/gapis/api/vulkan/api/util.api
+++ b/gapis/api/vulkan/api/util.api
@@ -354,7 +354,9 @@ class unpackedImageAspectFlagBits {
 
 sub ref!unpackedImageAspectFlagBits unpackImageAspectFlags(VkImageAspectFlags flag) {
   u := new!unpackedImageAspectFlagBits()
-  for i in (0 .. 32) {
+  // Till Vulkan 1.1, seven bits are used for image aspects.
+  // Update this accordingly if more image aspect flag bits are added to the spec
+  for i in (0 .. 7) {
     if (as!u32(1 << as!u32(i)) & as!u32(flag)) != as!u32(0) {
       u.Bits[len(u.Bits)] = as!VkImageAspectFlagBits(1 << as!u32(i))
     }

--- a/gapis/api/vulkan/externs.go
+++ b/gapis/api/vulkan/externs.go
@@ -321,10 +321,38 @@ func bindSparse(ctx context.Context, a api.Cmd, id api.CmdID, s *api.GlobalState
 func (e externs) fetchPhysicalDeviceProperties(inst VkInstance, devs VkPhysicalDeviceˢ) PhysicalDevicesAndPropertiesʳ {
 	for _, ee := range e.cmd.Extras().All() {
 		if p, ok := ee.(PhysicalDevicesAndProperties); ok {
-			return MakePhysicalDevicesAndPropertiesʳ().Set(p)
+			return MakePhysicalDevicesAndPropertiesʳ().Set(p).Clone()
 		}
 	}
 	return NilPhysicalDevicesAndPropertiesʳ
+}
+
+func (e externs) fetchImageMemoryRequirements(dev VkDevice, img VkImage, hasSparseBit bool) ImageMemoryRequirementsʳ {
+	// Only fetch memory requirements for application commands, skip any commands
+	// inserted by GAPID
+	if e.cmdID == api.CmdNoID {
+		return NilImageMemoryRequirementsʳ
+	}
+	for _, ee := range e.cmd.Extras().All() {
+		if r, ok := ee.(ImageMemoryRequirements); ok {
+			return MakeImageMemoryRequirementsʳ().Set(r).Clone()
+		}
+	}
+	return NilImageMemoryRequirementsʳ
+}
+
+func (e externs) fetchBufferMemoryRequirements(dev VkDevice, buf VkBuffer) VkMemoryRequirements {
+	// Only fetch memory requirements for application commands, skip any commands
+	// inserted by GAPID
+	if e.cmdID == api.CmdNoID {
+		return MakeVkMemoryRequirements()
+	}
+	for _, ee := range e.cmd.Extras().All() {
+		if r, ok := ee.(VkMemoryRequirements); ok {
+			return r.Clone()
+		}
+	}
+	return MakeVkMemoryRequirements()
 }
 
 func (e externs) vkErrInvalidHandle(handleType string, handle uint64) {

--- a/gapis/api/vulkan/templates/vk_spy_helpers.cpp.tmpl
+++ b/gapis/api/vulkan/templates/vk_spy_helpers.cpp.tmpl
@@ -105,13 +105,7 @@ PFN_vkVoidFunction VulkanSpy::SpyOverride_vkGetDeviceProcAddr(VkDevice device, c
         {{if (Macro "IsIndirected" "Command" $c "IndirectOn" "VkDevice")}}
             {{$name := Macro "CmdName" $c}}
             if(!strcmp(pName, "{{$name}}"))
-            {{if eq $name "vkCreateImage"}}
-              return reinterpret_cast<PFN_vkVoidFunction>(VulkanSpy::CreateImageAndGetMemoryRequirements);
-            {{else if eq $name "vkCreateBuffer"}}
-              return reinterpret_cast<PFN_vkVoidFunction>(VulkanSpy::CreateBufferAndGetMemoryRequirements);
-            {{else}}
               return reinterpret_cast<PFN_vkVoidFunction>(gapii::{{$name}});
-            {{end}}
         {{end}}
     {{end}}
     // This is not strictly correct, but some applications incorrectly

--- a/gapis/api/vulkan/vulkan.api
+++ b/gapis/api/vulkan/vulkan.api
@@ -112,6 +112,8 @@ extern void onCommandAdded(VkCommandBuffer buffer)
 extern void resetCmd(VkCommandBuffer buffer)
 extern void validate(string layerName, bool condition, string message)
 extern ref!PhysicalDevicesAndProperties fetchPhysicalDeviceProperties(VkInstance instance, VkPhysicalDevice[] devs)
+extern ref!ImageMemoryRequirements fetchImageMemoryRequirements(VkDevice device, VkImage image, bool hasSparseBit)
+extern VkMemoryRequirements fetchBufferMemoryRequirements(VkDevice device, VkBuffer buffer)
 
 ///////////////////////
 // Function pointers //


### PR DESCRIPTION
Sits on top of #1908 

Remove inserted command for fetching image/buffer memory requirements  …
So that we won't see an extra vkGetImage/BufferMemoryRequirements
command inserted by GAPID after each vkCreateImage/Buffer command in the
command tree.