### PR TITLE
Fix for linear image with preinitialized intial layout

### DIFF
--- a/gapis/api/vulkan/api/image.api
+++ b/gapis/api/vulkan/api/image.api
@@ -117,7 +117,7 @@
 }
 
 @internal class ImageMemoryRequirements {
-  VkMemoryRequirements MemoryRequirements
+  VkMemoryRequirements                       MemoryRequirements
   map!(u32, VkSparseImageMemoryRequirements) AspectBitsToSparseMemoryRequirements
 }
 
@@ -147,17 +147,17 @@ cmd VkResult vkCreateImage(
   queueFamilyIndices := info.pQueueFamilyIndices[0:info.queueFamilyIndexCount]
 
   imageInfo := ImageInfo(
-    Flags:        info.flags,
-    ImageType:    info.imageType,
-    Format:       info.format,
-    Extent:       info.extent,
-    MipLevels:    info.mipLevels,
-    ArrayLayers:  info.arrayLayers,
-    Samples:      info.samples,
-    Tiling:       info.tiling,
-    Usage:        info.usage,
-    SharingMode:  info.sharingMode,
-    InitialLayout:       info.initialLayout,
+    Flags:          info.flags,
+    ImageType:      info.imageType,
+    Format:         info.format,
+    Extent:         info.extent,
+    MipLevels:      info.mipLevels,
+    ArrayLayers:    info.arrayLayers,
+    Samples:        info.samples,
+    Tiling:         info.tiling,
+    Usage:          info.usage,
+    SharingMode:    info.sharingMode,
+    InitialLayout:  info.initialLayout,
   )
 
   for i in (0 .. info.queueFamilyIndexCount) {
@@ -245,16 +245,16 @@ cmd VkResult vkCreateImage(
   if (info.tiling == VK_IMAGE_TILING_LINEAR) {
     linearLayouts := fetchLinearImageSubresourceLayouts(device, object,
       VkImageSubresourceRange(
-        aspectMask:     imageAspect,
-        baseMipLevel:   0,
-        levelCount:     imageInfo.MipLevels,
-        baseArrayLayer: 0,
-        layerCount:     imageInfo.ArrayLayers,
+        aspectMask:      imageAspect,
+        baseMipLevel:    0,
+        levelCount:      imageInfo.MipLevels,
+        baseArrayLayer:  0,
+        layerCount:      imageInfo.ArrayLayers,
       ))
     if (linearLayouts != null) {
-      for _, aspectBit, al in linearLayouts.AspectLayouts {
-        for _, layer, layl in al.LayerLayouts {
-          for _, level, levl in layl.LevelLayouts {
+      for _ , aspectBit , al in linearLayouts.AspectLayouts {
+        for _ , layer , layl in al.LayerLayouts {
+          for _ , level , levl in layl.LevelLayouts {
             if levl != null {
               object.Aspects[as!VkImageAspectFlagBits(aspectBit)].Layers[layer].Levels[level].LinearLayout = levl
             }
@@ -356,11 +356,11 @@ cmd VkResult vkBindImageMemory(
         // no matter whether the tiling is LINEAR or OPTIMAL. But we need to
         // come up with a 'linear layout' used in GAPID.
         if (imageObject.Info.Tiling == VK_IMAGE_TILING_LINEAR) &&
-           (level.Layout == VK_IMAGE_LAYOUT_PREINITIALIZED) && 
-           (level.LinearLayout != null) {
-             loffset := as!u64(memoryOffset + level.LinearLayout.offset)
-             lsize := as!u64(level.LinearLayout.size)
-             level.Data = imageObject.BoundMemory.Data[loffset:lsize]
+            (level.Layout == VK_IMAGE_LAYOUT_PREINITIALIZED) &&
+            (level.LinearLayout != null) {
+          loffset := as!u64(memoryOffset + level.LinearLayout.offset)
+          lsize := as!u64(level.LinearLayout.size)
+          level.Data = imageObject.BoundMemory.Data[loffset:lsize]
         } else {
           level.Data = make!u8(size)
         }

--- a/gapis/api/vulkan/api/image.api
+++ b/gapis/api/vulkan/api/image.api
@@ -64,7 +64,7 @@
   VkDeviceSize            BoundMemoryOffset
   // mapping from the resource offsets to the sparse bindings in the unit of sparse blocks
   map!(u64, VkSparseMemoryBind) OpaqueSparseMemoryBindings
-  // mapping from image aspect flags to binding info
+  // mapping from image aspect flag bits to binding info
   map!(u32, ref!SparseBoundImageAspectInfo)    SparseImageMemoryBindings
   @unused bool                                 IsSwapchainImage
   VkImage                                      VulkanHandle
@@ -92,6 +92,7 @@
   @spy_disabled
   @hidden @nobox @internal u8[] Data
   VkImageLayout                 Layout
+  ref!VkSubresourceLayout       LinearLayout
 }
 
 @internal class SparseBoundImageAspectInfo {
@@ -118,6 +119,18 @@
 @internal class ImageMemoryRequirements {
   VkMemoryRequirements MemoryRequirements
   map!(u32, VkSparseImageMemoryRequirements) AspectBitsToSparseMemoryRequirements
+}
+
+@internal class LinearImageLayouts {
+  map!(u32, ref!LinearImageAspectLayouts) AspectLayouts
+}
+
+@internal class LinearImageAspectLayouts {
+  map!(u32, ref!LinearImageLayerLayouts) LayerLayouts
+}
+
+@internal class LinearImageLayerLayouts {
+  map!(u32, ref!VkSubresourceLayout) LevelLayouts
 }
 
 @threadSafety("system")
@@ -228,6 +241,29 @@ cmd VkResult vkCreateImage(
     }
   }
 
+  // If the image tiling is LINEAR, get the VkSubresourceLayout for each linear image level
+  if (info.tiling == VK_IMAGE_TILING_LINEAR) {
+    linearLayouts := fetchLinearImageSubresourceLayouts(device, object,
+      VkImageSubresourceRange(
+        aspectMask:     imageAspect,
+        baseMipLevel:   0,
+        levelCount:     imageInfo.MipLevels,
+        baseArrayLayer: 0,
+        layerCount:     imageInfo.ArrayLayers,
+      ))
+    if (linearLayouts != null) {
+      for _, aspectBit, al in linearLayouts.AspectLayouts {
+        for _, layer, layl in al.LayerLayouts {
+          for _, level, levl in layl.LevelLayouts {
+            if levl != null {
+              object.Aspects[as!VkImageAspectFlagBits(aspectBit)].Layers[layer].Levels[level].LinearLayout = levl
+            }
+          }
+        }
+      }
+    }
+  }
+
   Images[handle] = object
 
   return ?
@@ -310,9 +346,24 @@ cmd VkResult vkBindImageMemory(
             // stencil element is always 1 byte wide
             as!u32(1)
         }
-        // Align to the next multiple times of 8
         size := widthInBlocks * heightInBlocks * level.Depth * elementSize
-        level.Data = make!u8(size)
+
+        // If the image has LINEAR tiling and the image level has layout
+        // PREINITIALIZED, link the data back to the bound device memory.
+        // Otherwise creates its own shadow memory pool.
+        // TODO: If the image as a whole requires more memory than we
+        // calculated, we should link the data back to the bound device memory
+        // no matter whether the tiling is LINEAR or OPTIMAL. But we need to
+        // come up with a 'linear layout' used in GAPID.
+        if (imageObject.Info.Tiling == VK_IMAGE_TILING_LINEAR) &&
+           (level.Layout == VK_IMAGE_LAYOUT_PREINITIALIZED) && 
+           (level.LinearLayout != null) {
+             loffset := as!u64(memoryOffset + level.LinearLayout.offset)
+             lsize := as!u64(level.LinearLayout.size)
+             level.Data = imageObject.BoundMemory.Data[loffset:lsize]
+        } else {
+          level.Data = make!u8(size)
+        }
       }
     }
   }

--- a/gapis/api/vulkan/externs.go
+++ b/gapis/api/vulkan/externs.go
@@ -355,6 +355,20 @@ func (e externs) fetchBufferMemoryRequirements(dev VkDevice, buf VkBuffer) VkMem
 	return MakeVkMemoryRequirements(e.s.Arena)
 }
 
+func (e externs) fetchLinearImageSubresourceLayouts(dev VkDevice, img ImageObjectʳ, rng VkImageSubresourceRange) LinearImageLayoutsʳ {
+	// Only fetch linear image layouts for application commands, skip any commands
+	// inserted by GAPID
+	if e.cmdID == api.CmdNoID {
+		return NilLinearImageLayoutsʳ
+	}
+	for _, ee := range e.cmd.Extras().All() {
+		if r, ok := ee.(LinearImageLayouts); ok {
+			return MakeLinearImageLayoutsʳ(e.s.Arena).Set(r).Clone(e.s.Arena)
+		}
+	}
+	return NilLinearImageLayoutsʳ
+}
+
 func (e externs) vkErrInvalidHandle(handleType string, handle uint64) {
 	var issue replay.Issue
 	issue.Command = e.cmdID

--- a/gapis/api/vulkan/state_rebuilder.go
+++ b/gapis/api/vulkan/state_rebuilder.go
@@ -1361,9 +1361,10 @@ func (sb *stateBuilder) createImage(img ImageObjectʳ, imgPrimer *imagePrimer) {
 	storageBit := VkImageUsageFlags(VkImageUsageFlagBits_VK_IMAGE_USAGE_STORAGE_BIT)
 
 	isDepth := (img.Info().Usage() & VkImageUsageFlags(VkImageUsageFlagBits_VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT)) != 0
-    primeByBufCopy := (img.Info().Usage()&transDstBit) != 0 && (!isDepth)
+	primeByBufCopy := (img.Info().Usage()&transDstBit) != 0 && (!isDepth)
 	primeByRendering := (!primeByBufCopy) && ((img.Info().Usage() & attBits) != 0)
 	primeByImageStore := (!primeByBufCopy) && (!primeByRendering) && ((img.Info().Usage() & storageBit) != 0)
+	primeByPreinitialization := (!primeByBufCopy) && (!primeByRendering) && (!primeByImageStore) && (img.Info().Tiling() == VkImageTiling_VK_IMAGE_TILING_LINEAR) && (img.Info().InitialLayout() == VkImageLayout_VK_IMAGE_LAYOUT_PREINITIALIZED)
 
 	vkCreateImage(sb, img.Device(), img.Info(), img.VulkanHandle())
 	vkGetImageMemoryRequirements(sb, img.Device(), img.VulkanHandle(), img.MemoryRequirements())
@@ -1597,6 +1598,10 @@ func (sb *stateBuilder) createImage(img ImageObjectʳ, imgPrimer *imagePrimer) {
 		err = imgPrimer.primeByRendering(img, opaqueRanges, queue, sparseQueue)
 	} else if primeByImageStore {
 		err = imgPrimer.primeByImageStore(img, opaqueRanges, queue, sparseQueue)
+	} else if primeByPreinitialization {
+		err = imgPrimer.primeByPreinitialization(img, opaqueRanges, queue, sparseQueue)
+	} else {
+		err = log.Errf(sb.ctx, nil, "There is no valid way to prim data into image: %v", img.VulkanHandle())
 	}
 	if err != nil {
 		log.E(sb.ctx, "[Priming the data of image: %v] %v", img.VulkanHandle(), err)

--- a/gapis/api/vulkan/vulkan.api
+++ b/gapis/api/vulkan/vulkan.api
@@ -114,6 +114,7 @@ extern void validate(string layerName, bool condition, string message)
 extern ref!PhysicalDevicesAndProperties fetchPhysicalDeviceProperties(VkInstance instance, VkPhysicalDevice[] devs)
 extern ref!ImageMemoryRequirements fetchImageMemoryRequirements(VkDevice device, VkImage image, bool hasSparseBit)
 extern VkMemoryRequirements fetchBufferMemoryRequirements(VkDevice device, VkBuffer buffer)
+extern ref!LinearImageLayouts fetchLinearImageSubresourceLayouts(VkDevice device, ref!ImageObject image, VkImageSubresourceRange rng)
 
 ///////////////////////
 // Function pointers //


### PR DESCRIPTION
1) If an image has linear tiling and has initial layout set to
PREINITIALIZED, all its subresources data pool will be linked back to
the bound device memory, no new pool will be created for those
subresources.

2) If an image has linear tiling and has initial layout set to
PREINITIALIZED, and it can not be used as TRANSFER_DST, render target or
imageStore target, its data will be primed by maping memory and flush
map memory ranges.