### PR TITLE
A few fixes mostly related to references in the API language

### DIFF
--- a/gapis/api/api.go
+++ b/gapis/api/api.go
@@ -106,3 +106,6 @@ func Register(api API) {
 func Find(id ID) API {
 	return apis[id]
 }
+
+// CloneContext is used to keep track of references when cloning API objects.
+type CloneContext map[interface{}]interface{}

--- a/gapis/api/gles/externs.go
+++ b/gapis/api/gles/externs.go
@@ -61,15 +61,15 @@ func (e externs) unmapMemory(slice memory.Slice) {
 }
 
 func (e externs) GetEGLStaticContextState(EGLDisplay, EGLContext) StaticContextStateʳ {
-	return FindStaticContextState(e.s.Arena, e.cmd.Extras()).Clone(e.s.Arena)
+	return FindStaticContextState(e.s.Arena, e.cmd.Extras()).Clone(e.s.Arena, api.CloneContext{})
 }
 
 func (e externs) GetEGLDynamicContextState(EGLDisplay, EGLSurface, EGLContext) DynamicContextStateʳ {
-	return FindDynamicContextState(e.s.Arena, e.cmd.Extras()).Clone(e.s.Arena)
+	return FindDynamicContextState(e.s.Arena, e.cmd.Extras()).Clone(e.s.Arena, api.CloneContext{})
 }
 
 func (e externs) GetAndroidNativeBufferExtra(Voidᵖ) AndroidNativeBufferExtraʳ {
-	return FindAndroidNativeBufferExtra(e.s.Arena, e.cmd.Extras()).Clone(e.s.Arena)
+	return FindAndroidNativeBufferExtra(e.s.Arena, e.cmd.Extras()).Clone(e.s.Arena, api.CloneContext{})
 }
 
 func (e externs) GetEGLImageData(id EGLImageKHR, _ GLsizei, _ GLsizei) {
@@ -116,19 +116,19 @@ func (e externs) substr(str string, start, end int32) string {
 }
 
 func (e externs) GetCompileShaderExtra(ctx Contextʳ, obj Shaderʳ, bin BinaryExtraʳ) CompileShaderExtraʳ {
-	return FindCompileShaderExtra(e.s.Arena, e.cmd.Extras(), obj).Clone(e.s.Arena)
+	return FindCompileShaderExtra(e.s.Arena, e.cmd.Extras(), obj).Clone(e.s.Arena, api.CloneContext{})
 }
 
 func (e externs) GetLinkProgramExtra(ctx Contextʳ, obj Programʳ, bin BinaryExtraʳ) LinkProgramExtraʳ {
-	return FindLinkProgramExtra(e.s.Arena, e.cmd.Extras()).Clone(e.s.Arena)
+	return FindLinkProgramExtra(e.s.Arena, e.cmd.Extras()).Clone(e.s.Arena, api.CloneContext{})
 }
 
 func (e externs) GetValidateProgramExtra(ctx Contextʳ, obj Programʳ) ValidateProgramExtraʳ {
-	return FindValidateProgramExtra(e.s.Arena, e.cmd.Extras()).Clone(e.s.Arena)
+	return FindValidateProgramExtra(e.s.Arena, e.cmd.Extras()).Clone(e.s.Arena, api.CloneContext{})
 }
 
 func (e externs) GetValidateProgramPipelineExtra(ctx Contextʳ, obj Pipelineʳ) ValidateProgramPipelineExtraʳ {
-	return FindValidateProgramPipelineExtra(e.s.Arena, e.cmd.Extras()).Clone(e.s.Arena)
+	return FindValidateProgramPipelineExtra(e.s.Arena, e.cmd.Extras()).Clone(e.s.Arena, api.CloneContext{})
 }
 
 func (e externs) onGlError(err GLenum) {

--- a/gapis/api/gles/stub_program.go
+++ b/gapis/api/gles/stub_program.go
@@ -31,7 +31,7 @@ var (
 )
 
 func buildStubProgram(ctx context.Context, thread uint64, e *api.CmdExtras, s *api.GlobalState, programID ProgramId) []api.Cmd {
-	programInfo := FindLinkProgramExtra(s.Arena, e).Clone(s.Arena)
+	programInfo := FindLinkProgramExtra(s.Arena, e).Clone(s.Arena, api.CloneContext{})
 	vss, fss, err := stubShaderSource(programInfo)
 	if err != nil {
 		log.E(ctx, "Unable to build stub shader: %v", err)

--- a/gapis/api/templates/api.go.tmpl
+++ b/gapis/api/templates/api.go.tmpl
@@ -224,7 +224,7 @@ import (
   {{end}}
 
   // Clone makes a deep copy of this static array, using ϟa for allocations.
-  func (m {{$name}}) Clone(ϟa arena.Arena) {{$name}} {
+  func (m {{$name}}) Clone(ϟa arena.Arena, ϟseen ϟapi.CloneContext) {{$name}} {
     out := {{$name}}{ data: &[{{$ty.Size}}]{{$el}}{} }
     for i := 0; i < {{$ty.Size}}; i++ {
       out.Set(i, {{Template "Clone" "Type" $ty.ValueType "Src" "m.Get(i)"}})
@@ -341,8 +341,12 @@ import (
   }
 
   // Clone makes a deep copy of this map.
-  func (m {{$name}}) Clone(ϟa arena.Arena) {{$name}} {
+  func (m {{$name}}) Clone(ϟa arena.Arena, ϟseen ϟapi.CloneContext) {{$name}} {
+    if existing, ok := ϟseen[m.Map]; ok {
+      return {{$name}}{Map: existing.(*map[{{$key}}]{{$value}}), a: ϟa}
+    }
     out := make(map[{{$key}}]{{$value}}, len(*m.Map))
+    ϟseen[m.Map] = &out
     for k, v := range *m.Map {
       out[{{Template "Clone" "Type" $.KeyType "Src" "k"}}] = {{Template "Clone" "Type" $.ValueType "Src" "v"}}
     }
@@ -395,16 +399,18 @@ import (
   func (c {{$name}}) SetNil() { c.data = nil }
 
   // Clone makes a deep copy of this reference.
-  func (c {{$name}}) Clone(ϟa arena.Arena) {{$name}} {
+  func (c {{$name}}) Clone(ϟa arena.Arena, ϟseen ϟapi.CloneContext) {{$name}} {
     if c.IsNil() { return Nil{{$name}} }
-    return {{$name}}{
-      data: &{{$data}}{
-        {{range $f := $.To.Fields}}
-          {{$name := $f.Name | GoPrivateName}}
-          {{$name}}: c.data.{{Template "Clone" "Type" $f.Type "Src" $name}},
-        {{end}}
-      },
+    if existing, ok := ϟseen[c.data]; ok {
+      return {{$name}}{data: existing.(*{{$data}})}
     }
+    d := &{{$data}}{}
+    ϟseen[c.data] = d
+    {{range $f := $.To.Fields}}
+      {{$name := $f.Name | GoPrivateName}}
+      d.{{$name}} = c.data.{{Template "Clone" "Type" $f.Type "Src" $name}}
+    {{end}}
+    return {{$name}}{data: d}
   }
 
   {{if GetAnnotation $.To "resource"}}
@@ -1204,7 +1210,7 @@ import (
   {{end}}
 
   // Clone makes a deep copy of this class.
-  func (c {{$name}}) Clone(ϟa arena.Arena) {{$name}} {
+  func (c {{$name}}) Clone(ϟa arena.Arena, ϟseen ϟapi.CloneContext) {{$name}} {
     return {{$name}}{
       data: &{{$data}}{
         {{range $f := $.Fields}}
@@ -1339,9 +1345,14 @@ import (
       extras: ϟc.extras,
       caller: ϟc.caller,
       thread: ϟc.thread,
+      arena: ϟa,
     }
-    {{range $p := $.FullParameters}}
-      out.{{$p | GoPrivateName}} = {{Template "Clone" "Type" $p.Type "Src" (print "ϟc." ($p | GoPrivateName))}}
+    {{if len $.FullParameters}}
+      ϟseen := ϟapi.CloneContext{}
+      _ = ϟseen
+      {{range $p := $.FullParameters}}
+        out.{{$p | GoPrivateName}} = {{Template "Clone" "Type" $p.Type "Src" (print "ϟc." ($p | GoPrivateName))}}
+      {{end}}
     {{end}}
     return out
   }
@@ -1460,13 +1471,16 @@ import (
 	// Clone returns a deep copy of this state object.
   func (g *State) Clone(ϟa arena.Arena) ϟapi.State {
     out := &State{CustomState: g.CustomState}
-    {{range $g := $.Globals}}
-      {{$name := $g.Name | GoPublicName}}
-      out.Set{{$name}}({{Template "Clone" "Type" $g.Type "Src" (print "g." $name "()")}})
+    {{if len $.Globals}}
+      ϟseen := ϟapi.CloneContext{}
+      _ = ϟseen
+      {{range $g := $.Globals}}
+        {{$name := $g.Name | GoPublicName}}
+        out.Set{{$name}}({{Template "Clone" "Type" $g.Type "Src" (print "g." $name "()")}})
+      {{end}}
     {{end}}
     return out
   }
-
 {{end}}
 
 
@@ -1713,13 +1727,13 @@ import (
   {{AssertType $.Type "Type"}}
 
   {{     if IsPseudonym     $.Type}}{{Template "Clone" "Type" $.Type.To "Src" $.Src}}
-  {{else if IsStaticArray   $.Type}}{{$.Src}}.Clone(ϟa)
-  {{else if IsMap           $.Type}}{{$.Src}}.Clone(ϟa)
-  {{else if IsClass         $.Type}}{{$.Src}}.Clone(ϟa)
+  {{else if IsStaticArray   $.Type}}{{$.Src}}.Clone(ϟa, ϟseen)
+  {{else if IsMap           $.Type}}{{$.Src}}.Clone(ϟa, ϟseen)
+  {{else if IsClass         $.Type}}{{$.Src}}.Clone(ϟa, ϟseen)
   {{else if IsEnum          $.Type}}{{$.Src}}
   {{else if IsPointer       $.Type}}{{$.Src}}
   {{else if IsSlice         $.Type}}{{$.Src}}
-  {{else if IsReference     $.Type}}{{$.Src}}.Clone(ϟa)
+  {{else if IsReference     $.Type}}{{$.Src}}.Clone(ϟa, ϟseen)
   {{else if IsBool          $.Type}}{{$.Src}}
   {{else if IsInt           $.Type}}{{$.Src}}
   {{else if IsUint          $.Type}}{{$.Src}}

--- a/gapis/api/templates/api.go.tmpl
+++ b/gapis/api/templates/api.go.tmpl
@@ -346,7 +346,7 @@ import (
     for k, v := range *m.Map {
       out[{{Template "Clone" "Type" $.KeyType "Src" "k"}}] = {{Template "Clone" "Type" $.ValueType "Src" "v"}}
     }
-    return {{$name}}{Map: &out}
+    return {{$name}}{Map: &out, a: ϟa}
   }
 {{end}}
 
@@ -1098,6 +1098,7 @@ import (
           {{$f.Name | GoPrivateName}}: {{$f.Name | GoPrivateName}}, §
         {{end}}
       },
+      a: ϟa,
     }
   }
 
@@ -1211,6 +1212,7 @@ import (
           {{$name}}: c.data.{{Template "Clone" "Type" $f.Type "Src" $name}},
         {{end}}
       },
+      a: ϟa,
     }
   }
 {{end}}

--- a/gapis/api/test/BUILD.bazel
+++ b/gapis/api/test/BUILD.bazel
@@ -51,7 +51,15 @@ go_library(
     deps = [
         "//core/math/interval:go_default_library",
         "//gapis/api:go_default_library",
+        "//core/event/task:go_default_library",
+        "//core/memory/arena:go_default_library",
         "//gapis/service/path:go_default_library",
+        "//gapis/messages:go_default_library",
+        "//gapis/stringtable:go_default_library",
+        "//gapil/constset:go_default_library",
+        "//core/data/protoconv:go_default_library",
+        "//gapis/api/test/test_pb:go_default_library",
+        "//gapis/memory/memory_pb:go_default_library",
         "@com_github_golang_protobuf//proto:go_default_library",  # keep
     ],
 )

--- a/gapis/api/test/convert_test.go
+++ b/gapis/api/test/convert_test.go
@@ -21,18 +21,11 @@ import (
 	"github.com/google/gapid/core/data/protoconv"
 	"github.com/google/gapid/core/log"
 	"github.com/google/gapid/core/memory/arena"
+	"github.com/google/gapid/gapis/api"
 	"github.com/google/gapid/gapis/memory"
 )
 
-func TestReferences(t *testing.T) {
-	ctx := log.Testing(t)
-	assert := assert.To(t)
-
-	a := arena.New()
-	defer a.Dispose()
-
-	ctx = arena.Put(ctx, a)
-
+func CreateTestExtra(a arena.Arena) TestExtra {
 	o := NewTestObjectʳ(a, 42)
 	m := NewU32ːTestObjectᵐ(a).
 		Add(4, NewTestObject(a, 40)).
@@ -45,7 +38,7 @@ func TestReferences(t *testing.T) {
 		),
 	)
 	cycle.Next().SetNext(cycle)
-	extra := NewTestExtra(a,
+	return NewTestExtra(a,
 		NewU8ˢ(a, // Data
 			0x1000,           // root
 			0x1000,           // base
@@ -84,7 +77,23 @@ func TestReferences(t *testing.T) {
 			),
 		),
 		cycle, // Cycle
+		NewU32ːNestedRefʳᵐ(a). // NestedRefs
+					Add(6, NewNestedRefʳ(a, o)).
+					Add(7, NewNestedRefʳ(a, o)).
+					Add(8, NewNestedRefʳ(a, NilTestObjectʳ)).
+					Add(9, NilNestedRefʳ),
 	)
+}
+
+func TestReferences(t *testing.T) {
+	ctx := log.Testing(t)
+	assert := assert.To(t)
+
+	a := arena.New()
+	defer a.Dispose()
+
+	ctx = arena.Put(ctx, a)
+	extra := CreateTestExtra(a)
 
 	// extra -> protoA -> decoded -> protoB
 
@@ -100,8 +109,10 @@ func TestReferences(t *testing.T) {
 
 	decoded := decodedObj.(TestExtra)
 
-	assert.For("Object ref").That(decoded.RefObject()).Equals(decoded.RefObjectAlias())
-	assert.For("Map ref").That(decoded.Entries()).Equals(decoded.EntriesAlias())
+	assert.For("Object ref").That(decoded.RefObjectAlias()).Equals(decoded.RefObject())
+	assert.For("Map ref").That(decoded.EntriesAlias()).Equals(decoded.Entries())
+	assert.For("NestedRefs[6]").That(decoded.NestedRefs().Get(6).Ref()).Equals(decoded.RefObject())
+	assert.For("NestedRefs[7]").That(decoded.NestedRefs().Get(7).Ref()).Equals(decoded.RefObject())
 
 	protoB, err := protoconv.ToProto(ctx, decoded)
 	if !assert.For("ToProtoB").ThatError(err).Succeeded() {
@@ -109,4 +120,141 @@ func TestReferences(t *testing.T) {
 	}
 
 	assert.For("Protos").TestDeepEqual(protoA, protoB)
+
+	// Test that all decoded references see changes to their referenced objects.
+	decoded.RefObject().SetValue(55)               // was 42
+	decoded.Entries().Add(4, NewTestObject(a, 33)) // was 50
+	assert.For("Object ref").That(decoded.RefObjectAlias()).Equals(decoded.RefObject())
+	assert.For("Map ref").That(decoded.EntriesAlias()).Equals(decoded.Entries())
+	assert.For("RefEntries").That(decoded.RefEntries().Get(0)).Equals(decoded.RefObject())
+	assert.For("NestedRefs[6]").That(decoded.NestedRefs().Get(6).Ref()).Equals(decoded.RefObject())
+	assert.For("NestedRefs[7]").That(decoded.NestedRefs().Get(7).Ref()).Equals(decoded.RefObject())
+}
+
+func TestEquals(t *testing.T) {
+	ctx := log.Testing(t)
+	assert := assert.To(t)
+
+	a := arena.New()
+	defer a.Dispose()
+
+	ctx = arena.Put(ctx, a)
+	extra := CreateTestExtra(a)
+
+	assert.For("equals").That(extra.Equals(extra)).Equals(true)
+}
+
+func TestCloneReferences(t *testing.T) {
+	ctx := log.Testing(t)
+	assert := assert.To(t)
+
+	a := arena.New()
+	defer a.Dispose()
+
+	ctx = arena.Put(ctx, a)
+	extra := CreateTestExtra(a)
+
+	cloned := extra.Clone(a, api.CloneContext{})
+	assert.For("Data").That(cloned.Data()).Equals(extra.Data())
+	assert.For("Object").That(cloned.Object().Value()).Equals(extra.Object().Value())
+	assert.For("ObjectArray").That(cloned.ObjectArray().Equals(extra.ObjectArray())).Equals(true)
+	assert.For("RefObject").That(cloned.RefObject().Value()).Equals(extra.RefObject().Value())
+	assert.For("RefObjectAlias").That(cloned.RefObject().Value()).Equals(extra.RefObjectAlias().Value())
+	assert.For("NilRefObject").That(cloned.NilRefObject().IsNil()).Equals(true)
+	cloned.Entries().compare(assert.For("Entries"), extra.Entries())
+	cloned.EntriesAlias().compare(assert.For("EntriesAlias"), extra.EntriesAlias())
+	cloned.NilMap().compare(assert.For("NilMap"), extra.NilMap())
+	cloned.Strings().compare(assert.For("Strings"), extra.Strings())
+	cloned.BoolMap().compare(assert.For("BoolMap"), extra.BoolMap())
+	// RefEntries
+	assert.For("RefEntries.Len").That(cloned.RefEntries().Len()).Equals(extra.RefEntries().Len())
+	for _, k := range extra.RefEntries().Keys() {
+		assert.For("RefEntries[%d]", k).That(cloned.RefEntries().Contains(k)).Equals(true)
+		e, a := extra.RefEntries().Get(k), cloned.RefEntries().Get(k)
+		if e.IsNil() {
+			assert.For("RefEntries[%d]", k).That(a.IsNil()).Equals(true)
+		} else {
+			assert.For("RefEntries[%d]", k).That(a.Value()).Equals(e.Value())
+		}
+	}
+	// LinkedList
+	for i, e, a := 0, extra.LinkedList(), cloned.LinkedList(); !e.IsNil(); i++ {
+		assert.For("LinkedList[%d]", i).That(a.IsNil()).Equals(false)
+		assert.For("LinkedList[%d]", i).That(a.Value()).Equals(e.Value())
+		assert.For("LinkedList[%d]", i).That(a.Next().IsNil()).Equals(e.Next().IsNil())
+		e, a = e.Next(), a.Next()
+	}
+	// Cycle
+	assert.For("Cycle[0]").That(cloned.Cycle().IsNil()).Equals(false)
+	assert.For("Cycle[0]").That(cloned.Cycle().Value()).Equals(uint32(1))
+	assert.For("Cycle[1]").That(cloned.Cycle().Next().IsNil()).Equals(false)
+	assert.For("Cycle[1]").That(cloned.Cycle().Next().Value()).Equals(uint32(2))
+	assert.For("Cycle").That(cloned.Cycle().Next().Next()).Equals(cloned.Cycle())
+	// NestedRefs
+	assert.For("NestedRefs.Len").That(cloned.NestedRefs().Len()).Equals(extra.NestedRefs().Len())
+	for _, k := range extra.NestedRefs().Keys() {
+		assert.For("NestedRefs[%d]", k).That(cloned.NestedRefs().Contains(k)).Equals(true)
+		e, a := extra.NestedRefs().Get(k), cloned.NestedRefs().Get(k)
+		assert.For("NestedRefs[%d]", k).That(a.IsNil()).Equals(e.IsNil())
+		if !e.IsNil() {
+			assert.For("NestedRefs[%d].ref", k).That(a.Ref().IsNil()).Equals(e.Ref().IsNil())
+			if !e.Ref().IsNil() {
+				assert.For("NestedRefs[%d].ref", k).That(a.Ref().Value()).Equals(e.Ref().Value())
+			}
+		}
+	}
+
+	// Test that all cloned references see changes to their referenced objects.
+	cloned.RefObject().SetValue(55)               // was 42
+	cloned.Entries().Add(4, NewTestObject(a, 33)) // was 50
+	assert.For("Object ref").That(cloned.RefObjectAlias()).Equals(cloned.RefObject())
+	assert.For("Map ref").That(cloned.EntriesAlias()).Equals(cloned.Entries())
+	assert.For("RefEntries").That(cloned.RefEntries().Get(0)).Equals(cloned.RefObject())
+	assert.For("NestedRefs[6]").That(cloned.NestedRefs().Get(6).Ref()).Equals(cloned.RefObject())
+	assert.For("NestedRefs[7]").That(cloned.NestedRefs().Get(7).Ref()).Equals(cloned.RefObject())
+}
+
+func (actual U32ːTestObjectᵐ) compare(a *assert.Assertion, expected U32ːTestObjectᵐ) bool {
+	a.Compare(*actual.Map, "==", *expected.Map)
+	if !a.Test(actual.Len() == expected.Len()) {
+		return false
+	}
+
+	for _, k := range expected.Keys() {
+		if !a.Test(actual.Contains(k) && actual.Get(k).Equals(expected.Get(k))) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func (actual Stringːu32ᵐ) compare(a *assert.Assertion, expected Stringːu32ᵐ) bool {
+	a.Compare(*actual.Map, "==", *expected.Map)
+	if !a.Test(actual.Len() == expected.Len()) {
+		return false
+	}
+
+	for _, k := range expected.Keys() {
+		if !a.Test(actual.Contains(k) && actual.Get(k) == expected.Get(k)) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func (actual U32ːboolᵐ) compare(a *assert.Assertion, expected U32ːboolᵐ) bool {
+	a.Compare(*actual.Map, "==", *expected.Map)
+	if !a.Test(actual.Len() == expected.Len()) {
+		return false
+	}
+
+	for _, k := range expected.Keys() {
+		if !a.Test(actual.Contains(k) && actual.Get(k) == expected.Get(k)) {
+			return false
+		}
+	}
+
+	return true
 }

--- a/gapis/api/test/test.api
+++ b/gapis/api/test/test.api
@@ -286,6 +286,10 @@ class TestList {
   ref!TestList next
 }
 
+class NestedRef {
+  ref!TestObject ref
+}
+
 class TestExtra {
   u8[]                     Data
 
@@ -305,4 +309,5 @@ class TestExtra {
 
   ref!TestList             LinkedList
   ref!TestList             Cycle
+  map!(u32, ref!NestedRef) NestedRefs
 }

--- a/gapis/api/vulkan/externs.go
+++ b/gapis/api/vulkan/externs.go
@@ -321,7 +321,7 @@ func bindSparse(ctx context.Context, a api.Cmd, id api.CmdID, s *api.GlobalState
 func (e externs) fetchPhysicalDeviceProperties(inst VkInstance, devs VkPhysicalDeviceˢ) PhysicalDevicesAndPropertiesʳ {
 	for _, ee := range e.cmd.Extras().All() {
 		if p, ok := ee.(PhysicalDevicesAndProperties); ok {
-			return MakePhysicalDevicesAndPropertiesʳ(e.s.Arena).Set(p).Clone(e.s.Arena)
+			return MakePhysicalDevicesAndPropertiesʳ(e.s.Arena).Set(p).Clone(e.s.Arena, api.CloneContext{})
 		}
 	}
 	return NilPhysicalDevicesAndPropertiesʳ
@@ -344,7 +344,7 @@ func (e externs) fetchImageMemoryRequirements(dev VkDevice, img VkImage, hasSpar
 	}
 	for _, ee := range e.cmd.Extras().All() {
 		if r, ok := ee.(ImageMemoryRequirements); ok {
-			return MakeImageMemoryRequirementsʳ(e.s.Arena).Set(r).Clone(e.s.Arena)
+			return MakeImageMemoryRequirementsʳ(e.s.Arena).Set(r).Clone(e.s.Arena, api.CloneContext{})
 		}
 	}
 	return NilImageMemoryRequirementsʳ
@@ -358,7 +358,7 @@ func (e externs) fetchBufferMemoryRequirements(dev VkDevice, buf VkBuffer) VkMem
 	}
 	for _, ee := range e.cmd.Extras().All() {
 		if r, ok := ee.(VkMemoryRequirements); ok {
-			return r.Clone(e.s.Arena)
+			return r.Clone(e.s.Arena, api.CloneContext{})
 		}
 	}
 	return MakeVkMemoryRequirements(e.s.Arena)
@@ -372,7 +372,7 @@ func (e externs) fetchLinearImageSubresourceLayouts(dev VkDevice, img ImageObjec
 	}
 	for _, ee := range e.cmd.Extras().All() {
 		if r, ok := ee.(LinearImageLayouts); ok {
-			return MakeLinearImageLayoutsʳ(e.s.Arena).Set(r).Clone(e.s.Arena)
+			return MakeLinearImageLayoutsʳ(e.s.Arena).Set(r).Clone(e.s.Arena, api.CloneContext{})
 		}
 	}
 	return NilLinearImageLayoutsʳ

--- a/gapis/api/vulkan/image_primer.go
+++ b/gapis/api/vulkan/image_primer.go
@@ -301,7 +301,7 @@ func (p *imagePrimer) allocStagingImages(img ImageObjectʳ, aspect VkImageAspect
 	stagingElementInfo, _ := subGetElementAndTexelBlockSize(p.sb.ctx, nil, api.CmdNoID, nil, p.sb.oldState, GetState(p.sb.oldState), 0, nil, stagingImgFormat)
 	stagingElementSize := stagingElementInfo.ElementSize()
 
-	stagingInfo := img.Info().Clone(p.sb.newState.Arena)
+	stagingInfo := img.Info().Clone(p.sb.newState.Arena, api.CloneContext{})
 	stagingInfo.SetDedicatedAllocationNV(NilDedicatedAllocationBufferImageCreateInfoNVʳ)
 	stagingInfo.SetFmt(stagingImgFormat)
 	stagingInfo.SetUsage(VkImageUsageFlags(VkImageUsageFlagBits_VK_IMAGE_USAGE_TRANSFER_DST_BIT | VkImageUsageFlagBits_VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT | VkImageUsageFlagBits_VK_IMAGE_USAGE_SAMPLED_BIT))

--- a/gapis/api/vulkan/replay.go
+++ b/gapis/api/vulkan/replay.go
@@ -274,7 +274,7 @@ func (t *makeAttachementReadable) Transform(ctx context.Context, id api.CmdID, c
 		allProps := externs{ctx, cmd, id, s, nil}.fetchPhysicalDeviceProperties(e.Instance(), devSlice)
 		propList := []VkPhysicalDeviceProperties{}
 		for _, dev := range devs {
-			propList = append(propList, allProps.PhyDevToProperties().Get(dev).Clone(s.Arena))
+			propList = append(propList, allProps.PhyDevToProperties().Get(dev).Clone(s.Arena, api.CloneContext{}))
 		}
 		newEnumerate := buildReplayEnumeratePhysicalDevices(ctx, s, cb, e.Instance(), numDev, devs, propList)
 		out.MutateAndWrite(ctx, id, newEnumerate)


### PR DESCRIPTION
 - Don't lose the arena when creating/cloning.
 - Fix the cloning of API references and maps such that the share-tree is maintained in the cloned copy.