### PR TITLE
gapil/compiler: Ensure all blocks are scoped.

### DIFF
--- a/gapil/compiler/plugins/encoder/entities.go
+++ b/gapil/compiler/plugins/encoder/entities.go
@@ -507,7 +507,7 @@ func (e *entities) buildEncodeTypeFuncs(c *compiler.C, encodeType codegen.Functi
 			newType := s.GreaterOrEqualTo(signedTypeID, s.Scalar(int64(0)))
 			typeID := s.Select(newType, signedTypeID, s.Negate(signedTypeID))
 
-			s.If(newType, func() {
+			s.If(newType, func(s *compiler.S) {
 				// Encode dependent types.
 				deps := []*entity{}
 				seen := map[*entity]bool{}


### PR DESCRIPTION
There was a bug in the map functions where types were not getting released correctly as the scope was never popped.

To prevent this in the future, override all the `codegen` block building functions with variants that forcefully scopes the builder callbacks.