### PR TITLE
Allow wildcards in gapit state filter.

### DIFF
--- a/cmd/gapit/state.go
+++ b/cmd/gapit/state.go
@@ -136,7 +136,8 @@ func traverseStateTree(
 	}
 
 	nextFilter := filter
-	if len(filter) != 0 && filter[0] != n.Name {
+	if len(filter) != 0 &&
+			(filter[0] != n.Name && filter[0] != "*") {
 		return nil
 	}
 	if len(filter) != 0 {


### PR DESCRIPTION
This helps getting specific information out of the gapit state.