### PR TITLE
Vulkan: Fix support of sparse buffer

### DIFF
--- a/gapis/api/templates/api_spy.cpp.tmpl
+++ b/gapis/api/templates/api_spy.cpp.tmpl
@@ -400,8 +400,6 @@
   {{AssertType $ "Read"}}
   {{if (GetAnnotation ($.Slice | TargetField) "spy_disabled")}}
     // @spy_disabled
-  {{else if GetAnnotation ($.Slice | TargetField) "spy_disabled"}}
-    {{Error "Attempting to read from a @spy_disabled slice"}}
   {{else}}
     {{Template "C++.Statement.Default" $}}
   {{end}}

--- a/gapis/api/templates/api_spy.cpp.tmpl
+++ b/gapis/api/templates/api_spy.cpp.tmpl
@@ -321,6 +321,7 @@
   {{     if IsReturn $}}{{Template "Return" $}}
   {{else if IsFence  $}}{{Template "Fence" $}}
   {{else if IsCopy   $}}{{Template "Copy" $}}
+  {{else if IsRead   $}}{{Template "Read" $}}
   {{else if IsAssign $}}{{Template "Assign" $}}
   {{else              }}{{Template "C++.Statement.Default" $}}
   {{end}}
@@ -384,6 +385,23 @@
     {{Error "Attempting to copy from a @spy_disabled slice"}}
   {{else if GetAnnotation ($.Dst | TargetField) "spy_disabled"}}
     observer->read({{Template "C++.Read" $.Src}}); // @spy_disabled
+  {{else}}
+    {{Template "C++.Statement.Default" $}}
+  {{end}}
+{{end}}
+
+
+{{/*
+-------------------------------------------------------------------------------
+  An override for the "C++.Read" macro.
+-------------------------------------------------------------------------------
+*/}}
+{{define "Read"}}
+  {{AssertType $ "Read"}}
+  {{if (GetAnnotation ($.Slice | TargetField) "spy_disabled")}}
+    // @spy_disabled
+  {{else if GetAnnotation ($.Slice | TargetField) "spy_disabled"}}
+    {{Error "Attempting to read from a @spy_disabled slice"}}
   {{else}}
     {{Template "C++.Statement.Default" $}}
   {{end}}

--- a/gapis/api/vulkan/api/coherent_memory.api
+++ b/gapis/api/vulkan/api/coherent_memory.api
@@ -60,12 +60,7 @@ sub void readMemoryInBuffer(ref!BufferObject buffer, VkDeviceSize readOffset, Vk
   memPieces := getBufferBoundMemoryPiecesInRange(buffer, readOffset, readSize)
   for _, _, mp in memPieces {
     readCoherentMemory(mp.DeviceMemory, mp.MemoryOffset, mp.Size)
-    // On the trace side, 'Data' pool won't actually be created, so its length
-    // will be zero. But on the server side, the pool will be created and the
-    // state block should contains the data in the buffer memory.
-    if len(mp.DeviceMemory.Data) != 0 {
-      read(mp.DeviceMemory.Data[mp.MemoryOffset:mp.MemoryOffset+mp.Size])
-    }
+    read(mp.DeviceMemory.Data[mp.MemoryOffset:mp.MemoryOffset+mp.Size])
   }
 }
 

