### PR TITLE
Lazily resolve Vulkan commands (actually all indirect commands)

### DIFF
--- a/gapir/cc/gfx_api.h
+++ b/gapir/cc/gfx_api.h
@@ -45,7 +45,7 @@ template <typename FuncPtr>
 class LazyResolved {
  public:
   LazyResolved() : resolve_(nullptr), ptr_(nullptr) {}
-  LazyResolved(nullptr_t) : LazyResolved() {}
+  LazyResolved(std::nullptr_t) : LazyResolved() {}
   explicit LazyResolved(std::function<void*()> resolver)
       : resolve_(resolver), ptr_(nullptr) {}
   // Pass forward the arguments to the command, if the function has never been
@@ -59,7 +59,7 @@ class LazyResolved {
   }
   // Overloaded not-equal nullptr comparison. Returns true if the underlying
   // function can be resolved and is not nullptr.
-  bool operator!=(nullptr_t) {
+  bool operator!=(std::nullptr_t) {
     if (!resolve_) {
       return true;
     }

--- a/gapis/api/templates/cpp_common.tmpl
+++ b/gapis/api/templates/cpp_common.tmpl
@@ -1121,6 +1121,18 @@
 
 {{/*
 -------------------------------------------------------------------------------
+  Emits the C++ lazy resolved function variable extern for a given command.
+-------------------------------------------------------------------------------
+*/}}
+{{define "C++.LazyResolvedFunctionDecl"}}
+  {{AssertType $ "Function"}}
+
+  LazyResolved<{{Template "C++.FunctionPtrType" $}}> {{Template "CmdName" $}}
+{{end}}
+
+
+{{/*
+-------------------------------------------------------------------------------
   Emits the method name for the given command or subroutine.
 -------------------------------------------------------------------------------
 */}}

--- a/gapis/api/templates/specific_gfx_api.h.tmpl
+++ b/gapis/api/templates/specific_gfx_api.h.tmpl
@@ -40,6 +40,7 @@
 #include "core/cc/{{Global "API"}}_ptr_types.h"
 ¶
 #include <stdint.h>
+#include <functional>
 #include <string>
 ¶
 {{/* Forward declare structs used by the graphics API in the global namespace. */}}
@@ -88,7 +89,11 @@ class {{Title (Global "API")}} : public Api {
     struct {{$table}}FunctionStubs {
       {{range $f := $p}}
         {{if and (not (GetAnnotation $f "synthetic")) (not (GetAnnotation $f "pfn"))}}
-          {{Template "C++.FunctionPtrDecl" $f}} = nullptr;
+          {{if not (GetAnnotation $f "indirect")}}
+            {{Template "C++.FunctionPtrDecl" $f}} = nullptr;
+          {{else}}
+            {{Template "C++.LazyResolvedFunctionDecl" $f}} = nullptr;
+          {{end}}
         {{end}}
       {{end}}
     };

--- a/gapis/api/templates/vulkan_gfx_api_extras.tmpl
+++ b/gapis/api/templates/vulkan_gfx_api_extras.tmpl
@@ -64,7 +64,7 @@
 
 ¶
   std::vector<Vulkan::VkPhysicalDevice> getVkPhysicalDevices(§
-      Vulkan::PFNVKENUMERATEPHYSICALDEVICES vkEnumeratePhysicalDevices, Vulkan::VkInstance instance) {
+      LazyResolved<Vulkan::PFNVKENUMERATEPHYSICALDEVICES> vkEnumeratePhysicalDevices, Vulkan::VkInstance instance) {
     uint32_t count = 0;
     vkEnumeratePhysicalDevices(instance, &count, nullptr);
     std::vector<Vulkan::VkPhysicalDevice> devices(count);
@@ -73,7 +73,7 @@
   }
 ¶
   std::vector<Vulkan::VkQueue> getVkQueues(§
-      Vulkan::PFNVKGETDEVICEQUEUE vkGetDeviceQueue, Vulkan::VkDevice device, §
+      LazyResolved<Vulkan::PFNVKGETDEVICEQUEUE> vkGetDeviceQueue, Vulkan::VkDevice device, §
       Vulkan::VkDeviceCreateInfo* createInfo) {
     std::vector<Vulkan::VkQueue> queues;
     for (uint32_t i = 0; i < createInfo->queueCreateInfoCount; ++i) {
@@ -204,8 +204,8 @@ bool Vulkan::replayCreateVkDeviceImpl(Stack* stack, size_val physicalDevice,
       {{range $c := AllCommands $}}
         {{if (Macro "IsIndirected" "Command" $c "IndirectOn" "VkInstance")}}
           {{$name := Macro "CmdName" $c}}
-          stubs.{{$name}} = reinterpret_cast<{{Template "C++.FunctionPtrType" $c}}>(§
-              core::GetVulkanInstanceProcAddress(instance, "{{$name}}", false));
+          stubs.{{$name}} = LazyResolved<{{Template "C++.FunctionPtrType" $c}}>(
+            [instance]() -> void* { return core::GetVulkanInstanceProcAddress(instance, "{{$name}}", false); });
         {{end}}
       {{end}}
       // Get all physical devices for this instance and bind them.
@@ -255,8 +255,8 @@ bool Vulkan::replayCreateVkDeviceImpl(Stack* stack, size_val physicalDevice,
       {{range $c := AllCommands $}}
         {{if (Macro "IsIndirected" "Command" $c "IndirectOn" "VkDevice")}}
           {{$name := Macro "CmdName" $c}}
-          stubs.{{$name}} = reinterpret_cast<{{Template "C++.FunctionPtrType" $c}}>(§
-              core::GetVulkanDeviceProcAddress(instance, device, "{{$name}}", false));
+          stubs.{{$name}} = LazyResolved<{{Template "C++.FunctionPtrType" $c}}>(
+            [instance, device]() -> void* { return core::GetVulkanDeviceProcAddress(instance, device, "{{$name}}", false); });
         {{end}}
       {{end}}
       // Get all queues for this device and bind them.


### PR DESCRIPTION
This is to avoid some Vulkan driver (actually some ICDs) crashing when resolving unsupported and never used commands.

This is probably the 'minimum changes' approach. It uses lambda
functions, which will take a copy of the handles used for command resolving.

If we really want to avoid that copy, we probably need to use the template
system to scan through all the commands first and  generate c++ template
specialization code. But I think the benefit may be not worth of the extra work?