### PR TITLE
Don't build enum for nil node (fix #1929)

### DIFF
--- a/gapil/template/constant_sets.go
+++ b/gapil/template/constant_sets.go
@@ -158,8 +158,8 @@ func (nl *nodeLabeler) traverse(n semantic.Node, v analysis.Value) {
 		}
 	case *analysis.MapValue:
 		for k, v := range v.KeyToValue {
-			nl.traverse(nil, k)
-			nl.traverse(nil, v)
+			nl.traverse(n, k)
+			nl.traverse(n, v)
 		}
 	}
 }


### PR DESCRIPTION
It seems to be created non-deterministically, which can cause issues
with getting the right constant set ID value.

This change causes a constant set that was previously added to vulkan/constant_sets.go to be removed (`{QUERY_STATUS_INACTIVE, QUERY_STATUS_ACTIVE, QUERY_STATUS_COMPLETE}`), but I checked and this constant set was never actually referenced in vulkan/api.go.

This bug can be found (sometimes) with:
```
diff --git a/gapil/template/constant_sets.go b/gapil/template/constant_sets.go
index 58e821ff..83d33542 100644
--- a/gapil/template/constant_sets.go
+++ b/gapil/template/constant_sets.go
@@ -16,6 +16,7 @@ package template
 
 import (
 	"sort"
+	"strings"
 
 	"fmt"
 
@@ -66,6 +67,9 @@ func (b *constsetPackBuilder) addLabels(labels analysis.Labels, isBitfield bool)
 	}
 	set.idx = new(int)
 	b.sets[key] = set
+	if strings.Contains(key, "VK_IMAGE_ASPECT") && strings.Contains(key, "QUERY_STATUS") {
+		panic(":(")
+	}
 	return set.idx
 }
 ```
which checks for a specific bad enum that was being created.