### PR TITLE
Get the string table to work with "bazel run ..."

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -14,7 +14,7 @@
 
 load("@io_bazel_rules_go//go:def.bzl", "go_prefix")
 load("@bazel_gazelle//:def.bzl", "gazelle")
-load("//tools/build:rules.bzl", "copy", "copy_to")
+load("//tools/build:rules.bzl", "copy_to")
 
 go_prefix("github.com/google/gapid")
 

--- a/cmd/gapir/cc/BUILD.bazel
+++ b/cmd/gapir/cc/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//tools/build:rules.bzl", "cc_copts", "cc_stripped_binary", "android_dynamic_library", "android_native_app_glue")
+load("//tools/build:rules.bzl", "android_dynamic_library", "cc_copts", "cc_stripped_binary")
 
 cc_stripped_binary(
     name = "gapir",

--- a/gapic/src/main/com/google/gapid/server/GapiPaths.java
+++ b/gapic/src/main/com/google/gapid/server/GapiPaths.java
@@ -155,7 +155,7 @@ public final class GapiPaths {
                 gapit = new File(tokens[1]);
                 break;
               case "gapid/gapis/messages/en-us.stb":
-                strings = new File(tokens[1]);
+                strings = new File(tokens[1]).getParentFile();
                 break;
             }
           }

