### PR TITLE
gapis/api: Kill map Set method()

### DIFF
--- a/gapis/api/templates/api.go.tmpl
+++ b/gapis/api/templates/api.go.tmpl
@@ -264,10 +264,6 @@ import (
     return
   }
 
-  func (m {{$name}}) Set(key {{$key}}, val {{$value}}) {
-    (*m.Map)[key] = val
-  }
-
   func (m {{$name}}) Add(key {{$key}}, val {{$value}}) {{$name}} {
     (*m.Map)[key] = val
     return m

--- a/gapis/api/templates/mutate.go.tmpl
+++ b/gapis/api/templates/mutate.go.tmpl
@@ -575,7 +575,7 @@
   {{AssertType $ "MapAssign"}}
 
   {{if eq $.Operator "="}}
-    {{Template "Go.Read" $.To.Map}}.Set({{Template "Go.Read" $.To.Index}},{{Template "Go.Read" $.Value}})
+    {{Template "Go.Read" $.To.Map}}.Add({{Template "Go.Read" $.To.Index}},{{Template "Go.Read" $.Value}})
   {{else}}
     {{Error "Unsupported MapAssign operator %s" $.Operator}}
   {{end}}


### PR DESCRIPTION
This has been replaced by `Add()` and its existence is a relic.