### PR TITLE
core/log: Add SubTest()

### DIFF
--- a/core/log/testing.go
+++ b/core/log/testing.go
@@ -18,7 +18,21 @@ import "context"
 
 // Testing returns a default context with a TestHandler installed.
 func Testing(t delegate) context.Context {
-	ctx := context.Background()
+	return SubTest(context.Background(), t)
+}
+
+// SubTest returns the context with the TestHandler replaced with t.
+// This is intended to be used for sub-tests. For example:
+//
+//   func TestExample(t *testing.T) {
+//     ctx := log.Testing(t)
+//     for _, test := range tests {
+//       t.Run(test.name, func(t *testing.T) {
+//         test.run(log.SubTest(ctx, t))
+//       }
+//     }
+//   }
+func SubTest(ctx context.Context, t delegate) context.Context {
 	return PutHandler(ctx, TestHandler(t, Normal))
 }
 

--- a/gapil/compiler/compiler_test.go
+++ b/gapil/compiler/compiler_test.go
@@ -1818,8 +1818,7 @@ cmd void Read(StructInStruct* input) {
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			ctx := log.PutHandler(ctx, log.TestHandler(t, log.Normal))
-			test.run(ctx, c)
+			test.run(log.SubTest(ctx, t), c)
 		})
 	}
 }


### PR DESCRIPTION
SubTest is intended to be used with `testing.T.Run()` for running subtests.
These show up as child tests of the parent, which helps write cleaner tests.