### PR TITLE
Fix a warning in the GAPIR test

### DIFF
--- a/gapir/cc/context_test.cpp
+++ b/gapir/cc/context_test.cpp
@@ -181,6 +181,7 @@ TEST_F(ContextTest, PostDataErrorPost) {
              instruction(Interpreter::InstructionCode::POST)});
 
     EXPECT_CALL(*mConn, getPayload()).WillOnce(Return(ByMove(std::move(payload))));
+    EXPECT_CALL(*mConn, mockedSendPostData(NotNull())).WillOnce(Return(false));
 
     core::CrashHandler crash_handler;
     auto context = Context::create(mConn.get(), crash_handler, mResourceProvider.get(), mMemoryManager.get());


### PR DESCRIPTION
Fix the warning in #1977 