### PR TITLE
Add Arenas to struct fields & call parameters

### DIFF
--- a/gapis/api/BUILD.bazel
+++ b/gapis/api/BUILD.bazel
@@ -63,6 +63,7 @@ go_library(
         "//core/math/f32:go_default_library",
         "//core/math/interval:go_default_library",
         "//core/math/sint:go_default_library",
+        "//core/memory/arena:go_default_library",
         "//core/os/device:go_default_library",
         "//core/stream:go_default_library",
         "//core/stream/fmts:go_default_library",

--- a/gapis/api/gles/BUILD.bazel
+++ b/gapis/api/gles/BUILD.bazel
@@ -149,6 +149,7 @@ go_test(
         ":go_default_library",
         "//core/assert:go_default_library",
         "//core/log:go_default_library",
+        "//core/memory/arena:go_default_library",
         "//core/os/device:go_default_library",
         "//core/os/device/bind:go_default_library",
         "//gapis/api:go_default_library",

--- a/gapis/api/gles/BUILD.bazel
+++ b/gapis/api/gles/BUILD.bazel
@@ -105,6 +105,7 @@ go_library(
         "//core/math/sint:go_default_library",
         "//core/math/u32:go_default_library",
         "//core/math/u64:go_default_library",
+        "//core/memory/arena:go_default_library",  # keep
         "//core/os/device:go_default_library",
         "//core/os/device/bind:go_default_library",
         "//core/stream:go_default_library",

--- a/gapis/api/gles/compat.go
+++ b/gapis/api/gles/compat.go
@@ -199,7 +199,7 @@ func compat(ctx context.Context, device *device.Instance, onError onCompatError)
 	t = transform.Transform("compat", func(ctx context.Context, id api.CmdID, cmd api.Cmd, out transform.Writer) {
 		dID := id.Derived()
 		s := out.State()
-		cb := CommandBuilder{Thread: cmd.Thread()}
+		cb := CommandBuilder{Thread: cmd.Thread(), Arena: s.Arena}
 		switch cmd := cmd.(type) {
 		case *EglMakeCurrent: // TODO: Check for GLX, CGL, WGL...
 			// The compatibility layer introduces calls to GL functions that are defined for desktop GL
@@ -1273,7 +1273,7 @@ func compatMultiviewDraw(ctx context.Context, id api.CmdID, cmd api.Cmd, out tra
 	s := out.State()
 	c := GetContext(s, cmd.Thread())
 	dID := id.Derived()
-	cb := CommandBuilder{Thread: cmd.Thread()}
+	cb := CommandBuilder{Thread: cmd.Thread(), Arena: s.Arena}
 	numViews := uint32(1)
 	c.Bound().DrawFramebuffer().ForEachAttachment(func(name GLenum, att FramebufferAttachment) {
 		numViews = u32.Max(numViews, uint32(att.NumViews()))

--- a/gapis/api/gles/compat_client.go
+++ b/gapis/api/gles/compat_client.go
@@ -159,7 +159,7 @@ func moveClientVBsToVAs(
 		return
 	}
 
-	cb := CommandBuilder{Thread: cmd.Thread()}
+	cb := CommandBuilder{Thread: cmd.Thread(), Arena: s.Arena}
 	rngs := interval.U64RangeList{}
 	// Gather together all the client-buffers in use by the vertex-attribs.
 	// Merge together all the memory intervals that these use.

--- a/gapis/api/gles/compat_test.go
+++ b/gapis/api/gles/compat_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/google/gapid/core/assert"
 	"github.com/google/gapid/core/log"
+	"github.com/google/gapid/core/memory/arena"
 	"github.com/google/gapid/core/os/device"
 	"github.com/google/gapid/gapis/api"
 	"github.com/google/gapid/gapis/api/gles"
@@ -46,6 +47,9 @@ func newState(ctx context.Context) *api.GlobalState {
 func TestGlVertexAttribPointerCompatTest(t *testing.T) {
 	ctx := log.Testing(t)
 	ctx = database.Put(ctx, database.NewInMemory(ctx))
+
+	a := arena.New()
+	defer a.Dispose()
 
 	h := &capture.Header{Abi: device.AndroidARMv7a}
 	ml := h.Abi.MemoryLayout
@@ -77,7 +81,7 @@ func TestGlVertexAttribPointerCompatTest(t *testing.T) {
 	indices := []uint16{0, 1, 2, 1, 2, 3}
 	mw := &testcmd.Writer{S: newState(ctx)}
 	ctxHandle, displayHandle, surfaceHandle := p(1), p(2), p(3)
-	cb := gles.CommandBuilder{Thread: 0}
+	cb := gles.CommandBuilder{Thread: 0, Arena: a}
 	eglMakeCurrent := cb.EglMakeCurrent(displayHandle, surfaceHandle, surfaceHandle, ctxHandle, 0)
 	eglMakeCurrent.Extras().Add(gles.NewStaticContextStateForTest(), gles.NewDynamicContextStateForTest(64, 64, true))
 	api.ForeachCmd(ctx, []api.Cmd{

--- a/gapis/api/gles/custom_replay.go
+++ b/gapis/api/gles/custom_replay.go
@@ -259,7 +259,7 @@ func (ω *EglCreateContext) Mutate(ctx context.Context, id api.CmdID, s *api.Glo
 		return err
 	}
 	ctxID := uint32(GetState(s).EGLContexts().Get(ω.Result()).Identifier())
-	cb := CommandBuilder{Thread: ω.Thread()}
+	cb := CommandBuilder{Thread: ω.Thread(), Arena: s.Arena}
 	return cb.ReplayCreateRenderer(ctxID).Mutate(ctx, id, s, b)
 }
 
@@ -270,7 +270,7 @@ func (ω *EglMakeCurrent) Mutate(ctx context.Context, id api.CmdID, s *api.Globa
 	if b == nil || err != nil {
 		return err
 	}
-	cb := CommandBuilder{Thread: ω.Thread()}
+	cb := CommandBuilder{Thread: ω.Thread(), Arena: s.Arena}
 	if ω.Context() == 0 {
 		if prevContext.IsNil() {
 			return nil
@@ -311,7 +311,7 @@ func (ω *WglCreateContext) Mutate(ctx context.Context, id api.CmdID, s *api.Glo
 		return err
 	}
 	ctxID := uint32(GetState(s).WGLContexts().Get(ω.Result()).Identifier())
-	cb := CommandBuilder{Thread: ω.Thread()}
+	cb := CommandBuilder{Thread: ω.Thread(), Arena: s.Arena}
 	return cb.ReplayCreateRenderer(ctxID).Mutate(ctx, id, s, b)
 }
 
@@ -321,7 +321,7 @@ func (ω *WglCreateContextAttribsARB) Mutate(ctx context.Context, id api.CmdID, 
 		return err
 	}
 	ctxID := uint32(GetState(s).WGLContexts().Get(ω.Result()).Identifier())
-	cb := CommandBuilder{Thread: ω.Thread()}
+	cb := CommandBuilder{Thread: ω.Thread(), Arena: s.Arena}
 	return cb.ReplayCreateRenderer(ctxID).Mutate(ctx, id, s, b)
 }
 
@@ -334,7 +334,7 @@ func (ω *WglMakeCurrent) Mutate(ctx context.Context, id api.CmdID, s *api.Globa
 		return nil
 	}
 	ctxID := uint32(GetState(s).WGLContexts().Get(ω.Hglrc()).Identifier())
-	cb := CommandBuilder{Thread: ω.Thread()}
+	cb := CommandBuilder{Thread: ω.Thread(), Arena: s.Arena}
 	return cb.ReplayBindRenderer(ctxID).Mutate(ctx, id, s, b)
 }
 
@@ -344,7 +344,7 @@ func (ω *CGLCreateContext) Mutate(ctx context.Context, id api.CmdID, s *api.Glo
 		return err
 	}
 	ctxID := uint32(GetState(s).CGLContexts().Get(ω.Ctx().MustRead(ctx, ω, s, b)).Identifier())
-	cb := CommandBuilder{Thread: ω.Thread()}
+	cb := CommandBuilder{Thread: ω.Thread(), Arena: s.Arena}
 	return cb.ReplayCreateRenderer(ctxID).Mutate(ctx, id, s, b)
 }
 
@@ -357,7 +357,7 @@ func (ω *CGLSetCurrentContext) Mutate(ctx context.Context, id api.CmdID, s *api
 		return nil
 	}
 	ctxID := uint32(GetState(s).CGLContexts().Get(ω.Ctx()).Identifier())
-	cb := CommandBuilder{Thread: ω.Thread()}
+	cb := CommandBuilder{Thread: ω.Thread(), Arena: s.Arena}
 	return cb.ReplayBindRenderer(ctxID).Mutate(ctx, id, s, b)
 }
 
@@ -367,7 +367,7 @@ func (ω *GlXCreateContext) Mutate(ctx context.Context, id api.CmdID, s *api.Glo
 		return err
 	}
 	ctxID := uint32(GetState(s).GLXContexts().Get(ω.Result()).Identifier())
-	cb := CommandBuilder{Thread: ω.Thread()}
+	cb := CommandBuilder{Thread: ω.Thread(), Arena: s.Arena}
 	return cb.ReplayCreateRenderer(ctxID).Mutate(ctx, id, s, b)
 }
 
@@ -377,7 +377,7 @@ func (ω *GlXCreateNewContext) Mutate(ctx context.Context, id api.CmdID, s *api.
 		return err
 	}
 	ctxID := uint32(GetState(s).GLXContexts().Get(ω.Result()).Identifier())
-	cb := CommandBuilder{Thread: ω.Thread()}
+	cb := CommandBuilder{Thread: ω.Thread(), Arena: s.Arena}
 	return cb.ReplayCreateRenderer(ctxID).Mutate(ctx, id, s, b)
 }
 
@@ -390,7 +390,7 @@ func (ω *GlXMakeContextCurrent) Mutate(ctx context.Context, id api.CmdID, s *ap
 		return nil
 	}
 	ctxID := uint32(GetState(s).GLXContexts().Get(ω.Ctx()).Identifier())
-	cb := CommandBuilder{Thread: ω.Thread()}
+	cb := CommandBuilder{Thread: ω.Thread(), Arena: s.Arena}
 	return cb.ReplayBindRenderer(ctxID).Mutate(ctx, id, s, b)
 }
 
@@ -398,7 +398,7 @@ func (ω *GlXMakeContextCurrent) Mutate(ctx context.Context, id api.CmdID, s *ap
 func bindAttribLocations(ctx context.Context, cmd api.Cmd, id api.CmdID, s *api.GlobalState, b *builder.Builder, pid ProgramId) error {
 	pi := FindLinkProgramExtra(cmd.Extras())
 	if !pi.IsNil() && b != nil && !pi.ActiveResources().IsNil() {
-		cb := CommandBuilder{Thread: cmd.Thread()}
+		cb := CommandBuilder{Thread: cmd.Thread(), Arena: s.Arena}
 		for _, attr := range pi.ActiveResources().ProgramInputs().All() {
 			if int32(attr.Locations().Get(0)) != -1 {
 				tmp := s.AllocDataOrPanic(ctx, attr.Name())
@@ -423,7 +423,7 @@ func bindAttribLocations(ctx context.Context, cmd api.Cmd, id api.CmdID, s *api.
 func bindUniformBlocks(ctx context.Context, cmd api.Cmd, id api.CmdID, s *api.GlobalState, b *builder.Builder, pid ProgramId) error {
 	pi := FindLinkProgramExtra(cmd.Extras())
 	if !pi.IsNil() && b != nil && !pi.ActiveResources().IsNil() {
-		cb := CommandBuilder{Thread: cmd.Thread()}
+		cb := CommandBuilder{Thread: cmd.Thread(), Arena: s.Arena}
 		for i, ub := range pi.ActiveResources().UniformBlocks().All() {
 			// Query replay-time uniform block index so that the remapping is established
 			tmp := s.AllocDataOrPanic(ctx, ub.Name())

--- a/gapis/api/gles/dead_code_elimination_test.go
+++ b/gapis/api/gles/dead_code_elimination_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/google/gapid/core/assert"
 	"github.com/google/gapid/core/log"
+	"github.com/google/gapid/core/memory/arena"
 	"github.com/google/gapid/core/os/device"
 	"github.com/google/gapid/core/os/device/bind"
 	"github.com/google/gapid/gapis/api"
@@ -37,6 +38,9 @@ func TestDeadCommandRemoval(t *testing.T) {
 	ctx := log.Testing(t)
 	ctx = bind.PutRegistry(ctx, bind.NewRegistry())
 	ctx = database.Put(ctx, database.NewInMemory(ctx))
+
+	a := arena.New()
+	defer a.Dispose()
 
 	// Keep the given command alive in the optimization.
 	isLive := map[api.Cmd]bool{}
@@ -74,7 +78,7 @@ func TestDeadCommandRemoval(t *testing.T) {
 	ctxHandle2 := memory.BytePtr(2)
 	displayHandle := memory.BytePtr(3)
 	surfaceHandle := memory.BytePtr(4)
-	cb := gles.CommandBuilder{Thread: 0}
+	cb := gles.CommandBuilder{Thread: 0, Arena: a}
 	prologue := []api.Cmd{
 		cb.EglCreateContext(displayHandle, surfaceHandle, surfaceHandle, memory.Nullptr, ctxHandle1),
 		api.WithExtras(

--- a/gapis/api/gles/find_issues.go
+++ b/gapis/api/gles/find_issues.go
@@ -89,7 +89,7 @@ func (e ErrUnexpectedDriverTraceError) Error() string {
 
 func (t *findIssues) Transform(ctx context.Context, id api.CmdID, cmd api.Cmd, out transform.Writer) {
 	ctx = log.Enter(ctx, "findIssues")
-	cb := CommandBuilder{Thread: cmd.Thread()}
+	cb := CommandBuilder{Thread: cmd.Thread(), Arena: t.state.Arena}
 	t.lastGlError = GLenum_GL_NO_ERROR
 	mutateErr := cmd.Mutate(ctx, id, t.state, nil /* no builder */)
 
@@ -287,7 +287,7 @@ func (t *findIssues) Transform(ctx context.Context, id api.CmdID, cmd api.Cmd, o
 }
 
 func (t *findIssues) Flush(ctx context.Context, out transform.Writer) {
-	cb := CommandBuilder{Thread: 0}
+	cb := CommandBuilder{Thread: 0, Arena: t.state.Arena}
 	out.MutateAndWrite(ctx, api.CmdNoID, cb.Custom(func(ctx context.Context, s *api.GlobalState, b *builder.Builder) error {
 		// Since the PostBack function is called before the replay target has actually arrived at the post command,
 		// we need to actually write some data here. r.Uint32() is what actually waits for the replay target to have

--- a/gapis/api/gles/read_framebuffer.go
+++ b/gapis/api/gles/read_framebuffer.go
@@ -122,7 +122,7 @@ func postFBData(ctx context.Context,
 	}
 
 	dID := id.Derived()
-	cb := CommandBuilder{Thread: thread}
+	cb := CommandBuilder{Thread: thread, Arena: s.Arena}
 	t := newTweaker(out, dID, cb)
 	defer t.revert(ctx)
 	t.glBindFramebuffer_Read(ctx, fb)

--- a/gapis/api/gles/read_texture.go
+++ b/gapis/api/gles/read_texture.go
@@ -47,7 +47,7 @@ func (t *readTexture) add(ctx context.Context, r *ReadGPUTextureDataResolveable,
 		}
 
 		dID := id.Derived()
-		cb := CommandBuilder{Thread: r.Thread}
+		cb := CommandBuilder{Thread: r.Thread, Arena: s.Arena}
 
 		tex, ok := c.Objects().Textures().Lookup(TextureId(r.Texture))
 		if !ok {

--- a/gapis/api/gles/replay.go
+++ b/gapis/api/gles/replay.go
@@ -304,12 +304,12 @@ func (t *destroyResourcesAtEOS) Flush(ctx context.Context, out transform.Writer)
 		if c.IsNil() {
 			continue
 		}
-		cb := CommandBuilder{Thread: t}
+		cb := CommandBuilder{Thread: t, Arena: s.Arena}
 		cmds = append(cmds, cb.EglMakeCurrent(memory.Nullptr, memory.Nullptr, memory.Nullptr, memory.Nullptr, 1))
 	}
 
 	// Now using a single thread, bind each context and delete all objects.
-	cb := CommandBuilder{Thread: 0}
+	cb := CommandBuilder{Thread: 0, Arena: s.Arena}
 	for i, c := range GetState(s).EGLContexts().All() {
 		if !c.Other().Initialized() {
 			// This context was never bound. Skip it.

--- a/gapis/api/gles/resources.go
+++ b/gapis/api/gles/resources.go
@@ -352,7 +352,7 @@ func (a *GlShaderSource) Replace(ctx context.Context, c *capture.Capture, data *
 	src := state.AllocDataOrPanic(ctx, source)
 	srcLen := state.AllocDataOrPanic(ctx, GLint(len(source)))
 	srcPtr := state.AllocDataOrPanic(ctx, src.Ptr())
-	cb := CommandBuilder{Thread: a.Thread()}
+	cb := CommandBuilder{Thread: a.Thread(), Arena: state.Arena}
 	return cb.GlShaderSource(a.Shader(), 1, srcPtr.Ptr(), srcLen.Ptr()).
 		AddRead(srcPtr.Data()).
 		AddRead(srcLen.Data()).

--- a/gapis/api/gles/state_builder.go
+++ b/gapis/api/gles/state_builder.go
@@ -44,7 +44,7 @@ func (s *State) RebuildState(ctx context.Context, oldState *api.GlobalState) ([]
 		ctx:             ctx,
 		oldState:        oldState,
 		newState:        newState,
-		cb:              CommandBuilder{Thread: 0},
+		cb:              CommandBuilder{Thread: 0, Arena: newState.Arena},
 		seen:            map[interface{}]bool{},
 		memoryIntervals: interval.U64RangeList{},
 	}
@@ -424,7 +424,7 @@ func (sb *stateBuilder) bindContexts(ctx context.Context, s *State) {
 
 	for handle, c := range s.EGLContexts().All() {
 		if thread := c.Other().BoundOnThread(); thread != 0 {
-			cb := CommandBuilder{Thread: thread}
+			cb := CommandBuilder{Thread: thread, Arena: sb.cb.Arena}
 			write(api.WithExtras(cb.EglMakeCurrent(memory.Nullptr, memory.Nullptr, memory.Nullptr, handle, EGLBoolean(1)),
 				c.Other().StaticStateExtra(), c.Other().DynamicStateExtra()))
 		}

--- a/gapis/api/gles/stub_program.go
+++ b/gapis/api/gles/stub_program.go
@@ -45,7 +45,7 @@ func buildStubProgram(ctx context.Context, thread uint64, e *api.CmdExtras, s *a
 		ok := c.Objects().Buffers().Contains(BufferId(x))
 		return ok || x == uint32(vertexShaderID)
 	}))
-	cb := CommandBuilder{Thread: thread}
+	cb := CommandBuilder{Thread: thread, Arena: s.Arena}
 	glLinkProgram := cb.GlLinkProgram(programID)
 	glLinkProgram.Extras().Add(programInfo)
 	return append(

--- a/gapis/api/gles/texture_compat.go
+++ b/gapis/api/gles/texture_compat.go
@@ -149,7 +149,7 @@ func (tc *textureCompat) convertFormat(
 				// Remove the compat mapping and reset swizzles to the original values below.
 				delete(tc.compatSwizzle, t)
 			}
-			cb := CommandBuilder{Thread: cmd.Thread()}
+			cb := CommandBuilder{Thread: cmd.Thread(), Arena: s.Arena}
 			tc.writeCompatSwizzle(ctx, cb, t, GLenum_GL_TEXTURE_SWIZZLE_R, out, id)
 			tc.writeCompatSwizzle(ctx, cb, t, GLenum_GL_TEXTURE_SWIZZLE_G, out, id)
 			tc.writeCompatSwizzle(ctx, cb, t, GLenum_GL_TEXTURE_SWIZZLE_B, out, id)
@@ -207,7 +207,7 @@ func (tc *textureCompat) postTexParameter(ctx context.Context, target, parameter
 			// The tex parameter was recently mutated, so set the original swizzle from current state.
 			tc.origSwizzle[parameter][t] = curr
 			// Combine the original and compat swizzles and write out the commands to set it.
-			cb := CommandBuilder{Thread: cmd.Thread()}
+			cb := CommandBuilder{Thread: cmd.Thread(), Arena: s.Arena}
 			tc.writeCompatSwizzle(ctx, cb, t, parameter, out, id)
 		}
 	case GLenum_GL_TEXTURE_SWIZZLE_RGBA:
@@ -221,7 +221,7 @@ func decompressTexImage2D(ctx context.Context, i api.CmdID, a *GlCompressedTexIm
 	ctx = log.Enter(ctx, "decompressTexImage2D")
 	dID := i.Derived()
 	c := GetContext(s, a.Thread())
-	cb := CommandBuilder{Thread: a.Thread()}
+	cb := CommandBuilder{Thread: a.Thread(), Arena: s.Arena}
 	data := AsU8ˢ(a.Data().Slice(0, uint64(a.ImageSize()), s.MemoryLayout), s.MemoryLayout)
 	if pb := c.Bound().PixelUnpackBuffer(); !pb.IsNil() {
 		offset := a.Data().Address()
@@ -274,7 +274,7 @@ func decompressTexSubImage2D(ctx context.Context, i api.CmdID, a *GlCompressedTe
 	ctx = log.Enter(ctx, "decompressTexSubImage2D")
 	dID := i.Derived()
 	c := GetContext(s, a.Thread())
-	cb := CommandBuilder{Thread: a.Thread()}
+	cb := CommandBuilder{Thread: a.Thread(), Arena: s.Arena}
 	data := AsU8ˢ(a.Data().Slice(0, uint64(a.ImageSize()), s.MemoryLayout), s.MemoryLayout)
 	if pb := c.Bound().PixelUnpackBuffer(); !pb.IsNil() {
 		offset := a.Data().Address()

--- a/gapis/api/gles/undefined_framebuffer.go
+++ b/gapis/api/gles/undefined_framebuffer.go
@@ -94,7 +94,7 @@ func drawUndefinedFramebuffer(ctx context.Context, id api.CmdID, cmd api.Cmd, de
 	positions := []float32{-1., -1., 1., -1., -1., 1., 1., 1.}
 
 	dID := id.Derived()
-	cb := CommandBuilder{Thread: cmd.Thread()}
+	cb := CommandBuilder{Thread: cmd.Thread(), Arena: s.Arena}
 	t := newTweaker(out, id, cb)
 
 	// Temporarily change rasterizing/blending state and enable VAP 0.

--- a/gapis/api/gles/wireframe.go
+++ b/gapis/api/gles/wireframe.go
@@ -48,7 +48,7 @@ func wireframe(ctx context.Context, framebuffer FramebufferId) transform.Transfo
 			}
 
 			dID := id.Derived()
-			cb := CommandBuilder{Thread: cmd.Thread()}
+			cb := CommandBuilder{Thread: cmd.Thread(), Arena: s.Arena}
 
 			t := newTweaker(out, dID, cb)
 			defer t.revert(ctx)
@@ -78,7 +78,7 @@ func wireframeOverlay(ctx context.Context, i api.CmdID) transform.Transformer {
 				out.MutateAndWrite(ctx, id, dc)
 
 				dID := id.Derived()
-				cb := CommandBuilder{Thread: cmd.Thread()}
+				cb := CommandBuilder{Thread: cmd.Thread(), Arena: s.Arena}
 				t := newTweaker(out, dID, cb)
 				t.glEnable(ctx, GLenum_GL_POLYGON_OFFSET_LINE)
 				t.glPolygonOffset(ctx, -1, -1)
@@ -103,7 +103,7 @@ func wireframeOverlay(ctx context.Context, i api.CmdID) transform.Transformer {
 
 func drawWireframe(ctx context.Context, i api.CmdID, dc drawCall, s *api.GlobalState, out transform.Writer) error {
 	c := GetContext(s, dc.Thread())
-	cb := CommandBuilder{Thread: dc.Thread()}
+	cb := CommandBuilder{Thread: dc.Thread(), Arena: s.Arena}
 	dID := i.Derived()
 
 	dci, err := dc.getIndices(ctx, c, s)

--- a/gapis/api/gvr/BUILD.bazel
+++ b/gapis/api/gvr/BUILD.bazel
@@ -76,6 +76,7 @@ go_library(
         "//core/event/task:go_default_library",  # keep
         "//core/image:go_default_library",
         "//core/math/interval:go_default_library",
+        "//core/memory/arena:go_default_library",  # keep
         "//gapil/constset:go_default_library",  # keep
         "//gapis/api:go_default_library",
         "//gapis/api/gles:go_default_library",

--- a/gapis/api/state.go
+++ b/gapis/api/state.go
@@ -25,6 +25,7 @@ import (
 	"github.com/google/gapid/core/data/id"
 	"github.com/google/gapid/core/log"
 	"github.com/google/gapid/core/math/interval"
+	"github.com/google/gapid/core/memory/arena"
 	"github.com/google/gapid/core/os/device"
 	"github.com/google/gapid/gapis/database"
 	"github.com/google/gapid/gapis/memory"
@@ -38,6 +39,9 @@ type GlobalState struct {
 	// MemoryLayout holds information about the device memory layout that was
 	// used to create the capture.
 	MemoryLayout *device.MemoryLayout
+
+	// Arena is the memory arena used for state allocations.
+	Arena arena.Arena
 
 	// Memory holds the memory state of the application.
 	Memory memory.Pools
@@ -106,6 +110,7 @@ func NewStateWithEmptyAllocator(memoryLayout *device.MemoryLayout) *GlobalState 
 func NewStateWithAllocator(allocator memory.Allocator, memoryLayout *device.MemoryLayout) *GlobalState {
 	return &GlobalState{
 		MemoryLayout: memoryLayout,
+		Arena:        arena.New(),
 		Memory:       memory.NewPools(),
 		APIs:         map[ID]State{},
 		Allocator:    allocator,

--- a/gapis/api/state.go
+++ b/gapis/api/state.go
@@ -74,7 +74,7 @@ type State interface {
 	APIObject
 
 	// Clone returns a deep copy of the state object.
-	Clone() State
+	Clone(arena.Arena) State
 
 	// Root returns the path to the root of the state to display. It can vary
 	// based on filtering mode. Returning nil, nil indicates there is no state

--- a/gapis/api/templates/api.go.tmpl
+++ b/gapis/api/templates/api.go.tmpl
@@ -1320,6 +1320,7 @@ import (
   // CommandBuilder is used to construct new {{$.Name}} commands.
   type CommandBuilder struct {
     Thread uint64
+    Arena  arena.Arena
   }
   ¶
   func (cb CommandBuilder) Custom(f func(context.Context, *ϟapi.GlobalState, *builder.Builder) error) *replay.Custom {

--- a/gapis/api/templates/api.go.tmpl
+++ b/gapis/api/templates/api.go.tmpl
@@ -1293,8 +1293,8 @@ import (
     {{Template "DeclareGetterSetter" "Struct" $name "Name" $p.Name "Type" $p.Type "PtrMethod" "true"}}¶
   {{end}}
 
-  // Clone makes a copy of this command.
-  func (ϟc *{{$name}}) Clone() *{{$name}} {
+  // Clone returns a shallow clone of the command. Extras are shared.
+  func (ϟc *{{$name}}) Clone(ϟa arena.Arena) *{{$name}} {
     out := &{{$name}}{
       extras: ϟc.extras,
       caller: ϟc.caller,

--- a/gapis/api/templates/api.go.tmpl
+++ b/gapis/api/templates/api.go.tmpl
@@ -35,6 +35,7 @@ import (
     "github.com/google/gapid/core/data/dictionary"
     "github.com/google/gapid/core/data/id"
     "github.com/google/gapid/core/math/u64"
+    "github.com/google/gapid/core/memory/arena"
 	  "github.com/google/gapid/core/os/device"
     "github.com/google/gapid/gapis/replay"
     "github.com/google/gapid/gapis/replay/builder"
@@ -1405,8 +1406,8 @@ import (
     }
   }
 
-	// Clone returns a deep copy of this state object.
-  func (g *State) Clone() ϟapi.State {
+  // Clone returns a deep copy of this state object.
+  func (g *State) Clone(ϟa arena.Arena) ϟapi.State {
     out := &State{CustomState: g.CustomState}
     {{range $g := $.Globals}}
       {{$name := $g.Name | GoPublicName}}

--- a/gapis/api/templates/convert.go.tmpl
+++ b/gapis/api/templates/convert.go.tmpl
@@ -30,6 +30,7 @@
 ¶
     "github.com/golang/protobuf/proto"¶
 ¶
+    "github.com/google/gapid/core/memory/arena"¶
     "github.com/google/gapid/core/data/protoconv"¶
     "github.com/google/gapid/gapis/api/{{Global "OutputDir"}}/{{Global "Store"}}"¶
     "github.com/google/gapid/gapis/api"¶
@@ -142,7 +143,8 @@
   ¶
   // {{$name}}From builds a {{$name}} from the storage form.¶
   func {{$name}}From(ctx context.Context, from *{{$p}}, ϟrefs *protoconv.FromProtoContext) *{{$name}} {»¶
-    cb := CommandBuilder{uint64(from.GetThread())}¶
+    ϟa := arena.Get(ctx)¶
+    cb := CommandBuilder{uint64(from.GetThread()), ϟa}¶
     {{range $p := $.CallParameters}}
       {{$proto := $p.Name | ProtoGoName}}
       {{$underlying := Underlying $p.Type}}

--- a/gapis/api/test/BUILD.bazel
+++ b/gapis/api/test/BUILD.bazel
@@ -73,6 +73,7 @@ go_test(
         "//core/data/protoconv:go_default_library",
         "//core/event/task:go_default_library",  # keep
         "//core/log:go_default_library",
+        "//core/memory/arena:go_default_library",  # keep
         "//core/os/device:go_default_library",
         "//gapil/constset:go_default_library",  # keep
         "//gapir/client:go_default_library",

--- a/gapis/api/test/intrinsics_test.go
+++ b/gapis/api/test/intrinsics_test.go
@@ -31,7 +31,7 @@ func TestClone(t *testing.T) {
 	ctx := log.Testing(t)
 	ctx = database.Put(ctx, database.NewInMemory(ctx))
 	s := api.NewStateWithEmptyAllocator(device.Little32)
-	cb := CommandBuilder{Thread: 0}
+	cb := CommandBuilder{Thread: 0, Arena: s.Arena}
 	expected := []byte{0x54, 0x33, 0x42, 0x43, 0x46, 0x34, 0x63, 0x24, 0x14, 0x24}
 	api.MutateCmds(ctx, s, nil,
 		cb.CmdClone(p(0x1234), 10).
@@ -47,7 +47,7 @@ func TestMake(t *testing.T) {
 	ctx := log.Testing(t)
 	ctx = database.Put(ctx, database.NewInMemory(ctx))
 	s := api.NewStateWithEmptyAllocator(device.Little32)
-	cb := CommandBuilder{Thread: 0}
+	cb := CommandBuilder{Thread: 0, Arena: s.Arena}
 	idOfFirstPool, _ := s.Memory.New()
 	assert.For(ctx, "initial NextPoolID").That(idOfFirstPool).Equals(memory.PoolID(1))
 	api.MutateCmds(ctx, s, nil,
@@ -63,7 +63,7 @@ func TestCopy(t *testing.T) {
 	ctx := log.Testing(t)
 	ctx = database.Put(ctx, database.NewInMemory(ctx))
 	s := api.NewStateWithEmptyAllocator(device.Little32)
-	cb := CommandBuilder{Thread: 0}
+	cb := CommandBuilder{Thread: 0, Arena: s.Arena}
 	expected := []byte{0x54, 0x33, 0x42, 0x43, 0x46, 0x34, 0x63, 0x24, 0x14, 0x24}
 	api.MutateCmds(ctx, s, nil,
 		cb.CmdMake(10),
@@ -80,7 +80,7 @@ func TestCharsliceToString(t *testing.T) {
 	ctx := log.Testing(t)
 	ctx = database.Put(ctx, database.NewInMemory(ctx))
 	s := api.NewStateWithEmptyAllocator(device.Little32)
-	cb := CommandBuilder{Thread: 0}
+	cb := CommandBuilder{Thread: 0, Arena: s.Arena}
 	expected := "ħęľĺő ŵōřŀď"
 	api.MutateCmds(ctx, s, nil,
 		cb.CmdCharsliceToString(p(0x1234), uint32(len(expected))).
@@ -93,7 +93,7 @@ func TestCharptrToString(t *testing.T) {
 	ctx := log.Testing(t)
 	ctx = database.Put(ctx, database.NewInMemory(ctx))
 	s := api.NewStateWithEmptyAllocator(device.Little32)
-	cb := CommandBuilder{Thread: 0}
+	cb := CommandBuilder{Thread: 0, Arena: s.Arena}
 	expected := "ħęľĺő ŵōřŀď"
 	api.MutateCmds(ctx, s, nil,
 		cb.CmdCharptrToString(p(0x1234)).
@@ -106,7 +106,7 @@ func TestSliceCasts(t *testing.T) {
 	ctx := log.Testing(t)
 	ctx = database.Put(ctx, database.NewInMemory(ctx))
 	s := api.NewStateWithEmptyAllocator(device.Little32)
-	cb := CommandBuilder{Thread: 0}
+	cb := CommandBuilder{Thread: 0, Arena: s.Arena}
 	l := s.MemoryLayout.Clone()
 	l.Integer.Size = 6 // non-multiple of u16
 	s.MemoryLayout = l

--- a/gapis/api/test/mutate_test.go
+++ b/gapis/api/test/mutate_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/google/gapid/core/assert"
 	"github.com/google/gapid/core/data/id"
 	"github.com/google/gapid/core/log"
+	"github.com/google/gapid/core/memory/arena"
 	"github.com/google/gapid/core/os/device"
 	"github.com/google/gapid/gapir/client"
 	"github.com/google/gapid/gapis/api"
@@ -108,7 +109,9 @@ func max(a, b int) int {
 func TestOperationsOpCall_NoIn_NoOut(t *testing.T) {
 	ctx := log.Testing(t)
 	ctx = database.Put(ctx, database.NewInMemory(ctx))
-	cb := CommandBuilder{Thread: 0}
+	a := arena.New()
+	defer a.Dispose()
+	cb := CommandBuilder{Thread: 0, Arena: a}
 	ml := device.Little32
 	test{
 		cmds: []api.Cmd{
@@ -126,7 +129,9 @@ func TestOperationsOpCall_NoIn_NoOut(t *testing.T) {
 func TestOperationsOpCall_Clone(t *testing.T) {
 	ctx := log.Testing(t)
 	ctx = database.Put(ctx, database.NewInMemory(ctx))
-	cb := CommandBuilder{Thread: 0}
+	a := arena.New()
+	defer a.Dispose()
+	cb := CommandBuilder{Thread: 0, Arena: a}
 	ml := device.Little32
 	rng, rID := memory.Store(ctx, ml, p(0x100000), []uint8{5, 6, 7, 8, 9})
 
@@ -151,7 +156,9 @@ func TestOperationsOpCall_Clone(t *testing.T) {
 func TestOperationsOpCall_Make(t *testing.T) {
 	ctx := log.Testing(t)
 	ctx = database.Put(ctx, database.NewInMemory(ctx))
-	cb := CommandBuilder{Thread: 0}
+	a := arena.New()
+	defer a.Dispose()
+	cb := CommandBuilder{Thread: 0, Arena: a}
 	ml := device.Little32
 	test{
 		cmds: []api.Cmd{
@@ -170,7 +177,9 @@ func TestOperationsOpCall_Make(t *testing.T) {
 func TestOperationsOpCall_Copy(t *testing.T) {
 	ctx := log.Testing(t)
 	ctx = database.Put(ctx, database.NewInMemory(ctx))
-	cb := CommandBuilder{Thread: 0}
+	a := arena.New()
+	defer a.Dispose()
+	cb := CommandBuilder{Thread: 0, Arena: a}
 	ml := device.Little32
 	rng, rID := memory.Store(ctx, ml, p(0x100000), []uint8{5, 6, 7, 8, 9})
 
@@ -195,7 +204,9 @@ func TestOperationsOpCall_Copy(t *testing.T) {
 func TestOperationsOpCall_CharSliceToString(t *testing.T) {
 	ctx := log.Testing(t)
 	ctx = database.Put(ctx, database.NewInMemory(ctx))
-	cb := CommandBuilder{Thread: 0}
+	a := arena.New()
+	defer a.Dispose()
+	cb := CommandBuilder{Thread: 0, Arena: a}
 	ml := device.Little32
 	rng, rID := memory.Store(ctx, ml, p(0x100000), []uint8{5, 6, 0, 8, 9})
 
@@ -220,7 +231,9 @@ func TestOperationsOpCall_CharSliceToString(t *testing.T) {
 func TestOperationsOpCall_CharPtrToString(t *testing.T) {
 	ctx := log.Testing(t)
 	ctx = database.Put(ctx, database.NewInMemory(ctx))
-	cb := CommandBuilder{Thread: 0}
+	a := arena.New()
+	defer a.Dispose()
+	cb := CommandBuilder{Thread: 0, Arena: a}
 	ml := device.Little32
 	_, rID := memory.Store(ctx, ml, p(0x100000), []uint8{'g', 'o', 'o', 'd', 0})
 
@@ -245,7 +258,9 @@ func TestOperationsOpCall_CharPtrToString(t *testing.T) {
 func TestOperationsOpCall_Unknowns(t *testing.T) {
 	ctx := log.Testing(t)
 	ctx = database.Put(ctx, database.NewInMemory(ctx))
-	cb := CommandBuilder{Thread: 0}
+	a := arena.New()
+	defer a.Dispose()
+	cb := CommandBuilder{Thread: 0, Arena: a}
 	ml := &device.MemoryLayout{
 		Endian:  device.LittleEndian,
 		Pointer: &device.DataTypeLayout{Size: 4, Alignment: 4},
@@ -291,7 +306,9 @@ func TestOperationsOpCall_Unknowns(t *testing.T) {
 func TestOperationsOpCall_SingleInputArg(t *testing.T) {
 	ctx := log.Testing(t)
 	ctx = database.Put(ctx, database.NewInMemory(ctx))
-	cb := CommandBuilder{Thread: 0}
+	a := arena.New()
+	defer a.Dispose()
+	cb := CommandBuilder{Thread: 0, Arena: a}
 	ml := device.Little32
 	test{
 		cmds: []api.Cmd{
@@ -366,7 +383,9 @@ func TestOperationsOpCall_SingleInputArg(t *testing.T) {
 func TestOperationsOpCall_3_Strings(t *testing.T) {
 	ctx := log.Testing(t)
 	ctx = database.Put(ctx, database.NewInMemory(ctx))
-	cb := CommandBuilder{Thread: 0}
+	a := arena.New()
+	defer a.Dispose()
+	cb := CommandBuilder{Thread: 0, Arena: a}
 	ml := device.Little32
 	test{
 		cmds: []api.Cmd{
@@ -391,7 +410,9 @@ func TestOperationsOpCall_3_Strings(t *testing.T) {
 func TestOperationsOpCall_3_In_Arrays(t *testing.T) {
 	ctx := log.Testing(t)
 	ctx = database.Put(ctx, database.NewInMemory(ctx))
-	cb := CommandBuilder{Thread: 0}
+	a := arena.New()
+	defer a.Dispose()
+	cb := CommandBuilder{Thread: 0, Arena: a}
 	ml := device.Little64
 
 	aRng, aID := memory.Store(ctx, ml, p(0x40000+5* /* sizeof(u8)  */ 1), []uint8{
@@ -442,7 +463,9 @@ func TestOperationsOpCall_3_In_Arrays(t *testing.T) {
 func TestOperationsOpCall_InArrayOfStrings(t *testing.T) {
 	ctx := log.Testing(t)
 	ctx = database.Put(ctx, database.NewInMemory(ctx))
-	cb := CommandBuilder{Thread: 0}
+	a := arena.New()
+	defer a.Dispose()
+	cb := CommandBuilder{Thread: 0, Arena: a}
 	ml := device.Little32
 
 	aRng, aID := memory.Store(ctx, ml, p(0x100000), "array")
@@ -521,7 +544,9 @@ func TestOperationsOpCall_InArrayOfStrings(t *testing.T) {
 func TestOperationsOpCall_InArrayOfStrings_32bitTo64Bit(t *testing.T) {
 	ctx := log.Testing(t)
 	ctx = database.Put(ctx, database.NewInMemory(ctx))
-	cb := CommandBuilder{Thread: 0}
+	a := arena.New()
+	defer a.Dispose()
+	cb := CommandBuilder{Thread: 0, Arena: a}
 	ca := device.Little32
 	ra := device.Little64
 
@@ -601,7 +626,9 @@ func TestOperationsOpCall_InArrayOfStrings_32bitTo64Bit(t *testing.T) {
 func TestOperationsOpCall_SinglePointerElementRead(t *testing.T) {
 	ctx := log.Testing(t)
 	ctx = database.Put(ctx, database.NewInMemory(ctx))
-	cb := CommandBuilder{Thread: 0}
+	a := arena.New()
+	defer a.Dispose()
+	cb := CommandBuilder{Thread: 0, Arena: a}
 	ml := device.Little32
 	p := memory.Pointer(p(0x100000))
 	rng1, id1 := memory.Store(ctx, ml, p, []byte{
@@ -721,7 +748,9 @@ func TestOperationsOpCall_SinglePointerElementRead(t *testing.T) {
 func TestOperationsOpCall_MultiplePointerElementReads(t *testing.T) {
 	ctx := log.Testing(t)
 	ctx = database.Put(ctx, database.NewInMemory(ctx))
-	cb := CommandBuilder{Thread: 0}
+	a := arena.New()
+	defer a.Dispose()
+	cb := CommandBuilder{Thread: 0, Arena: a}
 	ml := &device.MemoryLayout{
 		Endian:  device.LittleEndian,
 		Pointer: &device.DataTypeLayout{Size: 4, Alignment: 16},
@@ -769,7 +798,9 @@ func TestOperationsOpCall_MultiplePointerElementReads(t *testing.T) {
 func TestOperationsOpCall_SinglePointerElementWrite(t *testing.T) {
 	ctx := log.Testing(t)
 	ctx = database.Put(ctx, database.NewInMemory(ctx))
-	cb := CommandBuilder{Thread: 0}
+	a := arena.New()
+	defer a.Dispose()
+	cb := CommandBuilder{Thread: 0, Arena: a}
 	ml := device.Little32
 	test{
 		cmds: []api.Cmd{
@@ -839,7 +870,9 @@ func TestOperationsOpCall_SinglePointerElementWrite(t *testing.T) {
 func TestOperationsOpCall_MultiplePointerElementWrites(t *testing.T) {
 	ctx := log.Testing(t)
 	ctx = database.Put(ctx, database.NewInMemory(ctx))
-	cb := CommandBuilder{Thread: 0}
+	a := arena.New()
+	defer a.Dispose()
+	cb := CommandBuilder{Thread: 0, Arena: a}
 	ml := &device.MemoryLayout{
 		Endian:  device.LittleEndian,
 		Pointer: &device.DataTypeLayout{Size: 4, Alignment: 16},
@@ -873,7 +906,9 @@ func TestOperationsOpCall_MultiplePointerElementWrites(t *testing.T) {
 func TestOperationsOpCall_ReturnValue(t *testing.T) {
 	ctx := log.Testing(t)
 	ctx = database.Put(ctx, database.NewInMemory(ctx))
-	cb := CommandBuilder{Thread: 0}
+	a := arena.New()
+	defer a.Dispose()
+	cb := CommandBuilder{Thread: 0, Arena: a}
 	ml := device.Little32
 	test{
 		cmds: []api.Cmd{
@@ -927,7 +962,9 @@ func TestOperationsOpCall_ReturnValue(t *testing.T) {
 func TestOperationsOpCall_3Remapped(t *testing.T) {
 	ctx := log.Testing(t)
 	ctx = database.Put(ctx, database.NewInMemory(ctx))
-	cb := CommandBuilder{Thread: 0}
+	a := arena.New()
+	defer a.Dispose()
+	cb := CommandBuilder{Thread: 0, Arena: a}
 	ml := device.Little32
 	test{
 		cmds: []api.Cmd{
@@ -957,7 +994,9 @@ func TestOperationsOpCall_3Remapped(t *testing.T) {
 func TestOperationsOpCall_InArrayOfRemapped(t *testing.T) {
 	ctx := log.Testing(t)
 	ctx = database.Put(ctx, database.NewInMemory(ctx))
-	cb := CommandBuilder{Thread: 0}
+	a := arena.New()
+	defer a.Dispose()
+	cb := CommandBuilder{Thread: 0, Arena: a}
 	ml := device.Little32
 	rng, id := memory.Store(ctx, ml, p(0x100000), []Remapped{10, 20, 10, 30, 20})
 
@@ -1009,7 +1048,9 @@ func TestOperationsOpCall_InArrayOfRemapped(t *testing.T) {
 func TestOperationsOpCall_OutArrayOfRemapped(t *testing.T) {
 	ctx := log.Testing(t)
 	ctx = database.Put(ctx, database.NewInMemory(ctx))
-	cb := CommandBuilder{Thread: 0}
+	a := arena.New()
+	defer a.Dispose()
+	cb := CommandBuilder{Thread: 0, Arena: a}
 	ml := device.Little32
 	pbase := uint32(4 * 3) // parameter array base address
 	tbase := uint32(0)     // remap table base address
@@ -1053,7 +1094,9 @@ func TestOperationsOpCall_OutArrayOfRemapped(t *testing.T) {
 func TestOperationsOpCall_OutArrayOfUnknownRemapped(t *testing.T) {
 	ctx := log.Testing(t)
 	ctx = database.Put(ctx, database.NewInMemory(ctx))
-	cb := CommandBuilder{Thread: 0}
+	a := arena.New()
+	defer a.Dispose()
+	cb := CommandBuilder{Thread: 0, Arena: a}
 	ml := device.Little32
 	pbase := uint32(4 * 3) // parameter array base address
 	tbase := uint32(0)     // remap table base address
@@ -1097,7 +1140,9 @@ func TestOperationsOpCall_OutArrayOfUnknownRemapped(t *testing.T) {
 func TestOperationsOpCall_Remapped(t *testing.T) {
 	ctx := log.Testing(t)
 	ctx = database.Put(ctx, database.NewInMemory(ctx))
-	cb := CommandBuilder{Thread: 0}
+	a := arena.New()
+	defer a.Dispose()
+	cb := CommandBuilder{Thread: 0, Arena: a}
 	ml := device.Little32
 	test{
 		cmds: []api.Cmd{
@@ -1131,7 +1176,9 @@ func TestOperationsOpCall_Remapped(t *testing.T) {
 func TestOperationsOpCall_ReadRemappedStruct(t *testing.T) {
 	ctx := log.Testing(t)
 	ctx = database.Put(ctx, database.NewInMemory(ctx))
-	cb := CommandBuilder{Thread: 0}
+	a := arena.New()
+	defer a.Dispose()
+	cb := CommandBuilder{Thread: 0, Arena: a}
 	ml := device.Little32
 
 	aRng, aID := memory.Store(ctx, ml, p(0x100000), NewRemappedStruct(10, 20, 30))
@@ -1205,7 +1252,9 @@ func TestOperationsOpCall_ReadRemappedStruct(t *testing.T) {
 func TestOperationsOpCall_ReadPointerStruct(t *testing.T) {
 	ctx := log.Testing(t)
 	ctx = database.Put(ctx, database.NewInMemory(ctx))
-	cb := CommandBuilder{Thread: 0}
+	a := arena.New()
+	defer a.Dispose()
+	cb := CommandBuilder{Thread: 0, Arena: a}
 	ml := device.Little32
 
 	aRng, aID := memory.Store(
@@ -1291,7 +1340,9 @@ func TestOperationsOpCall_ReadPointerStruct(t *testing.T) {
 func TestOperationsOpCall_ReadNestedStruct(t *testing.T) {
 	ctx := log.Testing(t)
 	ctx = database.Put(ctx, database.NewInMemory(ctx))
-	cb := CommandBuilder{Thread: 0}
+	a := arena.New()
+	defer a.Dispose()
+	cb := CommandBuilder{Thread: 0, Arena: a}
 	ml := device.Little32
 
 	nestedRng, nestedID := memory.Store(
@@ -1408,7 +1459,9 @@ func TestOperationsOpCall_ReadNestedStruct(t *testing.T) {
 func TestOperationsOpCall_ReadStringStruct(t *testing.T) {
 	ctx := log.Testing(t)
 	ctx = database.Put(ctx, database.NewInMemory(ctx))
-	cb := CommandBuilder{Thread: 0}
+	a := arena.New()
+	defer a.Dispose()
+	cb := CommandBuilder{Thread: 0, Arena: a}
 	ml := device.Little32
 
 	aRng, aID := memory.Store(ctx, ml, p(0x100000), "array")
@@ -1495,7 +1548,9 @@ func TestOperationsOpCall_ReadStringStruct(t *testing.T) {
 func TestOperationsOpCall_ReadAndConditionalWrite(t *testing.T) {
 	ctx := log.Testing(t)
 	ctx = database.Put(ctx, database.NewInMemory(ctx))
-	cb := CommandBuilder{Thread: 0}
+	a := arena.New()
+	defer a.Dispose()
+	cb := CommandBuilder{Thread: 0, Arena: a}
 	ml := device.Little32
 	rRng, rID := memory.Store(ctx, ml, p(0x100000), uint32(3))                  // read for all cases
 	awcRng, awcID := memory.Store(ctx, ml, p(0x100000), uint32(2))              // write to count for Case 1

--- a/gapis/api/test/subroutines_test.go
+++ b/gapis/api/test/subroutines_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/google/gapid/core/assert"
 	"github.com/google/gapid/core/log"
+	"github.com/google/gapid/core/memory/arena"
 	"github.com/google/gapid/core/os/device"
 	"github.com/google/gapid/gapis/api"
 	"github.com/google/gapid/gapis/database"
@@ -28,7 +29,9 @@ import (
 func TestSubAdd(t *testing.T) {
 	ctx := log.Testing(t)
 	ctx = database.Put(ctx, database.NewInMemory(ctx))
-	cb := CommandBuilder{Thread: 0}
+	a := arena.New()
+	defer a.Dispose()
+	cb := CommandBuilder{Thread: 0, Arena: a}
 	s := api.NewStateWithEmptyAllocator(device.Little32)
 	api.MutateCmds(ctx, s, nil, cb.CmdAdd(10, 20))
 	got, err := GetState(s).Ints().Read(ctx, nil, s, nil)

--- a/gapis/api/vulkan/BUILD.bazel
+++ b/gapis/api/vulkan/BUILD.bazel
@@ -86,6 +86,7 @@ go_library(
         "//core/image/astc:go_default_library",
         "//core/log:go_default_library",
         "//core/math/interval:go_default_library",
+        "//core/memory/arena:go_default_library",  # keep
         "//core/os/device:go_default_library",
         "//core/stream:go_default_library",
         "//core/stream/fmts:go_default_library",

--- a/gapis/api/vulkan/BUILD.bazel
+++ b/gapis/api/vulkan/BUILD.bazel
@@ -143,6 +143,7 @@ go_test(
         "//core/image:go_default_library",
         "//core/log:go_default_library",
         "//core/math/interval:go_default_library",
+        "//core/memory/arena:go_default_library",
         "//core/os/device:go_default_library",
         "//gapis/api:go_default_library",
         "//gapis/memory:go_default_library",

--- a/gapis/api/vulkan/custom_replay.go
+++ b/gapis/api/vulkan/custom_replay.go
@@ -235,7 +235,7 @@ func (i VkDebugReportCallbackEXT) remap(api.Cmd, *api.GlobalState) (key interfac
 }
 
 func (a *VkCreateInstance) Mutate(ctx context.Context, id api.CmdID, s *api.GlobalState, b *builder.Builder) error {
-	cb := CommandBuilder{Thread: a.Thread()}
+	cb := CommandBuilder{Thread: a.Thread(), Arena: s.Arena}
 	// Hijack VkCreateInstance's Mutate() method entirely with our ReplayCreateVkInstance's Mutate().
 
 	// As long as we guarantee that the synthetic replayCreateVkInstance API function has the same
@@ -258,7 +258,7 @@ func (a *VkCreateInstance) Mutate(ctx context.Context, id api.CmdID, s *api.Glob
 }
 
 func (a *VkDestroyInstance) Mutate(ctx context.Context, id api.CmdID, s *api.GlobalState, b *builder.Builder) error {
-	cb := CommandBuilder{Thread: a.Thread()}
+	cb := CommandBuilder{Thread: a.Thread(), Arena: s.Arena}
 	// Call the underlying vkDestroyInstance() and do the observation.
 	err := a.mutate(ctx, id, s, b)
 	if b == nil || err != nil {
@@ -308,7 +308,7 @@ func (a *VkCreateDevice) Mutate(ctx context.Context, id api.CmdID, s *api.Global
 		allocated = append(allocated, &newCreateInfoData)
 		createInfoPtr = NewVkDeviceCreateInfoᶜᵖ(newCreateInfoData.Ptr())
 
-		cb := CommandBuilder{Thread: a.Thread()}
+		cb := CommandBuilder{Thread: a.Thread(), Arena: s.Arena}
 		hijack := cb.ReplayCreateVkDevice(a.PhysicalDevice(), createInfoPtr, a.PAllocator(), a.PDevice(), a.Result())
 		hijack.Extras().MustClone(a.Extras().All()...)
 
@@ -330,7 +330,7 @@ func (a *VkCreateDevice) Mutate(ctx context.Context, id api.CmdID, s *api.Global
 
 func (a *VkDestroyDevice) Mutate(ctx context.Context, id api.CmdID, s *api.GlobalState, b *builder.Builder) error {
 	// Call the underlying vkDestroyDevice() and do the observation.
-	cb := CommandBuilder{Thread: a.Thread()}
+	cb := CommandBuilder{Thread: a.Thread(), Arena: s.Arena}
 	err := a.mutate(ctx, id, s, b)
 	if b == nil || err != nil {
 		return err
@@ -341,7 +341,7 @@ func (a *VkDestroyDevice) Mutate(ctx context.Context, id api.CmdID, s *api.Globa
 
 func (a *VkAllocateCommandBuffers) Mutate(ctx context.Context, id api.CmdID, s *api.GlobalState, b *builder.Builder) error {
 	// Call the underlying vkAllocateCommandBuffers() and do the observation.
-	cb := CommandBuilder{Thread: a.Thread()}
+	cb := CommandBuilder{Thread: a.Thread(), Arena: s.Arena}
 	err := a.mutate(ctx, id, s, b)
 	if b == nil || err != nil {
 		return err
@@ -353,7 +353,7 @@ func (a *VkAllocateCommandBuffers) Mutate(ctx context.Context, id api.CmdID, s *
 
 func (a *VkFreeCommandBuffers) Mutate(ctx context.Context, id api.CmdID, s *api.GlobalState, b *builder.Builder) error {
 	// Call the underlying vkFreeCommandBuffers() and do the observation.
-	cb := CommandBuilder{Thread: a.Thread()}
+	cb := CommandBuilder{Thread: a.Thread(), Arena: s.Arena}
 	err := a.mutate(ctx, id, s, b)
 	if b == nil || err != nil {
 		return err
@@ -368,7 +368,7 @@ func (a *VkCreateSwapchainKHR) Mutate(ctx context.Context, id api.CmdID, s *api.
 		return a.mutate(ctx, id, s, b)
 	}
 
-	cb := CommandBuilder{Thread: a.Thread()}
+	cb := CommandBuilder{Thread: a.Thread(), Arena: s.Arena}
 	hijack := cb.ReplayCreateSwapchain(a.Device(), a.PCreateInfo(), a.PAllocator(), a.PSwapchain(), a.Result())
 	hijack.Extras().MustClone(a.Extras().All()...)
 	err := hijack.Mutate(ctx, id, s, b)
@@ -399,7 +399,7 @@ func (a *VkAcquireNextImageKHR) Mutate(ctx context.Context, id api.CmdID, s *api
 }
 
 func (a *VkGetFenceStatus) Mutate(ctx context.Context, id api.CmdID, s *api.GlobalState, b *builder.Builder) error {
-	cb := CommandBuilder{Thread: a.Thread()}
+	cb := CommandBuilder{Thread: a.Thread(), Arena: s.Arena}
 	err := a.mutate(ctx, id, s, b)
 	if b == nil || err != nil {
 		return err
@@ -409,7 +409,7 @@ func (a *VkGetFenceStatus) Mutate(ctx context.Context, id api.CmdID, s *api.Glob
 }
 
 func (a *VkGetEventStatus) Mutate(ctx context.Context, id api.CmdID, s *api.GlobalState, b *builder.Builder) error {
-	cb := CommandBuilder{Thread: a.Thread()}
+	cb := CommandBuilder{Thread: a.Thread(), Arena: s.Arena}
 	err := a.mutate(ctx, id, s, b)
 	if b == nil || err != nil {
 		return err

--- a/gapis/api/vulkan/externs_test.go
+++ b/gapis/api/vulkan/externs_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/google/gapid/core/log"
+	"github.com/google/gapid/core/memory/arena"
 	"github.com/google/gapid/core/os/device"
 	"github.com/google/gapid/gapis/api"
 	"github.com/google/gapid/gapis/memory"
@@ -26,7 +27,9 @@ import (
 func TestCallReflectedCommand(t *testing.T) {
 	ctx := log.Testing(t)
 	s := api.NewStateWithEmptyAllocator(device.Little32)
-	cb := CommandBuilder{}
+	a := arena.New()
+	defer a.Dispose()
+	cb := CommandBuilder{Arena: a}
 	cmd := cb.VkCreateBuffer(
 		VkDevice(0),
 		memory.Nullptr,

--- a/gapis/api/vulkan/find_issues.go
+++ b/gapis/api/vulkan/find_issues.go
@@ -64,7 +64,7 @@ func (t *findIssues) Transform(ctx context.Context, id api.CmdID, cmd api.Cmd, o
 }
 
 func (t *findIssues) Flush(ctx context.Context, out transform.Writer) {
-	cb := CommandBuilder{Thread: 0}
+	cb := CommandBuilder{Thread: 0, Arena: t.state.Arena}
 	out.MutateAndWrite(ctx, api.CmdNoID, cb.Custom(func(ctx context.Context, s *api.GlobalState, b *builder.Builder) error {
 		// Since the PostBack function is called before the replay target has actually arrived at the post command,
 		// we need to actually write some data here. r.Uint32() is what actually waits for the replay target to have

--- a/gapis/api/vulkan/read_framebuffer.go
+++ b/gapis/api/vulkan/read_framebuffer.go
@@ -101,7 +101,7 @@ func (t *readFramebuffer) Depth(id api.CmdID, idx uint32, res replay.Result) {
 			res(nil, fmt.Errorf("Invalid depth attachment in the framebuffer, the attachment VkImage might have been destroyed"))
 			return
 		}
-		cb := CommandBuilder{Thread: cmd.Thread()}
+		cb := CommandBuilder{Thread: cmd.Thread(), Arena: s.Arena}
 		// Imageviews that are used in framebuffer attachments must contains
 		// only one mip level.
 		level := imageViewDepth.SubresourceRange().BaseMipLevel()
@@ -118,7 +118,7 @@ func (t *readFramebuffer) Color(id api.CmdID, width, height, bufferIdx uint32, r
 		s := out.State()
 		c := GetState(s)
 
-		cb := CommandBuilder{Thread: cmd.Thread()}
+		cb := CommandBuilder{Thread: cmd.Thread(), Arena: s.Arena}
 
 		// TODO: Figure out a better way to select the framebuffer here.
 		if GetState(s).LastSubmission() == LastSubmissionType_SUBMIT {

--- a/gapis/api/vulkan/replay.go
+++ b/gapis/api/vulkan/replay.go
@@ -148,7 +148,7 @@ func patchImageUsage(usage VkImageUsageFlags) (VkImageUsageFlags, bool) {
 func (t *makeAttachementReadable) Transform(ctx context.Context, id api.CmdID, cmd api.Cmd, out transform.Writer) {
 	s := out.State()
 	l := s.MemoryLayout
-	cb := CommandBuilder{Thread: cmd.Thread()}
+	cb := CommandBuilder{Thread: cmd.Thread(), Arena: s.Arena}
 	cmd.Extras().Observations().ApplyReads(s.Memory.ApplicationPool())
 
 	if image, ok := cmd.(*VkCreateImage); ok {
@@ -317,7 +317,7 @@ func (t *destroyResourcesAtEOS) Flush(ctx context.Context, out transform.Writer)
 	s := out.State()
 	so := getStateObject(s)
 	id := api.CmdNoID
-	cb := CommandBuilder{Thread: 0} // TODO: Check that using any old thread is okay.
+	cb := CommandBuilder{Thread: 0, Arena: s.Arena} // TODO: Check that using any old thread is okay.
 	// TODO: use the correct pAllocator once we handle it.
 	p := memory.Nullptr
 

--- a/gapis/api/vulkan/resources.go
+++ b/gapis/api/vulkan/resources.go
@@ -770,7 +770,7 @@ func (shader ShaderModuleObjectʳ) SetResourceData(
 
 func (cmd *VkCreateShaderModule) Replace(ctx context.Context, c *capture.Capture, data *api.ResourceData) interface{} {
 	ctx = log.Enter(ctx, "VkCreateShaderModule.Replace()")
-	cb := CommandBuilder{Thread: cmd.Thread()}
+	cb := CommandBuilder{Thread: cmd.Thread(), Arena: c.Arena} // TODO: We probably should have a new arena passed in here!
 	state := c.NewState(ctx)
 	cmd.Mutate(ctx, api.CmdNoID, state, nil)
 

--- a/gapis/api/vulkan/state_rebuilder.go
+++ b/gapis/api/vulkan/state_rebuilder.go
@@ -45,7 +45,7 @@ func (s *State) RebuildState(ctx context.Context, oldState *api.GlobalState) ([]
 		s:               s,
 		oldState:        oldState,
 		newState:        newState,
-		cb:              CommandBuilder{Thread: 0},
+		cb:              CommandBuilder{Thread: 0, Arena: newState.Arena},
 		memoryIntervals: interval.U64RangeList{},
 	}
 

--- a/gapis/api/vulkan/vulkan.go
+++ b/gapis/api/vulkan/vulkan.go
@@ -409,7 +409,7 @@ func (API) RecoverMidExecutionCommand(ctx context.Context, c *path.Capture, dat 
 	}
 	s := GetState(st)
 
-	cb := CommandBuilder{Thread: 0}
+	cb := CommandBuilder{Thread: 0, Arena: st.Arena}
 	_, a, err := AddCommand(ctx, cb, cr.Buffer(), st, st, GetCommandArgs(ctx, cr, s))
 	if err != nil {
 		return nil, log.Errf(ctx, err, "Invalid Command")

--- a/gapis/api/vulkan/vulkan_terminator.go
+++ b/gapis/api/vulkan/vulkan_terminator.go
@@ -311,7 +311,7 @@ func rebuildCommandBuffer(ctx context.Context,
 func cutCommandBuffer(ctx context.Context, id api.CmdID,
 	a *VkQueueSubmit, idx api.SubCmdIdx, out transform.Writer) {
 	s := out.State()
-	cb := CommandBuilder{Thread: a.Thread()}
+	cb := CommandBuilder{Thread: a.Thread(), Arena: s.Arena}
 	c := GetState(s)
 	l := s.MemoryLayout
 	o := a.Extras().Observations()

--- a/gapis/api/vulkan/wireframe.go
+++ b/gapis/api/vulkan/wireframe.go
@@ -30,7 +30,7 @@ func wireframe(ctx context.Context) transform.Transformer {
 		id api.CmdID, cmd api.Cmd, out transform.Writer) {
 		s := out.State()
 		l := s.MemoryLayout
-		cb := CommandBuilder{Thread: cmd.Thread()}
+		cb := CommandBuilder{Thread: cmd.Thread(), Arena: s.Arena}
 		cmd.Extras().Observations().ApplyReads(s.Memory.ApplicationPool())
 		switch cmd := cmd.(type) {
 		case *VkCreateGraphicsPipelines:

--- a/gapis/capture/BUILD.bazel
+++ b/gapis/capture/BUILD.bazel
@@ -35,6 +35,7 @@ go_library(
         "//core/data/protoconv:go_default_library",
         "//core/log:go_default_library",
         "//core/math/interval:go_default_library",
+        "//core/memory/arena:go_default_library",
         "//gapis/api:go_default_library",
         "//gapis/database:go_default_library",
         "//gapis/memory:go_default_library",

--- a/gapis/capture/capture.go
+++ b/gapis/capture/capture.go
@@ -142,7 +142,7 @@ func (c *Capture) NewState(ctx context.Context) *api.GlobalState {
 			pool.Write(m.Range.Base, memory.Resource(m.ID, m.Range.Size))
 		}
 		for k, v := range c.InitialState.APIs {
-			s.APIs[k.ID()] = v.Clone()
+			s.APIs[k.ID()] = v.Clone(s.Arena)
 		}
 		for _, v := range s.APIs {
 			v.SetupInitialState(ctx, s)

--- a/test/integration/gles/snippets/builder.go
+++ b/test/integration/gles/snippets/builder.go
@@ -43,10 +43,12 @@ type Builder struct {
 // NewBuilder returns a new builder.
 func NewBuilder(ctx context.Context, dev *device.Instance) *Builder {
 	abi := dev.Configuration.ABIs[0]
+	state := api.NewStateWithEmptyAllocator(abi.MemoryLayout)
 	return &Builder{
+		CB:               gles.CommandBuilder{Arena: state.Arena},
 		device:           dev,
 		abi:              abi,
-		state:            api.NewStateWithEmptyAllocator(abi.MemoryLayout),
+		state:            state,
 		programResources: map[gles.ProgramId]gles.ActiveProgramResourcesʳ{},
 	}
 }


### PR DESCRIPTION
This is the first of a bunch of changes that introduces arenas to the API types.
Currently these arenas are not used by anything - I want this in now so that the CLs that use them (impending, but some way off) don't need continual rebasing.