### PR TITLE
Keep vkUnmapMemory alive.

### DIFF
--- a/gapis/api/vulkan/footprint_builder.go
+++ b/gapis/api/vulkan/footprint_builder.go
@@ -1686,6 +1686,7 @@ func (vb *FootprintBuilder) BuildFootprint(ctx context.Context,
 		if _, mappedCoherent := vb.mappedCoherentMemories[cmd.Memory()]; mappedCoherent {
 			delete(vb.mappedCoherentMemories, cmd.Memory())
 		}
+		bh.Alive = true
 	case *VkFlushMappedMemoryRanges:
 		coherentMemDone := false
 		count := uint64(cmd.MemoryRangeCount())


### PR DESCRIPTION
This makes changes on host-pointer side. It would be bad
to keep the memory mapped, if someone else
maps into the same location in the future.