### PR TITLE
Fix crashes with Vulkan sparse bindings

### DIFF
--- a/gapis/api/vulkan/api/buffer.api
+++ b/gapis/api/vulkan/api/buffer.api
@@ -61,6 +61,7 @@
   VkMemoryRequirements              MemoryRequirements
   ref!DedicatedRequirementsKHR      DedicatedRequirementsKHR
 }
+
 @threadSafety("system")
 @indirect("VkDevice")
 @override

--- a/gapis/api/vulkan/api/copy_clear_commands.api
+++ b/gapis/api/vulkan/api/copy_clear_commands.api
@@ -311,7 +311,6 @@ sub void dovkCmdCopyBufferToImage(ref!vkCmdCopyBufferToImageArgs args) {
       // When multiple layers are specified in the buffer image copy region,
       // Vulkan assumes the data of all the layers are placed continuously in
       // the source buffer memory.
-      // TODO: (qining) Handle aspect mask
       for j in (0 .. region.imageSubresource.layerCount) {
         layerIndex := region.imageSubresource.baseArrayLayer + j
         bufferLayerOffset := (as!u64(j) * layerSize) + as!u64(region.bufferOffset)

--- a/gapis/api/vulkan/api/image.api
+++ b/gapis/api/vulkan/api/image.api
@@ -104,6 +104,7 @@
 }
 
 @internal class SparseBoundImageLevelInfo {
+  // mapping from memory offset to sparse block info
   map!(u64, ref!SparseBoundImageBlockInfo) Blocks
 }
 

--- a/gapis/api/vulkan/api/queued_command_tracking.api
+++ b/gapis/api/vulkan/api/queued_command_tracking.api
@@ -108,12 +108,75 @@ sub void execPendingCommands(VkQueue queue) {
                   bind.flags)
               }
             }
+            // Creates the shadow image data memory here if has not been done so.
+            // This is exactly the same to vkBindImageMemory except for linear
+            // and preinitialized images, we also create individual pool here.
+            // TODO: Redirect to bound memories for the data of linear preinitialized
+            // images.
+            for _, _, aspectBit in unpackImageAspectFlags(image.ImageAspect).Bits {
+              aspect := image.Aspects[aspectBit]
+              for lay in (0 .. image.Info.ArrayLayers) {
+                for lev in (0 .. image.Info.MipLevels) {
+                  level := aspect.Layers[lay].Levels[lev]
+                  if len(level.Data) == 0 {
+                    elementAndTexelBlockSize := getElementAndTexelBlockSize(image.Info.Format)
+                    depthElementSize := getDepthElementSize(image.Info.Format, false)
+                    // Roundup the width and height in the number of blocks.
+                    widthInBlocks := roundUpTo(level.Width, elementAndTexelBlockSize.TexelBlockSize.Width)
+                    heightInBlocks := roundUpTo(level.Height, elementAndTexelBlockSize.TexelBlockSize.Height)
+                    elementSize := switch (aspectBit) {
+                      case VK_IMAGE_ASPECT_COLOR_BIT:
+                        elementAndTexelBlockSize.ElementSize
+                      case VK_IMAGE_ASPECT_DEPTH_BIT:
+                        depthElementSize
+                      case VK_IMAGE_ASPECT_STENCIL_BIT:
+                        // stencil element is always 1 byte wide
+                        as!u32(1)
+                    }
+                    size := widthInBlocks * heightInBlocks * level.Depth * elementSize
+                    level.Data = make!u8(size)
+                  }
+                }
+              }
+            }
           }
 
           for _ , img , binds in cmd.SparseBinds.ImageBinds {
             if (!img in Images) { vkErrorInvalidImage(img) }
             for _ , _ , bind in binds.SparseImageMemoryBinds {
               addSparseImageMemoryBinding(img, bind)
+            }
+            image := Images[img]
+            // Creates the shadow image data memory here if has not been done so.
+            // This is exactly the same to vkBindImageMemory except for linear
+            // and preinitialized images, we also create individual pool here.
+            // TODO: Redirect to bound memories for the data of linear preinitialized
+            // images.
+            for _, _, aspectBit in unpackImageAspectFlags(image.ImageAspect).Bits {
+              aspect := image.Aspects[aspectBit]
+              for lay in (0 .. image.Info.ArrayLayers) {
+                for lev in (0 .. image.Info.MipLevels) {
+                  level := aspect.Layers[lay].Levels[lev]
+                  if len(level.Data) == 0 {
+                    elementAndTexelBlockSize := getElementAndTexelBlockSize(image.Info.Format)
+                    depthElementSize := getDepthElementSize(image.Info.Format, false)
+                    // Roundup the width and height in the number of blocks.
+                    widthInBlocks := roundUpTo(level.Width, elementAndTexelBlockSize.TexelBlockSize.Width)
+                    heightInBlocks := roundUpTo(level.Height, elementAndTexelBlockSize.TexelBlockSize.Height)
+                    elementSize := switch (aspectBit) {
+                      case VK_IMAGE_ASPECT_COLOR_BIT:
+                        elementAndTexelBlockSize.ElementSize
+                      case VK_IMAGE_ASPECT_DEPTH_BIT:
+                        depthElementSize
+                      case VK_IMAGE_ASPECT_STENCIL_BIT:
+                        // stencil element is always 1 byte wide
+                        as!u32(1)
+                    }
+                    size := widthInBlocks * heightInBlocks * level.Depth * elementSize
+                    level.Data = make!u8(size)
+                  }
+                }
+              }
             }
           }
 


### PR DESCRIPTION
Three issues fixed:

1) The opaque sparse memory binding info cached in Buffer and Image
object should not be fed to MustUnpackReadMap(), as they are actually
mapping from offsets to info, not a list of info.

2) IsFullyBound() does not work correctly.

3) Since the creation of ImageLevel.Data() slice has been moved from
vkCreateImage to vkBindImageMemory, for sparse binding images, the Data
slice is empty. For now we just check the size of the Data slice for
each time a sparse binding is to be submitted and if the Data slice is
empty, create the shadow memory Data slice for each image level.