### PR TITLE
Vulkan: Image/Buffer view stores back refs to their users

### DIFF
--- a/gapis/api/vulkan/api/buffer.api
+++ b/gapis/api/vulkan/api/buffer.api
@@ -153,6 +153,8 @@ cmd void vkDestroyBuffer(
   @unused VkDeviceSize              Offset
   @unused VkDeviceSize              Range
   @unused ref!VulkanDebugMarkerInfo DebugInfo
+  // Do not track depedency for the following back-references.
+  map!(VkDescriptorSet, map!(u32, map!(u32, u32))) DescriptorUsers
 }
 
 // Buffer view functions
@@ -189,7 +191,26 @@ cmd void vkDestroyBufferView(
     VkBufferView                 bufferView,
     AllocationCallbacks          pAllocator) {
   if !(device in Devices) { vkErrorInvalidDevice(device) }
-  delete(BufferViews, bufferView)
+  if bufferView in BufferViews {
+    viewObj := BufferViews[bufferView]
+
+    // Release the binding with descriptor sets
+    for _, vkDesSet, bindingAndIndices in viewObj.DescriptorUsers {
+      if vkDesSet in DescriptorSets {
+        desSetObj := DescriptorSets[vkDesSet]
+        for _, binding, indices in bindingAndIndices {
+          switch desSetObj.Bindings[binding].BindingType {
+            case VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER,
+                VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER:
+              for _, _, index in indices {
+                desSetObj.Bindings[binding].BufferViewBindings[index] = as!VkBufferView(0)
+              }
+          }
+        }
+      }
+    }
+    delete(BufferViews, bufferView)
+  }
 }
 
 @indirect("VkDevice")

--- a/gapis/api/vulkan/api/descriptor.api
+++ b/gapis/api/vulkan/api/descriptor.api
@@ -542,16 +542,39 @@ cmd void vkUpdateDescriptorSets(
           VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE,
           VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
           VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT: {
-        imageBinding := setBinding.ImageBinding
-        imageBinding[arrayIndex] = w.ImageInfo
-        setBinding.ImageBinding = imageBinding
-      }
+            imageBinding := setBinding.ImageBinding
+            imageBinding[arrayIndex] = w.ImageInfo
+            setBinding.ImageBinding = imageBinding
+            if w.ImageInfo.Sampler in Samplers {
+              samObj := Samplers[w.ImageInfo.Sampler]
+              if samObj != null {
+                samObj.DescriptorUsers[w.DstSet][binding][
+                  as!u32(len(samObj.DescriptorUsers[w.DstSet][binding]))] = arrayIndex
+              }
+            }
+            if w.ImageInfo.ImageView in ImageViews {
+              viewObj := ImageViews[w.ImageInfo.ImageView]
+              if viewObj != null {
+                viewObj.DescriptorUsers[w.DstSet][binding][
+                  as!u32(len(viewObj.DescriptorUsers[w.DstSet][binding]))] = arrayIndex
+              }
+            }
+          }
+
       case VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER,
           VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER: {
-        viewBindings := setBinding.BufferViewBindings
-        viewBindings[arrayIndex] = w.BufferView
-        setBinding.BufferViewBindings = viewBindings
-      }
+            viewBindings := setBinding.BufferViewBindings
+            viewBindings[arrayIndex] = w.BufferView
+            setBinding.BufferViewBindings = viewBindings
+            if w.BufferView in BufferViews {
+              viewObj := BufferViews[w.BufferView]
+              if viewObj != null {
+                viewObj.DescriptorUsers[w.DstSet][binding][
+                  as!u32(len(viewObj.DescriptorUsers[w.DstSet][binding]))] = arrayIndex
+              }
+            }
+          }
+      
       case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
           VK_DESCRIPTOR_TYPE_STORAGE_BUFFER,
           VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC,
@@ -582,14 +605,42 @@ cmd void vkUpdateDescriptorSets(
         imageBinding[c.DstArrayIndex] =
         srcBinding.ImageBinding[c.SrcArrayIndex]
         dstBinding.ImageBinding = imageBinding
+
+        vkSam := srcBinding.ImageBinding[c.SrcArrayIndex].Sampler
+        if vkSam in Samplers {
+          samObj := Samplers[vkSam]
+          if samObj != null {
+            samObj.DescriptorUsers[c.DstSet][c.DstBinding][
+              as!u32(len(samObj.DescriptorUsers[c.DstSet][c.DstBinding]))] = c.DstArrayIndex
+          }
+        }
+        vkView := srcBinding.ImageBinding[c.SrcArrayIndex].ImageView
+        if vkView in ImageViews {
+          viewObj := ImageViews[vkView]
+          if viewObj != null {
+            viewObj.DescriptorUsers[c.DstSet][c.DstBinding][
+              as!u32(len(viewObj.DescriptorUsers[c.DstSet][c.DstBinding]))] = c.DstArrayIndex
+          }
+        }
       }
