### PR TITLE
Follow the existing pattern for grpc dependencies

### DIFF
--- a/tools/build/rules/grpc_c++.bzl
+++ b/tools/build/rules/grpc_c++.bzl
@@ -38,6 +38,7 @@
 # Each rule listed must be re-written for Google's internal build system, and
 # each change must be ported from one to the other.
 #
+load("@gapid//tools/build/rules:repository.bzl", "github_repository", "maybe_repository")
 
 # The set of pollers to test against if a test exercises polling
 
@@ -111,7 +112,7 @@ def grpc_cc_library(name, srcs = [], public_hdrs = [], hdrs = [],
 
 """Load dependencies needed to compile and test the grpc library as a 3rd-party consumer."""
 
-def grpc_deps():
+def grpc_deps(locals = {}):
     """Loads dependencies need to compile and test the grpc library."""
     native.bind(
         name = "libssl",
@@ -185,66 +186,70 @@ def grpc_deps():
             url = "https://boringssl.googlesource.com/boringssl/+archive/6ae5a54bedae2c29e5b67382667871c527e68326.tar.gz",
         )
 
-    if "com_github_madler_zlib" not in native.existing_rules():
-        native.new_http_archive(
-            name = "com_github_madler_zlib",
-            build_file = "@com_github_grpc_grpc//third_party:zlib.BUILD",
-            strip_prefix = "zlib-cacf7f1d4e3d44d871b605da3b647f07d718623f",
-            url = "https://github.com/madler/zlib/archive/cacf7f1d4e3d44d871b605da3b647f07d718623f.tar.gz",
-        )
+    maybe_repository(github_repository,
+        name = "com_github_madler_zlib",
+        locals = locals,
+        organization = "madler",
+        project = "zlib",
+        commit = "cacf7f1d4e3d44d871b605da3b647f07d718623f",
+        build_file = "@com_github_grpc_grpc//third_party:zlib.BUILD",
+    )
 
-    if "com_google_protobuf" not in native.existing_rules():
-        native.http_archive(
-            name = "com_google_protobuf",
-            strip_prefix = "protobuf-2761122b810fe8861004ae785cc3ab39f384d342",
-            url = "https://github.com/google/protobuf/archive/2761122b810fe8861004ae785cc3ab39f384d342.tar.gz",
-        )
+    maybe_repository(github_repository,
+        name = "com_google_protobuf",
+        locals = locals,
+        organization = "google",
+        project = "protobuf",
+        commit = "2761122b810fe8861004ae785cc3ab39f384d342",
+    )
 
-    if "com_github_google_googletest" not in native.existing_rules():
-        native.new_http_archive(
-            name = "com_github_google_googletest",
-            build_file = "@com_github_grpc_grpc//third_party:gtest.BUILD",
-            strip_prefix = "googletest-ec44c6c1675c25b9827aacd08c02433cccde7780",
-            url = "https://github.com/google/googletest/archive/ec44c6c1675c25b9827aacd08c02433cccde7780.tar.gz",
-        )
+    maybe_repository(github_repository,
+        name = "com_github_google_googletest",
+        locals = locals,
+        organization = "google",
+        project = "googletest",
+        commit = "ec44c6c1675c25b9827aacd08c02433cccde7780",
+        build_file = "@com_github_grpc_grpc//third_party:gtest.BUILD",
+    )
 
-    if "com_github_gflags_gflags" not in native.existing_rules():
-        native.http_archive(
-            name = "com_github_gflags_gflags",
-            strip_prefix = "gflags-30dbc81fb5ffdc98ea9b14b1918bfe4e8779b26e",
-            url = "https://github.com/gflags/gflags/archive/30dbc81fb5ffdc98ea9b14b1918bfe4e8779b26e.tar.gz",
-        )
+    maybe_repository(github_repository,
+        name = "com_github_gflags_gflags",
+        locals = locals,
+        organization = "gflags",
+        project = "gflags",
+        commit = "30dbc81fb5ffdc98ea9b14b1918bfe4e8779b26e",
+    )
 
-    if "com_github_google_benchmark" not in native.existing_rules():
-        native.new_http_archive(
-            name = "com_github_google_benchmark",
-            build_file = "@com_github_grpc_grpc//third_party:benchmark.BUILD",
-            strip_prefix = "benchmark-5b7683f49e1e9223cf9927b24f6fd3d6bd82e3f8",
-            url = "https://github.com/google/benchmark/archive/5b7683f49e1e9223cf9927b24f6fd3d6bd82e3f8.tar.gz",
-        )
+    maybe_repository(github_repository,
+        name = "com_github_google_benchmark",
+        locals = locals,
+        organization = "google",
+        project = "benchmark",
+        commit = "5b7683f49e1e9223cf9927b24f6fd3d6bd82e3f8",
+        build_file = "@com_github_grpc_grpc//third_party:benchmark.BUILD",
+    )
 
-    if "com_github_cares_cares" not in native.existing_rules():
-        native.new_http_archive(
-            name = "com_github_cares_cares",
-            build_file = "@com_github_grpc_grpc//third_party:cares/cares.BUILD",
-            strip_prefix = "c-ares-3be1924221e1326df520f8498d704a5c4c8d0cce",
-            url = "https://github.com/c-ares/c-ares/archive/3be1924221e1326df520f8498d704a5c4c8d0cce.tar.gz",
-        )
+    maybe_repository(github_repository,
+        name = "com_github_cares_cares",
+        locals = locals,
+        organization = "c-ares",
+        project = "c-ares",
+        commit = "3be1924221e1326df520f8498d704a5c4c8d0cce",
+        build_file = "@com_github_grpc_grpc//third_party:cares/cares.BUILD",
+    )
 
-    if "com_google_absl" not in native.existing_rules():
-        native.http_archive(
-            name = "com_google_absl",
-            strip_prefix = "abseil-cpp-cc4bed2d74f7c8717e31f9579214ab52a9c9c610",
-            url = "https://github.com/abseil/abseil-cpp/archive/cc4bed2d74f7c8717e31f9579214ab52a9c9c610.tar.gz",
-        )
+    maybe_repository(github_repository,
+        name = "com_google_absl",
+        locals = locals,
+        organization = "abseil",
+        project = "abseil-cpp",
+        commit = "cc4bed2d74f7c8717e31f9579214ab52a9c9c610",
+    )
 
-    if "com_github_bazelbuild_bazeltoolchains" not in native.existing_rules():
-        native.http_archive(
-            name = "com_github_bazelbuild_bazeltoolchains",
-            strip_prefix = "bazel-toolchains-b850ccdf53fed1ccab7670f52d6b297d74348d1b",
-            urls = [
-                "https://mirror.bazel.build/github.com/bazelbuild/bazel-toolchains/archive/b850ccdf53fed1ccab7670f52d6b297d74348d1b.tar.gz",
-                "https://github.com/bazelbuild/bazel-toolchains/archive/b850ccdf53fed1ccab7670f52d6b297d74348d1b.tar.gz",
-            ],
-            sha256 = "d84d6b2fe88ef99963febf91ddce33503eed14c155ace922e2122271b483be64",
-        )
+    maybe_repository(github_repository,
+        name = "com_github_bazelbuild_bazeltoolchains",
+        locals = locals,
+        organization = "bazelbuild",
+        project = "bazel-toolchains",
+        commit = "b850ccdf53fed1ccab7670f52d6b297d74348d1b",
+    )

--- a/tools/build/rules/repository.bzl
+++ b/tools/build/rules/repository.bzl
@@ -89,3 +89,24 @@ def github_repository(name, path="", **kwargs):
     native.local_repository(name = name, path = path)
   else:
     _github_repository(name=name, **kwargs)
+
+def maybe_repository(repo_rule, name, locals, **kwargs):
+    if name in native.existing_rules():
+        return
+
+    if name not in locals:
+        repo_rule(name = name, **kwargs)
+        return
+
+    build_file = kwargs.get("build_file")
+    if build_file == None:
+        native.local_repository(
+            name = name,
+            path = locals.get(name)
+        )
+    else:
+        native.new_local_repository(
+            name = name,
+            path = locals.get(name),
+            build_file = build_file
+        )

--- a/tools/build/workspace.bzl
+++ b/tools/build/workspace.bzl
@@ -17,7 +17,7 @@
 
 load("@gapid//tools/build:cc_toolchain.bzl", "cc_configure")
 load("@gapid//tools/build/rules:android.bzl", "android_native_app_glue")
-load("@gapid//tools/build/rules:repository.bzl", "github_http_args", "github_repository")
+load("@gapid//tools/build/rules:repository.bzl", "github_repository", "maybe_repository")
 load("@gapid//tools/build/third_party:breakpad.bzl", "breakpad")
 load("@gapid//tools/build/rules:grpc_c++.bzl", "grpc_deps")
 
@@ -32,7 +32,7 @@ def gapid_dependencies(android = True, java_client = True, mingw = True, locals 
     #####################################################
     # Get repositories with workspace rules we need first
 
-    _maybe(github_repository,
+    maybe_repository(github_repository,
         name = "io_bazel_rules_go",
         locals = locals,
         organization = "bazelbuild",
@@ -40,7 +40,7 @@ def gapid_dependencies(android = True, java_client = True, mingw = True, locals 
         commit = "2d3336269eab48bac7adcaff03e7232e14463619",
     )
 
-    _maybe(github_repository,
+    maybe_repository(github_repository,
         name = "bazel_gazelle",
         locals = locals,
         organization = "bazelbuild",
@@ -48,7 +48,7 @@ def gapid_dependencies(android = True, java_client = True, mingw = True, locals 
         commit = "f4ae892927eeabd060c59693c38e82303f41558d",
     )
 
-    _maybe(github_repository,
+    maybe_repository(github_repository,
         name = "com_google_protobuf",
         locals = locals,
         organization = "google",
@@ -59,7 +59,7 @@ def gapid_dependencies(android = True, java_client = True, mingw = True, locals 
         build_file = "@gapid//tools/build/third_party:protobuf.BUILD",
     )
 
-    _maybe(github_repository,
+    maybe_repository(github_repository,
         name = "com_github_grpc_grpc",
         locals = locals,
         organization = "grpc",
@@ -69,12 +69,12 @@ def gapid_dependencies(android = True, java_client = True, mingw = True, locals 
         # Override with our own BUILD file, to make Android build work.
         build_file = "@gapid//tools/build/third_party:grpc_c++.BUILD",
     )
-    grpc_deps()
+    grpc_deps(locals)
 
     ###########################################
     # Now get all our other non-go dependencies
 
-    _maybe(github_repository,
+    maybe_repository(github_repository,
         name = "com_google_googletest",
         locals = locals,
         organization = "google",
@@ -82,7 +82,7 @@ def gapid_dependencies(android = True, java_client = True, mingw = True, locals 
         commit = "62dbaa2947f7d058ea7e16703faea69b1134b024",
     )
 
-    _maybe(github_repository,
+    maybe_repository(github_repository,
         name = "astc_encoder",
         locals = locals,
         organization = "ARM-software",
@@ -91,14 +91,14 @@ def gapid_dependencies(android = True, java_client = True, mingw = True, locals 
         build_file = "@gapid//tools/build/third_party:astc-encoder.BUILD",
     )
 
-    _maybe(breakpad,
+    maybe_repository(breakpad,
         name = "breakpad",
         locals = locals,
         commit = "a61afe7a3e865f1da7ff7185184fe23977c2adca",
         build_file = "@gapid//tools/build/third_party/breakpad:breakpad.BUILD",
     )
 
-    _maybe(github_repository,
+    maybe_repository(github_repository,
         name = "cityhash",
         locals = locals,
         organization = "google",
@@ -107,7 +107,7 @@ def gapid_dependencies(android = True, java_client = True, mingw = True, locals 
         build_file = "@gapid//tools/build/third_party:cityhash.BUILD",
     )
 
-    _maybe(github_repository,
+    maybe_repository(github_repository,
         name = "glslang",
         locals = locals,
         organization = "KhronosGroup",
@@ -116,7 +116,7 @@ def gapid_dependencies(android = True, java_client = True, mingw = True, locals 
         build_file = "@gapid//tools/build/third_party:glslang.BUILD",
     )
 
-    _maybe(github_repository,
+    maybe_repository(github_repository,
         name = "llvm",
         locals = locals,
         organization = "llvm-mirror",
@@ -125,7 +125,7 @@ def gapid_dependencies(android = True, java_client = True, mingw = True, locals 
         build_file = "@gapid//tools/build/third_party:llvm.BUILD",
     )
 
-    _maybe(native.new_git_repository,
+    maybe_repository(native.new_git_repository,
         name = "lss",
         locals = locals,
         remote = "https://chromium.googlesource.com/linux-syscall-support",
@@ -133,7 +133,7 @@ def gapid_dependencies(android = True, java_client = True, mingw = True, locals 
         build_file = "@gapid//tools/build/third_party:lss.BUILD",
     )
 
-    _maybe(github_repository,
+    maybe_repository(github_repository,
         name = "spirv_headers",
         locals = locals,
         organization = "KhronosGroup",
@@ -142,7 +142,7 @@ def gapid_dependencies(android = True, java_client = True, mingw = True, locals 
         build_file = "@gapid//tools/build/third_party:spirv-headers.BUILD",
     )
 
-    _maybe(github_repository,
+    maybe_repository(github_repository,
         name = "spirv_cross",
         locals = locals,
         organization = "KhronosGroup",
@@ -151,7 +151,7 @@ def gapid_dependencies(android = True, java_client = True, mingw = True, locals 
         build_file = "@gapid//tools/build/third_party:spirv-cross.BUILD",
     )
 
-    _maybe(github_repository,
+    maybe_repository(github_repository,
         name = "spirv_tools",
         locals = locals,
         organization = "KhronosGroup",
@@ -161,7 +161,7 @@ def gapid_dependencies(android = True, java_client = True, mingw = True, locals 
     )
 
     if java_client:
-        _maybe(github_repository,
+        maybe_repository(github_repository,
             name = "com_github_grpc_java",
             locals = locals,
             organization = "grpc",
@@ -171,19 +171,19 @@ def gapid_dependencies(android = True, java_client = True, mingw = True, locals 
         )
 
     if android:
-        _maybe(native.android_sdk_repository,
+        maybe_repository(native.android_sdk_repository,
             name = "androidsdk",
             locals = locals,
             api_level = 21,
         )
 
-        _maybe(native.android_ndk_repository,
+        maybe_repository(native.android_ndk_repository,
             name = "androidndk",
             locals = locals,
             api_level = 21,
         )
 
-        _maybe(android_native_app_glue,
+        maybe_repository(android_native_app_glue,
             name = "android_native_app_glue",
             locals = locals,
         )
@@ -196,24 +196,3 @@ def gapid_dependencies(android = True, java_client = True, mingw = True, locals 
 
     if mingw:
         cc_configure()
-
-def _maybe(repo_rule, name, locals, **kwargs):
-    if name in native.existing_rules():
-        return
-
-    if name not in locals:
-        repo_rule(name = name, **kwargs)
-        return
-
-    build_file = kwargs.get("build_file")
-    if build_file == None:
-        native.local_repository(
-            name = name,
-            path = locals.get(name)
-        )
-    else:
-        native.new_local_repository(
-            name = name,
-            path = locals.get(name),
-            build_file = build_file
-        )


### PR DESCRIPTION
Makes it easier to build gapid as a dependency and override
its dependencies.