### PR TITLE
Fix command buffers whose recording spans a frame.

### DIFF
--- a/gapis/api/vulkan/vulkan.go
+++ b/gapis/api/vulkan/vulkan.go
@@ -84,6 +84,11 @@ func (c *State) SetupInitialState(ctx context.Context, s *api.GlobalState) {
 func (c *State) InitializeCustomState() {
 	c.queuedCommands = make(map[CommandReferenceʳ]QueuedCommand)
 	c.initialCommands = make(map[VkCommandBuffer][]api.Cmd)
+
+	for b, cb := range c.CommandBuffers().All() {
+		existingCommands := cb.CommandReferences().Len()
+		c.initialCommands[b] = make([]api.Cmd, existingCommands)
+	}
 }
 
 func (c *State) preMutate(ctx context.Context, s *api.GlobalState, cmd api.Cmd) error {
@@ -293,7 +298,9 @@ func (API) ResolveSynchronization(ctx context.Context, d *sync.Data, c *path.Cap
 		id := api.CmdNoID
 
 		if initialCommands, ok := s.initialCommands[data.Buffer()]; ok {
-			id = commandMap[initialCommands[data.CommandIndex()]]
+			if initialCommands[data.CommandIndex()] != nil {
+				id = commandMap[initialCommands[data.CommandIndex()]]
+			}
 		}
 
 		if v, ok := d.SubcommandReferences[k]; ok {


### PR DESCRIPTION
This fixes an issue where if we started a MidExecution capture
where a command-buffer spanned a frame, we would crash
in generating synchronization data (other bad things would happen
as a result).

This sets up the initial state so that our intial commands
have been properly initialized.