### PR TITLE
Response for failed connection quicker so we can restart gapir earlier

### DIFF
--- a/gapir/client/session.go
+++ b/gapir/client/session.go
@@ -45,6 +45,7 @@ const (
 	maxCheckSocketFileAttempts = 10
 	checkSocketFileRetryDelay  = time.Second
 	connectTimeout             = time.Second * 10
+	heartbeatInterval          = time.Millisecond * 500
 )
 
 type session struct {
@@ -79,7 +80,7 @@ func (s *session) init(ctx context.Context, d bind.Device, abi *device.ABI, laun
 		return err
 	}
 
-	crash.Go(func() { s.heartbeat(ctx, sessionTimeout/2) })
+	crash.Go(func() { s.heartbeat(ctx, heartbeatInterval) })
 	return nil
 }
 


### PR DESCRIPTION
Mitigate #1934 

A replay session will closed if heartbeat PING failed. If the interval
is too long, the user need to wait for a longer time before the next
request can be issued and restart a new replay session and connection.
With a shorter PING interval, we find such connectionf failure sooner so
we can start to process next comming request sooner.

This is probably not a perfect fix. But the go-grpc currently does not
have a 'signal' for connection failure.

A newer version of go-grpc may have 'GetState()' interface for client
connection, with which we can set a go routine to pull and set signal
for connection failure. This may not occupy communication bandwidth. But
the general idea is similar.