### PR TITLE
Small fixes to memory breakdown

### DIFF
--- a/cmd/gapit/memory.go
+++ b/cmd/gapit/memory.go
@@ -108,9 +108,9 @@ func (verb *memoryVerb) Run(ctx context.Context, flags flag.FlagSet) error {
 
 	for _, alloc := range mem.Allocations {
 		fmt.Fprintln(w, "Name:", alloc.Name)
-		fmt.Fprintln(w, "\tDevice:      ", alloc.Device)
-		fmt.Fprintln(w, "\tMemory Type: ", alloc.MemoryType)
-		fmt.Fprintln(w, "\tSize:        ", alloc.Size)
+		fmt.Fprintf(w, "\tDevice: \t%v\n", alloc.Device)
+		fmt.Fprintf(w, "\tMemory Type: \t%v\n", alloc.MemoryType)
+		fmt.Fprintf(w, "\tSize: \t%v\n", alloc.Size)
 
 		if alloc.Flags != 0 && len(allocationFlags) != 0 {
 			fmt.Fprintln(w, "\tFlags:")
@@ -124,8 +124,8 @@ func (verb *memoryVerb) Run(ctx context.Context, flags flag.FlagSet) error {
 		if alloc.Mapping.Size != 0 {
 			fmt.Fprintf(w, "\tMapped into host memory at 0x%x\n",
 				alloc.Mapping.MappedAddress)
-			fmt.Fprintln(w, "\t\tOffset:", alloc.Mapping.Offset)
-			fmt.Fprintln(w, "\t\tSize:  ", alloc.Mapping.Size)
+			fmt.Fprintf(w, "\t\tOffset: \t%v\n", alloc.Mapping.Offset)
+			fmt.Fprintf(w, "\t\tSize: \t%v\n", alloc.Mapping.Size)
 		}
 
 		bindings := bindingSlice(alloc.Bindings)
@@ -151,33 +151,33 @@ func (verb *memoryVerb) Run(ctx context.Context, flags flag.FlagSet) error {
 			}
 			fmt.Fprintf(w, "\t%v: %v\n", typ, binding.Name)
 
-			fmt.Fprintln(w, "\t\tOffset:", binding.Offset)
-			fmt.Fprintln(w, "\t\tSize:  ", binding.Size)
+			fmt.Fprintf(w, "\t\tOffset: \t%v\n", binding.Offset)
+			fmt.Fprintf(w, "\t\tSize: \t%v\n", binding.Size)
 
 			switch val := binding.Type.(type) {
 			case *api.MemoryBinding_SparseImageBlock:
 				info := val.SparseImageBlock
-				fmt.Fprintf(w, "\t\tBlock Offset: (%v, %v)\n",
+				fmt.Fprintf(w, "\t\tBlock Offset: \t(%v, %v)\n",
 					info.XOffset, info.YOffset)
-				fmt.Fprintf(w, "\t\tBlock Extent: (%v, %v)\n",
+				fmt.Fprintf(w, "\t\tBlock Extent: \t(%v, %v)\n",
 					info.Width, info.Height)
-				fmt.Fprintf(w, "\t\tMip Level:    %v\n", info.MipLevel)
-				fmt.Fprintf(w, "\t\tArray Layer:  %v\n", info.ArrayLayer)
-				fmt.Fprintf(w, "\t\tAspects:      %v\n", aspectList(info.Aspects))
+				fmt.Fprintf(w, "\t\tMip Level: \t%v\n", info.MipLevel)
+				fmt.Fprintf(w, "\t\tArray Layer: \t%v\n", info.ArrayLayer)
+				fmt.Fprintf(w, "\t\tAspects: \t%v\n", strings.Trim(fmt.Sprint(info.Aspects), "[]"))
 			case *api.MemoryBinding_SparseImageMetadata:
 				info := val.SparseImageMetadata
-				fmt.Fprintf(w, "\t\tArray Layer:     %v\n", info.ArrayLayer)
-				fmt.Fprintf(w, "\t\tMip Tail Offset: %v\n", info.Offset)
+				fmt.Fprintf(w, "\t\tArray Layer: \t%v\n", info.ArrayLayer)
+				fmt.Fprintf(w, "\t\tMip Tail Offset: \t%v\n", info.Offset)
 			case *api.MemoryBinding_SparseImageMipTail:
 				info := val.SparseImageMipTail
-				fmt.Fprintf(w, "\t\tArray Layer:     %v\n", info.ArrayLayer)
-				fmt.Fprintf(w, "\t\tMip Tail Offset: %v\n", info.Offset)
-				fmt.Fprintf(w, "\t\tAspects:         %v\n", aspectList(info.Aspects))
+				fmt.Fprintf(w, "\t\tArray Layer: \t%v\n", info.ArrayLayer)
+				fmt.Fprintf(w, "\t\tMip Tail Offset: \t%v\n", info.Offset)
+				fmt.Fprintf(w, "\t\tAspects: \t%v\n", strings.Trim(fmt.Sprint(info.Aspects), "[]"))
 			case *api.MemoryBinding_SparseOpaqueImageBlock:
-				fmt.Fprintf(w, "\t\tImage Memory Offset: %v\n",
+				fmt.Fprintf(w, "\t\tImage Memory Offset: \t%v\n",
 					val.SparseOpaqueImageBlock.Offset)
 			case *api.MemoryBinding_SparseBufferBlock:
-				fmt.Fprintf(w, "\t\tBuffer Memory Offset: %v\n",
+				fmt.Fprintf(w, "\t\tBuffer Memory Offset: \t%v\n",
 					val.SparseBufferBlock.Offset)
 			}
 		}
@@ -189,9 +189,9 @@ func (verb *memoryVerb) Run(ctx context.Context, flags flag.FlagSet) error {
 			fmt.Fprintf(w, "\t%v aliased regions:\n", len(aliases))
 			for i, a := range aliases {
 				fmt.Fprintf(w, "\t%v:\n", i)
-				fmt.Fprintln(w, "\t\tOffset: ", a.offset)
-				fmt.Fprintln(w, "\t\tSize:   ", a.size)
-				fmt.Fprintln(w, "\t\tShared by:")
+				fmt.Fprintf(w, "\t\tOffset: \t%v\n", a.offset)
+				fmt.Fprintf(w, "\t\tSize: \t%v\n", a.size)
+				fmt.Fprintf(w, "\t\tShared by:\n")
 				for _, s := range a.sharers {
 					fmt.Fprintf(w, "\t\t\t%v\n", s)
 				}
@@ -200,28 +200,6 @@ func (verb *memoryVerb) Run(ctx context.Context, flags flag.FlagSet) error {
 	}
 	w.Flush()
 	return nil
-}
-
-type aspectList []api.AspectType
-
-func (a aspectList) Format(f fmt.State, c rune) {
-	if len(a) == 0 {
-		return
-	}
-	strs := make([]string, len(a))
-	for i, asp := range a {
-		var typ string
-		switch asp {
-		case api.AspectType_COLOR:
-			typ = "Color"
-		case api.AspectType_DEPTH:
-			typ = "Depth"
-		case api.AspectType_STENCIL:
-			typ = "Stencil"
-		}
-		strs[i] = typ
-	}
-	fmt.Fprintf(f, strings.Join(strs, ", "))
 }
 
 type bindingSlice []*api.MemoryBinding

--- a/gapis/api/service.go
+++ b/gapis/api/service.go
@@ -14,6 +14,8 @@
 
 package api
 
+import "fmt"
+
 // IsColor returns true if a is a color attachment.
 func (a FramebufferAttachment) IsColor() bool {
 	switch a {
@@ -35,4 +37,17 @@ func (a FramebufferAttachment) IsDepth() bool {
 // IsStencil returns true if a is a stencil attachment.
 func (a FramebufferAttachment) IsStencil() bool {
 	return a == FramebufferAttachment_Stencil
+}
+
+func (a AspectType) Format(f fmt.State, c rune) {
+	switch a {
+	case AspectType_COLOR:
+		fmt.Fprint(f, "Color")
+	case AspectType_DEPTH:
+		fmt.Fprint(f, "Depth")
+	case AspectType_STENCIL:
+		fmt.Fprint(f, "Stencil")
+	default:
+		fmt.Fprintf(f, "Unknown AspectType %d", int(a))
+	}
 }

--- a/gapis/api/service.proto
+++ b/gapis/api/service.proto
@@ -239,10 +239,10 @@ message CubemapLevel {
 	image.Info positive_z = 6;
 }
 
+// Metrics about the state at some point in a trace
 message Metrics {
-  oneof metrics {
-    MemoryBreakdown memory_breakdown = 1;
-  }
+  // The brekadown of memory allocations and bindings.
+  MemoryBreakdown memory_breakdown = 1;
 }
 
 // The description of the memory layout of the API state
@@ -251,8 +251,9 @@ message MemoryBreakdown {
   path.API api = 1;
   // The memory allocations that are currently in use.
   repeated MemoryAllocation allocations = 2;
-  // The index to get the constants names for MemoryAllocation `flags`.
-  // A value of -1 indicates no flag names should be fetched.
+  // The index to get the constants names for `MemoryAllocation.flags`, to be
+  // fetched with the path.ConstantSet endpoint.  A value of -1 indicates no
+  // flag names should be fetched.
   int32 allocation_flags_index = 3;
 }
 
@@ -263,20 +264,20 @@ message MemoryAllocation {
   // The memory type this allocation is from
   uint32 memory_type = 2;
   // Flags describing properties of the allocation, e.g. whether it's device
-  // local, whether it's host visible, etc.
+  // local, whether it's host visible, etc.  The names for the flags can be
+  // fetched from path.ConstantSet with the index in
+  // `MemoryBreakdown.allocation_flags_index`.
   uint32 flags = 3;
-  // Constant index for looking up the flag values with the path.ConstantSet endpoint
-  uint32 constant_set = 4;
   // The API specific ID for this allocation
-  uint64 handle = 5;
+  uint64 handle = 4;
   // The user-readable name for this allocation
-  string name = 6;
+  string name = 5;
   // This size of the memory allocated
-  uint64 size = 7;
+  uint64 size = 6;
   // The regions of host memory this allocation has been mapped into
-  MemoryMapping mapping = 8;
+  MemoryMapping mapping = 7;
   // All buffers/images bound to this memory allocation
-  repeated MemoryBinding bindings = 9;
+  repeated MemoryBinding bindings = 8;
 }
 
 // A mapping from part of a memory allocation into host memory

--- a/gapis/service/path/path.proto
+++ b/gapis/service/path/path.proto
@@ -346,16 +346,14 @@ message MeshOptions {
     repeated SemanticHint vertex_semantics = 3;
 }
 
-// Metrics requests metrics for a given command.  Resolves to service.Metrics
+// Metrics requests a set of metrics for a given command.  Resolves to
+// service.Metrics.
 message Metrics {
-  // The command to get the metrics from
+  // The command after which to get the metrics from.
   Command command = 1;
 
-  enum Type {
-    MEMORY_BREAKDOWN = 0;
-  }
-  // The type of metrics to report
-  Type type = 2;
+  // Whether to get the memory breakdown metrics.
+  bool memory_breakdown = 2;
 }
 
 // Report is a path to a list of report items for a capture.


### PR DESCRIPTION
Recommended changes by @ben-clayton in #1954
- Change Metrics proto to not be oneof, and change path.Metrics to have
  a flag per type instead of an enum
- Remove redudancy on flags ConstantSet index, and document better
- Add aspectList type with Format method
- Use text/tabwriter in cmd/gapit/memory