### PR TITLE
Add enum annotation @analyze_usage to opt-in to usage analysis

### DIFF
--- a/gapil/analysis/value.go
+++ b/gapil/analysis/value.go
@@ -409,27 +409,7 @@ func (s *scope) valueOf(n semantic.Expression) (out Value, setter func(Value)) {
 
 	case *semantic.EnumEntry:
 		v, _ := s.valueOf(n.Value)
-		var i uint64
-		switch v := n.Value.(type) {
-		case semantic.Uint8Value:
-			i = uint64(v)
-		case semantic.Int8Value:
-			i = uint64(v)
-		case semantic.Uint16Value:
-			i = uint64(v)
-		case semantic.Int16Value:
-			i = uint64(v)
-		case semantic.Uint32Value:
-			i = uint64(v)
-		case semantic.Int32Value:
-			i = uint64(v)
-		case semantic.Uint64Value:
-			i = uint64(v)
-		case semantic.Int64Value:
-			i = uint64(v)
-		default:
-			panic(fmt.Errorf("EnumEntry value was of type %v", n.Value))
-		}
+		i := semantic.AsUint64(n.Value)
 		return &EnumValue{
 			Ty:      n.Owner().(*semantic.Enum),
 			Numbers: v.(*UintValue),

--- a/gapil/analysis/value.go
+++ b/gapil/analysis/value.go
@@ -409,7 +409,10 @@ func (s *scope) valueOf(n semantic.Expression) (out Value, setter func(Value)) {
 
 	case *semantic.EnumEntry:
 		v, _ := s.valueOf(n.Value)
-		i := semantic.AsUint64(n.Value)
+		i, ok := semantic.AsUint64(n.Value)
+		if !ok {
+			panic(fmt.Errorf("EnumEntry value was of type %v", n.Value))
+		}
 		return &EnumValue{
 			Ty:      n.Owner().(*semantic.Enum),
 			Numbers: v.(*UintValue),

--- a/gapil/semantic/type.go
+++ b/gapil/semantic/type.go
@@ -512,6 +512,30 @@ func UnsignedInteger(size int32) Type {
 	}
 }
 
+// AsUint64 converts a sized integer value to a uint64.
+func AsUint64(val Expression) uint64 {
+	switch v := val.(type) {
+	case Int8Value:
+		return uint64(v)
+	case Uint8Value:
+		return uint64(v)
+	case Int16Value:
+		return uint64(v)
+	case Uint16Value:
+		return uint64(v)
+	case Int32Value:
+		return uint64(v)
+	case Uint32Value:
+		return uint64(v)
+	case Int64Value:
+		return uint64(v)
+	case Uint64Value:
+		return uint64(v)
+	default:
+		panic(fmt.Sprintf("Attempted to convert %v to uint64", val.ExpressionType()))
+	}
+}
+
 // Underlying returns the underlying type for ty by recursively traversing the
 // pseudonym chain until reaching and returning the first non-pseudoym type.
 // If ty is not a pseudonym then it is simply returned.

--- a/gapil/semantic/type.go
+++ b/gapil/semantic/type.go
@@ -513,26 +513,26 @@ func UnsignedInteger(size int32) Type {
 }
 
 // AsUint64 converts a sized integer value to a uint64.
-func AsUint64(val Expression) uint64 {
+func AsUint64(val Expression) (uint64, bool) {
 	switch v := val.(type) {
 	case Int8Value:
-		return uint64(v)
+		return uint64(v), true
 	case Uint8Value:
-		return uint64(v)
+		return uint64(v), true
 	case Int16Value:
-		return uint64(v)
+		return uint64(v), true
 	case Uint16Value:
-		return uint64(v)
+		return uint64(v), true
 	case Int32Value:
-		return uint64(v)
+		return uint64(v), true
 	case Uint32Value:
-		return uint64(v)
+		return uint64(v), true
 	case Int64Value:
-		return uint64(v)
+		return uint64(v), true
 	case Uint64Value:
-		return uint64(v)
+		return uint64(v), true
 	default:
-		panic(fmt.Sprintf("Attempted to convert %v to uint64", val.ExpressionType()))
+		return uint64(0), false
 	}
 }
 

--- a/gapil/template/constant_sets.go
+++ b/gapil/template/constant_sets.go
@@ -182,7 +182,10 @@ func buildConstantSets(api *semantic.API, mappings *resolver.Mappings) *Constant
 		if e.Annotations.GetAnnotation("analyze_usage") == nil {
 			labels := analysis.Labels{}
 			for _, entry := range e.Entries {
-				value := semantic.AsUint64(entry.Value)
+				value, ok := semantic.AsUint64(entry.Value)
+				if !ok {
+					panic(fmt.Sprintf("Unsupported enum number type: %v", e.NumberType))
+				}
 				if l, ok := labels[value]; ok {
 					panic(fmt.Sprintf("Enum %v has multiple labels for value %v: %v, %v",
 						e.Named, value, l, entry.Named))

--- a/gapil/template/constant_sets.go
+++ b/gapil/template/constant_sets.go
@@ -175,31 +175,14 @@ func buildConstantSets(api *semantic.API, mappings *resolver.Mappings) *Constant
 
 	constsets := map[semantic.Node]*int{}
 
+	// Create a constant set for all the API's enums that didn't opt out
 	for _, e := range api.Enums {
+		// "analyze_usage" opts out of the default constant set generation,
+		// uses analysis to determine which constants should go together
 		if e.Annotations.GetAnnotation("analyze_usage") == nil {
 			labels := analysis.Labels{}
 			for _, entry := range e.Entries {
-				value := uint64(0)
-				switch v := entry.Value.(type) {
-				case semantic.Int8Value:
-					value = uint64(v)
-				case semantic.Uint8Value:
-					value = uint64(v)
-				case semantic.Int16Value:
-					value = uint64(v)
-				case semantic.Uint16Value:
-					value = uint64(v)
-				case semantic.Int32Value:
-					value = uint64(v)
-				case semantic.Uint32Value:
-					value = uint64(v)
-				case semantic.Int64Value:
-					value = uint64(v)
-				case semantic.Uint64Value:
-					value = uint64(v)
-				default:
-					panic(fmt.Sprintf("Unsupported enum number type: %v", e.NumberType))
-				}
+				value := semantic.AsUint64(entry.Value)
 				if l, ok := labels[value]; ok {
 					panic(fmt.Sprintf("Enum %v has multiple labels for value %v: %v, %v",
 						e.Named, value, l, entry.Named))

--- a/gapis/api/gles/api/android_native.api
+++ b/gapis/api/gles/api/android_native.api
@@ -38,6 +38,7 @@ enum AndroidGraphicsBufferFormat {
   HAL_PIXEL_FORMAT_YCrCb_420_SP = 0x11, // NV21
 }
 
+@analyze_usage
 enum AndroidGraphicsBufferUsage {
   USAGE_SW_READ_NEVER   = 0x00000000,
   USAGE_SW_READ_RARELY  = 0x00000002,

--- a/gapis/api/gles/api/eglenum.api
+++ b/gapis/api/gles/api/eglenum.api
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+@analyze_usage
 enum EGLenum {
   EGL_ALPHA_FORMAT                               = 0x3088,
   EGL_ALPHA_FORMAT_NONPRE                        = 0x308B,

--- a/gapis/api/gles/api/glbitfield.api
+++ b/gapis/api/gles/api/glbitfield.api
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+@analyze_usage
 bitfield GLbitfield {
   GL_CURRENT_BIT                             = 0x00000001,
   GL_POINT_BIT                               = 0x00000002,

--- a/gapis/api/gles/api/glenum.api
+++ b/gapis/api/gles/api/glenum.api
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+@analyze_usage
 enum GLenum {
   GL_TERMINATE_SEQUENCE_COMMAND_NV                              = 0x00000000,
   GL_NOP_COMMAND_NV                                             = 0x00000001,

--- a/gapis/api/gvr/types.api
+++ b/gapis/api/gvr/types.api
@@ -236,6 +236,7 @@ enum gvr_arm_model_behavior {
 class gvr_user_prefs {}
 
 // Anonymous enum for miscellaneous integer constants.
+@analyze_usage
 enum gvr_enum {
   GVR_EXTERNAL_SURFACE_ID_NONE = 0xffffffff,
   GVR_BUFFER_INDEX_EXTERNAL_SURFACE = 0xffffffff,

--- a/gapis/api/templates/api.go.tmpl
+++ b/gapis/api/templates/api.go.tmpl
@@ -145,6 +145,10 @@ import (
   func Decode{{$name}}(ϟd *ϟmem.Decoder) {{$name}} {
     return {{$name}}({{Template "Go.Decode" $.NumberType}})
   }
+
+  func {{$name}}Constants() int {
+    return {{ConstantSetIndex $}}
+  }
 {{end}}
 
 

--- a/gapis/api/vulkan/api/bitfields.api
+++ b/gapis/api/vulkan/api/bitfields.api
@@ -508,6 +508,7 @@ bitfield VkExternalSemaphoreHandleTypeFlagBits {
 type VkFlags VkExternalSemaphoreHandleTypeFlags
 
 @unused
+@analyze_usage
 bitfield VkFenceImportFlagBits {
   VK_FENCE_IMPORT_TEMPORARY_BIT     = 0x00000001,
   VK_FENCE_IMPORT_TEMPORARY_BIT_KHR = 0x000000001, // VK_FENCE_IMPORT_TEMPORARY_BIT,
@@ -530,6 +531,7 @@ bitfield VkPeerMemoryFeatureFlagBits {
 type VkFlags VkPeerMemoryFeatureFlags
 
 @unused
+@analyze_usage
 bitfield VkSemaphoreImportFlagBits {
   VK_SEMAPHORE_IMPORT_TEMPORARY_BIT     = 0x00000001,
   VK_SEMAPHORE_IMPORT_TEMPORARY_BIT_KHR = 0x00000001, // VK_SEMAPHORE_IMPORT_TEMPORARY_BIT,

--- a/gapis/api/vulkan/api/enums.api
+++ b/gapis/api/vulkan/api/enums.api
@@ -91,6 +91,7 @@ enum VkResult {
 }
 
 /// Structure type enumerant
+@analyze_usage
 enum VkStructureType {
   VK_STRUCTURE_TYPE_APPLICATION_INFO                          = 0,
   VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO                      = 1,
@@ -282,6 +283,7 @@ enum VkStructureType {
   VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_DRAW_PARAMETER_FEATURES        = 1000063000,
 }
 
+@analyze_usage
 enum VkObjectType {
   VK_OBJECT_TYPE_UNKNOWN                        = 0,
   VK_OBJECT_TYPE_INSTANCE                       = 1,


### PR DESCRIPTION
Currently only enums that get used as parameters or return values from
API functions get added to constant_sets, which doesn't work well for
Vulkan since so many of the enums are used indirectly through parameter
structs.
This allows any enum to be added to constant_sets by annotating it with
@unique.

Tested by adding @unique to VkMemoryPropertyFlagBits, needed for a WIP
memory breakdown feature.