### PR TITLE
gapil/compiler: Move useful test code to testutils

### DIFF
--- a/gapil/compiler/BUILD.bazel
+++ b/gapil/compiler/BUILD.bazel
@@ -70,7 +70,7 @@ go_test(
         "//core/os/device:go_default_library",
         "//core/text/parse:go_default_library",
         "//gapil:go_default_library",
-        "//gapil/compiler/testexterns:go_default_library",
+        "//gapil/compiler/testutils:go_default_library",
         "//gapil/executor:go_default_library",
         "//gapis/api:go_default_library",
         "//gapis/capture:go_default_library",

--- a/gapil/compiler/testutils/BUILD.bazel
+++ b/gapil/compiler/testutils/BUILD.bazel
@@ -16,15 +16,27 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "go_default_library",
-    srcs = ["testexterns.go"],
+    srcs = [
+        "cmd.go",
+        "data.go",
+        "doc.go",
+        "externs.go",
+    ],
     cdeps = [
         "//gapil/runtime/cc:arena",
     ],
     cgo = True,
     clinkopts = [],  # keep
-    importpath = "github.com/google/gapid/gapil/compiler/testexterns",
+    importpath = "github.com/google/gapid/gapil/compiler/testutils",
     visibility = ["//visibility:public"],
     deps = [
+        "//core/data/binary:go_default_library",
+        "//core/data/endian:go_default_library",
+        "//core/data/id:go_default_library",
+        "//core/os/device:go_default_library",
         "//gapil/executor:go_default_library",
+        "//gapis/api:go_default_library",
+        "//gapis/memory:go_default_library",
+        "//gapis/replay/builder:go_default_library",
     ],
 )

--- a/gapil/compiler/testutils/cmd.go
+++ b/gapil/compiler/testutils/cmd.go
@@ -1,0 +1,125 @@
+// Copyright (C) 2018 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testutils
+
+import (
+	"bytes"
+	"context"
+
+	"github.com/google/gapid/core/data/endian"
+	"github.com/google/gapid/core/data/id"
+	"github.com/google/gapid/core/os/device"
+	"github.com/google/gapid/gapis/api"
+	"github.com/google/gapid/gapis/memory"
+	"github.com/google/gapid/gapis/replay/builder"
+)
+
+// Cmd is a custom implementation of the api.Cmd interface that simplifies
+// testing compiler generated commands.
+type Cmd struct {
+	N string  // Command name
+	D []byte  // Encoded command used by the compiler generated execute function
+	E *Extras // Command extras
+	T uint64  // Command thread
+}
+
+var _ api.Cmd = &Cmd{}
+
+// API stubs the api.Cmd interface.
+func (c *Cmd) API() api.API { return nil }
+
+// Caller stubs the api.Cmd interface.
+func (c *Cmd) Caller() api.CmdID { return 0 }
+
+// SetCaller stubs the api.Cmd interface.
+func (c *Cmd) SetCaller(api.CmdID) {}
+
+// Thread stubs the api.Cmd interface.
+func (c *Cmd) Thread() uint64 { return c.T }
+
+// SetThread stubs the api.Cmd interface.
+func (c *Cmd) SetThread(thread uint64) { c.T = thread }
+
+// CmdName stubs the api.Cmd interface.
+func (c *Cmd) CmdName() string { return c.N }
+
+// CmdParams stubs the api.Cmd interface.
+func (c *Cmd) CmdParams() api.Properties { return nil }
+
+// CmdResult stubs the api.Cmd interface.
+func (c *Cmd) CmdResult() *api.Property { return nil }
+
+// CmdFlags stubs the api.Cmd interface.
+func (c *Cmd) CmdFlags(context.Context, api.CmdID, *api.GlobalState) api.CmdFlags { return 0 }
+
+// Extras stubs the api.Cmd interface.
+func (c *Cmd) Extras() *api.CmdExtras {
+	if c.E == nil {
+		return &api.CmdExtras{}
+	}
+	return c.E.e
+}
+
+// Mutate stubs the api.Cmd interface.
+func (c *Cmd) Mutate(context.Context, api.CmdID, *api.GlobalState, *builder.Builder) error { return nil }
+
+// Encode implements the executor.Encodable interface to encode the command to
+// a buffer used by the compiler generated execute function.
+func (c Cmd) Encode(out []byte) bool {
+	w := endian.Writer(bytes.NewBuffer(out), device.LittleEndian)
+	w.Uint64(c.T)
+	copy(out[8:], c.D)
+	return true
+}
+
+// Extras is a helper wrapper around an api.CmdExtras has helpers methods for
+// adding read and writ observations.
+type Extras struct {
+	e *api.CmdExtras
+}
+
+// R adds a read using the given range and data, returning this Extras so calls
+// can be chained.
+func (e *Extras) R(base uint64, size uint64, id id.ID) *Extras {
+	if e.e == nil {
+		e.e = &api.CmdExtras{}
+	}
+	e.e.GetOrAppendObservations().AddRead(memory.Range{Base: base, Size: size}, id)
+	return e
+}
+
+// W adds a write using the given range and data, returning this Extras so calls
+// can be chained.
+func (e *Extras) W(base uint64, size uint64, id id.ID) *Extras {
+	if e.e == nil {
+		e.e = &api.CmdExtras{}
+	}
+	e.e.GetOrAppendObservations().AddWrite(memory.Range{Base: base, Size: size}, id)
+	return e
+}
+
+// R creates and returns a new Extras containing a single read using the given
+// range and data.
+func R(base uint64, size uint64, id id.ID) *Extras {
+	e := &Extras{}
+	return e.R(base, size, id)
+}
+
+// W creates and returns a new Extras containing a single write using the given
+// range and data.
+func W(base uint64, size uint64, id id.ID) *Extras {
+	e := &Extras{}
+	return e.W(base, size, id)
+}