+
       case VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER,
           VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER: {
         bufferViews := dstBinding.BufferViewBindings
         bufferViews[c.DstArrayIndex] =
         srcBinding.BufferViewBindings[c.SrcArrayIndex]
         dstBinding.BufferViewBindings = bufferViews
+
+        vkView := srcBinding.BufferViewBindings[c.SrcArrayIndex]
+        if vkView in BufferViews {
+          viewObj := BufferViews[vkView]
+          if viewObj != null {
+            viewObj.DescriptorUsers[c.DstSet][c.DstBinding][
+              as!u32(len(viewObj.DescriptorUsers[c.DstSet][c.DstBinding]))] = c.DstArrayIndex
+          }
+        }
       }
+
       case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
           VK_DESCRIPTOR_TYPE_STORAGE_BUFFER,
           VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC,

--- a/gapis/api/vulkan/api/image.api
+++ b/gapis/api/vulkan/api/image.api
@@ -382,6 +382,7 @@ cmd VkResult vkBindImageMemory(
 // Image view //
 ////////////////
 
+
 @internal class ImageViewObject {
   @unused VkDevice                  Device
   @unused VkImageView               VulkanHandle
@@ -391,6 +392,9 @@ cmd VkResult vkBindImageMemory(
   @unused VkImageSubresourceRange   SubresourceRange
   ref!ImageObject                   Image
   @unused ref!VulkanDebugMarkerInfo DebugInfo
+  // Do not track dependency for the following back-references.
+  map!(VkDescriptorSet, map!(u32, map!(u32, u32))) DescriptorUsers
+  map!(VkFramebuffer, map!(u32, u32)) FramebufferUsers
 }
 
 @threadSafety("system")
@@ -428,24 +432,46 @@ cmd void vkDestroyImageView(
     VkImageView         imageView,
     AllocationCallbacks pAllocator) {
   if !(device in Devices) { vkErrorInvalidDevice(device) }
-  delete(ImageViews, imageView)
-  for _ , _ , drawInfo in LastDrawInfos {
-    if (drawInfo.Framebuffer != null) {
-      for _ , i , v in drawInfo.Framebuffer.ImageAttachments {
-        if (v != null) && (v.VulkanHandle == imageView) {
-          drawInfo.Framebuffer.ImageAttachments[i] = null
+
+  if imageView in ImageViews {
+    viewObj := ImageViews[imageView]
+
+    // Release the binding with descriptor sets
+    for _, vkDesSet, bindingAndIndices in viewObj.DescriptorUsers {
+      if vkDesSet in DescriptorSets {
+        desSetObj := DescriptorSets[vkDesSet]
+        for _, binding, indices in bindingAndIndices {
+          switch desSetObj.Bindings[binding].BindingType {
+            case VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
+                VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE,
+                VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
+                VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT:
+              for _, _, index in indices {
+                desSetObj.Bindings[binding].ImageBinding[index].ImageView = as!VkImageView(0)
+              }
+          }
         }
       }
     }
-  }
-  for _ , _ , descSet in DescriptorSets {
-    for _ , _ , binding in descSet.Bindings {
-      for _ , _ , imgBinding in binding.ImageBinding {
-        if imgBinding.ImageView == imageView {
-          imgBinding.ImageView = as!VkImageView(0)
+
+    // Releae the binding with framebuffers
+    for _, vkFmBuf, attachmentIndices in viewObj.FramebufferUsers {
+      if vkFmBuf in Framebuffers {
+        fmBufObj := Framebuffers[vkFmBuf]
+        if fmBufObj != null {
+          for _, _, index in attachmentIndices {
+            if index in fmBufObj.ImageAttachments {
+              v := fmBufObj.ImageAttachments[index]
+              if (v != null) && (v == viewObj) {
+                fmBufObj.ImageAttachments[index] = null
+              }
+            }
+          }
         }
       }
     }
+
+    delete(ImageViews, imageView)
   }
 }
 
@@ -472,6 +498,8 @@ cmd void vkDestroyImageView(
   @unused VkBorderColor             BorderColor
   @unsued VkBool32                  UnnormalizedCoordinates
   @unused ref!VulkanDebugMarkerInfo DebugInfo
+  // Do not track dependency for the following back-references.
+  map!(VkDescriptorSet, map!(u32, map!(u32, u32))) DescriptorUsers
 }
 
 @threadSafety("system")
@@ -517,7 +545,26 @@ cmd void vkDestroySampler(
     VkSampler           sampler,
     AllocationCallbacks pAllocator) {
   if !(device in Devices) { vkErrorInvalidDevice(device) }
-  delete(Samplers, sampler)
+  if sampler in Samplers {
+    obj := Samplers[sampler] 
+    if obj != null {
+      for _, vkDesSet, bindingAndIndices in obj.DescriptorUsers {
+        if vkDesSet in DescriptorSets {
+          desSetObj := DescriptorSets[vkDesSet]
+          for _, binding, indices in bindingAndIndices {
+            switch desSetObj.Bindings[binding].BindingType {
+              case VK_DESCRIPTOR_TYPE_SAMPLER,
+                VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER:
+              for _, _, index in indices {
+                desSetObj.Bindings[binding].ImageBinding[index].Sampler = as!VkSampler(0)
+              }
+            }
+          }
+        }
+      }
+    }
+    delete(Samplers, sampler)
+  }
 }
 
 sub void readImageSubresource(ref!ImageObject image, VkImageSubresourceRange rng, VkImageLayout layout) {

--- a/gapis/api/vulkan/api/renderpass_framebuffer.api
+++ b/gapis/api/vulkan/api/renderpass_framebuffer.api
@@ -78,6 +78,11 @@ cmd VkResult vkCreateFramebuffer(
   framebufferObject.VulkanHandle = handle
   Framebuffers[handle] = framebufferObject
 
+  for _, i, viewObj in framebufferObject.ImageAttachments {
+    viewObj.FramebufferUsers[handle][
+      as!u32(len(viewObj.FramebufferUsers[handle]))] = i
+  }
+
   return ?
 }
 

--- a/gapis/api/vulkan/replay.go
+++ b/gapis/api/vulkan/replay.go
@@ -345,8 +345,12 @@ func (t *destroyResourcesAtEOS) Flush(ctx context.Context, out transform.Writer)
 		out.MutateAndWrite(ctx, id, cb.VkDestroySampler(object.Device(), handle, p))
 	}
 
-	for handle, object := range so.ImageViews().All() {
-		out.MutateAndWrite(ctx, id, cb.VkDestroyImageView(object.Device(), handle, p))
+	// Descriptor sets.
+	for handle, object := range so.DescriptorPools().All() {
+		out.MutateAndWrite(ctx, id, cb.VkDestroyDescriptorPool(object.Device(), handle, p))
+	}
+	for handle, object := range so.DescriptorSetLayouts().All() {
+		out.MutateAndWrite(ctx, id, cb.VkDestroyDescriptorSetLayout(object.Device(), handle, p))
 	}
 
 	// Buffers.
@@ -355,14 +359,6 @@ func (t *destroyResourcesAtEOS) Flush(ctx context.Context, out transform.Writer)
 	}
 	for handle, object := range so.Buffers().All() {
 		out.MutateAndWrite(ctx, id, cb.VkDestroyBuffer(object.Device(), handle, p))
-	}
-
-	// Descriptor sets.
-	for handle, object := range so.DescriptorPools().All() {
-		out.MutateAndWrite(ctx, id, cb.VkDestroyDescriptorPool(object.Device(), handle, p))
-	}
-	for handle, object := range so.DescriptorSetLayouts().All() {
-		out.MutateAndWrite(ctx, id, cb.VkDestroyDescriptorSetLayout(object.Device(), handle, p))
 	}
 
 	// Shader modules.
@@ -408,6 +404,10 @@ func (t *destroyResourcesAtEOS) Flush(ctx context.Context, out transform.Writer)
 		out.MutateAndWrite(ctx, id, cb.VkFreeMemory(object.Device(), handle, p))
 	}
 
+	// Images
+	for handle, object := range so.ImageViews().All() {
+		out.MutateAndWrite(ctx, id, cb.VkDestroyImageView(object.Device(), handle, p))
+	}
 	// Note: so.Images also contains Swapchain images. We do not want
 	// to delete those, as that must be handled by VkDestroySwapchainKHR
 	for handle, object := range so.Images().All() {
@@ -415,6 +415,7 @@ func (t *destroyResourcesAtEOS) Flush(ctx context.Context, out transform.Writer)
 			out.MutateAndWrite(ctx, id, cb.VkDestroyImage(object.Device(), handle, p))
 		}
 	}
+
 	// Devices.
 	for handle := range so.Devices().All() {
 		out.MutateAndWrite(ctx, id, cb.VkDestroyDevice(handle, p))


### PR DESCRIPTION
1) Changed the destruction order in EOS transform
2) Store a back-ref to the descriptors, framebuffers in image view,
buffer view and samplers, so each image view, buffer view sampler knows
which descriptor or frambuffer uses it. So that when destroy those
image/buffer views and samplers, we can unregister them from the
descriptors and frambuffers without looping all the descriptor sets or
frambuffers.

This should mitigate #1965 