### PR TITLE
Optimize byte slice copies

### DIFF
--- a/gapis/api/templates/api.go.tmpl
+++ b/gapis/api/templates/api.go.tmpl
@@ -628,11 +628,15 @@ import (
     func (s {{$slice_ty}}) Read(ϟctx context.Context, ϟc ϟapi.Cmd, ϟg *ϟapi.GlobalState, ϟb *builder.Builder) ([]{{$el_ty}}, error) {
       ϟa := ϟg.Arena; _ = ϟa
       s.OnRead(ϟctx, ϟc, ϟg, ϟb)
-      ϟd := s.Decoder(ϟctx, ϟg)
       out := make([]{{$el_ty}}, s.Count())
-      for i := range out {
-        out[i] = {{Template "Go.Decode" $s.To}}
-      }
+      ϟd := s.Decoder(ϟctx, ϟg)
+      {{if IsU8 $s.To}}
+        ϟd.Data(out)
+      {{else}}
+        for i := range out {
+          out[i] = {{Template "Go.Decode" $s.To}}
+        }
+      {{end}}
       if err := ϟd.Error(); err != nil {
         return nil, err
       }


### PR DESCRIPTION
This optimizes byte slice operations, we know the alignment/padding of all byte slice copies, and can short-circuit that.
```
sha                         | 439258          | 9763af
report-time                 | 35.587207037    | 15.145947193  (-57.4%)
linearize-time              | 68.196633551    | 25.444779976  (-62.7%)
```