### PR TITLE
Cleaned up a bunch of error message in Vulkan.

### DIFF
--- a/gapis/api/vulkan/read_framebuffer.go
+++ b/gapis/api/vulkan/read_framebuffer.go
@@ -80,25 +80,25 @@ func (t *readFramebuffer) Depth(id api.CmdID, idx uint32, res replay.Result) {
 		c := GetState(s)
 		lastQueue := c.LastBoundQueue()
 		if lastQueue.IsNil() {
-			res(nil, fmt.Errorf("No previous queue submission"))
+			res(nil, &service.ErrDataUnavailable{Reason: messages.ErrMessage("No previous queue submission")})
 			return
 		}
 
 		lastDrawInfo, ok := c.LastDrawInfos().Lookup(lastQueue.VulkanHandle())
 		if !ok {
-			res(nil, fmt.Errorf("There have been no previous draws"))
+			res(nil, &service.ErrDataUnavailable{Reason: messages.ErrMessage("There have been no previous draws")})
 			return
 		}
 		w, h := lastDrawInfo.Framebuffer().Width(), lastDrawInfo.Framebuffer().Height()
 
 		imageViewDepth := lastDrawInfo.Framebuffer().ImageAttachments().Get(idx)
 		if imageViewDepth.IsNil() {
-			res(nil, fmt.Errorf("Invalid depth attachment in the framebuffer, the attachment VkImageView might have been destroyed"))
+			res(nil, &service.ErrDataUnavailable{Reason: messages.ErrMessage("Invalid depth attachment in the framebuffer, the attachment VkImageView might have been destroyed")})
 			return
 		}
 		depthImageObject := imageViewDepth.Image()
 		if depthImageObject.IsNil() {
-			res(nil, fmt.Errorf("Invalid depth attachment in the framebuffer, the attachment VkImage might have been destroyed"))
+			res(nil, &service.ErrDataUnavailable{Reason: messages.ErrMessage("Invalid depth attachment in the framebuffer, the attachment VkImage might have been destroyed")})
 			return
 		}
 		cb := CommandBuilder{Thread: cmd.Thread(), Arena: s.Arena}
@@ -124,27 +124,27 @@ func (t *readFramebuffer) Color(id api.CmdID, width, height, bufferIdx uint32, r
 		if GetState(s).LastSubmission() == LastSubmissionType_SUBMIT {
 			lastQueue := c.LastBoundQueue()
 			if lastQueue.IsNil() {
-				res(nil, fmt.Errorf("No previous queue submission"))
+				res(nil, &service.ErrDataUnavailable{Reason: messages.ErrMessage("No previous queue submission")})
 				return
 			}
 
 			lastDrawInfo, ok := c.LastDrawInfos().Lookup(lastQueue.VulkanHandle())
 			if !ok {
-				res(nil, fmt.Errorf("There have been no previous draws"))
+				res(nil, &service.ErrDataUnavailable{Reason: messages.ErrMessage("There have been no previous draws")})
 				return
 			}
 			if lastDrawInfo.Framebuffer().IsNil() {
-				res(nil, fmt.Errorf("There has been no framebuffer"))
+				res(nil, &service.ErrDataUnavailable{Reason: messages.ErrMessage("There has been no framebuffer")})
 				return
 			}
 
 			imageView, ok := lastDrawInfo.Framebuffer().ImageAttachments().Lookup(bufferIdx)
 			if !ok {
-				res(nil, fmt.Errorf("There has been no attchment %v in the framebuffer", bufferIdx))
+				res(nil, &service.ErrDataUnavailable{Reason: messages.ErrMessage("There has been no attchment in the framebuffer")})
 				return
 			}
 			if imageView.IsNil() {
-				res(nil, fmt.Errorf("Invalid attachment %v in the framebuffer, the attachment VkImageView might have been destroyed", bufferIdx))
+				res(nil, &service.ErrDataUnavailable{Reason: messages.ErrMessage("Invalid attachment in the framebuffer, the attachment VkImageView might have been destroyed")})
 				return
 			}
 			// Imageviews that are used in framebuffer attachments must contains
@@ -156,7 +156,7 @@ func (t *readFramebuffer) Color(id api.CmdID, width, height, bufferIdx uint32, r
 			layer := imageView.SubresourceRange().BaseArrayLayer()
 			imageObject := imageView.Image()
 			if imageObject.IsNil() {
-				res(nil, fmt.Errorf("Invalid attachment %v in the framebuffer, the attachment VkImage might have been destroyed", bufferIdx))
+				res(nil, &service.ErrDataUnavailable{Reason: messages.ErrMessage("Invalid attachment in the framebuffer, the attachment VkImage might have been destroyed")})
 				return
 			}
 			w, h, form := lastDrawInfo.Framebuffer().Width(), lastDrawInfo.Framebuffer().Height(), imageView.Fmt()
@@ -164,7 +164,7 @@ func (t *readFramebuffer) Color(id api.CmdID, width, height, bufferIdx uint32, r
 		} else {
 			imageObject := GetState(s).LastPresentInfo().PresentImages().Get(bufferIdx)
 			if imageObject.IsNil() {
-				res(nil, fmt.Errorf("Could not find imageObject %v, %v", id, bufferIdx))
+				res(nil, &service.ErrDataUnavailable{Reason: messages.ErrMessage("Could not find imageObject")})
 				return
 			}
 			w, h, form := imageObject.Info().Extent().Width(), imageObject.Info().Extent().Height(), imageObject.Info().Fmt()

--- a/gapis/api/vulkan/vulkan.go
+++ b/gapis/api/vulkan/vulkan.go
@@ -23,8 +23,10 @@ import (
 	"github.com/google/gapid/gapis/api/sync"
 	"github.com/google/gapid/gapis/api/transform"
 	"github.com/google/gapid/gapis/capture"
+	"github.com/google/gapid/gapis/messages"
 	"github.com/google/gapid/gapis/resolve"
 	"github.com/google/gapid/gapis/resolve/dependencygraph"
+	"github.com/google/gapid/gapis/service"
 	"github.com/google/gapid/gapis/service/path"
 )
 
@@ -127,7 +129,7 @@ func (API) Mesh(ctx context.Context, o interface{}, p *path.Mesh) (*api.Mesh, er
 	case *VkQueueSubmit:
 		return drawCallMesh(ctx, dc, p)
 	}
-	return nil, fmt.Errorf("Cannot get the mesh data from %v", o)
+	return nil, &service.ErrDataUnavailable{Reason: messages.ErrMeshNotAvailable()}
 }
 
 type MarkerType int

--- a/gapis/resolve/commands.go
+++ b/gapis/resolve/commands.go
@@ -121,7 +121,7 @@ func Cmd(ctx context.Context, p *path.Command) (api.Cmd, error) {
 			}
 		}
 		if !found {
-			return nil, log.Errf(ctx, nil, "Could not find subcommand %v", p.Indices)
+			return nil, &service.ErrDataUnavailable{Reason: messages.ErrMessage("Not a valid subcommand")}
 		}
 	}
 	cmds, err := NCmds(ctx, p.Capture, cmdIdx+1)


### PR DESCRIPTION
Instead of returning a normal fmt.Errorf(), we now return
a proper service.ErrDataUnavailable. This allow the
UI to show a proper error message unstead of just a
panic in the log view.