--- a/gapil/compiler/testutils/data.go
+++ b/gapil/compiler/testutils/data.go
@@ -1,0 +1,38 @@
+// Copyright (C) 2018 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testutils
+
+import (
+	"bytes"
+
+	"github.com/google/gapid/core/data/binary"
+	"github.com/google/gapid/core/data/endian"
+	"github.com/google/gapid/core/os/device"
+)
+
+// Encode encodes all the vals to the returned byte slice with
+// little-endianness. Struct alignment and padding is ignored.
+func Encode(vals ...interface{}) []byte {
+	buf := &bytes.Buffer{}
+	w := endian.Writer(buf, device.LittleEndian)
+	for _, d := range vals {
+		binary.Write(w, d)
+	}
+	return buf.Bytes()
+}
+
+// Pad returns a slice of n zero bytes. Pad can be used to align data passed
+// to Encode.
+func Pad(n int) []byte { return make([]byte, n) }

--- a/gapil/compiler/testutils/doc.go
+++ b/gapil/compiler/testutils/doc.go
@@ -1,0 +1,16 @@
+// Copyright (C) 2018 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package testutils implements reusable helpers for writing compiler tests.
+package testutils

--- a/gapil/compiler/testutils/externs.go
+++ b/gapil/compiler/testutils/externs.go
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package testexterns implements some extern functions used for compiler tests.
-package testexterns
+package testutils
 
 import (
 	"unsafe"
@@ -25,7 +24,12 @@ import (
 import "C"
 
 var (
+	// ExternA will be called whenever the test_extern_a extern function is
+	// called.
 	ExternA func(*executor.Env, uint64, float32, bool) uint64
+
+	// ExternB will be called whenever the test_extern_b extern function is
+	// called.
 	ExternB func(*executor.Env, string) bool
 )
 


### PR DESCRIPTION
Move `gapil/compiler/testextern` to `gapil/compiler/testutils`.
Move the useful bits of the compiler test code into new package.