--- a/gapil/compiler/plugins/encoder/test/BUILD.bazel
+++ b/gapil/compiler/plugins/encoder/test/BUILD.bazel
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
-load("//tools/build:rules.bzl", "api_library", "apic_compile", "apic_template", "cc_copts", "filter")
+load("//tools/build:rules.bzl", "api_library", "apic_compile", "apic_template", "cc_copts")
 
 api_library(
     name = "api",

--- a/gapil/compiler/plugins/encoder/test/BUILD.bazel
+++ b/gapil/compiler/plugins/encoder/test/BUILD.bazel
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
-load("//tools/build:rules.bzl", "api_library", "apic_compile", "apic_template", "cc_copts")
+load("//tools/build:rules.bzl", "api_library", "apic_compile", "cc_copts")
 
 api_library(
     name = "api",

--- a/gapil/compiler/plugins/encoder/test/encoder_pb/BUILD.bazel
+++ b/gapil/compiler/plugins/encoder/test/encoder_pb/BUILD.bazel
@@ -15,7 +15,7 @@ load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 # limitations under the License.
 
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
-load("//tools/build:rules.bzl", "api_library", "apic_compile", "apic_template", "cc_copts")
+load("//tools/build:rules.bzl", "apic_template")
 
 apic_template(
     name = "api_proto",

--- a/gapil/compiler/plugins/encoder/test/encoder_pb/BUILD.bazel
+++ b/gapil/compiler/plugins/encoder/test/encoder_pb/BUILD.bazel
@@ -15,7 +15,7 @@ load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 # limitations under the License.
 
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
-load("//tools/build:rules.bzl", "api_library", "apic_compile", "apic_template", "cc_copts", "filter")
+load("//tools/build:rules.bzl", "api_library", "apic_compile", "apic_template", "cc_copts")
 
 apic_template(
     name = "api_proto",

--- a/gapil/executor/BUILD.bazel
+++ b/gapil/executor/BUILD.bazel
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
-load("//tools/build:rules.bzl", "cc_copts")
 
 go_library(
     name = "go_default_library",

--- a/gapis/api/gles/BUILD.bazel
+++ b/gapis/api/gles/BUILD.bazel
@@ -14,7 +14,7 @@
 
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
-load("//tools/build:rules.bzl", "api_library", "apic_template", "filter")
+load("//tools/build:rules.bzl", "api_library", "apic_template")
 
 api_library(
     name = "api",

--- a/gapis/api/gvr/BUILD.bazel
+++ b/gapis/api/gvr/BUILD.bazel
@@ -14,7 +14,7 @@
 
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
-load("//tools/build:rules.bzl", "api_library", "apic_template", "filter")
+load("//tools/build:rules.bzl", "api_library", "apic_template")
 
 proto_library(
     name = "gvr_proto",

--- a/gapis/api/test/BUILD.bazel
+++ b/gapis/api/test/BUILD.bazel
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
-load("//tools/build:rules.bzl", "api_library", "apic_template", "filter")
+load("//tools/build:rules.bzl", "api_library", "apic_template")
 
 api_library(
     name = "api",

--- a/gapis/api/vulkan/BUILD.bazel
+++ b/gapis/api/vulkan/BUILD.bazel
@@ -14,7 +14,7 @@
 
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
-load("//tools/build:rules.bzl", "api_library", "apic_template", "filter")
+load("//tools/build:rules.bzl", "api_library", "apic_template")
 
 api_library(
     name = "api",

--- a/gapis/messages/BUILD.bazel
+++ b/gapis/messages/BUILD.bazel
@@ -21,24 +21,24 @@ stringgen(
     visibility = ["//visibility:public"],
 )
 
-filter(
+filegroup(
     name = "messages_api",
     srcs = [":messages"],
-    suffix = [".api"],
+    output_group = "api",
     visibility = ["//visibility:private"],
 )
 
-filter(
+filegroup(
     name = "stb",
     srcs = [":messages"],
-    suffix = [".stb"],
+    output_group = "table",
     visibility = ["//visibility:public"],
 )
 
-filter(
+filegroup(
     name = "messages_go",
     srcs = [":messages"],
-    suffix = [".go"],
+    output_group = "go",
     visibility = ["//visibility:private"],
 )
 

--- a/gapis/messages/BUILD.bazel
+++ b/gapis/messages/BUILD.bazel
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
-load("//tools/build:rules.bzl", "stringgen", "api_library", "filter")
+load("//tools/build:rules.bzl", "stringgen", "api_library")
 
 stringgen(
     name = "messages",

--- a/tools/build/rules.bzl
+++ b/tools/build/rules.bzl
@@ -15,7 +15,7 @@
 load("//tools/build/rules:android.bzl", "android_native_app_glue", "android_native")
 load("//tools/build/rules:apic.bzl", "apic_compile", "apic_template")
 load("//tools/build/rules:cc.bzl", "cc_copts", "cc_stripped_binary", "strip")
-load("//tools/build/rules:common.bzl", "generate", "copy", "copy_to", "copy_tree", "filter")
+load("//tools/build/rules:common.bzl", "generate", "copy", "copy_to", "copy_tree")
 load("//tools/build/rules:dynlib.bzl", "android_dynamic_library", "cc_dynamic_library")
 load("//tools/build/rules:embed.bzl", "embed")
 load("//tools/build/rules:filehash.bzl", "filehash")

--- a/tools/build/rules/common.bzl
+++ b/tools/build/rules/common.bzl
@@ -112,26 +112,6 @@ copy_tree = rule(
     },
 )
 
-def filter_impl(ctx):
-    return [
-        DefaultInfo(
-            files=depset([
-                src for src in ctx.files.srcs
-                if any([
-                    src.basename.endswith(ext) for ext in ctx.attr.suffix
-                ])
-            ]),
-        ),
-    ]
-
-filter = rule(
-    filter_impl,
-    attrs = {
-        "srcs": attr.label_list(allow_files = True, mandatory = True),
-        "suffix": attr.string_list(),
-    },
-)
-
 # Implementation of the copy_exec rule.
 def _copy_exec_impl(ctx):
     if len(ctx.files.srcs) != 1:

--- a/tools/build/rules/stringgen.bzl
+++ b/tools/build/rules/stringgen.bzl
@@ -29,7 +29,14 @@ def _stringgen_impl(ctx):
         ],
         use_default_shell_env = True,
     )
-    return [DefaultInfo(files=depset([go, api, table]))]
+    return [
+        DefaultInfo(files = depset([go, api, table])),
+        OutputGroupInfo(
+            go = depset([go]),
+            api = depset([api]),
+            table = depset([table]),
+        )
+    ]
 
 """Builds a stringgen source converter rule"""
 stringgen = rule(


### PR DESCRIPTION
Fixes the string table targets so they show up in runfiles and fixes the handling of the string table in the runfiles for gapic.