### PR TITLE
Allow state cloning to handle references properly.

### DIFF
--- a/core/data/BUILD.bazel
+++ b/core/data/BUILD.bazel
@@ -19,6 +19,7 @@ go_library(
     srcs = [
         "assignable.go",
         "dedupe.go",
+        "cloner.go",
     ],
     importpath = "github.com/google/gapid/core/data",
     visibility = ["//visibility:public"],

--- a/core/data/cloner.go
+++ b/core/data/cloner.go
@@ -1,0 +1,37 @@
+// Copyright (C) 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package data
+
+// Cloner holds onto references as a type is being
+// cloned, making sure to handle back-references and
+// circular references
+type Cloner struct {
+	cloned map[interface{}]interface{}
+}
+
+func (c *Cloner) Get(i interface{}) (interface{}, bool) {
+	if cloned, ok := c.cloned[i]; ok {
+		return cloned, true
+	}
+	return nil, false
+}
+
+func (c *Cloner) Add(src, dst interface{}) {
+	c.cloned[src] = dst
+}
+
+func NewCloner() *Cloner {
+	return &Cloner{make(map[interface{}]interface{})}
+}

--- a/gapis/api/BUILD.bazel
+++ b/gapis/api/BUILD.bazel
@@ -49,6 +49,7 @@ go_library(
     deps = [
         "//core/context/keys:go_default_library",
         "//core/data/binary:go_default_library",
+        "//core/data:go_default_library",
         "//core/data/deep:go_default_library",
         "//core/data/endian:go_default_library",
         "//core/data/generic:go_default_library",

--- a/gapis/api/gles/externs.go
+++ b/gapis/api/gles/externs.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/google/gapid/core/data"
 	"github.com/google/gapid/core/log"
 	"github.com/google/gapid/core/os/device"
 	"github.com/google/gapid/core/os/device/bind"
@@ -61,15 +62,15 @@ func (e externs) unmapMemory(slice memory.Slice) {
 }
 
 func (e externs) GetEGLStaticContextState(EGLDisplay, EGLContext) StaticContextStateʳ {
-	return FindStaticContextState(e.s.Arena, e.cmd.Extras()).Clone(e.s.Arena)
+	return FindStaticContextState(e.s.Arena, e.cmd.Extras()).Clone(e.s.Arena, data.NewCloner())
 }
 
 func (e externs) GetEGLDynamicContextState(EGLDisplay, EGLSurface, EGLContext) DynamicContextStateʳ {
-	return FindDynamicContextState(e.s.Arena, e.cmd.Extras()).Clone(e.s.Arena)
+	return FindDynamicContextState(e.s.Arena, e.cmd.Extras()).Clone(e.s.Arena, data.NewCloner())
 }
 
 func (e externs) GetAndroidNativeBufferExtra(Voidᵖ) AndroidNativeBufferExtraʳ {
-	return FindAndroidNativeBufferExtra(e.s.Arena, e.cmd.Extras()).Clone(e.s.Arena)
+	return FindAndroidNativeBufferExtra(e.s.Arena, e.cmd.Extras()).Clone(e.s.Arena, data.NewCloner())
 }
 
 func (e externs) GetEGLImageData(id EGLImageKHR, _ GLsizei, _ GLsizei) {
@@ -116,19 +117,19 @@ func (e externs) substr(str string, start, end int32) string {
 }
 
 func (e externs) GetCompileShaderExtra(ctx Contextʳ, obj Shaderʳ, bin BinaryExtraʳ) CompileShaderExtraʳ {
-	return FindCompileShaderExtra(e.s.Arena, e.cmd.Extras(), obj).Clone(e.s.Arena)
+	return FindCompileShaderExtra(e.s.Arena, e.cmd.Extras(), obj).Clone(e.s.Arena, data.NewCloner())
 }
 
 func (e externs) GetLinkProgramExtra(ctx Contextʳ, obj Programʳ, bin BinaryExtraʳ) LinkProgramExtraʳ {
-	return FindLinkProgramExtra(e.s.Arena, e.cmd.Extras()).Clone(e.s.Arena)
+	return FindLinkProgramExtra(e.s.Arena, e.cmd.Extras()).Clone(e.s.Arena, data.NewCloner())
 }
 
 func (e externs) GetValidateProgramExtra(ctx Contextʳ, obj Programʳ) ValidateProgramExtraʳ {
-	return FindValidateProgramExtra(e.s.Arena, e.cmd.Extras()).Clone(e.s.Arena)
+	return FindValidateProgramExtra(e.s.Arena, e.cmd.Extras()).Clone(e.s.Arena, data.NewCloner())
 }
 
 func (e externs) GetValidateProgramPipelineExtra(ctx Contextʳ, obj Pipelineʳ) ValidateProgramPipelineExtraʳ {
-	return FindValidateProgramPipelineExtra(e.s.Arena, e.cmd.Extras()).Clone(e.s.Arena)
+	return FindValidateProgramPipelineExtra(e.s.Arena, e.cmd.Extras()).Clone(e.s.Arena, data.NewCloner())
 }
 
 func (e externs) onGlError(err GLenum) {

--- a/gapis/api/gles/stub_program.go
+++ b/gapis/api/gles/stub_program.go
@@ -20,6 +20,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/google/gapid/core/data"
 	"github.com/google/gapid/core/log"
 	"github.com/google/gapid/gapis/api"
 )
@@ -31,7 +32,7 @@ var (
 )
 
 func buildStubProgram(ctx context.Context, thread uint64, e *api.CmdExtras, s *api.GlobalState, programID ProgramId) []api.Cmd {
-	programInfo := FindLinkProgramExtra(s.Arena, e).Clone(s.Arena)
+	programInfo := FindLinkProgramExtra(s.Arena, e).Clone(s.Arena, data.NewCloner())
 	vss, fss, err := stubShaderSource(programInfo)
 	if err != nil {
 		log.E(ctx, "Unable to build stub shader: %v", err)

--- a/gapis/api/state.go
+++ b/gapis/api/state.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/google/gapid/core/data"
 	"github.com/google/gapid/core/data/binary"
 	"github.com/google/gapid/core/data/endian"
 	"github.com/google/gapid/core/data/id"
@@ -74,7 +75,7 @@ type State interface {
 	APIObject
 
 	// Clone returns a deep copy of the state object.
-	Clone(arena.Arena) State
+	Clone(arena.Arena, *data.Cloner) State
 
 	// Root returns the path to the root of the state to display. It can vary
 	// based on filtering mode. Returning nil, nil indicates there is no state

--- a/gapis/api/templates/api.go.tmpl
+++ b/gapis/api/templates/api.go.tmpl
@@ -224,7 +224,7 @@ import (
   {{end}}
 
   // Clone makes a deep copy of this static array, using ϟa for allocations.
-  func (m {{$name}}) Clone(ϟa arena.Arena) {{$name}} {
+  func (m {{$name}}) Clone(ϟa arena.Arena, ϟd *data.Cloner) {{$name}} {
     out := {{$name}}{ data: &[{{$ty.Size}}]{{$el}}{} }
     for i := 0; i < {{$ty.Size}}; i++ {
       out.Set(i, {{Template "Clone" "Type" $ty.ValueType "Src" "m.Get(i)"}})
@@ -341,8 +341,12 @@ import (
   }
 
   // Clone makes a deep copy of this map.
-  func (m {{$name}}) Clone(ϟa arena.Arena) {{$name}} {
+  func (m {{$name}}) Clone(ϟa arena.Arena, ϟd *data.Cloner) {{$name}} {
+    if val, ok := ϟd.Get(&m.Map); ok {
+      return {{$name}}{Map: val.(*map[{{$key}}]{{$value}})}
+    }
     out := make(map[{{$key}}]{{$value}}, len(*m.Map))
+    ϟd.Add(m.Map, &out)
     for k, v := range *m.Map {
       out[{{Template "Clone" "Type" $.KeyType "Src" "k"}}] = {{Template "Clone" "Type" $.ValueType "Src" "v"}}
     }
@@ -395,16 +399,20 @@ import (
   func (c {{$name}}) SetNil() { c.data = nil }
 
   // Clone makes a deep copy of this reference.
-  func (c {{$name}}) Clone(ϟa arena.Arena) {{$name}} {
+  func (c {{$name}}) Clone(ϟa arena.Arena, ϟd *data.Cloner) {{$name}} {
     if c.IsNil() { return Nil{{$name}} }
-    return {{$name}}{
-      data: &{{$data}}{
-        {{range $f := $.To.Fields}}
-          {{$name := $f.Name | GoPrivateName}}
-          {{$name}}: c.data.{{Template "Clone" "Type" $f.Type "Src" $name}},
-        {{end}}
-      },
+    if val, ok := ϟd.Get(c.data); ok {
+      return {{$name}}{data: val.(*{{$data}})}
     }
+
+    outVal := {{$name}}{data: &{{$data}}{}}
+    ϟd.Add(c.data, outVal.data)
+    {{range $f := $.To.Fields}}
+      {{$name := $f.Name | GoPrivateName}}
+      outVal.data.{{$name}} = c.data.{{Template "Clone" "Type" $f.Type "Src" $name}}
+    {{end}}
+    
+    return outVal
   }
 
   {{if GetAnnotation $.To "resource"}}
@@ -1203,7 +1211,7 @@ import (
   {{end}}
 
   // Clone makes a deep copy of this class.
-  func (c {{$name}}) Clone(ϟa arena.Arena) {{$name}} {
+  func (c {{$name}}) Clone(ϟa arena.Arena, ϟd *data.Cloner) {{$name}} {
     return {{$name}}{
       data: &{{$data}}{
         {{range $f := $.Fields}}
@@ -1338,6 +1346,8 @@ import (
       caller: ϟc.caller,
       thread: ϟc.thread,
     }
+    ϟd := data.NewCloner()
+    _ = ϟd
     {{range $p := $.FullParameters}}
       out.{{$p | GoPrivateName}} = {{Template "Clone" "Type" $p.Type "Src" (print "ϟc." ($p | GoPrivateName))}}
     {{end}}
@@ -1456,7 +1466,7 @@ import (
   }
 
 	// Clone returns a deep copy of this state object.
-  func (g *State) Clone(ϟa arena.Arena) ϟapi.State {
+  func (g *State) Clone(ϟa arena.Arena, ϟd *data.Cloner) ϟapi.State {
     out := &State{CustomState: g.CustomState}
     {{range $g := $.Globals}}
       {{$name := $g.Name | GoPublicName}}
@@ -1711,13 +1721,13 @@ import (
   {{AssertType $.Type "Type"}}
 
   {{     if IsPseudonym     $.Type}}{{Template "Clone" "Type" $.Type.To "Src" $.Src}}
-  {{else if IsStaticArray   $.Type}}{{$.Src}}.Clone(ϟa)
-  {{else if IsMap           $.Type}}{{$.Src}}.Clone(ϟa)
-  {{else if IsClass         $.Type}}{{$.Src}}.Clone(ϟa)
+  {{else if IsStaticArray   $.Type}}{{$.Src}}.Clone(ϟa, ϟd)
+  {{else if IsMap           $.Type}}{{$.Src}}.Clone(ϟa, ϟd)
+  {{else if IsClass         $.Type}}{{$.Src}}.Clone(ϟa, ϟd)
   {{else if IsEnum          $.Type}}{{$.Src}}
   {{else if IsPointer       $.Type}}{{$.Src}}
   {{else if IsSlice         $.Type}}{{$.Src}}
-  {{else if IsReference     $.Type}}{{$.Src}}.Clone(ϟa)
+  {{else if IsReference     $.Type}}{{$.Src}}.Clone(ϟa, ϟd)
   {{else if IsBool          $.Type}}{{$.Src}}
   {{else if IsInt           $.Type}}{{$.Src}}
   {{else if IsUint          $.Type}}{{$.Src}}

--- a/gapis/api/test/BUILD.bazel
+++ b/gapis/api/test/BUILD.bazel
@@ -51,7 +51,15 @@ go_library(
     deps = [
         "//core/math/interval:go_default_library",
         "//gapis/api:go_default_library",
+        "//core/event/task:go_default_library",
+        "//core/memory/arena:go_default_library",
         "//gapis/service/path:go_default_library",
+        "//gapis/messages:go_default_library",
+        "//gapis/stringtable:go_default_library",
+        "//gapil/constset:go_default_library",
+        "//core/data/protoconv:go_default_library",
+        "//gapis/api/test/test_pb:go_default_library",
+        "//gapis/memory/memory_pb:go_default_library",
         "@com_github_golang_protobuf//proto:go_default_library",  # keep
     ],
 )
@@ -64,6 +72,7 @@ go_test(
         "map_test.go",
         "mutate_test.go",
         "subroutines_test.go",
+        "clone_test.go",
     ],
     embed = [":go_default_library"],
     deps = [

--- a/gapis/api/test/convert_test.go
+++ b/gapis/api/test/convert_test.go
@@ -84,6 +84,7 @@ func TestReferences(t *testing.T) {
 			),
 		),
 		cycle, // Cycle
+		NewU32ːNestedRefʳᵐ(a),
 	)
 
 	// extra -> protoA -> decoded -> protoB

--- a/gapis/api/test/test.api
+++ b/gapis/api/test/test.api
@@ -286,6 +286,10 @@ class TestList {
   ref!TestList next
 }
 
+class NestedRef {
+  ref!TestObject           Data
+}
+
 class TestExtra {
   u8[]                     Data
 
@@ -305,4 +309,6 @@ class TestExtra {
 
   ref!TestList             LinkedList
   ref!TestList             Cycle
+
+  map!(u32, ref!NestedRef)     NestedRefs
 }

--- a/gapis/api/vulkan/externs.go
+++ b/gapis/api/vulkan/externs.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"reflect"
 
+	"github.com/google/gapid/core/data"
 	"github.com/google/gapid/core/log"
 	"github.com/google/gapid/gapis/api"
 	"github.com/google/gapid/gapis/memory"
@@ -319,9 +320,10 @@ func bindSparse(ctx context.Context, a api.Cmd, id api.CmdID, s *api.GlobalState
 }
 
 func (e externs) fetchPhysicalDeviceProperties(inst VkInstance, devs VkPhysicalDeviceˢ) PhysicalDevicesAndPropertiesʳ {
+	cloner := data.NewCloner()
 	for _, ee := range e.cmd.Extras().All() {
 		if p, ok := ee.(PhysicalDevicesAndProperties); ok {
-			return MakePhysicalDevicesAndPropertiesʳ(e.s.Arena).Set(p).Clone(e.s.Arena)
+			return MakePhysicalDevicesAndPropertiesʳ(e.s.Arena).Set(p).Clone(e.s.Arena, cloner)
 		}
 	}
 	return NilPhysicalDevicesAndPropertiesʳ
@@ -330,18 +332,20 @@ func (e externs) fetchPhysicalDeviceProperties(inst VkInstance, devs VkPhysicalD
 func (e externs) fetchImageMemoryRequirements(dev VkDevice, img VkImage, hasSparseBit bool) ImageMemoryRequirementsʳ {
 	// Only fetch memory requirements for application commands, skip any commands
 	// inserted by GAPID
+	cloner := data.NewCloner()
 	if e.cmdID == api.CmdNoID {
 		return NilImageMemoryRequirementsʳ
 	}
 	for _, ee := range e.cmd.Extras().All() {
 		if r, ok := ee.(ImageMemoryRequirements); ok {
-			return MakeImageMemoryRequirementsʳ(e.s.Arena).Set(r).Clone(e.s.Arena)
+			return MakeImageMemoryRequirementsʳ(e.s.Arena).Set(r).Clone(e.s.Arena, cloner)
 		}
 	}
 	return NilImageMemoryRequirementsʳ
 }
 
 func (e externs) fetchBufferMemoryRequirements(dev VkDevice, buf VkBuffer) VkMemoryRequirements {
+	cloner := data.NewCloner()
 	// Only fetch memory requirements for application commands, skip any commands
 	// inserted by GAPID
 	if e.cmdID == api.CmdNoID {
@@ -349,7 +353,7 @@ func (e externs) fetchBufferMemoryRequirements(dev VkDevice, buf VkBuffer) VkMem
 	}
 	for _, ee := range e.cmd.Extras().All() {
 		if r, ok := ee.(VkMemoryRequirements); ok {
-			return r.Clone(e.s.Arena)
+			return r.Clone(e.s.Arena, cloner)
 		}
 	}
 	return MakeVkMemoryRequirements(e.s.Arena)

--- a/gapis/api/vulkan/image_primer.go
+++ b/gapis/api/vulkan/image_primer.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	"github.com/golang/protobuf/proto"
+	"github.com/google/gapid/core/data"
 	"github.com/google/gapid/core/image"
 	"github.com/google/gapid/core/log"
 	"github.com/google/gapid/core/stream"
@@ -233,8 +234,8 @@ func (p *imagePrimer) allocStagingImages(img ImageObjectʳ, aspect VkImageAspect
 	}
 	stagingElementInfo, _ := subGetElementAndTexelBlockSize(p.sb.ctx, nil, api.CmdNoID, nil, p.sb.oldState, GetState(p.sb.oldState), 0, nil, stagingImgFormat)
 	stagingElementSize := stagingElementInfo.ElementSize()
-
-	stagingInfo := img.Info().Clone(p.sb.newState.Arena)
+	cloner := data.NewCloner()
+	stagingInfo := img.Info().Clone(p.sb.newState.Arena, cloner)
 	stagingInfo.SetDedicatedAllocationNV(NilDedicatedAllocationBufferImageCreateInfoNVʳ)
 	stagingInfo.SetFmt(stagingImgFormat)
 	stagingInfo.SetUsage(VkImageUsageFlags(VkImageUsageFlagBits_VK_IMAGE_USAGE_TRANSFER_DST_BIT | VkImageUsageFlagBits_VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT | VkImageUsageFlagBits_VK_IMAGE_USAGE_SAMPLED_BIT))

--- a/gapis/api/vulkan/replay.go
+++ b/gapis/api/vulkan/replay.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/google/gapid/core/data"
 	"github.com/google/gapid/core/image"
 	"github.com/google/gapid/core/log"
 	"github.com/google/gapid/core/os/device"
@@ -273,8 +274,9 @@ func (t *makeAttachementReadable) Transform(ctx context.Context, id api.CmdID, c
 		devs := devSlice.MustRead(ctx, cmd, s, nil)
 		allProps := externs{ctx, cmd, id, s, nil}.fetchPhysicalDeviceProperties(e.Instance(), devSlice)
 		propList := []VkPhysicalDeviceProperties{}
+		cloner := data.NewCloner()
 		for _, dev := range devs {
-			propList = append(propList, allProps.PhyDevToProperties().Get(dev).Clone(s.Arena))
+			propList = append(propList, allProps.PhyDevToProperties().Get(dev).Clone(s.Arena, cloner))
 		}
 		newEnumerate := buildReplayEnumeratePhysicalDevices(ctx, s, cb, e.Instance(), numDev, devs, propList)
 		out.MutateAndWrite(ctx, id, newEnumerate)

--- a/gapis/capture/BUILD.bazel
+++ b/gapis/capture/BUILD.bazel
@@ -30,6 +30,7 @@ go_library(
     deps = [
         "//core/app/analytics:go_default_library",
         "//core/context/keys:go_default_library",
+        "//core/data:go_default_library",
         "//core/data/id:go_default_library",
         "//core/data/pack:go_default_library",
         "//core/data/protoconv:go_default_library",

--- a/gapis/capture/capture.go
+++ b/gapis/capture/capture.go
@@ -22,6 +22,7 @@ import (
 	"sync"
 
 	"github.com/google/gapid/core/app/analytics"
+	"github.com/google/gapid/core/data"
 	"github.com/google/gapid/core/data/id"
 	"github.com/google/gapid/core/data/pack"
 	"github.com/google/gapid/core/data/protoconv"
@@ -135,6 +136,7 @@ func (c *Capture) NewUninitializedState(ctx context.Context, rngs interval.U64Ra
 // capture.
 func (c *Capture) NewState(ctx context.Context) *api.GlobalState {
 	s := c.NewUninitializedState(ctx, interval.U64RangeList{})
+	cloner := data.NewCloner()
 	if c.InitialState != nil {
 		for _, m := range c.InitialState.Memory {
 			pool, _ := s.Memory.Get(memory.PoolID(m.Pool))
@@ -144,7 +146,7 @@ func (c *Capture) NewState(ctx context.Context) *api.GlobalState {
 			pool.Write(m.Range.Base, memory.Resource(m.ID, m.Range.Size))
 		}
 		for k, v := range c.InitialState.APIs {
-			s.APIs[k.ID()] = v.Clone(s.Arena)
+			s.APIs[k.ID()] = v.Clone(s.Arena, cloner)
 		}
 		for _, v := range s.APIs {
 			v.SetupInitialState(ctx, s)


### PR DESCRIPTION
State cloning was broken with the getter/setter MR.
Track references, and make sure that we are keeping multiple
references to the same object together rather than uniquing them.