--- a/gapis/api/vulkan/api/coherent_memory.api
+++ b/gapis/api/vulkan/api/coherent_memory.api
@@ -57,19 +57,14 @@ sub void readCoherentMemory(ref!DeviceMemoryObject memory, VkDeviceSize readOffs
 }
 
 sub void readMemoryInBuffer(ref!BufferObject buffer, VkDeviceSize readOffset, VkDeviceSize readSize) {
-  mem := buffer.Memory
-  if mem != null {
-    readBegin := buffer.MemoryOffset + readOffset
-    actualReadSize := switch as!u64(readSize) {
-      case 0xFFFFFFFFFFFFFFFF:
-        buffer.Info.Size - readOffset
-      default:
-        readSize
-    }
-    readEnd := readBegin + actualReadSize
-    readCoherentMemory(mem, readBegin, actualReadSize)
-    if len(mem.Data) != 0 {
-      read(mem.Data[readBegin : readEnd])
+  memPieces := getBufferBoundMemoryPiecesInRange(buffer, readOffset, readSize)
+  for _, _, mp in memPieces {
+    readCoherentMemory(mp.DeviceMemory, mp.MemoryOffset, mp.Size)
+    // On the trace side, 'Data' pool won't actually be created, so its length
+    // will be zero. But on the server side, the pool will be created and the
+    // state block should contains the data in the buffer memory.
+    if len(mp.DeviceMemory.Data) != 0 {
+      read(mp.DeviceMemory.Data[mp.MemoryOffset:mp.MemoryOffset+mp.Size])
     }
   }
 }

--- a/gapis/api/vulkan/api/copy_clear_commands.api
+++ b/gapis/api/vulkan/api/copy_clear_commands.api
@@ -46,12 +46,132 @@ sub void dovkCmdCopyBuffer(ref!vkCmdCopyBufferArgs buffer) {
   sourceBuffer := Buffers[buffer.SrcBuffer]
   destBuffer := Buffers[buffer.DstBuffer]
   for _ , _ , region in buffer.CopyRegions {
-    srcMemoryOffset := sourceBuffer.MemoryOffset + region.srcOffset
-    dstMemoryOffset := destBuffer.MemoryOffset + region.dstOffset
     readMemoryInBuffer(sourceBuffer, region.srcOffset, region.size)
-    copy(destBuffer.Memory.Data[dstMemoryOffset:dstMemoryOffset + region.size],
-      sourceBuffer.Memory.Data[srcMemoryOffset:srcMemoryOffset + region.size])
+    copyBufferToBuffer(destBuffer, region.dstOffset, sourceBuffer, region.srcOffset, region.size)
   }
+}
+
+@internal class OpaqueResourceMemoryBoundPiece {
+  VkDeviceSize ResourceOffset
+  VkDeviceSize Size
+  ref!DeviceMemoryObject DeviceMemory
+  VkDeviceSize MemoryOffset
+}
+
+@internal class OpaqueResourceMemoryBoundPieceReturnMap {
+  map!(VkDeviceSize, OpaqueResourceMemoryBoundPiece) Map
+}
+
+// getBufferBoundMemoryPiecesInRange returns all the memory-bound ranges that
+// overlaps with the buffer range given with offset and size. The returned
+// memory-bound ranges are guaranteed to be valid to access, and so as a whole
+// may be a subset of the given range. For each returned memory-bound range, it
+// is guaranteed to be a subset of the buffer's total resource range, the
+// corresponding sparse memory bind (if any), and the underlying device memory
+// allocation range.
+sub map!(VkDeviceSize, OpaqueResourceMemoryBoundPiece) getBufferBoundMemoryPiecesInRange(
+  ref!BufferObject buf, VkDeviceSize offset, VkDeviceSize size) {
+  ret_val := OpaqueResourceMemoryBoundPieceReturnMap()
+
+  noOverflowEnd := switch (size == 0xFFFFFFFFFFFFFFFF) ||
+                    ((size+offset) < size) {
+    case true:
+      // size value is VK_WHOLE_SIZE or can overflow
+      buf.Info.Size
+    case false:
+      size+offset
+  }
+  end := min!VkDeviceSize(noOverflowEnd, buf.Info.Size)
+  if offset < end {
+    if buf.Memory != null {
+      memOffset := offset+buf.MemoryOffset
+      memEnd := min!VkDeviceSize(end+buf.MemoryOffset, buf.Memory.AllocationSize)
+      if memOffset < memEnd {
+        ret_val.Map[offset] = OpaqueResourceMemoryBoundPiece(
+          ResourceOffset: offset,
+          Size: memEnd - memOffset,
+          DeviceMemory: buf.Memory,
+          MemoryOffset: memOffset,
+        )
+      }
+
+    } else {
+      // sparsely bound
+      for _, blkOffset, bind in buf.SparseMemoryBindings {
+        resStart := max!VkDeviceSize(as!VkDeviceSize(blkOffset), offset)
+        resEnd := min!VkDeviceSize(as!VkDeviceSize(blkOffset)+bind.size, end)
+        if (resStart < resEnd) && (DeviceMemories[bind.memory] != null) {
+          mem := DeviceMemories[bind.memory]
+          memStart := resStart-bind.resourceOffset+bind.memoryOffset
+          memEnd := min!VkDeviceSize(resEnd-bind.resourceOffset+bind.memoryOffset, mem.AllocationSize)
+          if memStart < memEnd {
+            ret_val.Map[resStart] = OpaqueResourceMemoryBoundPiece(
+              ResourceOffset: resStart,
+              Size: memEnd - memStart,
+              DeviceMemory: mem,
+              MemoryOffset: memStart,
+            )
+          }
+        }
+      }
+    }
+  }
+  return ret_val.Map
+}
+
+sub void copyBufferToBuffer(ref!BufferObject dstBuf, VkDeviceSize dstOffset, ref!BufferObject srcBuf, VkDeviceSize srcOffset, VkDeviceSize size) {
+  if (dstBuf.Memory != null) && (srcBuf.Memory != null) {
+    // No sparse binding in either dst and src
+    srcMemOffset := srcBuf.MemoryOffset + srcOffset
+    dstMemOffset := dstBuf.MemoryOffset + dstOffset
+    srcMemEnd := min!VkDeviceSize(srcMemOffset+size, srcBuf.Memory.AllocationSize)
+    dstMemEnd := min!VkDeviceSize(dstMemOffset+size, dstBuf.Memory.AllocationSize)
+    if (srcMemOffset < srcMemEnd) && (dstMemOffset < dstMemEnd) {
+      copy(dstBuf.Memory.Data[dstMemOffset:dstMemEnd], srcBuf.Memory.Data[srcMemOffset:srcMemEnd])
+    }
+
+  } else if (dstBuf.Memory != null) && (len(srcBuf.SparseMemoryBindings) != 0) {
+    // Sparse binding in src
+    srcMemPieces := getBufferBoundMemoryPiecesInRange(srcBuf, srcOffset, size)
+    for _, _, smp in srcMemPieces {
+      srcMemOffset := as!u64(smp.MemoryOffset)
+      dstMemOffset := as!u64(smp.ResourceOffset - srcOffset + dstOffset)
+      if dstMemOffset < as!u64(dstBuf.Memory.AllocationSize) {
+        memSize := min!u64(as!u64(smp.Size), as!u64(dstBuf.Memory.AllocationSize) - dstMemOffset)
+        copy(dstBuf.Memory.Data[dstMemOffset:dstMemOffset+memSize],
+             srcBuf.Memory.Data[srcMemOffset:srcMemOffset+memSize])
+      }
+    }
+
+  } else if (len(dstBuf.SparseMemoryBindings) != 0) && (srcBuf.Memory != null) {
+    // Sparse binding in dst
+    dstMemPieces := getBufferBoundMemoryPiecesInRange(dstBuf, dstOffset, size)
+    for _, _, dmp in dstMemPieces {
+      dstMemOffset := dmp.MemoryOffset
+      srcMemOffset := dmp.ResourceOffset - dstOffset + srcOffset
+      if srcMemOffset < as!VkDeviceSize(srcBuf.Memory.AllocationSize) {
+        memSize := min!VkDeviceSize(dmp.Size, as!VkDeviceSize(srcBuf.Memory.AllocationSize) - srcMemOffset)
+        copy(dstBuf.Memory.Data[dstMemOffset:dstMemOffset+memSize],
+             srcBuf.Memory.Data[srcMemOffset:srcMemOffset+memSize])
+      }
+    }
+
+  } else if (len(dstBuf.SparseMemoryBindings) != 0) && (len(srcBuf.SparseMemoryBindings) != 0) {
+    // Sparse binding in src and dst
+    dstMemPieces := getBufferBoundMemoryPiecesInRange(dstBuf, dstOffset, size)
+    for _, _, dmp in dstMemPieces {
+      tmpSrcOffset := dmp.ResourceOffset - dstOffset + srcOffset
+      tmpSize := dmp.Size
+      srcMemPieces := getBufferBoundMemoryPiecesInRange(srcBuf, tmpSrcOffset, tmpSize)
+      for _, _, smp in srcMemPieces {
+        srcMemOffset := as!u64(smp.MemoryOffset)
+        dstMemOffset := as!u64(smp.ResourceOffset - tmpSrcOffset + dmp.ResourceOffset)
+        memSize := as!u64(smp.Size)
+        copy(dstBuf.Memory.Data[dstMemOffset:dstMemOffset+memSize],
+             srcBuf.Memory.Data[srcMemOffset:srcMemOffset+memSize])
+      }
+    }
+  } 
 }
 
 @threadSafety("app")
@@ -327,21 +447,34 @@ sub void dovkCmdCopyBufferToImage(ref!vkCmdCopyBufferToImageArgs args) {
             if ((format == VK_FORMAT_D24_UNORM_S8_UINT) || (format == VK_FORMAT_X8_D24_UNORM_PACK32)) && (aspectBit == VK_IMAGE_ASPECT_DEPTH_BIT) {
               elementSizeInImage := as!u64(getDepthElementSize(format, false))
               for x in (xStart .. xEnd) {
-                dstStart := (rowStartBlock + x) * elementSizeInImage
+                dstStart := as!VkDeviceSize((rowStartBlock + x) * elementSizeInImage)
                 rowStartInExtent := (rowStartBlockInExtent + x) * elementSize
-                srcStart := as!u64(bufferObject.MemoryOffset) + bufferLayerOffset + rowStartInExtent
-                readCoherentMemory(bufferObject.Memory, as!VkDeviceSize(srcStart), as!VkDeviceSize(elementSize))
-                copy(imageLevel.Data[dstStart:dstStart + elementSizeInImage], bufferObject.Memory.Data[srcStart:srcStart + elementSize])
+                bufStart := as!VkDeviceSize(bufferLayerOffset + rowStartInExtent)
+                readMemoryInBuffer(bufferObject, bufStart, as!VkDeviceSize(elementSize))
+                // Discard the 4th byte in the buffer for current pixel.
+                bufMemPieces := getBufferBoundMemoryPiecesInRange(bufferObject, bufStart, as!VkDeviceSize(elementSizeInImage))
+                for _, _, piece in bufMemPieces {
+                  srcStart := piece.MemoryOffset
+                  srcEnd := srcStart + piece.Size
+                  dstPieceStart := piece.ResourceOffset - bufStart + dstStart
+                  dstPieceEnd := dstPieceStart + piece.Size
+                  copy(imageLevel.Data[dstPieceStart:dstPieceEnd], piece.DeviceMemory.Data[srcStart:srcEnd])
+                }
               }
             } else {
-              copySize := (xEnd - xStart) * elementSize
+              copySize := as!VkDeviceSize((xEnd - xStart) * elementSize)
               dstStart := (rowStartBlock + xStart) * elementSize
-              dstEnd := dstStart + copySize
               rowStartInExtent := rowStartBlockInExtent * elementSize
-              srcStart := as!u64(bufferObject.MemoryOffset) + bufferLayerOffset + rowStartInExtent
-              srcEnd := srcStart + copySize
-              readMemoryInBuffer(bufferObject, as!VkDeviceSize(bufferLayerOffset + rowStartInExtent), as!VkDeviceSize(copySize))
-              copy(imageLevel.Data[dstStart:dstEnd], bufferObject.Memory.Data[srcStart:srcEnd])
+              bufStart := as!VkDeviceSize(bufferLayerOffset + rowStartInExtent)
+              readMemoryInBuffer(bufferObject, bufStart, copySize)
+              bufMemPieces := getBufferBoundMemoryPiecesInRange(bufferObject, bufStart, copySize)
+              for _, _, piece in bufMemPieces {
+                srcStart := piece.MemoryOffset
+                srcEnd := srcStart + piece.Size
+                dstPieceStart := as!u64(piece.ResourceOffset - bufStart) + dstStart
+                dstPieceEnd := dstPieceStart + as!u64(piece.Size)
+                copy(imageLevel.Data[dstPieceStart:dstPieceEnd], piece.DeviceMemory.Data[srcStart:srcEnd])
+              }
             }
           }
         }
@@ -426,9 +559,12 @@ cmd void vkCmdCopyImageToBuffer(
 sub void dovkCmdUpdateBuffer(ref!vkCmdUpdateBufferArgs args) {
   Buffers[args.DstBuffer].LastBoundQueue = LastBoundQueue
   buff := Buffers[args.DstBuffer]
-  start := buff.MemoryOffset + args.DstOffset
-  copy(buff.Memory.Data[start:start + args.DataSize],
-    args.Data[0:args.DataSize])
+  bufPieces := getBufferBoundMemoryPiecesInRange(buff, args.DstOffset, args.DataSize)
+  for _, _, p in bufPieces {
+    srcOffset := p.ResourceOffset - args.DstOffset
+    size := min!VkDeviceSize(p.Size, as!VkDeviceSize(len(args.Data))-srcOffset)
+    copy(buff.Memory.Data[p.MemoryOffset:p.MemoryOffset+size], args.Data[srcOffset:srcOffset+size])
+  }
 }
 
 @threadSafety("app")
@@ -464,7 +600,25 @@ class vkCmdFillBufferArgs {
 }
 
 sub void dovkCmdFillBuffer(ref!vkCmdFillBufferArgs args) {
-  // DO NOT CHECK IN: IMPLEMENT THIS
+  buf := Buffers[args.Buffer]
+  bufPieces := getBufferBoundMemoryPiecesInRange(buf, args.DstOffset, args.Size)
+  for _, _, p in bufPieces {
+    if as!VkDeviceSize(len(p.DeviceMemory.Data)) >= (p.MemoryOffset + p.Size) {
+      for i in (0 .. p.Size) {
+        offset := as!VkDeviceSize(p.ResourceOffset + i)
+        p.DeviceMemory.Data[p.MemoryOffset + i] = switch (offset-((offset/4)*4)) {
+          case as!VkDeviceSize(0):
+            as!u8(args.Data & 0xFF)
+          case as!VkDeviceSize(1):
+            as!u8((args.Data >> 8) & 0xFF)
+          case as!VkDeviceSize(2):
+            as!u8((args.Data >> 16) & 0xFF)
+          case as!VkDeviceSize(3):
+            as!u8((args.Data >> 24) & 0xFF)
+        }
+      }
+    }
+  }
 }
 
 @threadSafety("app")

--- a/gapis/api/vulkan/api/copy_clear_commands.api
+++ b/gapis/api/vulkan/api/copy_clear_commands.api
@@ -52,10 +52,10 @@ sub void dovkCmdCopyBuffer(ref!vkCmdCopyBufferArgs buffer) {
 }
 
 @internal class OpaqueResourceMemoryBoundPiece {
-  VkDeviceSize ResourceOffset
-  VkDeviceSize Size
+  VkDeviceSize           ResourceOffset
+  VkDeviceSize           Size
   ref!DeviceMemoryObject DeviceMemory
-  VkDeviceSize MemoryOffset
+  VkDeviceSize           MemoryOffset
 }
 
 @internal class OpaqueResourceMemoryBoundPieceReturnMap {
@@ -70,46 +70,46 @@ sub void dovkCmdCopyBuffer(ref!vkCmdCopyBufferArgs buffer) {
 // corresponding sparse memory bind (if any), and the underlying device memory
 // allocation range.
 sub map!(VkDeviceSize, OpaqueResourceMemoryBoundPiece) getBufferBoundMemoryPiecesInRange(
-  ref!BufferObject buf, VkDeviceSize offset, VkDeviceSize size) {
+    ref!BufferObject buf, VkDeviceSize offset, VkDeviceSize size) {
   ret_val := OpaqueResourceMemoryBoundPieceReturnMap()
 
   noOverflowEnd := switch (size == 0xFFFFFFFFFFFFFFFF) ||
-                    ((size+offset) < size) {
+  ((size + offset) < size) {
     case true:
       // size value is VK_WHOLE_SIZE or can overflow
       buf.Info.Size
     case false:
-      size+offset
+      size + offset
   }
   end := min!VkDeviceSize(noOverflowEnd, buf.Info.Size)
   if offset < end {
     if buf.Memory != null {
-      memOffset := offset+buf.MemoryOffset
-      memEnd := min!VkDeviceSize(end+buf.MemoryOffset, buf.Memory.AllocationSize)
+      memOffset := offset + buf.MemoryOffset
+      memEnd := min!VkDeviceSize(end + buf.MemoryOffset, buf.Memory.AllocationSize)
       if memOffset < memEnd {
         ret_val.Map[offset] = OpaqueResourceMemoryBoundPiece(
           ResourceOffset: offset,
-          Size: memEnd - memOffset,
-          DeviceMemory: buf.Memory,
-          MemoryOffset: memOffset,
+          Size:           memEnd - memOffset,
+          DeviceMemory:   buf.Memory,
+          MemoryOffset:   memOffset,
         )
       }
 
     } else {
       // sparsely bound
-      for _, blkOffset, bind in buf.SparseMemoryBindings {
+      for _ , blkOffset , bind in buf.SparseMemoryBindings {
         resStart := max!VkDeviceSize(as!VkDeviceSize(blkOffset), offset)
-        resEnd := min!VkDeviceSize(as!VkDeviceSize(blkOffset)+bind.size, end)
+        resEnd := min!VkDeviceSize(as!VkDeviceSize(blkOffset) + bind.size, end)
         if (resStart < resEnd) && (DeviceMemories[bind.memory] != null) {
           mem := DeviceMemories[bind.memory]
-          memStart := resStart-bind.resourceOffset+bind.memoryOffset
-          memEnd := min!VkDeviceSize(resEnd-bind.resourceOffset+bind.memoryOffset, mem.AllocationSize)
+          memStart := resStart - bind.resourceOffset + bind.memoryOffset
+          memEnd := min!VkDeviceSize(resEnd - bind.resourceOffset + bind.memoryOffset, mem.AllocationSize)
           if memStart < memEnd {
             ret_val.Map[resStart] = OpaqueResourceMemoryBoundPiece(
               ResourceOffset: resStart,
-              Size: memEnd - memStart,
-              DeviceMemory: mem,
-              MemoryOffset: memStart,
+              Size:           memEnd - memStart,
+              DeviceMemory:   mem,
+              MemoryOffset:   memStart,
             )
           }
         }
@@ -124,54 +124,54 @@ sub void copyBufferToBuffer(ref!BufferObject dstBuf, VkDeviceSize dstOffset, ref
     // No sparse binding in either dst and src
     srcMemOffset := srcBuf.MemoryOffset + srcOffset
     dstMemOffset := dstBuf.MemoryOffset + dstOffset
-    srcMemEnd := min!VkDeviceSize(srcMemOffset+size, srcBuf.Memory.AllocationSize)
-    dstMemEnd := min!VkDeviceSize(dstMemOffset+size, dstBuf.Memory.AllocationSize)
+    srcMemEnd := min!VkDeviceSize(srcMemOffset + size, srcBuf.Memory.AllocationSize)
+    dstMemEnd := min!VkDeviceSize(dstMemOffset + size, dstBuf.Memory.AllocationSize)
     if (srcMemOffset < srcMemEnd) && (dstMemOffset < dstMemEnd) {
       copy(dstBuf.Memory.Data[dstMemOffset:dstMemEnd], srcBuf.Memory.Data[srcMemOffset:srcMemEnd])
     }
 
   } else if (dstBuf.Memory != null) && (len(srcBuf.SparseMemoryBindings) != 0) {
-    // Sparse binding in src
-    srcMemPieces := getBufferBoundMemoryPiecesInRange(srcBuf, srcOffset, size)
-    for _, _, smp in srcMemPieces {
-      srcMemOffset := as!u64(smp.MemoryOffset)
-      dstMemOffset := as!u64(smp.ResourceOffset - srcOffset + dstOffset)
-      if dstMemOffset < as!u64(dstBuf.Memory.AllocationSize) {
-        memSize := min!u64(as!u64(smp.Size), as!u64(dstBuf.Memory.AllocationSize) - dstMemOffset)
-        copy(dstBuf.Memory.Data[dstMemOffset:dstMemOffset+memSize],
-             srcBuf.Memory.Data[srcMemOffset:srcMemOffset+memSize])
-      }
-    }
-
-  } else if (len(dstBuf.SparseMemoryBindings) != 0) && (srcBuf.Memory != null) {
-    // Sparse binding in dst
-    dstMemPieces := getBufferBoundMemoryPiecesInRange(dstBuf, dstOffset, size)
-    for _, _, dmp in dstMemPieces {
-      dstMemOffset := dmp.MemoryOffset
-      srcMemOffset := dmp.ResourceOffset - dstOffset + srcOffset
-      if srcMemOffset < as!VkDeviceSize(srcBuf.Memory.AllocationSize) {
-        memSize := min!VkDeviceSize(dmp.Size, as!VkDeviceSize(srcBuf.Memory.AllocationSize) - srcMemOffset)
-        copy(dstBuf.Memory.Data[dstMemOffset:dstMemOffset+memSize],
-             srcBuf.Memory.Data[srcMemOffset:srcMemOffset+memSize])
-      }
-    }
-
-  } else if (len(dstBuf.SparseMemoryBindings) != 0) && (len(srcBuf.SparseMemoryBindings) != 0) {
-    // Sparse binding in src and dst
-    dstMemPieces := getBufferBoundMemoryPiecesInRange(dstBuf, dstOffset, size)
-    for _, _, dmp in dstMemPieces {
-      tmpSrcOffset := dmp.ResourceOffset - dstOffset + srcOffset
-      tmpSize := dmp.Size
-      srcMemPieces := getBufferBoundMemoryPiecesInRange(srcBuf, tmpSrcOffset, tmpSize)
-      for _, _, smp in srcMemPieces {
+      // Sparse binding in src
+      srcMemPieces := getBufferBoundMemoryPiecesInRange(srcBuf, srcOffset, size)
+      for _ , _ , smp in srcMemPieces {
         srcMemOffset := as!u64(smp.MemoryOffset)
-        dstMemOffset := as!u64(smp.ResourceOffset - tmpSrcOffset + dmp.ResourceOffset)
-        memSize := as!u64(smp.Size)
-        copy(dstBuf.Memory.Data[dstMemOffset:dstMemOffset+memSize],
-             srcBuf.Memory.Data[srcMemOffset:srcMemOffset+memSize])
+        dstMemOffset := as!u64(smp.ResourceOffset - srcOffset + dstOffset)
+        if dstMemOffset < as!u64(dstBuf.Memory.AllocationSize) {
+          memSize := min!u64(as!u64(smp.Size), as!u64(dstBuf.Memory.AllocationSize) - dstMemOffset)
+          copy(dstBuf.Memory.Data[dstMemOffset:dstMemOffset + memSize],
+            srcBuf.Memory.Data[srcMemOffset:srcMemOffset + memSize])
+        }
       }
-    }
-  } 
+
+    } else if (len(dstBuf.SparseMemoryBindings) != 0) && (srcBuf.Memory != null) {
+        // Sparse binding in dst
+        dstMemPieces := getBufferBoundMemoryPiecesInRange(dstBuf, dstOffset, size)
+        for _ , _ , dmp in dstMemPieces {
+          dstMemOffset := dmp.MemoryOffset
+          srcMemOffset := dmp.ResourceOffset - dstOffset + srcOffset
+          if srcMemOffset < as!VkDeviceSize(srcBuf.Memory.AllocationSize) {
+            memSize := min!VkDeviceSize(dmp.Size, as!VkDeviceSize(srcBuf.Memory.AllocationSize) - srcMemOffset)
+            copy(dstBuf.Memory.Data[dstMemOffset:dstMemOffset + memSize],
+              srcBuf.Memory.Data[srcMemOffset:srcMemOffset + memSize])
+          }
+        }
+
+      } else if (len(dstBuf.SparseMemoryBindings) != 0) && (len(srcBuf.SparseMemoryBindings) != 0) {
+          // Sparse binding in src and dst
+          dstMemPieces := getBufferBoundMemoryPiecesInRange(dstBuf, dstOffset, size)
+          for _ , _ , dmp in dstMemPieces {
+            tmpSrcOffset := dmp.ResourceOffset - dstOffset + srcOffset
+            tmpSize := dmp.Size
+            srcMemPieces := getBufferBoundMemoryPiecesInRange(srcBuf, tmpSrcOffset, tmpSize)
+            for _ , _ , smp in srcMemPieces {
+              srcMemOffset := as!u64(smp.MemoryOffset)
+              dstMemOffset := as!u64(smp.ResourceOffset - tmpSrcOffset + dmp.ResourceOffset)
+              memSize := as!u64(smp.Size)
+              copy(dstBuf.Memory.Data[dstMemOffset:dstMemOffset + memSize],
+                srcBuf.Memory.Data[srcMemOffset:srcMemOffset + memSize])
+            }
+          }
+        }
 }
 
 @threadSafety("app")
@@ -453,7 +453,7 @@ sub void dovkCmdCopyBufferToImage(ref!vkCmdCopyBufferToImageArgs args) {
                 readMemoryInBuffer(bufferObject, bufStart, as!VkDeviceSize(elementSize))
                 // Discard the 4th byte in the buffer for current pixel.
                 bufMemPieces := getBufferBoundMemoryPiecesInRange(bufferObject, bufStart, as!VkDeviceSize(elementSizeInImage))
-                for _, _, piece in bufMemPieces {
+                for _ , _ , piece in bufMemPieces {
                   srcStart := piece.MemoryOffset
                   srcEnd := srcStart + piece.Size
                   dstPieceStart := piece.ResourceOffset - bufStart + dstStart
@@ -468,7 +468,7 @@ sub void dovkCmdCopyBufferToImage(ref!vkCmdCopyBufferToImageArgs args) {
               bufStart := as!VkDeviceSize(bufferLayerOffset + rowStartInExtent)
               readMemoryInBuffer(bufferObject, bufStart, copySize)
               bufMemPieces := getBufferBoundMemoryPiecesInRange(bufferObject, bufStart, copySize)
-              for _, _, piece in bufMemPieces {
+              for _ , _ , piece in bufMemPieces {
                 srcStart := piece.MemoryOffset
                 srcEnd := srcStart + piece.Size
                 dstPieceStart := as!u64(piece.ResourceOffset - bufStart) + dstStart
@@ -560,10 +560,10 @@ sub void dovkCmdUpdateBuffer(ref!vkCmdUpdateBufferArgs args) {
   Buffers[args.DstBuffer].LastBoundQueue = LastBoundQueue
   buff := Buffers[args.DstBuffer]
   bufPieces := getBufferBoundMemoryPiecesInRange(buff, args.DstOffset, args.DataSize)
-  for _, _, p in bufPieces {
+  for _ , _ , p in bufPieces {
     srcOffset := p.ResourceOffset - args.DstOffset
-    size := min!VkDeviceSize(p.Size, as!VkDeviceSize(len(args.Data))-srcOffset)
-    copy(buff.Memory.Data[p.MemoryOffset:p.MemoryOffset+size], args.Data[srcOffset:srcOffset+size])
+    size := min!VkDeviceSize(p.Size, as!VkDeviceSize(len(args.Data)) - srcOffset)
+    copy(buff.Memory.Data[p.MemoryOffset:p.MemoryOffset + size], args.Data[srcOffset:srcOffset + size])
   }
 }
 
@@ -602,11 +602,11 @@ class vkCmdFillBufferArgs {
 sub void dovkCmdFillBuffer(ref!vkCmdFillBufferArgs args) {
   buf := Buffers[args.Buffer]
   bufPieces := getBufferBoundMemoryPiecesInRange(buf, args.DstOffset, args.Size)
-  for _, _, p in bufPieces {
+  for _ , _ , p in bufPieces {
     if as!VkDeviceSize(len(p.DeviceMemory.Data)) >= (p.MemoryOffset + p.Size) {
       for i in (0 .. p.Size) {
         offset := as!VkDeviceSize(p.ResourceOffset + i)
-        p.DeviceMemory.Data[p.MemoryOffset + i] = switch (offset-((offset/4)*4)) {
+        p.DeviceMemory.Data[p.MemoryOffset + i] = switch (offset - ((offset / 4) * 4)) {
           case as!VkDeviceSize(0):
             as!u8(args.Data & 0xFF)
           case as!VkDeviceSize(1):
@@ -772,12 +772,12 @@ cmd void vkCmdClearAttachments(
 
 sub void dovkCmdResolveImage(ref!vkCmdResolveImageArgs args) {
   for _ , _ , r in args.ResolveRegions {
-    srcRange := VkImageSubresourceRange(r.srcSubresource.aspectMask,
-                                        r.srcSubresource.mipLevel, 1,
-                                        r.srcSubresource.baseArrayLayer, r.srcSubresource.layerCount)
-    dstRange := VkImageSubresourceRange(r.dstSubresource.aspectMask,
-                                        r.dstSubresource.mipLevel, 1,
-                                        r.dstSubresource.baseArrayLayer, r.dstSubresource.layerCount)
+    srcRange := VkImageSubresourceRange(               r.srcSubresource.aspectMask,
+      r.srcSubresource.mipLevel,       1,
+      r.srcSubresource.baseArrayLayer, r.srcSubresource.layerCount)
+    dstRange := VkImageSubresourceRange(               r.dstSubresource.aspectMask,
+      r.dstSubresource.mipLevel,       1,
+      r.dstSubresource.baseArrayLayer, r.dstSubresource.layerCount)
     readImageSubresource(Images[args.SrcImage], srcRange, args.SrcImageLayout)
     writeImageSubresource(Images[args.DstImage], dstRange, args.DstImageLayout)
   }

--- a/gapis/api/vulkan/api/copy_clear_commands.api
+++ b/gapis/api/vulkan/api/copy_clear_commands.api
@@ -772,12 +772,18 @@ cmd void vkCmdClearAttachments(
 
 sub void dovkCmdResolveImage(ref!vkCmdResolveImageArgs args) {
   for _ , _ , r in args.ResolveRegions {
-    srcRange := VkImageSubresourceRange(               r.srcSubresource.aspectMask,
-      r.srcSubresource.mipLevel,       1,
-      r.srcSubresource.baseArrayLayer, r.srcSubresource.layerCount)
-    dstRange := VkImageSubresourceRange(               r.dstSubresource.aspectMask,
-      r.dstSubresource.mipLevel,       1,
-      r.dstSubresource.baseArrayLayer, r.dstSubresource.layerCount)
+    srcRange := VkImageSubresourceRange(
+      r.srcSubresource.aspectMask,
+      r.srcSubresource.mipLevel,
+      1,
+      r.srcSubresource.baseArrayLayer,
+      r.srcSubresource.layerCount)
+    dstRange := VkImageSubresourceRange(
+      r.dstSubresource.aspectMask,
+      r.dstSubresource.mipLevel,
+      1,
+      r.dstSubresource.baseArrayLayer,
+      r.dstSubresource.layerCount)
     readImageSubresource(Images[args.SrcImage], srcRange, args.SrcImageLayout)
     writeImageSubresource(Images[args.DstImage], dstRange, args.DstImageLayout)
   }

--- a/gapis/api/vulkan/api/queued_command_tracking.api
+++ b/gapis/api/vulkan/api/queued_command_tracking.api
@@ -74,7 +74,7 @@ sub void execPendingCommands(VkQueue queue) {
           }
         }
       if processSubcommand.b {
-        // Handle sparse image binding.
+        // Handle sparse buffer/image binding.
         if (cmd.SparseBinds != null) {
           for _ , buf , binds in cmd.SparseBinds.BufferBinds {
             if !(buf in Buffers) { vkErrorInvalidBuffer(buf) }

--- a/gapis/api/vulkan/api/util.api
+++ b/gapis/api/vulkan/api/util.api
@@ -402,3 +402,20 @@ class VulkanStructHeader {
   VkStructureType SType
   void*           PNext
 }
+
+// Following utility subroutines are exact copies from GLES.
+// TODO: Apic should support one api file to be imported in multiple dependee
+// api files. Once this is done, use a single definiton shared with GLES.
+sub T max!T(T a, T b) {
+  return switch a > b {
+    case true:  a
+    case false: b
+  }
+}
+
+sub T min!T(T a, T b) {
+  return switch (a < b) {
+    case true:  a
+    case false: b
+  }
+}


### PR DESCRIPTION
1) Support sparse buffer in vkCmdCopyBuffer, vkCmdFillBuffer and
vkCmdCopyBufferToImage.

2) Support extract geometry data from sparse buffer

3) 'Read' the memory of sparse buffers

4) Implement doVkCmdFillBuffer

Tested with all the samples we have.