### PR TITLE
clang-format all C / C++ / ObjC

### DIFF
--- a/cmd/device-info/main.cpp
+++ b/cmd/device-info/main.cpp
@@ -20,61 +20,64 @@
 #include <string>
 
 #if _WIN32
-#include <stdio.h>
 #include <fcntl.h>
+#include <stdio.h>
 #endif
 
-#include "core/os/device/deviceinfo/cc/instance.h"
-#include "core/os/device/device.pb.h"
 #include <google/protobuf/util/json_util.h>
+#include "core/os/device/device.pb.h"
+#include "core/os/device/deviceinfo/cc/instance.h"
 
 void print_help() {
-    std::cout << "Usage: device-info [--binary]" << std::endl;
-    std::cout << "Output information about the current device." << std::endl;
-    std::cout << " --binary         Output a binary protobuf instead of json" << std::endl;
+  std::cout << "Usage: device-info [--binary]" << std::endl;
+  std::cout << "Output information about the current device." << std::endl;
+  std::cout << " --binary         Output a binary protobuf instead of json"
+            << std::endl;
 }
 
 int main(int argc, char const *argv[]) {
-    bool output_binary = false;
-    for (int i = 1; i < argc; ++i) {
-        if (strcmp(argv[i], "--help") == 0 ||
-            strcmp(argv[i], "-help") == 0 ||
-            strcmp(argv[i], "-h") == 0) {
-            print_help();
-            return 0;
-        } else if (strcmp(argv[i], "--binary") == 0) {
-            output_binary = true;
-        } else {
-            print_help();
-            return -1;
-        }
-    }
-
-    device_instance instance = get_device_instance(nullptr);
-    if (output_binary) {
-#if _WIN32
-  _setmode(_fileno(stdout), _O_BINARY);
-#endif
-        std::cout << std::string(reinterpret_cast<char*>(instance.data), instance.size);
+  bool output_binary = false;
+  for (int i = 1; i < argc; ++i) {
+    if (strcmp(argv[i], "--help") == 0 || strcmp(argv[i], "-help") == 0 ||
+        strcmp(argv[i], "-h") == 0) {
+      print_help();
+      return 0;
+    } else if (strcmp(argv[i], "--binary") == 0) {
+      output_binary = true;
     } else {
-        device::Instance device_inst;
-        if (!device_inst.ParseFromArray(instance.data, instance.size)) {
-            std::cerr << "Internal error." << std::endl;
-            free_device_instance(instance);
-            return -1;
-        }
-        std::string output;
-        google::protobuf::util::JsonPrintOptions options;
-        options.add_whitespace = true;
-        if (google::protobuf::util::Status::OK != google::protobuf::util::MessageToJsonString(device_inst, &output, options)) {
-            std::cerr << "Internal error: Could not convert to json" << std::endl;
-            free_device_instance(instance);
-            return -1;
-        }
-        std::cout << output;
+      print_help();
+      return -1;
     }
+  }
 
-    free_device_instance(instance);
+  device_instance instance = get_device_instance(nullptr);
+  if (output_binary) {
+#if _WIN32
+    _setmode(_fileno(stdout), _O_BINARY);
+#endif
+    std::cout << std::string(reinterpret_cast<char *>(instance.data),
+                             instance.size);
+  } else {
+    device::Instance device_inst;
+    if (!device_inst.ParseFromArray(instance.data, instance.size)) {
+      std::cerr << "Internal error." << std::endl;
+      free_device_instance(instance);
+      return -1;
+    }
+    std::string output;
+    google::protobuf::util::JsonPrintOptions options;
+    options.add_whitespace = true;
+    if (google::protobuf::util::Status::OK !=
+        google::protobuf::util::MessageToJsonString(device_inst, &output,
+                                                    options)) {
+      std::cerr << "Internal error: Could not convert to json" << std::endl;
+      free_device_instance(instance);
+      return -1;
+    }
+    std::cout << output;
+  }
 
-    return 0;
+  free_device_instance(instance);
+
+  return 0;
 }

--- a/cmd/gapir/cc/main.cpp
+++ b/cmd/gapir/cc/main.cpp
@@ -31,12 +31,12 @@
 #include "core/cc/target.h"
 
 #include <stdio.h>
-#include <memory>
-#include <mutex>
 #include <stdlib.h>
 #include <string.h>
-#include <thread>
 #include <unistd.h>
+#include <memory>
+#include <mutex>
+#include <thread>
 
 #if TARGET_OS == GAPID_OS_ANDROID
 #include <sys/stat.h>
@@ -51,27 +51,25 @@ namespace {
 std::vector<uint32_t> memorySizes{
     2 * 1024 * 1024 * 1024U,  // 2GB
     1 * 1024 * 1024 * 1024U,  // 1GB
-         512 * 1024 * 1024U,  // 512MB
-         256 * 1024 * 1024U,  // 256MB
-         128 * 1024 * 1024U,  // 128MB
+    512 * 1024 * 1024U,       // 512MB
+    256 * 1024 * 1024U,       // 256MB
+    128 * 1024 * 1024U,       // 128MB
 };
 
 // createResourceProvider constructs and returns a ResourceInMemoryCache.
 // If cachePath is non-null then the ResourceInMemoryCache will be backed by a
 // disk-cache.
 std::unique_ptr<ResourceInMemoryCache> createResourceProvider(
-        const char* cachePath, MemoryManager* memoryManager) {
-    if (cachePath != nullptr) {
-        GAPID_FATAL("Disk cache is currently out of service. Got %s", cachePath);
-        return std::unique_ptr<ResourceInMemoryCache>(
-            ResourceInMemoryCache::create(
-                ResourceDiskCache::create(ResourceRequester::create(), cachePath),
-                memoryManager->getBaseAddress()));
-    } else {
-        return std::unique_ptr<ResourceInMemoryCache>(
-            ResourceInMemoryCache::create(
-                ResourceRequester::create(), memoryManager->getBaseAddress()));
-    }
+    const char* cachePath, MemoryManager* memoryManager) {
+  if (cachePath != nullptr) {
+    GAPID_FATAL("Disk cache is currently out of service. Got %s", cachePath);
+    return std::unique_ptr<ResourceInMemoryCache>(ResourceInMemoryCache::create(
+        ResourceDiskCache::create(ResourceRequester::create(), cachePath),
+        memoryManager->getBaseAddress()));
+  } else {
+    return std::unique_ptr<ResourceInMemoryCache>(ResourceInMemoryCache::create(
+        ResourceRequester::create(), memoryManager->getBaseAddress()));
+  }
 }
 
 // Setup creates and starts a replay server at the given URI port. Returns the
@@ -119,188 +117,200 @@ std::unique_ptr<Server> Setup(const char* uri, const char* authToken,
 
 const char* pipeName() {
 #ifdef __x86_64
-    return "gapir-x86-64";
+  return "gapir-x86-64";
 #elif defined __i386
-    return "gapir-x86";
+  return "gapir-x86";
 #elif defined __ARM_ARCH_7A__
-    return "gapir-arm";
+  return "gapir-arm";
 #elif defined __aarch64__
-    return "gapir-arm64";
+  return "gapir-arm64";
 #else
-#   error "Unrecognised target architecture"
+#error "Unrecognised target architecture"
 #endif
 }
 
 // Main function for android
 void android_main(struct android_app* app) {
-    MemoryManager memoryManager(memorySizes);
-    CrashHandler crashHandler;
+  MemoryManager memoryManager(memorySizes);
+  CrashHandler crashHandler;
 
-    // Get the path of the file system socket.
-    const char* pipe = pipeName();
-    std::string internal_data_path =
-        std::string(app->activity->internalDataPath);
-    std::string socket_file_path = internal_data_path + "/" + std::string(pipe);
-    std::string uri = std::string("unix://") + socket_file_path;
+  // Get the path of the file system socket.
+  const char* pipe = pipeName();
+  std::string internal_data_path = std::string(app->activity->internalDataPath);
+  std::string socket_file_path = internal_data_path + "/" + std::string(pipe);
+  std::string uri = std::string("unix://") + socket_file_path;
 
-    __android_log_print(ANDROID_LOG_DEBUG, "GAPIR",
-                        "Started Graphics API Replay daemon.\n"
-                        "Listening on unix socket '%s'\n"
-                        "Supported ABIs: %s\n",
-                        uri.c_str(), core::supportedABIs());
+  __android_log_print(ANDROID_LOG_DEBUG, "GAPIR",
+                      "Started Graphics API Replay daemon.\n"
+                      "Listening on unix socket '%s'\n"
+                      "Supported ABIs: %s\n",
+                      uri.c_str(), core::supportedABIs());
 
-    int idleTimeoutSec = 0; // No timeout
-    std::mutex lock;
-    std::unique_ptr<Server> server =
-        Setup(uri.c_str(), nullptr, nullptr, idleTimeoutSec, &crashHandler,
-              &memoryManager, &lock);
-    std::thread waiting_thread([&]() { server.get()->wait(); });
-    if (chmod(socket_file_path.c_str(),
-              S_IRUSR | S_IWUSR | S_IROTH | S_IWOTH)) {
-      GAPID_ERROR("Chmod failed!");
-    }
+  int idleTimeoutSec = 0;  // No timeout
+  std::mutex lock;
+  std::unique_ptr<Server> server =
+      Setup(uri.c_str(), nullptr, nullptr, idleTimeoutSec, &crashHandler,
+            &memoryManager, &lock);
+  std::thread waiting_thread([&]() { server.get()->wait(); });
+  if (chmod(socket_file_path.c_str(), S_IRUSR | S_IWUSR | S_IROTH | S_IWOTH)) {
+    GAPID_ERROR("Chmod failed!");
+  }
 
-    bool alive = true;
-    while (alive) {
-      int ident;
-      int fdesc;
-      int events;
-      struct android_poll_source* source;
-      while ((ident = ALooper_pollAll(0, &fdesc, &events, (void**)&source)) >=
-             0) {
-        // process this event
-        if (source) {
-          source->process(app, source);
-        }
-        if (app->destroyRequested) {
-          unlink(socket_file_path.c_str());
-          server->shutdown();
-          alive = false;
-          break;
-        }
+  bool alive = true;
+  while (alive) {
+    int ident;
+    int fdesc;
+    int events;
+    struct android_poll_source* source;
+    while ((ident = ALooper_pollAll(0, &fdesc, &events, (void**)&source)) >=
+           0) {
+      // process this event
+      if (source) {
+        source->process(app, source);
+      }
+      if (app->destroyRequested) {
+        unlink(socket_file_path.c_str());
+        server->shutdown();
+        alive = false;
+        break;
       }
     }
-    waiting_thread.join();
+  }
+  waiting_thread.join();
 }
 
 #else  // TARGET_OS == GAPID_OS_ANDROID
 
 // Main function for PC
 int main(int argc, const char* argv[]) {
-    int logLevel = LOG_LEVEL;
-    const char* logPath = "logs/gapir.log";
+  int logLevel = LOG_LEVEL;
+  const char* logPath = "logs/gapir.log";
 
-    bool wait_for_debugger = false;
-    const char* cachePath = nullptr;
-    const char* portArgStr = "0";
-    const char* authTokenFile = nullptr;
-    int idleTimeoutSec = 0;
+  bool wait_for_debugger = false;
+  const char* cachePath = nullptr;
+  const char* portArgStr = "0";
+  const char* authTokenFile = nullptr;
+  int idleTimeoutSec = 0;
 
-    for (int i = 1; i < argc; i++) {
-        if (strcmp(argv[i], "--auth-token-file") == 0) {
-            if (i + 1 >= argc) {
-                GAPID_FATAL("Usage: --auth-token-file <token-string>");
-            }
-            authTokenFile = argv[++i];
-        } else if (strcmp(argv[i], "--cache") == 0) {
-            if (i + 1 >= argc) {
-                GAPID_FATAL("Usage: --cache <cache-directory>");
-            }
-            cachePath = argv[++i];
-        } else if (strcmp(argv[i], "--port") == 0) {
-            if (i + 1 >= argc) {
-                GAPID_FATAL("Usage: --port <port_num>");
-            }
-            portArgStr = argv[++i];
-        } else if (strcmp(argv[i], "--log-level") == 0) {
-            if (i + 1 >= argc) {
-                GAPID_FATAL("Usage: --log-level <F|E|W|I|D|V>");
-            }
-            switch (argv[++i][0]) {
-              case 'F': logLevel = LOG_LEVEL_FATAL; break;
-              case 'E': logLevel = LOG_LEVEL_ERROR; break;
-              case 'W': logLevel = LOG_LEVEL_WARNING; break;
-              case 'I': logLevel = LOG_LEVEL_INFO; break;
-              case 'D': logLevel = LOG_LEVEL_DEBUG; break;
-              case 'V': logLevel = LOG_LEVEL_VERBOSE; break;
-              default:
-                GAPID_FATAL("Usage: --log-level <F|E|W|I|D|V>");
-            }
-        } else if (strcmp(argv[i], "--log") == 0) {
-            if (i + 1 >= argc) {
-                GAPID_FATAL("Usage: --log <log-file-path>");
-            }
-            logPath = argv[++i];
-        } else if (strcmp(argv[i], "--idle-timeout-sec") == 0) {
-            if (i + 1 >= argc) {
-                GAPID_FATAL("Usage: --idle-timeout-sec <timeout in seconds>");
-            }
-            idleTimeoutSec = atoi(argv[++i]);
-        } else if (strcmp(argv[i], "--wait-for-debugger") == 0) {
-            wait_for_debugger = true;
-        } else if (strcmp(argv[i], "--version") == 0) {
-            printf("GAPIR version " GAPID_VERSION_AND_BUILD "\n");
-            return 0;
-        } else {
-            GAPID_FATAL("Unknown argument: %s", argv[i]);
-        }
-    }
-
-    if (wait_for_debugger) {
-        GAPID_INFO("Waiting for debugger to attach");
-        core::Debugger::waitForAttach();
-    }
-
-    core::CrashHandler crashHandler;
-
-    GAPID_LOGGER_INIT(logLevel, "gapir", logPath);
-
-    // Read the auth-token.
-    // Note: This must come before the socket is created as the auth token
-    // file is deleted by GAPIS as soon as the port is written to stdout.
-    std::vector<char> authToken;
-    if (authTokenFile != nullptr) {
-        FILE* file = fopen(authTokenFile, "rb");
-        if (file == nullptr) {
-            GAPID_FATAL("Unable to open auth-token file: %s", authTokenFile);
-        }
-        if (fseek(file, 0, SEEK_END) != 0) {
-            GAPID_FATAL("Unable to get length of auth-token file: %s", authTokenFile);
-        }
-        size_t size = ftell(file);
-        fseek(file, 0, SEEK_SET);
-        authToken.resize(size + 1, 0);
-        if (fread(&authToken[0], 1, size, file) != size) {
-            GAPID_FATAL("Unable to read auth-token file: %s", authTokenFile);
-        }
-        fclose(file);
-    }
-
-    MemoryManager memoryManager(memorySizes);
-
-    // If the user does not assign a port to use, get a free TCP port from OS.
-    const char local_host_name[] = "127.0.0.1";
-    std::string portStr(portArgStr);
-    if (portStr == "0") {
-      uint32_t port = SocketConnection::getFreePort(local_host_name);
-      if (port == 0) {
-          GAPID_FATAL("Failed to find a free port for hostname: '%s'", local_host_name);
+  for (int i = 1; i < argc; i++) {
+    if (strcmp(argv[i], "--auth-token-file") == 0) {
+      if (i + 1 >= argc) {
+        GAPID_FATAL("Usage: --auth-token-file <token-string>");
       }
-      portStr = std::to_string(port);
+      authTokenFile = argv[++i];
+    } else if (strcmp(argv[i], "--cache") == 0) {
+      if (i + 1 >= argc) {
+        GAPID_FATAL("Usage: --cache <cache-directory>");
+      }
+      cachePath = argv[++i];
+    } else if (strcmp(argv[i], "--port") == 0) {
+      if (i + 1 >= argc) {
+        GAPID_FATAL("Usage: --port <port_num>");
+      }
+      portArgStr = argv[++i];
+    } else if (strcmp(argv[i], "--log-level") == 0) {
+      if (i + 1 >= argc) {
+        GAPID_FATAL("Usage: --log-level <F|E|W|I|D|V>");
+      }
+      switch (argv[++i][0]) {
+        case 'F':
+          logLevel = LOG_LEVEL_FATAL;
+          break;
+        case 'E':
+          logLevel = LOG_LEVEL_ERROR;
+          break;
+        case 'W':
+          logLevel = LOG_LEVEL_WARNING;
+          break;
+        case 'I':
+          logLevel = LOG_LEVEL_INFO;
+          break;
+        case 'D':
+          logLevel = LOG_LEVEL_DEBUG;
+          break;
+        case 'V':
+          logLevel = LOG_LEVEL_VERBOSE;
+          break;
+        default:
+          GAPID_FATAL("Usage: --log-level <F|E|W|I|D|V>");
+      }
+    } else if (strcmp(argv[i], "--log") == 0) {
+      if (i + 1 >= argc) {
+        GAPID_FATAL("Usage: --log <log-file-path>");
+      }
+      logPath = argv[++i];
+    } else if (strcmp(argv[i], "--idle-timeout-sec") == 0) {
+      if (i + 1 >= argc) {
+        GAPID_FATAL("Usage: --idle-timeout-sec <timeout in seconds>");
+      }
+      idleTimeoutSec = atoi(argv[++i]);
+    } else if (strcmp(argv[i], "--wait-for-debugger") == 0) {
+      wait_for_debugger = true;
+    } else if (strcmp(argv[i], "--version") == 0) {
+      printf("GAPIR version " GAPID_VERSION_AND_BUILD "\n");
+      return 0;
+    } else {
+      GAPID_FATAL("Unknown argument: %s", argv[i]);
     }
-    std::string uri = std::string(local_host_name) + std::string(":") + std::string(portStr);
+  }
 
-    std::mutex lock;
-    std::unique_ptr<Server> server =
-        Setup(uri.c_str(), (authToken.size() > 0) ? authToken.data() : nullptr,
-              cachePath, idleTimeoutSec, &crashHandler, &memoryManager, &lock);
-    // The following message is parsed by launchers to detect the selected port.
-    // DO NOT CHANGE!
-    printf("Bound on port '%s'\n", portStr.c_str());
-    fflush(stdout);
+  if (wait_for_debugger) {
+    GAPID_INFO("Waiting for debugger to attach");
+    core::Debugger::waitForAttach();
+  }
 
-    server->wait();
-    return EXIT_SUCCESS;
+  core::CrashHandler crashHandler;
+
+  GAPID_LOGGER_INIT(logLevel, "gapir", logPath);
+
+  // Read the auth-token.
+  // Note: This must come before the socket is created as the auth token
+  // file is deleted by GAPIS as soon as the port is written to stdout.
+  std::vector<char> authToken;
+  if (authTokenFile != nullptr) {
+    FILE* file = fopen(authTokenFile, "rb");
+    if (file == nullptr) {
+      GAPID_FATAL("Unable to open auth-token file: %s", authTokenFile);
+    }
+    if (fseek(file, 0, SEEK_END) != 0) {
+      GAPID_FATAL("Unable to get length of auth-token file: %s", authTokenFile);
+    }
+    size_t size = ftell(file);
+    fseek(file, 0, SEEK_SET);
+    authToken.resize(size + 1, 0);
+    if (fread(&authToken[0], 1, size, file) != size) {
+      GAPID_FATAL("Unable to read auth-token file: %s", authTokenFile);
+    }
+    fclose(file);
+  }
+
+  MemoryManager memoryManager(memorySizes);
+
+  // If the user does not assign a port to use, get a free TCP port from OS.
+  const char local_host_name[] = "127.0.0.1";
+  std::string portStr(portArgStr);
+  if (portStr == "0") {
+    uint32_t port = SocketConnection::getFreePort(local_host_name);
+    if (port == 0) {
+      GAPID_FATAL("Failed to find a free port for hostname: '%s'",
+                  local_host_name);
+    }
+    portStr = std::to_string(port);
+  }
+  std::string uri =
+      std::string(local_host_name) + std::string(":") + std::string(portStr);
+
+  std::mutex lock;
+  std::unique_ptr<Server> server =
+      Setup(uri.c_str(), (authToken.size() > 0) ? authToken.data() : nullptr,
+            cachePath, idleTimeoutSec, &crashHandler, &memoryManager, &lock);
+  // The following message is parsed by launchers to detect the selected port.
+  // DO NOT CHANGE!
+  printf("Bound on port '%s'\n", portStr.c_str());
+  fflush(stdout);
+
+  server->wait();
+  return EXIT_SUCCESS;
 }
 
 #endif  // TARGET_OS == GAPID_OS_ANDROID

--- a/core/cc/android/compatibility.cpp
+++ b/core/cc/android/compatibility.cpp
@@ -15,14 +15,15 @@
  */
 
 /*
- * Between Android K and L, some platform functions were changed from inline to system library
- * functions. We build against the Android 21 (L) NDK so we can support 64-bit ARM devices.
- * gtest makes calls to sigemptyset and getpagesize which are part of these functions that were
- * un-inlined. To keep the tests working on older devices, stub these two functions here.
+ * Between Android K and L, some platform functions were changed from inline to
+ * system library functions. We build against the Android 21 (L) NDK so we can
+ * support 64-bit ARM devices. gtest makes calls to sigemptyset and getpagesize
+ * which are part of these functions that were un-inlined. To keep the tests
+ * working on older devices, stub these two functions here.
  */
 
-#include <cstring>
 #include <signal.h>
+#include <cstring>
 
 extern "C" {
 
@@ -38,4 +39,4 @@ int getpagesize(void) {
 }
 */
 
-} // extern "C"
+}  // extern "C"

--- a/core/cc/android/crash_handler.cpp
+++ b/core/cc/android/crash_handler.cpp
@@ -20,27 +20,29 @@
 
 namespace {
 
-static bool handleCrash(const google_breakpad::MinidumpDescriptor& descriptor, void* crashHandlerPtr, bool succeeded) {
-    core::CrashHandler* crashHandler = reinterpret_cast<core::CrashHandler*>(crashHandlerPtr);
-    std::string minidumpPath(descriptor.path());
-    return crashHandler->handleMinidump(minidumpPath, succeeded);
+static bool handleCrash(const google_breakpad::MinidumpDescriptor& descriptor,
+                        void* crashHandlerPtr, bool succeeded) {
+  core::CrashHandler* crashHandler =
+      reinterpret_cast<core::CrashHandler*>(crashHandlerPtr);
+  std::string minidumpPath(descriptor.path());
+  return crashHandler->handleMinidump(minidumpPath, succeeded);
 }
 
-}
+}  // namespace
 
 namespace core {
 
-CrashHandler::CrashHandler() :
-    mNextHandlerID(0),
-    mExceptionHandler(new google_breakpad::ExceptionHandler(
-            google_breakpad::MinidumpDescriptor("./crashes"),
-            NULL, ::handleCrash, reinterpret_cast<void*>(this), true, -1)) {
-
-    registerHandler(defaultHandler);
+CrashHandler::CrashHandler()
+    : mNextHandlerID(0),
+      mExceptionHandler(new google_breakpad::ExceptionHandler(
+          google_breakpad::MinidumpDescriptor("./crashes"), NULL, ::handleCrash,
+          reinterpret_cast<void*>(this), true, -1)) {
+  registerHandler(defaultHandler);
 }
 
-// this prevents unique_ptr<CrashHandler> from causing an incomplete type error from inlining the destructor.
-// The incomplete type is the previously forward declared google_breakpad::ExceptionHandler.
+// this prevents unique_ptr<CrashHandler> from causing an incomplete type error
+// from inlining the destructor. The incomplete type is the previously forward
+// declared google_breakpad::ExceptionHandler.
 CrashHandler::~CrashHandler() = default;
 
-} // namespace core
+}  // namespace core

--- a/core/cc/android/debugger.cpp
+++ b/core/cc/android/debugger.cpp
@@ -21,12 +21,10 @@ static volatile bool gIsDebuggerAttached = false;
 namespace core {
 
 void Debugger::waitForAttach() {
-    while (!isAttached()) {}
+  while (!isAttached()) {
+  }
 }
 
-bool Debugger::isAttached() {
-    return gIsDebuggerAttached;
-}
+bool Debugger::isAttached() { return gIsDebuggerAttached; }
 
 }  // namespace core
-

--- a/core/cc/android/get_gles_proc_address.cpp
+++ b/core/cc/android/get_gles_proc_address.cpp
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#include "../dl_loader.h"
 #include "../get_gles_proc_address.h"
+#include "../dl_loader.h"
 #include "../log.h"
 
 #include <string>
@@ -30,72 +30,87 @@
 namespace {
 
 void* ResolveSymbol(const char* name, bool bypassLocal) {
-    using namespace core;
-    typedef void* (*GPAPROC)(const char *name);
+  using namespace core;
+  typedef void* (*GPAPROC)(const char* name);
 
-    if (bypassLocal) {
-        static DlLoader libegl(SYSTEM_LIB_PATH "libEGL.so");
-        if (void* proc = libegl.lookup(name)) {
-            GAPID_DEBUG("GetGlesProcAddress(%s, %d) -> %p (from libEGL dlsym)", name, bypassLocal, proc);
-            return proc;
-        }
-
-        static DlLoader libglesv2(SYSTEM_LIB_PATH "libGLESv2.so");
-        if (void* proc = libglesv2.lookup(name)) {
-            GAPID_DEBUG("GetGlesProcAddress(%s, %d) -> %p (from libGLESv2 dlsym)", name, bypassLocal, proc);
-            return proc;
-        }
-
-        static DlLoader libglesv1(SYSTEM_LIB_PATH "libGLESv1_CM.so");
-        if (void* proc = libglesv1.lookup(name)) {
-            GAPID_DEBUG("GetGlesProcAddress(%s, %d) -> %p (from libGLESv1_CM dlsym)", name, bypassLocal, proc);
-            return proc;
-        }
-
-        if (GPAPROC gpa = reinterpret_cast<GPAPROC>(libegl.lookup("eglGetProcAddress"))) {
-            if (void* proc = gpa(name)) {
-                static DlLoader local(nullptr);
-                void* local_proc = local.lookup(name);
-                if (local_proc == proc) {
-                  GAPID_WARNING(
-                      "libEGL eglGetProcAddress returned a local address %p for %s, this will be ignored", proc, name);
-                } else {
-                  GAPID_DEBUG("GetGlesProcAddress(%s, %d) -> %p (via libEGL eglGetProcAddress)", name, (int)bypassLocal, proc);
-                  return proc;
-                }
-            }
-        }
-    } else {
-        static DlLoader local(nullptr);
-        if (GPAPROC gpa = reinterpret_cast<GPAPROC>(local.lookup("eglGetProcAddress"))) {
-            if (void* proc = gpa(name)) {
-                GAPID_DEBUG("GetGlesProcAddress(%s, %d) -> %p (via local eglGetProcAddress)", name, (int)bypassLocal, proc);
-                return proc;
-            }
-        }
-        if (void* proc = local.lookup(name)) {
-            GAPID_DEBUG("GetGlesProcAddress(%s, %d) -> %p (from local dlsym)", name, (int)bypassLocal, proc);
-            return proc;
-        }
+  if (bypassLocal) {
+    static DlLoader libegl(SYSTEM_LIB_PATH "libEGL.so");
+    if (void* proc = libegl.lookup(name)) {
+      GAPID_DEBUG("GetGlesProcAddress(%s, %d) -> %p (from libEGL dlsym)", name,
+                  bypassLocal, proc);
+      return proc;
     }
 
-    GAPID_DEBUG("GetGlesProcAddress(%s, %d) -> not found", name, (int)bypassLocal);
-    return nullptr;
+    static DlLoader libglesv2(SYSTEM_LIB_PATH "libGLESv2.so");
+    if (void* proc = libglesv2.lookup(name)) {
+      GAPID_DEBUG("GetGlesProcAddress(%s, %d) -> %p (from libGLESv2 dlsym)",
+                  name, bypassLocal, proc);
+      return proc;
+    }
+
+    static DlLoader libglesv1(SYSTEM_LIB_PATH "libGLESv1_CM.so");
+    if (void* proc = libglesv1.lookup(name)) {
+      GAPID_DEBUG("GetGlesProcAddress(%s, %d) -> %p (from libGLESv1_CM dlsym)",
+                  name, bypassLocal, proc);
+      return proc;
+    }
+
+    if (GPAPROC gpa =
+            reinterpret_cast<GPAPROC>(libegl.lookup("eglGetProcAddress"))) {
+      if (void* proc = gpa(name)) {
+        static DlLoader local(nullptr);
+        void* local_proc = local.lookup(name);
+        if (local_proc == proc) {
+          GAPID_WARNING(
+              "libEGL eglGetProcAddress returned a local address %p for %s, "
+              "this will be ignored",
+              proc, name);
+        } else {
+          GAPID_DEBUG(
+              "GetGlesProcAddress(%s, %d) -> %p (via libEGL eglGetProcAddress)",
+              name, (int)bypassLocal, proc);
+          return proc;
+        }
+      }
+    }
+  } else {
+    static DlLoader local(nullptr);
+    if (GPAPROC gpa =
+            reinterpret_cast<GPAPROC>(local.lookup("eglGetProcAddress"))) {
+      if (void* proc = gpa(name)) {
+        GAPID_DEBUG(
+            "GetGlesProcAddress(%s, %d) -> %p (via local eglGetProcAddress)",
+            name, (int)bypassLocal, proc);
+        return proc;
+      }
+    }
+    if (void* proc = local.lookup(name)) {
+      GAPID_DEBUG("GetGlesProcAddress(%s, %d) -> %p (from local dlsym)", name,
+                  (int)bypassLocal, proc);
+      return proc;
+    }
+  }
+
+  GAPID_DEBUG("GetGlesProcAddress(%s, %d) -> not found", name,
+              (int)bypassLocal);
+  return nullptr;
 }
 
 void* getGlesProcAddress(const char* name, bool bypassLocal) {
-    static std::unordered_map<std::string, void*> cache;
+  static std::unordered_map<std::string, void*> cache;
 
-    const std::string cacheKey = std::string(name) + (bypassLocal ? "/direct" : "/local");
-    auto it = cache.find(cacheKey);
-    if (it != cache.end()) {
-        GAPID_DEBUG("GetGlesProcAddress(%s, %d) -> %p (from cache)", name, (int)bypassLocal, it->second);
-        return it->second;
-    }
+  const std::string cacheKey =
+      std::string(name) + (bypassLocal ? "/direct" : "/local");
+  auto it = cache.find(cacheKey);
+  if (it != cache.end()) {
+    GAPID_DEBUG("GetGlesProcAddress(%s, %d) -> %p (from cache)", name,
+                (int)bypassLocal, it->second);
+    return it->second;
+  }
 
-    void* proc = ResolveSymbol(name, bypassLocal);
-    cache[cacheKey] = proc;
-    return proc;
+  void* proc = ResolveSymbol(name, bypassLocal);
+  cache[cacheKey] = proc;
+  return proc;
 }
 
 }  // anonymous namespace
@@ -104,10 +119,9 @@ namespace core {
 
 GetGlesProcAddressFunc* GetGlesProcAddress = getGlesProcAddress;
 bool hasGLorGLES() {
-    return DlLoader::can_load(SYSTEM_LIB_PATH "libEGL.so") ||
-           DlLoader::can_load(SYSTEM_LIB_PATH "libGLESv2.so") ||
-           DlLoader::can_load(SYSTEM_LIB_PATH SYSTEM_LIB_PATH "libGLESv1_CM.so");
+  return DlLoader::can_load(SYSTEM_LIB_PATH "libEGL.so") ||
+         DlLoader::can_load(SYSTEM_LIB_PATH "libGLESv2.so") ||
+         DlLoader::can_load(SYSTEM_LIB_PATH SYSTEM_LIB_PATH "libGLESv1_CM.so");
 }
-
 
 }  // namespace core

--- a/core/cc/android/get_vulkan_proc_address.cpp
+++ b/core/cc/android/get_vulkan_proc_address.cpp
@@ -14,64 +14,76 @@
  * limitations under the License.
  */
 
-#include "../dl_loader.h"
 #include "../get_vulkan_proc_address.h"
+#include "../dl_loader.h"
 #include "../log.h"
 
 namespace {
 
 using namespace core;
 
-// Definitions from the Vulkan API. Should keep the same with those in vulkan_types.h.
+// Definitions from the Vulkan API. Should keep the same with those in
+// vulkan_types.h.
 typedef void* PFN_vkVoidFunction;
 typedef size_t VkDevice;
 typedef size_t VkInstance;
 
-void* getVulkanInstanceProcAddress(size_t instance, const char *name, bool bypassLocal) {
-    typedef PFN_vkVoidFunction (*VPAPROC)(VkInstance instance, const char *name);
+void* getVulkanInstanceProcAddress(size_t instance, const char* name,
+                                   bool bypassLocal) {
+  typedef PFN_vkVoidFunction (*VPAPROC)(VkInstance instance, const char* name);
 
-    static DlLoader dylib("libvulkan.so");
+  static DlLoader dylib("libvulkan.so");
 
-    if (VPAPROC vpa = reinterpret_cast<VPAPROC>(dylib.lookup("vkGetInstanceProcAddr"))) {
-        if (void* proc = vpa(instance, name)) {
-            GAPID_DEBUG("GetVulkanInstanceProcAddress(0x%zx, %s, %d) -> %p (via %s vkGetInstanceProcAddr)",
-                instance, name, bypassLocal, proc, (bypassLocal ? "libvulkan" : "local"));
-            return proc;
-        }
+  if (VPAPROC vpa =
+          reinterpret_cast<VPAPROC>(dylib.lookup("vkGetInstanceProcAddr"))) {
+    if (void* proc = vpa(instance, name)) {
+      GAPID_DEBUG(
+          "GetVulkanInstanceProcAddress(0x%zx, %s, %d) -> %p "
+          "(via %s vkGetInstanceProcAddr)",
+          instance, name, bypassLocal, proc,
+          (bypassLocal ? "libvulkan" : "local"));
+      return proc;
     }
+  }
 
-    GAPID_DEBUG("GetVulkanInstanceProcAddress(0x%zx, %s, %d) -> not found", instance, name, bypassLocal);
-    return nullptr;
+  GAPID_DEBUG("GetVulkanInstanceProcAddress(0x%zx, %s, %d) -> not found",
+              instance, name, bypassLocal);
+  return nullptr;
 }
 
-void* getVulkanDeviceProcAddress(size_t instance, size_t device, const char *name, bool bypassLocal) {
-    typedef PFN_vkVoidFunction (*VPAPROC)(VkDevice device, const char *name);
+void* getVulkanDeviceProcAddress(size_t instance, size_t device,
+                                 const char* name, bool bypassLocal) {
+  typedef PFN_vkVoidFunction (*VPAPROC)(VkDevice device, const char* name);
 
-    if (auto vpa = reinterpret_cast<VPAPROC>(
-        getVulkanInstanceProcAddress(instance, "vkGetDeviceProcAddr", bypassLocal))) {
-        if (void* proc = vpa(device, name)) {
-            GAPID_DEBUG("GetVulkanDeviceProcAddress(0x%zx, 0x%zx, %s, %d) -> %p (via %s vkGetDeviceProcAddr)",
-                instance, device, name, bypassLocal, proc, (bypassLocal ? "libvulkan" : "local"));
-            return proc;
-        }
+  if (auto vpa = reinterpret_cast<VPAPROC>(getVulkanInstanceProcAddress(
+          instance, "vkGetDeviceProcAddr", bypassLocal))) {
+    if (void* proc = vpa(device, name)) {
+      GAPID_DEBUG(
+          "GetVulkanDeviceProcAddress(0x%zx, 0x%zx, %s, %d) -> %p "
+          "(via %s vkGetDeviceProcAddr)",
+          instance, device, name, bypassLocal, proc,
+          (bypassLocal ? "libvulkan" : "local"));
+      return proc;
     }
+  }
 
-    GAPID_DEBUG("GetVulkanDeviceProcAddress(0x%zx, 0x%zx, %s, %d) -> not found", instance, device, name, bypassLocal);
-    return nullptr;
+  GAPID_DEBUG("GetVulkanDeviceProcAddress(0x%zx, 0x%zx, %s, %d) -> not found",
+              instance, device, name, bypassLocal);
+  return nullptr;
 }
 
 void* getVulkanProcAddress(const char* name, bool bypassLocal) {
-    return getVulkanInstanceProcAddress(0u, name, bypassLocal);
+  return getVulkanInstanceProcAddress(0u, name, bypassLocal);
 }
 
 }  // anonymous namespace
 
 namespace core {
 
-GetVulkanInstanceProcAddressFunc* GetVulkanInstanceProcAddress = getVulkanInstanceProcAddress;
-GetVulkanDeviceProcAddressFunc* GetVulkanDeviceProcAddress = getVulkanDeviceProcAddress;
+GetVulkanInstanceProcAddressFunc* GetVulkanInstanceProcAddress =
+    getVulkanInstanceProcAddress;
+GetVulkanDeviceProcAddressFunc* GetVulkanDeviceProcAddress =
+    getVulkanDeviceProcAddress;
 GetVulkanProcAddressFunc* GetVulkanProcAddress = getVulkanProcAddress;
-bool HasVulkanLoader() {
-  return DlLoader::can_load("libvulkan.so");
-}
+bool HasVulkanLoader() { return DlLoader::can_load("libvulkan.so"); }
 }  // namespace core

--- a/core/cc/android/thread.cpp
+++ b/core/cc/android/thread.cpp
@@ -23,9 +23,10 @@
 namespace core {
 
 Thread Thread::current() {
-    auto thread = pthread_self();
-    auto asUnsigned = static_cast<std::make_unsigned<decltype(thread)>::type>(thread);
-    return Thread(static_cast<uint64_t>(asUnsigned));
+  auto thread = pthread_self();
+  auto asUnsigned =
+      static_cast<std::make_unsigned<decltype(thread)>::type>(thread);
+  return Thread(static_cast<uint64_t>(asUnsigned));
 }
 
 }  // namespace core

--- a/core/cc/android/trace.cpp
+++ b/core/cc/android/trace.cpp
@@ -28,57 +28,60 @@
 
 #include <android/log.h>
 
-
 namespace core {
 namespace {
 
 constexpr size_t kBufferSize = 1024;
-constexpr const char kTraceMarkerPath[] = "sys/kernel/debug/tracing/trace_marker";
+constexpr const char kTraceMarkerPath[] =
+    "sys/kernel/debug/tracing/trace_marker";
 
 int sTraceFD = -1;
 volatile bool sInitialized = false;
 std::once_flag sInitializeOnce;
 
 void Initialize() {
-    sTraceFD = open(kTraceMarkerPath, O_WRONLY);
-    if (sTraceFD == -1) {
-        __android_log_print(ANDROID_LOG_INFO, "TRACE", "error opening trace file: %s (%d)", strerror(errno), errno);
-    }
-    // Even if we've failed to open, we have opened the subsystem.
-    sInitialized = true;
+  sTraceFD = open(kTraceMarkerPath, O_WRONLY);
+  if (sTraceFD == -1) {
+    __android_log_print(ANDROID_LOG_INFO, "TRACE",
+                        "error opening trace file: %s (%d)", strerror(errno),
+                        errno);
+  }
+  // Even if we've failed to open, we have opened the subsystem.
+  sInitialized = true;
 }
 
 bool EnsureInitialized() {
-    if (!sInitialized) {
-        std::call_once(sInitializeOnce, Initialize);
-    }
+  if (!sInitialized) {
+    std::call_once(sInitializeOnce, Initialize);
+  }
 
-    return sTraceFD != -1;
+  return sTraceFD != -1;
 }
 
 }  // namespace
 
 TraceScope::TraceScope(const char* name) {
-    if (EnsureInitialized()) {
-        char buffer[kBufferSize];
-        size_t length = snprintf(buffer, kBufferSize, "B|%d|%s", getpid(), name);
-        write(sTraceFD, buffer, length);
-    }
+  if (EnsureInitialized()) {
+    char buffer[kBufferSize];
+    size_t length = snprintf(buffer, kBufferSize, "B|%d|%s", getpid(), name);
+    write(sTraceFD, buffer, length);
+  }
 }
 
 TraceScope::~TraceScope() {
-    if (EnsureInitialized()) {
-        char value = 'E';
-        write(sTraceFD, &value, sizeof(value));
-    }
+  if (EnsureInitialized()) {
+    char value = 'E';
+    write(sTraceFD, &value, sizeof(value));
+  }
 }
 
 void TraceInt(const char* name, std::int32_t value) {
-    if (EnsureInitialized()) {
-        char buffer[kBufferSize];
-        size_t length = snprintf(buffer, kBufferSize, "C|%d|%s|%d", getpid(), name, value);
-        write(sTraceFD, buffer, length);
-    }
+  if (EnsureInitialized()) {
+    char buffer[kBufferSize];
+    size_t length =
+        snprintf(buffer, kBufferSize, "C|%d|%s|%d", getpid(), name, value);
+    write(sTraceFD, buffer, length);
+  }
 }
 
 }  // namespace core

--- a/core/cc/android/trace.h
+++ b/core/cc/android/trace.h
@@ -22,10 +22,10 @@
 namespace core {
 
 class TraceScope {
-public:
-    TraceScope(const char* name);
+ public:
+  TraceScope(const char* name);
 
-    ~TraceScope();
+  ~TraceScope();
 };
 
 void TraceInt(const char* name, std::int32_t value);

--- a/core/cc/archive.cpp
+++ b/core/cc/archive.cpp
@@ -17,24 +17,24 @@
 #include "archive.h"
 #include "assert.h"
 #include "log.h"
-#include "target.h" // ftruncate
+#include "target.h"  // ftruncate
 
-#ifdef _MSC_VER // MSVC
-#   include <io.h>
+#ifdef _MSC_VER  // MSVC
+#include <io.h>
 #ifndef __GNUC__
 // MSYS GCC allows fileno, MSVC itself does not.
 #define fileno _fileno
 #endif
-#else // not MSVC
-#   include <unistd.h>
+#else  // not MSVC
+#include <unistd.h>
 #endif
 
 namespace {
 
 void must_truncate(int fd, off_t length) {
-    if (!ftruncate(fd, length)) {
-        GAPID_ASSERT("Unable to truncate the achive file");
-    }
+  if (!ftruncate(fd, length)) {
+    GAPID_ASSERT("Unable to truncate the achive file");
+  }
 }
 
 }  // anonymous namespace
@@ -42,88 +42,90 @@ void must_truncate(int fd, off_t length) {
 namespace core {
 
 Archive::Archive(const std::string& archiveName) {
-    // Open or create the archive data file in binary read/write mode.
-    const std::string dataFilename(archiveName + ".data");
-    if (!(mDataFile = fopen(dataFilename.c_str(), "ab+"))) {
-        GAPID_FATAL("Unable to open archive data file %s", dataFilename.c_str());
+  // Open or create the archive data file in binary read/write mode.
+  const std::string dataFilename(archiveName + ".data");
+  if (!(mDataFile = fopen(dataFilename.c_str(), "ab+"))) {
+    GAPID_FATAL("Unable to open archive data file %s", dataFilename.c_str());
+  }
+
+  // Open or create the archive index file in binary read/write mode.
+  const std::string indexFilename(archiveName + ".index");
+  if (!(mIndexFile = fopen(indexFilename.c_str(), "ab+"))) {
+    GAPID_FATAL("Unable to open archive index file %s", indexFilename.c_str());
+  }
+
+  // Load the archive index in memory.
+  for (;;) {
+    uint32_t idSize;
+    if (!fread(&idSize, sizeof(idSize), 1, mIndexFile)) break;
+
+    std::string id(idSize, 0);
+    uint64_t offset;
+    uint32_t size;
+    if (!fread(&id.front(), idSize, 1, mIndexFile) ||
+        !fread(&offset, sizeof(offset), 1, mIndexFile) ||
+        !fread(&size, sizeof(size), 1, mIndexFile)) {
+      break;
     }
 
-    // Open or create the archive index file in binary read/write mode.
-    const std::string indexFilename(archiveName + ".index");
-    if (!(mIndexFile = fopen(indexFilename.c_str(), "ab+"))) {
-        GAPID_FATAL("Unable to open archive index file %s", indexFilename.c_str());
-    }
+    mRecords.emplace(id, ArchiveRecord{offset, size});
+  }
 
-    // Load the archive index in memory.
-    for (;;) {
-        uint32_t idSize;
-        if (!fread(&idSize, sizeof(idSize), 1, mIndexFile)) break;
-
-        std::string id(idSize, 0);
-        uint64_t offset;
-        uint32_t size;
-        if (!fread(&id.front(), idSize, 1, mIndexFile) ||
-            !fread(&offset, sizeof(offset), 1, mIndexFile) ||
-            !fread(&size, sizeof(size), 1, mIndexFile)) {
-            break;
-        }
-
-        mRecords.emplace(id, ArchiveRecord{ offset, size });
-    }
-
-    // Make sure we're at the end of the index file, likely a no-op.
-    fseek(mIndexFile, 0, SEEK_END);
+  // Make sure we're at the end of the index file, likely a no-op.
+  fseek(mIndexFile, 0, SEEK_END);
 }
 
 Archive::~Archive() {
-    if (mDataFile) fclose(mDataFile);
-    if (mIndexFile) fclose(mIndexFile);
+  if (mDataFile) fclose(mDataFile);
+  if (mIndexFile) fclose(mIndexFile);
 }
 
 bool Archive::contains(const std::string& id) const {
-    return mRecords.find(id) != mRecords.end();
+  return mRecords.find(id) != mRecords.end();
 }
 
 bool Archive::read(const std::string& id, void* buffer, uint32_t size) {
-    const auto r = mRecords.find(id);
-    if (r == mRecords.end() || r->second.size != size) return false;
+  const auto r = mRecords.find(id);
+  if (r == mRecords.end() || r->second.size != size) return false;
 
-    fseek(mDataFile, r->second.offset, SEEK_SET);
-    return fread(buffer, size, 1, mDataFile) == 1;
+  fseek(mDataFile, r->second.offset, SEEK_SET);
+  return fread(buffer, size, 1, mDataFile) == 1;
 }
 
 bool Archive::write(const std::string& id, const void* buffer, uint32_t size) {
-    // Skip if we already have a record by this id.
-    if (mRecords.find(id) != mRecords.end()) {
-        return true;
-    }
-
-    // Update the archive data file.
-    fseek(mDataFile, 0, SEEK_END);
-    const uint64_t dataOffset = ftell(mDataFile);
-    if (!fwrite(buffer, size, 1, mDataFile)) {
-        GAPID_WARNING("Couldn't write '%s' to the archive data file, dropping it.", id.c_str());
-        must_truncate(fileno(mDataFile), dataOffset);
-        return false;
-    }
-
-    // Update the archive index file.
-    const uint32_t idSize = id.size();
-    const uint64_t indexOffset = ftell(mIndexFile);
-    if (!fwrite(&idSize, sizeof(idSize), 1, mIndexFile) ||
-        !fwrite(&id.front(), id.size(), 1, mIndexFile) ||
-        !fwrite(&dataOffset, sizeof(dataOffset), 1, mIndexFile) ||
-        !fwrite(&size, sizeof(size), 1, mIndexFile)) {
-        GAPID_WARNING("Couldn't write '%s' to the archive index file, dropping it.", id.c_str());
-        must_truncate(fileno(mDataFile), dataOffset);
-        must_truncate(fileno(mIndexFile), indexOffset);
-        fseek(mIndexFile, 0, SEEK_END);
-        return false;
-    }
-
-    // Update the memory index.
-    mRecords.emplace(id, ArchiveRecord{ dataOffset, size });
+  // Skip if we already have a record by this id.
+  if (mRecords.find(id) != mRecords.end()) {
     return true;
+  }
+
+  // Update the archive data file.
+  fseek(mDataFile, 0, SEEK_END);
+  const uint64_t dataOffset = ftell(mDataFile);
+  if (!fwrite(buffer, size, 1, mDataFile)) {
+    GAPID_WARNING("Couldn't write '%s' to the archive data file, dropping it.",
+                  id.c_str());
+    must_truncate(fileno(mDataFile), dataOffset);
+    return false;
+  }
+
+  // Update the archive index file.
+  const uint32_t idSize = id.size();
+  const uint64_t indexOffset = ftell(mIndexFile);
+  if (!fwrite(&idSize, sizeof(idSize), 1, mIndexFile) ||
+      !fwrite(&id.front(), id.size(), 1, mIndexFile) ||
+      !fwrite(&dataOffset, sizeof(dataOffset), 1, mIndexFile) ||
+      !fwrite(&size, sizeof(size), 1, mIndexFile)) {
+    GAPID_WARNING("Couldn't write '%s' to the archive index file, dropping it.",
+                  id.c_str());
+    must_truncate(fileno(mDataFile), dataOffset);
+    must_truncate(fileno(mIndexFile), indexOffset);
+    fseek(mIndexFile, 0, SEEK_END);
+    return false;
+  }
+
+  // Update the memory index.
+  mRecords.emplace(id, ArchiveRecord{dataOffset, size});
+  return true;
 }
 
 }  // namespace core

--- a/core/cc/archive.h
+++ b/core/cc/archive.h
@@ -28,29 +28,31 @@
 namespace core {
 
 class Archive {
-public:
-    // Opens or creates an archive at the specified location archiveName (full path).
-    Archive(const std::string& archiveName);
-    ~Archive();
+ public:
+  // Opens or creates an archive at the specified location archiveName (full
+  // path).
+  Archive(const std::string& archiveName);
+  ~Archive();
 
-    // Checks if the archive contains a record for the given id.
-    bool contains(const std::string& id) const;
+  // Checks if the archive contains a record for the given id.
+  bool contains(const std::string& id) const;
 
-    // Reads the resource keyed by id into buffer if it exists and if its size matches.
-    bool read(const std::string& id, void* buffer, uint32_t size);
+  // Reads the resource keyed by id into buffer if it exists and if its size
+  // matches.
+  bool read(const std::string& id, void* buffer, uint32_t size);
 
-    // Write a resource of size size keyed by id from buffer into the archive.
-    bool write(const std::string& id, const void* buffer, uint32_t size);
+  // Write a resource of size size keyed by id from buffer into the archive.
+  bool write(const std::string& id, const void* buffer, uint32_t size);
 
-protected:
-    struct ArchiveRecord {
-        uint64_t offset;
-        uint32_t size;
-    };
+ protected:
+  struct ArchiveRecord {
+    uint64_t offset;
+    uint32_t size;
+  };
 
-    FILE* mDataFile;
-    FILE* mIndexFile;
-    std::unordered_map<std::string, ArchiveRecord> mRecords;
+  FILE* mDataFile;
+  FILE* mIndexFile;
+  std::unordered_map<std::string, ArchiveRecord> mRecords;
 };
 
 }  // namespace core

--- a/core/cc/armlinux/get_gles_proc_address.cpp
+++ b/core/cc/armlinux/get_gles_proc_address.cpp
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#include "../dl_loader.h"
 #include "../get_gles_proc_address.h"
+#include "../dl_loader.h"
 #include "../log.h"
 
 #include <string>
@@ -26,81 +26,97 @@
 namespace {
 
 void* ResolveSymbol(const char* name, bool bypassLocal) {
-    using namespace core;
-    typedef void* (*GPAPROC)(const char *name);
+  using namespace core;
+  typedef void* (*GPAPROC)(const char* name);
 
-    if (bypassLocal) {
-        static DlLoader libegl(SYSTEM_LIB_PATH "libEGL.so");
-        if (void* proc = libegl.lookup(name)) {
-            GAPID_DEBUG("GetGlesProcAddress(%s, %d) -> 0x%x (from libEGL dlsym)", name, bypassLocal, proc);
-            return proc;
-        }
-
-        static DlLoader libglesv2(SYSTEM_LIB_PATH "libGLESv2.so");
-        if (void* proc = libglesv2.lookup(name)) {
-            GAPID_DEBUG("GetGlesProcAddress(%s, %d) -> 0x%x (from libGLESv2 dlsym)", name, bypassLocal, proc);
-            return proc;
-        }
-
-        static DlLoader libglesv1(SYSTEM_LIB_PATH "libGLESv1_CM.so");
-        if (void* proc = libglesv1.lookup(name)) {
-            GAPID_DEBUG("GetGlesProcAddress(%s, %d) -> 0x%x (from libGLESv1_CM dlsym)", name, bypassLocal, proc);
-            return proc;
-        }
-
-        if (GPAPROC gpa = reinterpret_cast<GPAPROC>(libegl.lookup("eglGetProcAddress"))) {
-            if (void* proc = gpa(name)) {
-                static DlLoader local(nullptr);
-                void* local_proc = local.lookup(name);
-                if (local_proc == proc) {
-                  GAPID_WARNING(
-                      "libEGL eglGetProcAddress returned a local address %p for %s, this will be ignored", proc, name);
-                } else {
-                  GAPID_DEBUG("GetGlesProcAddress(%s, %d) -> 0x%x (via libEGL eglGetProcAddress)", name, bypassLocal, proc);
-                  return proc;
-                }
-            }
-        }
-    } else {
-        static DlLoader local(nullptr);
-        if (GPAPROC gpa = reinterpret_cast<GPAPROC>(local.lookup("eglGetProcAddress"))) {
-            if (void* proc = gpa(name)) {
-                GAPID_DEBUG("GetGlesProcAddress(%s, %d) -> 0x%x (via local eglGetProcAddress)", name, bypassLocal, proc);
-                return proc;
-            }
-        }
-        if (void* proc = local.lookup(name)) {
-            GAPID_DEBUG("GetGlesProcAddress(%s, %d) -> 0x%x (from local dlsym)", name, bypassLocal, proc);
-            return proc;
-        }
+  if (bypassLocal) {
+    static DlLoader libegl(SYSTEM_LIB_PATH "libEGL.so");
+    if (void* proc = libegl.lookup(name)) {
+      GAPID_DEBUG("GetGlesProcAddress(%s, %d) -> 0x%x (from libEGL dlsym)",
+                  name, bypassLocal, proc);
+      return proc;
     }
 
-    GAPID_DEBUG("GetGlesProcAddress(%s, %d) -> not found", name, bypassLocal);
-    return nullptr;
+    static DlLoader libglesv2(SYSTEM_LIB_PATH "libGLESv2.so");
+    if (void* proc = libglesv2.lookup(name)) {
+      GAPID_DEBUG("GetGlesProcAddress(%s, %d) -> 0x%x (from libGLESv2 dlsym)",
+                  name, bypassLocal, proc);
+      return proc;
+    }
+
+    static DlLoader libglesv1(SYSTEM_LIB_PATH "libGLESv1_CM.so");
+    if (void* proc = libglesv1.lookup(name)) {
+      GAPID_DEBUG(
+          "GetGlesProcAddress(%s, %d) -> 0x%x (from libGLESv1_CM dlsym)", name,
+          bypassLocal, proc);
+      return proc;
+    }
+
+    if (GPAPROC gpa =
+            reinterpret_cast<GPAPROC>(libegl.lookup("eglGetProcAddress"))) {
+      if (void* proc = gpa(name)) {
+        static DlLoader local(nullptr);
+        void* local_proc = local.lookup(name);
+        if (local_proc == proc) {
+          GAPID_WARNING(
+              "libEGL eglGetProcAddress returned a local address %p for %s, "
+              "this will be ignored",
+              proc, name);
+        } else {
+          GAPID_DEBUG(
+              "GetGlesProcAddress(%s, %d) -> 0x%x "
+              "(via libEGL eglGetProcAddress)",
+              name, bypassLocal, proc);
+          return proc;
+        }
+      }
+    }
+  } else {
+    static DlLoader local(nullptr);
+    if (GPAPROC gpa =
+            reinterpret_cast<GPAPROC>(local.lookup("eglGetProcAddress"))) {
+      if (void* proc = gpa(name)) {
+        GAPID_DEBUG(
+            "GetGlesProcAddress(%s, %d) -> 0x%x (via local eglGetProcAddress)",
+            name, bypassLocal, proc);
+        return proc;
+      }
+    }
+    if (void* proc = local.lookup(name)) {
+      GAPID_DEBUG("GetGlesProcAddress(%s, %d) -> 0x%x (from local dlsym)", name,
+                  bypassLocal, proc);
+      return proc;
+    }
+  }
+
+  GAPID_DEBUG("GetGlesProcAddress(%s, %d) -> not found", name, bypassLocal);
+  return nullptr;
 }
 
 void* getGlesProcAddress(const char* name, bool bypassLocal) {
-    static std::unordered_map<std::string, void*> cache;
+  static std::unordered_map<std::string, void*> cache;
 
-    const std::string cacheKey = std::string(name) + (bypassLocal ? "/direct" : "/local");
-    auto it = cache.find(cacheKey);
-    if (it != cache.end()) {
-        GAPID_DEBUG("GetGlesProcAddress(%s, %d) -> 0x%x (from cache)", name, bypassLocal, it->second);
-        return it->second;
-    }
+  const std::string cacheKey =
+      std::string(name) + (bypassLocal ? "/direct" : "/local");
+  auto it = cache.find(cacheKey);
+  if (it != cache.end()) {
+    GAPID_DEBUG("GetGlesProcAddress(%s, %d) -> 0x%x (from cache)", name,
+                bypassLocal, it->second);
+    return it->second;
+  }
 
-    void* proc = ResolveSymbol(name, bypassLocal);
-    cache[cacheKey] = proc;
-    return proc;
+  void* proc = ResolveSymbol(name, bypassLocal);
+  cache[cacheKey] = proc;
+  return proc;
 }
 
 }  // anonymous namespace
 
 namespace core {
 bool hasGLorGLES() {
-    return DlLoader::can_load(SYSTEM_LIB_PATH "libEGL.so") ||
-           DlLoader::can_load(SYSTEM_LIB_PATH "libGLESv2.so") ||
-           DlLoader::can_load(SYSTEM_LIB_PATH SYSTEM_LIB_PATH "libGLESv1_CM.so");
+  return DlLoader::can_load(SYSTEM_LIB_PATH "libEGL.so") ||
+         DlLoader::can_load(SYSTEM_LIB_PATH "libGLESv2.so") ||
+         DlLoader::can_load(SYSTEM_LIB_PATH SYSTEM_LIB_PATH "libGLESv1_CM.so");
 }
 
 GetGlesProcAddressFunc* GetGlesProcAddress = getGlesProcAddress;

--- a/core/cc/armlinux/get_vulkan_proc_address.cpp
+++ b/core/cc/armlinux/get_vulkan_proc_address.cpp
@@ -14,64 +14,79 @@
  * limitations under the License.
  */
 
-#include "../dl_loader.h"
 #include "../get_vulkan_proc_address.h"
+#include "../dl_loader.h"
 #include "../log.h"
 
 namespace {
 
 using namespace core;
 
-// Definitions from the Vulkan API. Should keep the same with those in vulkan_types.h.
+// Definitions from the Vulkan API. Should keep the same with those in
+// vulkan_types.h.
 typedef void* PFN_vkVoidFunction;
 typedef size_t VkDevice;
 typedef size_t VkInstance;
 
-void* getVulkanInstanceProcAddress(size_t instance, const char *name, bool bypassLocal) {
-    typedef PFN_vkVoidFunction (*VPAPROC)(VkInstance instance, const char *name);
+void* getVulkanInstanceProcAddress(size_t instance, const char* name,
+                                   bool bypassLocal) {
+  typedef PFN_vkVoidFunction (*VPAPROC)(VkInstance instance, const char* name);
 
-    static DlLoader dylib("libvulkan.so");
+  static DlLoader dylib("libvulkan.so");
 
-    if (VPAPROC vpa = reinterpret_cast<VPAPROC>(dylib.lookup("vkGetInstanceProcAddr"))) {
-        if (void* proc = vpa(instance, name)) {
-            GAPID_DEBUG("GetVulkanInstanceProcAddress(0x%x, %s, %d) -> 0x%x (via %s vkGetInstanceProcAddr)",
-                instance, name, bypassLocal, proc, (bypassLocal ? "libvulkan" : "local"));
-            return proc;
-        }
+  if (VPAPROC vpa =
+          reinterpret_cast<VPAPROC>(dylib.lookup("vkGetInstanceProcAddr"))) {
+    if (void* proc = vpa(instance, name)) {
+      GAPID_DEBUG(
+          "GetVulkanInstanceProcAddress(0x%x, %s, %d) -> 0x%x "
+          "(via %s vkGetInstanceProcAddr)",
+          instance, name, bypassLocal, proc,
+          (bypassLocal ? "libvulkan" : "local"));
+      return proc;
     }
+  }
 
-    GAPID_DEBUG("GetVulkanInstanceProcAddress(0x%x, %s, %d) -> not found", instance, name, bypassLocal);
-    return nullptr;
+  GAPID_DEBUG("GetVulkanInstanceProcAddress(0x%x, %s, %d) -> not found",
+              instance, name, bypassLocal);
+  return nullptr;
 }
 
-void* getVulkanDeviceProcAddress(size_t instance, size_t device, const char *name, bool bypassLocal) {
-    typedef PFN_vkVoidFunction (*VPAPROC)(VkDevice device, const char *name);
+void* getVulkanDeviceProcAddress(size_t instance, size_t device,
+                                 const char* name, bool bypassLocal) {
+  typedef PFN_vkVoidFunction (*VPAPROC)(VkDevice device, const char* name);
 
-    if (auto vpa = reinterpret_cast<VPAPROC>(
-        getVulkanInstanceProcAddress(instance, "vkGetDeviceProcAddr", bypassLocal))) {
-        if (void* proc = vpa(device, name)) {
-            GAPID_DEBUG("GetVulkanDeviceProcAddress(0x%x, 0x%x, %s, %d) -> 0x%x (via %s vkGetDeviceProcAddr)",
-                instance, device, name, bypassLocal, proc, (bypassLocal ? "libvulkan" : "local"));
-            return proc;
-        }
+  if (auto vpa = reinterpret_cast<VPAPROC>(getVulkanInstanceProcAddress(
+          instance, "vkGetDeviceProcAddr", bypassLocal))) {
+    if (void* proc = vpa(device, name)) {
+      GAPID_DEBUG(
+          "GetVulkanDeviceProcAddress(0x%x, 0x%x, %s, %d) -> 0x%x "
+          "(via %s vkGetDeviceProcAddr)",
+          instance, device, name, bypassLocal, proc,
+          (bypassLocal ? "libvulkan" : "local"));
+      return proc;
     }
+  }
 
-    GAPID_DEBUG("GetVulkanDeviceProcAddress(0x%x, 0x%x, %s, %d) -> not found", instance, device, name, bypassLocal);
-    return nullptr;
+  GAPID_DEBUG("GetVulkanDeviceProcAddress(0x%x, 0x%x, %s, %d) -> not found",
+              instance, device, name, bypassLocal);
+  return nullptr;
 }
 
 void* getVulkanProcAddress(const char* name, bool bypassLocal) {
-    return getVulkanInstanceProcAddress(0u, name, bypassLocal);
+  return getVulkanInstanceProcAddress(0u, name, bypassLocal);
 }
 
 }  // anonymous namespace
 
 namespace core {
 
-GetVulkanInstanceProcAddressFunc* GetVulkanInstanceProcAddress = getVulkanInstanceProcAddress;
-GetVulkanDeviceProcAddressFunc* GetVulkanDeviceProcAddress = getVulkanDeviceProcAddress;
+GetVulkanInstanceProcAddressFunc* GetVulkanInstanceProcAddress =
+    getVulkanInstanceProcAddress;
+GetVulkanDeviceProcAddressFunc* GetVulkanDeviceProcAddress =
+    getVulkanDeviceProcAddress;
 GetVulkanProcAddressFunc* GetVulkanProcAddress = getVulkanProcAddress;
 bool HasVulkanLoader() {
-  return DlLoader::can_load("libvulkan.so") || DlLoader::can_load("libvulkan.so.1");
+  return DlLoader::can_load("libvulkan.so") ||
+         DlLoader::can_load("libvulkan.so.1");
 }
 }  // namespace core

--- a/core/cc/armlinux/thread.cpp
+++ b/core/cc/armlinux/thread.cpp
@@ -23,9 +23,10 @@
 namespace core {
 
 Thread Thread::current() {
-    auto thread = pthread_self();
-    auto asUnsigned = static_cast<std::make_unsigned<decltype(thread)>::type>(thread);
-    return Thread(static_cast<uint64_t>(asUnsigned));
+  auto thread = pthread_self();
+  auto asUnsigned =
+      static_cast<std::make_unsigned<decltype(thread)>::type>(thread);
+  return Thread(static_cast<uint64_t>(asUnsigned));
 }
 
 }  // namespace core

--- a/core/cc/assert.h
+++ b/core/cc/assert.h
@@ -19,7 +19,17 @@
 
 #include "log.h"
 
-#define GAPID_ASSERT(cond) do { if (!(cond)) { GAPID_FATAL("Assert: " GAPID_STR(cond)); } } while(false)
-#define GAPID_ASSERT_MSG(cond, msg, ...) do { if (!(cond)) { GAPID_FATAL("Assert: <" GAPID_STR(cond) ">: " msg, ##__VA_ARGS__); } } while(false)
+#define GAPID_ASSERT(cond)                     \
+  do {                                         \
+    if (!(cond)) {                             \
+      GAPID_FATAL("Assert: " GAPID_STR(cond)); \
+    }                                          \
+  } while (false)
+#define GAPID_ASSERT_MSG(cond, msg, ...)                                 \
+  do {                                                                   \
+    if (!(cond)) {                                                       \
+      GAPID_FATAL("Assert: <" GAPID_STR(cond) ">: " msg, ##__VA_ARGS__); \
+    }                                                                    \
+  } while (false)
 
 #endif  // CORE_ASSERT_H

--- a/core/cc/connection.cpp
+++ b/core/cc/connection.cpp
@@ -16,31 +16,38 @@
 
 #include "connection.h"
 
-#include <string>
 #include <cstring>
+#include <string>
 
 namespace core {
 
 bool Connection::sendString(const std::string& s) {
-    const uint32_t length = static_cast<uint32_t>(s.size())+1;
-    return this->send(s.c_str(), length) == length;
+  const uint32_t length = static_cast<uint32_t>(s.size()) + 1;
+  return this->send(s.c_str(), length) == length;
 }
 
-// This handles nullptr, since the overload above would crash on the implicit conversion.
+// This handles nullptr, since the overload above would crash on the implicit
+// conversion.
 bool Connection::sendString(const char* s) {
-    if (s == nullptr) { s = ""; }
-    const uint32_t length = strlen(s)+1;
-    return this->send(s, length) == length;
+  if (s == nullptr) {
+    s = "";
+  }
+  const uint32_t length = strlen(s) + 1;
+  return this->send(s, length) == length;
 }
 
 bool Connection::readString(std::string* s) {
-    char c;
-    s->clear();
-    while(true) {
-        if (this->recv(&c, 1) != 1) { return false; }
-        if (c == 0) { return true; }
-        s->push_back(c);
+  char c;
+  s->clear();
+  while (true) {
+    if (this->recv(&c, 1) != 1) {
+      return false;
     }
+    if (c == 0) {
+      return true;
+    }
+    s->push_back(c);
+  }
 }
 
 }  // namespace core

--- a/core/cc/connection.h
+++ b/core/cc/connection.h
@@ -23,50 +23,54 @@
 
 namespace core {
 
-// Abstract base class for representing a connection to a remote with simple helper methods for
-// sending specific data types.
+// Abstract base class for representing a connection to a remote with simple
+// helper methods for sending specific data types.
 class Connection {
-public:
-    // Constant that can be passed to accept() to indicate that the call should
-    // block with no timeouts until a connection is made, or the socket closes.
-    static const int NO_TIMEOUT = -1;
+ public:
+  // Constant that can be passed to accept() to indicate that the call should
+  // block with no timeouts until a connection is made, or the socket closes.
+  static const int NO_TIMEOUT = -1;
 
-    virtual ~Connection() {}
+  virtual ~Connection() {}
 
-    // Try to send size bytes of data from the specified buffer using the underlying connection.
-    // Will block if the connection is not ready. Returns the number of bytes successfully sent
-    // (possibly less then size if an error occurred).
-    virtual size_t send(const void* data, size_t size) = 0;
+  // Try to send size bytes of data from the specified buffer using the
+  // underlying connection. Will block if the connection is not ready. Returns
+  // the number of bytes successfully sent (possibly less then size if an error
+  // occurred).
+  virtual size_t send(const void* data, size_t size) = 0;
 
-    // Tries to read size bytes to the buffer specified by data on the underlying connection and
-    // blocks until the data is available. Returns the number of bytes successfully retrieved
-    // (possibly less then size if an error occurred).
-    virtual size_t recv(void* data, size_t size) = 0;
+  // Tries to read size bytes to the buffer specified by data on the underlying
+  // connection and blocks until the data is available. Returns the number of
+  // bytes successfully retrieved (possibly less then size if an error
+  // occurred).
+  virtual size_t recv(void* data, size_t size) = 0;
 
-    // Returns the last error message raised by the connection.
-    virtual const char* error() = 0;
+  // Returns the last error message raised by the connection.
+  virtual const char* error() = 0;
 
-    // Accept an incoming connection request on the underlying connection and returns the new
-    // connection corresponding to it. The returned connection is ready to use.
-    // If timeoutMS is NO_TIMEOUT, then the connection will block forever.
-    virtual std::unique_ptr<Connection> accept(int timeoutMS = NO_TIMEOUT) = 0;
+  // Accept an incoming connection request on the underlying connection and
+  // returns the new connection corresponding to it. The returned connection is
+  // ready to use. If timeoutMS is NO_TIMEOUT, then the connection will block
+  // forever.
+  virtual std::unique_ptr<Connection> accept(int timeoutMS = NO_TIMEOUT) = 0;
 
-    // Helper methods for sending and receiving strings
-    bool sendString(const std::string& s);
-    bool sendString(const char* s);
-    bool readString(std::string* s);
+  // Helper methods for sending and receiving strings
+  bool sendString(const std::string& s);
+  bool sendString(const char* s);
+  bool readString(std::string* s);
 
-    // Helper method for sending plain-old-data values.
-    // Returns true if the send was successful, otherwise false.
-    template<typename T> inline bool send(const T& data);
+  // Helper method for sending plain-old-data values.
+  // Returns true if the send was successful, otherwise false.
+  template <typename T>
+  inline bool send(const T& data);
 
-    // Closes the connection for read/write but leaves the object around.
-    virtual void close() = 0;
+  // Closes the connection for read/write but leaves the object around.
+  virtual void close() = 0;
 };
 
-template<typename T>
+template <typename T>
 inline bool Connection::send(const T& data) {
-    return send(&data, sizeof(T)) == sizeof(T);
+  return send(&data, sizeof(T)) == sizeof(T);
 }
 
 }  // namespace core

--- a/core/cc/connection_test.cpp
+++ b/core/cc/connection_test.cpp
@@ -21,13 +21,13 @@
 
 #include <string>
 
-using ::testing::_;
 using ::testing::DoAll;
+using ::testing::ElementsAre;
 using ::testing::Return;
 using ::testing::ReturnArg;
 using ::testing::StrictMock;
 using ::testing::WithArg;
-using ::testing::ElementsAre;
+using ::testing::_;
 
 namespace core {
 namespace test {
@@ -36,12 +36,10 @@ namespace {
 const std::string testString = "ABCDE";
 
 class ConnectionTest : public ::testing::Test {
-protected:
-    virtual void SetUp() {
-        mConnection.reset(new MockConnection());
-    }
+ protected:
+  virtual void SetUp() { mConnection.reset(new MockConnection()); }
 
-    std::unique_ptr<MockConnection> mConnection;
+  std::unique_ptr<MockConnection> mConnection;
 };
 
 void pushBytes(std::vector<uint8_t>* buf, const std::vector<uint8_t>& v) {
@@ -49,15 +47,15 @@ void pushBytes(std::vector<uint8_t>* buf, const std::vector<uint8_t>& v) {
 }
 
 void pushString(std::vector<uint8_t>* buf, const std::string& str) {
-  for(char c : str) {
-      buf->push_back(c);
+  for (char c : str) {
+    buf->push_back(c);
   }
   buf->push_back(0);
 }
 
 void pushString(std::vector<uint8_t>* buf, const char* str) {
-  for(char c = *str; c != 0; str++, c = *str) {
-      buf->push_back(c);
+  for (char c = *str; c != 0; str++, c = *str) {
+    buf->push_back(c);
   }
   buf->push_back(0);
 }
@@ -65,39 +63,38 @@ void pushString(std::vector<uint8_t>* buf, const char* str) {
 }  // anonymous namespace
 
 TEST_F(ConnectionTest, SendEmptyString) {
-    EXPECT_TRUE(mConnection->sendString(""));
-    EXPECT_THAT(mConnection->out, ElementsAre(0));
+  EXPECT_TRUE(mConnection->sendString(""));
+  EXPECT_THAT(mConnection->out, ElementsAre(0));
 }
 
 TEST_F(ConnectionTest, SendString) {
-    EXPECT_TRUE(mConnection->sendString(testString));
-    EXPECT_THAT(mConnection->out, ElementsAre(
-        'A', 'B', 'C', 'D', 'E', 0));
+  EXPECT_TRUE(mConnection->sendString(testString));
+  EXPECT_THAT(mConnection->out, ElementsAre('A', 'B', 'C', 'D', 'E', 0));
 }
 
 TEST_F(ConnectionTest, SendStringError) {
-    mConnection->out_limit = 3;
-    EXPECT_FALSE(mConnection->sendString(testString));
+  mConnection->out_limit = 3;
+  EXPECT_FALSE(mConnection->sendString(testString));
 }
 
 TEST_F(ConnectionTest, ReadEmptyString) {
-    pushString(&mConnection->in, "");
-    std::string s;
-    EXPECT_TRUE(mConnection->readString(&s));
-    EXPECT_EQ("", s);
+  pushString(&mConnection->in, "");
+  std::string s;
+  EXPECT_TRUE(mConnection->readString(&s));
+  EXPECT_EQ("", s);
 }
 
 TEST_F(ConnectionTest, ReadString) {
-    pushString(&mConnection->in, testString);
-    std::string s;
-    EXPECT_TRUE(mConnection->readString(&s));
-    EXPECT_EQ(testString, s);
+  pushString(&mConnection->in, testString);
+  std::string s;
+  EXPECT_TRUE(mConnection->readString(&s));
+  EXPECT_EQ(testString, s);
 }
 
 TEST_F(ConnectionTest, ReadStringError) {
-    pushBytes(&mConnection->in, {'A', 'B'});
-    std::string s;
-    EXPECT_FALSE(mConnection->readString(&s));
+  pushBytes(&mConnection->in, {'A', 'B'});
+  std::string s;
+  EXPECT_FALSE(mConnection->readString(&s));
 }
 
 }  // namespace test

--- a/core/cc/crash_handler.cpp
+++ b/core/cc/crash_handler.cpp
@@ -20,25 +20,25 @@
 namespace core {
 
 CrashHandler::Handler CrashHandler::defaultHandler =
-        [] (const std::string& minidump_path, bool succeeded) {
-            if (!succeeded) {
-                GAPID_ERROR("Failed to write minidump out to %s", minidump_path.c_str());
-            }
-        };
+    [](const std::string& minidump_path, bool succeeded) {
+      if (!succeeded) {
+        GAPID_ERROR("Failed to write minidump out to %s",
+                    minidump_path.c_str());
+      }
+    };
 
 CrashHandler::Unregister CrashHandler::registerHandler(Handler handler) {
-    auto id = mNextHandlerID++;
-    mHandlers[id] = handler;
-    return [this, id] () {
-        mHandlers.erase(id);
-    };
+  auto id = mNextHandlerID++;
+  mHandlers[id] = handler;
+  return [this, id]() { mHandlers.erase(id); };
 }
 
-bool CrashHandler::handleMinidump(const std::string& minidumpPath, bool succeeded) {
-    for (const auto& it : mHandlers) {
-        it.second(minidumpPath, succeeded);
-    }
-    return succeeded;
+bool CrashHandler::handleMinidump(const std::string& minidumpPath,
+                                  bool succeeded) {
+  for (const auto& it : mHandlers) {
+    it.second(minidumpPath, succeeded);
+  }
+  return succeeded;
 }
 
-} // namespace core
+}  // namespace core

--- a/core/cc/crash_handler.h
+++ b/core/cc/crash_handler.h
@@ -30,25 +30,26 @@ namespace core {
 
 // Utility class for attaching a crash handler.
 class CrashHandler {
-public:
-    typedef std::function<void(const std::string& minidumpPath, bool succeeded)> Handler;
-    typedef std::function<void()> Unregister;
+ public:
+  typedef std::function<void(const std::string& minidumpPath, bool succeeded)>
+      Handler;
+  typedef std::function<void()> Unregister;
 
-    CrashHandler();
-    ~CrashHandler();
+  CrashHandler();
+  ~CrashHandler();
 
-    Unregister registerHandler(Handler handler);
+  Unregister registerHandler(Handler handler);
 
-    bool handleMinidump(const std::string& minidumpPath, bool succeeded);
+  bool handleMinidump(const std::string& minidumpPath, bool succeeded);
 
-private:
-    unsigned int mNextHandlerID;
-    std::unordered_map<unsigned int, Handler> mHandlers;
-    std::unique_ptr<google_breakpad::ExceptionHandler> mExceptionHandler;
+ private:
+  unsigned int mNextHandlerID;
+  std::unordered_map<unsigned int, Handler> mHandlers;
+  std::unique_ptr<google_breakpad::ExceptionHandler> mExceptionHandler;
 
-    static Handler defaultHandler;
+  static Handler defaultHandler;
 };
 
-}
+}  // namespace core
 
 #endif

--- a/core/cc/crash_handler_test.cpp
+++ b/core/cc/crash_handler_test.cpp
@@ -26,20 +26,22 @@
 namespace core {
 namespace test {
 
-#if TARGET_OS != GAPID_OS_OSX // Work around for https://github.com/google/gapid/issues/1788
+#if TARGET_OS != GAPID_OS_OSX  // Work around for
+                               // https://github.com/google/gapid/issues/1788
 TEST(CrashHandlerTest, HandleCrash) {
-    CrashHandler crashHandler;
-    crashHandler.registerHandler([] (const std::string& minidumpPath, bool succeeded) {
+  CrashHandler crashHandler;
+  crashHandler.registerHandler(
+      [](const std::string& minidumpPath, bool succeeded) {
         if (succeeded) {
-            std::cerr << "crash handled.";
+          std::cerr << "crash handled.";
         } else {
-            std::cerr << "crash not handled.";
+          std::cerr << "crash not handled.";
         }
-    });
+      });
 
-    EXPECT_DEATH({ (void)*((volatile int*)(0)); }, "crash handled.");
+  EXPECT_DEATH({ (void)*((volatile int*)(0)); }, "crash handled.");
 }
-#endif // TARGET_OS != GAPID_OS_OSX
+#endif  // TARGET_OS != GAPID_OS_OSX
 
-} // namespace test
-} // namespace core
+}  // namespace test
+}  // namespace core

--- a/core/cc/debugger.h
+++ b/core/cc/debugger.h
@@ -21,9 +21,9 @@ namespace core {
 
 // Utility class for detecting debugger attachment.
 class Debugger {
-public:
-    static bool isAttached();
-    static void waitForAttach();
+ public:
+  static bool isAttached();
+  static void waitForAttach();
 };
 
 }  // namespace core

--- a/core/cc/dl_loader.h
+++ b/core/cc/dl_loader.h
@@ -21,31 +21,31 @@ namespace core {
 
 // Utility class for retrieving function pointers from dynamic libraries.
 class DlLoader {
-public:
-    // Loads the dynamic library specified by the given name and fallback names
-    // (if any). Names will be used to try to find the library in order. If the
-    // library cannot be loaded then this is a fatal error. For *nix systems,
-    // a nullptr can be used to search the application's functions.
-    template<typename... ConstCharPtrs>
-    DlLoader(const char* name, ConstCharPtrs... fallback_names);
+ public:
+  // Loads the dynamic library specified by the given name and fallback names
+  // (if any). Names will be used to try to find the library in order. If the
+  // library cannot be loaded then this is a fatal error. For *nix systems,
+  // a nullptr can be used to search the application's functions.
+  template <typename... ConstCharPtrs>
+  DlLoader(const char* name, ConstCharPtrs... fallback_names);
 
-    // Unloads the library loaded in the constructor.
-    ~DlLoader();
+  // Unloads the library loaded in the constructor.
+  ~DlLoader();
 
-    // Looks up the function with the specified name from the library.
-    // Returns nullptr if the function is not found.
-    void* lookup(const char* name);
+  // Looks up the function with the specified name from the library.
+  // Returns nullptr if the function is not found.
+  void* lookup(const char* name);
 
-    // can_load checks if the dynamic library specified with the given name can
-    // be loaded. Returns true if so, otherwise returns false.
-    static bool can_load(const char* lib_name);
+  // can_load checks if the dynamic library specified with the given name can
+  // be loaded. Returns true if so, otherwise returns false.
+  static bool can_load(const char* lib_name);
 
-private:
-    DlLoader() =default;
-    DlLoader(const DlLoader&) =delete;
-    DlLoader& operator=(const DlLoader&) =delete;
+ private:
+  DlLoader() = default;
+  DlLoader(const DlLoader&) = delete;
+  DlLoader& operator=(const DlLoader&) = delete;
 
-    void* mLibrary;
+  void* mLibrary;
 };
 
 }  // namespace core

--- a/core/cc/file_reader.cpp
+++ b/core/cc/file_reader.cpp
@@ -20,40 +20,36 @@
 
 namespace core {
 
-FileReader::FileReader(const char* path) {
-    mFile = fopen(path, "rb");
-}
-FileReader::~FileReader() {
-    fclose(mFile);
-}
+FileReader::FileReader(const char* path) { mFile = fopen(path, "rb"); }
+FileReader::~FileReader() { fclose(mFile); }
 
 const char* FileReader::error() const {
-    if (mFile == 0) {
-        return "File did not open";
-    }
-    return 0;
+  if (mFile == 0) {
+    return "File did not open";
+  }
+  return 0;
 }
 
 uint64_t FileReader::read(void* data, uint64_t max_size) {
-    return fread(data, 1, max_size, mFile);
+  return fread(data, 1, max_size, mFile);
 }
 
 uint64_t FileReader::size() {
-    // TODO: this is not portable, need to move to platform file.
-    if (fseek(mFile, 0, SEEK_END) != 0) {
-        GAPID_ERROR("Failed to seek to the end of file");
-        return 0u;
-    }
+  // TODO: this is not portable, need to move to platform file.
+  if (fseek(mFile, 0, SEEK_END) != 0) {
+    GAPID_ERROR("Failed to seek to the end of file");
+    return 0u;
+  }
 
-    long int sizeTemp = ftell(mFile);
-    if (sizeTemp == -1L) {
-        GAPID_ERROR("Failed to get size of file")
-        rewind(mFile);
-        return 0u;
-    }
-    uint64_t size = static_cast<uint64_t>(sizeTemp);
+  long int sizeTemp = ftell(mFile);
+  if (sizeTemp == -1L) {
+    GAPID_ERROR("Failed to get size of file")
     rewind(mFile);
-    return size;
+    return 0u;
+  }
+  uint64_t size = static_cast<uint64_t>(sizeTemp);
+  rewind(mFile);
+  return size;
 }
 
-} // namespace core
+}  // namespace core

--- a/core/cc/file_reader.h
+++ b/core/cc/file_reader.h
@@ -19,31 +19,32 @@
 
 #include "stream_reader.h"
 
-#include <stdio.h>
 #include <stdint.h>
+#include <stdio.h>
 
 namespace core {
 
 // FileReader is an implementation of the StreamReader interface that reads
 // from binary files.
 class FileReader : public StreamReader {
-public:
-    FileReader(const char* path);
-    ~FileReader();
+ public:
+  FileReader(const char* path);
+  ~FileReader();
 
-    // error returns an error string if the reader has encountered an error.
-    const char* error() const;
+  // error returns an error string if the reader has encountered an error.
+  const char* error() const;
 
-    // read attempts to read max_size bytes to the pointer data, blocking until
-    // the data is available. Returns the number of bytes successfully read,
-    // which may be less than size if the stream was closed or there was an
-    // error.
-    virtual uint64_t read(void* data, uint64_t max_size);
+  // read attempts to read max_size bytes to the pointer data, blocking until
+  // the data is available. Returns the number of bytes successfully read,
+  // which may be less than size if the stream was closed or there was an
+  // error.
+  virtual uint64_t read(void* data, uint64_t max_size);
 
-    // size returns the number of bytes in the underlying file.
-    uint64_t size();
-private:
-    FILE* mFile;
+  // size returns the number of bytes in the underlying file.
+  uint64_t size();
+
+ private:
+  FILE* mFile;
 };
 
 }  // namespace core

--- a/core/cc/file_writer.cpp
+++ b/core/cc/file_writer.cpp
@@ -19,16 +19,14 @@
 namespace core {
 
 FileWriter::FileWriter(const char* path) {
-    mFile = fopen(path, "wb");
-    // TODO: assert(mFile != nullptr)
+  mFile = fopen(path, "wb");
+  // TODO: assert(mFile != nullptr)
 }
 
-FileWriter::~FileWriter() {
-    fclose(mFile);
-}
+FileWriter::~FileWriter() { fclose(mFile); }
 
 uint64_t FileWriter::write(const void* data, uint64_t size) {
-    return fwrite(data, static_cast<size_t>(size), 1, mFile);
+  return fwrite(data, static_cast<size_t>(size), 1, mFile);
 }
 
 }  // namespace core

--- a/core/cc/file_writer.h
+++ b/core/cc/file_writer.h
@@ -26,15 +26,15 @@ namespace core {
 // FileWriter is an implementation of the StreamWriter interface that writes to
 // a binary file.
 class FileWriter : public StreamWriter {
-public:
-    FileWriter(const char* path);
-    ~FileWriter();
+ public:
+  FileWriter(const char* path);
+  ~FileWriter();
 
-    // StreamWriter compliance
-    virtual uint64_t write(const void* data, uint64_t size) override;
+  // StreamWriter compliance
+  virtual uint64_t write(const void* data, uint64_t size) override;
 
-private:
-    FILE* mFile;
+ private:
+  FILE* mFile;
 };
 
 }  // namespace core

--- a/core/cc/get_gles_proc_address.h
+++ b/core/cc/get_gles_proc_address.h
@@ -19,7 +19,7 @@
 
 namespace core {
 
-typedef void* (GetGlesProcAddressFunc)(const char* name, bool bypassLocal);
+typedef void*(GetGlesProcAddressFunc)(const char* name, bool bypassLocal);
 
 // GetGlesProcAddress returns the GLES function pointer to the function with
 // the given name, or nullptr if the function was not found. If bypassLocal

--- a/core/cc/get_vulkan_proc_address.h
+++ b/core/cc/get_vulkan_proc_address.h
@@ -21,9 +21,13 @@
 
 namespace core {
 
-typedef void* (GetVulkanProcAddressFunc)(const char* name, bool bypassLocal);
-typedef void* (GetVulkanInstanceProcAddressFunc)(size_t instance, const char* name, bool bypassLocal);
-typedef void* (GetVulkanDeviceProcAddressFunc)(size_t instance, size_t device, const char* name, bool bypassLocal);
+typedef void*(GetVulkanProcAddressFunc)(const char* name, bool bypassLocal);
+typedef void*(GetVulkanInstanceProcAddressFunc)(size_t instance,
+                                                const char* name,
+                                                bool bypassLocal);
+typedef void*(GetVulkanDeviceProcAddressFunc)(size_t instance, size_t device,
+                                              const char* name,
+                                              bool bypassLocal);
 
 // GetVulkanProcAddress returns the Vulkan function pointer to the function with
 // the given name, or nullptr if the function was not found. If bypassLocal

--- a/core/cc/gl/formats.cpp
+++ b/core/cc/gl/formats.cpp
@@ -22,109 +22,118 @@ namespace core {
 namespace gl {
 
 bool getColorFormat(int r, int g, int b, int a, uint32_t& format) {
-    if (r == 8 && g == 8 && b == 8 && a == 8) {
-        format = GL_RGBA8;
-        return true;
-    } else if (r == 8 && g == 8 && b == 8 && a == 0) {
-        format = GL_RGB8;
-        return true;
-    } else if (r == 5 && g == 6 && b == 5 && a == 0) {
-        format = GL_RGB565;
-        return true;
-    }
-    return false;  // Not a recognised combination.
+  if (r == 8 && g == 8 && b == 8 && a == 8) {
+    format = GL_RGBA8;
+    return true;
+  } else if (r == 8 && g == 8 && b == 8 && a == 0) {
+    format = GL_RGB8;
+    return true;
+  } else if (r == 5 && g == 6 && b == 5 && a == 0) {
+    format = GL_RGB565;
+    return true;
+  }
+  return false;  // Not a recognised combination.
 }
 
 bool getColorBits(uint32_t format, int& r, int& g, int& b, int& a) {
-    switch (format) {
-        case GL_RGBA8:
-            r = 8; g = 8; b = 8; a = 8;
-            return true;
-        case GL_RGB8:
-            r = 8; g = 8; b = 8; a = 0;
-            return true;
-        case GL_RGB565:
-            r = 5; g = 6; b = 5; a = 0;
-            return true;
-    }
-    return false;  // Not a recognised combination.
+  switch (format) {
+    case GL_RGBA8:
+      r = 8;
+      g = 8;
+      b = 8;
+      a = 8;
+      return true;
+    case GL_RGB8:
+      r = 8;
+      g = 8;
+      b = 8;
+      a = 0;
+      return true;
+    case GL_RGB565:
+      r = 5;
+      g = 6;
+      b = 5;
+      a = 0;
+      return true;
+  }
+  return false;  // Not a recognised combination.
 }
 
-
-// See: https://www.khronos.org/opengles/sdk/docs/man3/docbook4/xhtml/glRenderbufferStorage.xml
+// See:
+// https://www.khronos.org/opengles/sdk/docs/man3/docbook4/xhtml/glRenderbufferStorage.xml
 bool getDepthStencilFormat(int d, int s, uint32_t& depth, uint32_t& stencil) {
-    depth = 0;
-    stencil = 0;
+  depth = 0;
+  stencil = 0;
 
-    if (d == 0 && s == 0) {
-        return true; // No depth, no stencil.
-    }
+  if (d == 0 && s == 0) {
+    return true;  // No depth, no stencil.
+  }
 
-    switch (s) {
+  switch (s) {
+    case 0:
+      switch (d) {
+        case 16:
+          depth = GL_DEPTH_COMPONENT16;
+          return true;
+        case 24:
+          depth = GL_DEPTH_COMPONENT24;
+          return true;
+        case 32:
+          depth = GL_DEPTH_COMPONENT32F;
+          return true;
+      }
+      break;
+    case 8:
+      switch (d) {
         case 0:
-            switch (d) {
-                case 16:
-                    depth = GL_DEPTH_COMPONENT16;
-                    return true;
-                case 24:
-                    depth = GL_DEPTH_COMPONENT24;
-                    return true;
-                case 32:
-                    depth = GL_DEPTH_COMPONENT32F;
-                    return true;
-            }
-            break;
-        case 8:
-            switch (d) {
-                case 0:
-                    stencil = GL_STENCIL_INDEX8;
-                    return true;
-                case 24:
-                    depth = GL_DEPTH24_STENCIL8;
-                    stencil = GL_DEPTH24_STENCIL8;
-                    return true;
-                case 32:
-                    depth = GL_DEPTH24_STENCIL8;
-                    stencil = GL_DEPTH32F_STENCIL8;
-                    return true;
-            }
-            break;
-    }
-    return false;  // Not a recognised combination.
+          stencil = GL_STENCIL_INDEX8;
+          return true;
+        case 24:
+          depth = GL_DEPTH24_STENCIL8;
+          stencil = GL_DEPTH24_STENCIL8;
+          return true;
+        case 32:
+          depth = GL_DEPTH24_STENCIL8;
+          stencil = GL_DEPTH32F_STENCIL8;
+          return true;
+      }
+      break;
+  }
+  return false;  // Not a recognised combination.
 }
 
 bool getDepthBits(uint32_t format, int& d) {
-    d = 0;
-    switch (format) {
-        case 0:
-            return true;
-        case GL_DEPTH_COMPONENT16:
-            d = 16;
-            return true;
-        case GL_DEPTH_COMPONENT24:
-        case GL_DEPTH24_STENCIL8:
-            d = 24;
-            return true;
-        case GL_DEPTH_COMPONENT32F:
-        case GL_DEPTH32F_STENCIL8:
-            d = 32;
-            return true;
-    }
-    return false;  // Not a recognised combination.
+  d = 0;
+  switch (format) {
+    case 0:
+      return true;
+    case GL_DEPTH_COMPONENT16:
+      d = 16;
+      return true;
+    case GL_DEPTH_COMPONENT24:
+    case GL_DEPTH24_STENCIL8:
+      d = 24;
+      return true;
+    case GL_DEPTH_COMPONENT32F:
+    case GL_DEPTH32F_STENCIL8:
+      d = 32;
+      return true;
+  }
+  return false;  // Not a recognised combination.
 }
 
 bool getStencilBits(uint32_t format, int& s) {
-    s = 0;
-    switch (format) {
-        case 0:
-            return true;
-        case GL_STENCIL_INDEX8:
-        case GL_DEPTH24_STENCIL8:
-        case GL_DEPTH32F_STENCIL8:
-            s = 8;
-            return true;
-    }
-    return false;  // Not a recognised combination.
+  s = 0;
+  switch (format) {
+    case 0:
+      return true;
+    case GL_STENCIL_INDEX8:
+    case GL_DEPTH24_STENCIL8:
+    case GL_DEPTH32F_STENCIL8:
+      s = 8;
+      return true;
+  }
+  return false;  // Not a recognised combination.
 }
 
 }  // namespace gl

--- a/core/cc/gl/formats.h
+++ b/core/cc/gl/formats.h
@@ -22,37 +22,39 @@
 namespace core {
 namespace gl {
 
-const uint32_t GL_RGB8               = 0x00008051;
-const uint32_t GL_RGBA8              = 0x00008058;
-const uint32_t GL_RGB565             = 0x00008D62;
-const uint32_t GL_DEPTH_COMPONENT16  = 0x000081A5;
-const uint32_t GL_DEPTH_COMPONENT24  = 0x000081A6;
+const uint32_t GL_RGB8 = 0x00008051;
+const uint32_t GL_RGBA8 = 0x00008058;
+const uint32_t GL_RGB565 = 0x00008D62;
+const uint32_t GL_DEPTH_COMPONENT16 = 0x000081A5;
+const uint32_t GL_DEPTH_COMPONENT24 = 0x000081A6;
 const uint32_t GL_DEPTH_COMPONENT32F = 0x00008CAC;
-const uint32_t GL_DEPTH32F_STENCIL8  = 0x00008CAD;
-const uint32_t GL_DEPTH24_STENCIL8   = 0x000088F0;
-const uint32_t GL_STENCIL_INDEX8     = 0x00008D48;
+const uint32_t GL_DEPTH32F_STENCIL8 = 0x00008CAD;
+const uint32_t GL_DEPTH24_STENCIL8 = 0x000088F0;
+const uint32_t GL_STENCIL_INDEX8 = 0x00008D48;
 
-// getColorFormat gets the color buffer format given the number of bits for the red, green,
-// blue and alpha channels.
-// Returns true on success, or false if there is no format for the given bit combination.
+// getColorFormat gets the color buffer format given the number of bits for the
+// red, green, blue and alpha channels. Returns true on success, or false if
+// there is no format for the given bit combination.
 bool getColorFormat(int r, int g, int b, int a, uint32_t& format);
 
-// getColorBits gets the number of bits for the red, green, blue and alpha channels for the
-// given format.
-// Returns true on success, or false if the format is not recognised.
+// getColorBits gets the number of bits for the red, green, blue and alpha
+// channels for the given format. Returns true on success, or false if the
+// format is not recognised.
 bool getColorBits(uint32_t format, int& r, int& g, int& b, int& a);
 
-// getDepthStencilFormat gets the depth and stencil buffer formats given the number of bits for the
-// depth and stencil channels.
-// Returns true on success, or false if there is no format combination for the given bits.
+// getDepthStencilFormat gets the depth and stencil buffer formats given the
+// number of bits for the depth and stencil channels. Returns true on success,
+// or false if there is no format combination for the given bits.
 bool getDepthStencilFormat(int d, int s, uint32_t& depth, uint32_t& stencil);
 
-// getDepthBits gets the number of bits for the depth channel for the given depth format.
-// Returns true on success, or false if the format is not recognised.
+// getDepthBits gets the number of bits for the depth channel for the given
+// depth format. Returns true on success, or false if the format is not
+// recognised.
 bool getDepthBits(uint32_t format, int& d);
 
-// getStencilBits gets the number of bits for the stencil channel for the given stencil format.
-// Returns true on success, or false if the format is not recognised.
+// getStencilBits gets the number of bits for the stencil channel for the given
+// stencil format. Returns true on success, or false if the format is not
+// recognised.
 bool getStencilBits(uint32_t format, int& s);
 
 }  // namespace gl

--- a/core/cc/gl/versions.h
+++ b/core/cc/gl/versions.h
@@ -22,10 +22,9 @@ namespace gl {
 
 // Version represents a single major.minor version of an OpenGL context.
 struct Version {
-    int major;
-    int minor;
+  int major;
+  int minor;
 };
-
 
 // sVersionSearchOrder is an preference-ordered list of OpenGL context versions
 // that should be searched in order to pick the most recent version of OpenGL.
@@ -33,6 +32,7 @@ struct Version {
 // implementations will return the precise version requested, so if we request
 // 3.2, we would get 3.2 even if a new version is available.
 static const Version sVersionSearchOrder[] = {
+    // clang-format off
     {4, 5}, // Compatible with OpenGL ES 3.1
     {4, 4},
     {4, 3}, // Compatible with OpenGL ES 3.0
@@ -41,6 +41,7 @@ static const Version sVersionSearchOrder[] = {
     {4, 0},
     {3, 3},
     {3, 2}, // Introduces core profile
+    // clang-format on
 };
 
 }  // namespace gl

--- a/core/cc/gles_ptr_types.h
+++ b/core/cc/gles_ptr_types.h
@@ -17,7 +17,7 @@
 #ifndef CORE_GLES_PTR_TYPES_H_
 #define CORE_GLES_PTR_TYPES_H_
 
-#include "core/cc/target.h" // STDCALL
+#include "core/cc/target.h"  // STDCALL
 
 #define GLES_API_ATTR
 #define GLES_API_CALL

--- a/core/cc/gvr_ptr_types.h
+++ b/core/cc/gvr_ptr_types.h
@@ -17,7 +17,7 @@
 #ifndef CORE_GVR_PTR_TYPES_H_
 #define CORE_GVR_PTR_TYPES_H_
 
-#include "core/cc/target.h" // STDCALL
+#include "core/cc/target.h"  // STDCALL
 
 #define GVR_API_ATTR
 #define GVR_API_CALL

--- a/core/cc/id.cpp
+++ b/core/cc/id.cpp
@@ -21,43 +21,42 @@
 #include <string.h>
 
 #include <iomanip>
-#include <string>
 #include <sstream>
+#include <string>
 
 namespace {
 
 void hash(const void* ptr, uint64_t size, core::Id& out) {
-    auto buf = reinterpret_cast<const char*>(ptr);
-    auto len = static_cast<size_t>(size);
-    auto hash128 = CityHash128(buf, len);
-    auto hash32 = CityHash32(buf, len);
-    memcpy(&out.data[0], &hash128, 16);
-    memcpy(&out.data[16], &hash32, 4);
+  auto buf = reinterpret_cast<const char*>(ptr);
+  auto len = static_cast<size_t>(size);
+  auto hash128 = CityHash128(buf, len);
+  auto hash32 = CityHash32(buf, len);
+  memcpy(&out.data[0], &hash128, 16);
+  memcpy(&out.data[16], &hash32, 4);
 }
 
-} // anonymous namespace
+}  // anonymous namespace
 
 namespace core {
 
 Id Id::Hash(const void* ptr, uint64_t size) {
-    Id id;
-    hash(ptr, size, id);
-    return id;
+  Id id;
+  hash(ptr, size, id);
+  return id;
 }
 
-bool Id::operator == (const Id& rhs) const {
-    return memcmp(data, rhs.data, sizeof(data)) == 0;
+bool Id::operator==(const Id& rhs) const {
+  return memcmp(data, rhs.data, sizeof(data)) == 0;
 }
 
 std::string Id::string() const {
-    std::stringstream ss;
-    ss << "0x";
-    ss << std::setfill('0') << std::hex;
-    for(int i = 0; i < 20; ++i) {
-        ss << std::setw(2) << (unsigned int)data[i];
-    }
-    return ss.str();
+  std::stringstream ss;
+  ss << "0x";
+  ss << std::setfill('0') << std::hex;
+  for (int i = 0; i < 20; ++i) {
+    ss << std::setw(2) << (unsigned int)data[i];
+  }
+  return ss.str();
 }
-
 
 }  // namespace core

--- a/core/cc/id.h
+++ b/core/cc/id.h
@@ -17,45 +17,42 @@
 #ifndef CORE_ID_H
 #define CORE_ID_H
 
+#include <stdint.h>
 #include <cstring>
 #include <functional>
-#include <stdint.h>
 
 namespace core {
 
 // Id is a 20-byte unique identifier.
 struct Id {
-    // Construct an Id with the hash of the given memory address.
-    static Id Hash(const void* ptr, uint64_t size);
+  // Construct an Id with the hash of the given memory address.
+  static Id Hash(const void* ptr, uint64_t size);
 
-    bool operator == (const Id& rhs) const;
+  bool operator==(const Id& rhs) const;
 
-    inline operator uint8_t*();
-    inline operator const uint8_t*() const;
+  inline operator uint8_t*();
+  inline operator const uint8_t*() const;
 
-    std::string string() const;
+  std::string string() const;
 
-    uint8_t data[20];
+  uint8_t data[20];
 };
 
-inline Id::operator uint8_t*() {
-  return data;
-}
+inline Id::operator uint8_t*() { return data; }
 
-inline Id::operator const uint8_t*() const {
-  return data;
-}
+inline Id::operator const uint8_t*() const { return data; }
 
 }  // namespace core
 
 namespace std {
 
-template <> struct hash<core::Id> {
-    inline size_t operator()(const core::Id& id) const {
-        size_t hash;
-        memcpy(&hash, id.data, sizeof(hash));
-        return hash;
-    }
+template <>
+struct hash<core::Id> {
+  inline size_t operator()(const core::Id& id) const {
+    size_t hash;
+    memcpy(&hash, id.data, sizeof(hash));
+    return hash;
+  }
 };
 
 }  // namespace std

--- a/core/cc/interval_list.h
+++ b/core/cc/interval_list.h
@@ -17,8 +17,8 @@
 #ifndef CORE_INTERVAL_LIST_H
 #define CORE_INTERVAL_LIST_H
 
-#include <cstdint>
 #include <algorithm>
+#include <cstdint>
 #include <vector>
 
 #include "core/cc/target.h"
@@ -29,260 +29,273 @@ namespace core {
 // This is the default interval type to be used by IntervalList<T>.
 template <typename T>
 struct Interval {
-    typedef T interval_unit_type;
+  typedef T interval_unit_type;
 
-    inline T    start() const { return mStart; }
-    inline T    end()   const { return mEnd; }
-    inline void adjust(T start, T end) { mStart = start; mEnd = end; }
+  inline T start() const { return mStart; }
+  inline T end() const { return mEnd; }
+  inline void adjust(T start, T end) {
+    mStart = start;
+    mEnd = end;
+  }
 
-    T mStart; // The index of the first item in the interval range.
-    T mEnd;   // The index of the one-past the last item in the interval range.
+  T mStart;  // The index of the first item in the interval range.
+  T mEnd;    // The index of the one-past the last item in the interval range.
 };
 
 // Interval equality operator.
 template <typename T>
-inline bool operator == (const Interval<T>& lhs, const Interval<T>& rhs) {
-    return lhs.start() == rhs.start() && lhs.end() == rhs.end();
+inline bool operator==(const Interval<T>& lhs, const Interval<T>& rhs) {
+  return lhs.start() == rhs.start() && lhs.end() == rhs.end();
 }
 
 // Range is a stl-compatibile iteratable that allows iteration over all
 // memory-contiguous elements of type T between a start and end pointer.
 template <typename T>
 class Range {
-public:
-    typedef T value_type;
-    typedef const T* const_iterator;
+ public:
+  typedef T value_type;
+  typedef const T* const_iterator;
 
-    // Constructs the iterable with a pointer to the first element in the list
-    // and a pointer to one-past the last element in the list.
-    inline Range(const T* start, const T* end) : mStart(start), mEnd(end) {}
+  // Constructs the iterable with a pointer to the first element in the list
+  // and a pointer to one-past the last element in the list.
+  inline Range(const T* start, const T* end) : mStart(start), mEnd(end) {}
 
-    // begin() returns the pointer to the first element in the list.
-    inline const T* begin() const { return mStart; }
-    // end() returns the pointer to one-past the last element in the list.
-    inline const T* end() const { return mEnd; }
-    // size() returns the number of items in the list.
-    inline const size_t size() const { return mEnd - mStart; }
-private:
-    const T* mStart;
-    const T* mEnd;
+  // begin() returns the pointer to the first element in the list.
+  inline const T* begin() const { return mStart; }
+  // end() returns the pointer to one-past the last element in the list.
+  inline const T* end() const { return mEnd; }
+  // size() returns the number of items in the list.
+  inline const size_t size() const { return mEnd - mStart; }
+
+ private:
+  const T* mStart;
+  const T* mEnd;
 };
 
 // CustomIntervalList holds a ascendingly-sorted list of custom interval types.
 // Intervals can be added to the list using merge(), where they may be merged
-// with existing intervals if the spans are within the specified merge-threshold.
-// Intervals can also be added to the list using replace(), where any completely
-// overlapping intervals are removed and partially overlapping intervals are
-// trimmed, before inserting the new interval.
+// with existing intervals if the spans are within the specified
+// merge-threshold. Intervals can also be added to the list using replace(),
+// where any completely overlapping intervals are removed and partially
+// overlapping intervals are trimmed, before inserting the new interval.
 // CustomIntervalList supports for-range looping.
 template <typename T>
 class CustomIntervalList {
-public:
-    typedef T                              value_type;
-    typedef const T*                       const_iterator;
-    typedef typename T::interval_unit_type interval_unit_type;
+ public:
+  typedef T value_type;
+  typedef const T* const_iterator;
+  typedef typename T::interval_unit_type interval_unit_type;
 
-    // Constructs an CustomIntervalList with a default merge threshold of 1.
-    inline CustomIntervalList();
+  // Constructs an CustomIntervalList with a default merge threshold of 1.
+  inline CustomIntervalList();
 
-    // intersect returns a iterable range covering all the intervals that
-    // intersect the span between start and end.
-    inline Range<T> intersect(interval_unit_type start, interval_unit_type end) const;
+  // intersect returns a iterable range covering all the intervals that
+  // intersect the span between start and end.
+  inline Range<T> intersect(interval_unit_type start,
+                            interval_unit_type end) const;
 
-    // replace removes and/or trims any intervals overlapping i and then adds i
-    // to this list. No merging is performed.
-    inline void replace(const T& i);
+  // replace removes and/or trims any intervals overlapping i and then adds i
+  // to this list. No merging is performed.
+  inline void replace(const T& i);
 
-    // merge adds the interval i to this list, merging any overlapping intervals.
-    inline void merge(const T& i);
+  // merge adds the interval i to this list, merging any overlapping intervals.
+  inline void merge(const T& i);
 
-    // setMergeThreshold sets the edge-distance threshold for merging intervals when
-    // calling merge(). Intervals will merge if: edge-distance < threshold.
-    // Examples:
-    // • A threshold of 0 will require intervals to overlap before they are merged.
-    // • A threshold of 1 will merge intervals if they overlap or touch edges.
-    // • A threshold of 2 will merge intervals as described above, and those with a
-    //   single unit gap.
-    // Changing the merge thresholds will not affect any existing intervals in the list.
-    inline void setMergeThreshold(interval_unit_type threshold);
+  // setMergeThreshold sets the edge-distance threshold for merging intervals
+  // when calling merge(). Intervals will merge if: edge-distance < threshold.
+  // Examples:
+  // • A threshold of 0 will require intervals to overlap before they are
+  // merged. • A threshold of 1 will merge intervals if they overlap or touch
+  // edges. • A threshold of 2 will merge intervals as described above, and
+  // those with a
+  //   single unit gap.
+  // Changing the merge thresholds will not affect any existing intervals in the
+  // list.
+  inline void setMergeThreshold(interval_unit_type threshold);
 
-    // clear removes all intervals from the list.
-    inline void clear();
+  // clear removes all intervals from the list.
+  inline void clear();
 
-    // count returns the number of intervals in the list.
-    inline uint32_t count() const;
+  // count returns the number of intervals in the list.
+  inline uint32_t count() const;
 
-    // begin() returns the pointer to the first interval in the list.
-    inline const T* begin() const;
+  // begin() returns the pointer to the first interval in the list.
+  inline const T* begin() const;
 
-    // end() returns the pointer to one-past the last interval in the list.
-    inline const T* end() const;
+  // end() returns the pointer to one-past the last interval in the list.
+  inline const T* end() const;
 
-    // operator[] returns the const reference to the element at the specified
-    // location pos.
-    inline const T& operator[](size_t pos) const;
+  // operator[] returns the const reference to the element at the specified
+  // location pos.
+  inline const T& operator[](size_t pos) const;
 
-protected:
-    // rangeFirst returns the index of the first interval + bias that touches or
-    // exceeds start.
-    inline ssize_t rangeFirst(interval_unit_type start, interval_unit_type bias) const;
+ protected:
+  // rangeFirst returns the index of the first interval + bias that touches or
+  // exceeds start.
+  inline ssize_t rangeFirst(interval_unit_type start,
+                            interval_unit_type bias) const;
 
-    // rangeLast returns the index of the last interval that touches or
-    // is less than end + bias.
-    inline ssize_t rangeLast(interval_unit_type end, interval_unit_type bias) const;
+  // rangeLast returns the index of the last interval that touches or
+  // is less than end + bias.
+  inline ssize_t rangeLast(interval_unit_type end,
+                           interval_unit_type bias) const;
 
-    std::vector< T > mIntervals;
-    interval_unit_type mMergeBias;
+  std::vector<T> mIntervals;
+  interval_unit_type mMergeBias;
 };
 
-template<typename T>
+template <typename T>
 CustomIntervalList<T>::CustomIntervalList() : mMergeBias(0) {}
 
-template<typename T>
-inline Range<T> CustomIntervalList<T>::intersect(interval_unit_type start, interval_unit_type end) const {
-    auto first = begin() + rangeFirst(start, -1);
-    auto last  = begin() + rangeLast(end, -1);
-    return Range<T>(first, last+1);
+template <typename T>
+inline Range<T> CustomIntervalList<T>::intersect(interval_unit_type start,
+                                                 interval_unit_type end) const {
+  auto first = begin() + rangeFirst(start, -1);
+  auto last = begin() + rangeLast(end, -1);
+  return Range<T>(first, last + 1);
 }
 
-template<typename T>
+template <typename T>
 inline void CustomIntervalList<T>::replace(const T& i) {
-    auto first = rangeFirst(i.start(), mMergeBias);
-    auto last  = rangeLast(i.end(), mMergeBias);
+  auto first = rangeFirst(i.start(), mMergeBias);
+  auto last = rangeLast(i.end(), mMergeBias);
 
-    if (first <= last) {
-        bool trimTail = mIntervals[first].start() < i.start();
-        bool trimHead = mIntervals[last].end() > i.end();
+  if (first <= last) {
+    bool trimTail = mIntervals[first].start() < i.start();
+    bool trimHead = mIntervals[last].end() > i.end();
 
-        if (first == last && trimTail && trimHead) {
-            // i sits within a single interval. Split it into two.
-            //           ┏━━━━━━━━━━━━━━┓
-            //           ┗━━━━━━━━━━━━━━┛
-            //━━━━━━━━━━━┳═─═─═─═─═─═─═─┳━━━━━━━━━━━
-            //━━━━━━━━━━━┻─═─═─═─═─═─═─═┻━━━━━━━━━━━
-            auto interval = mIntervals.begin() + first;
-            mIntervals.insert(interval, *interval);
-            last++;
-        }
-        if (trimTail) {
-            // Trim end of first interval.
-            //           ┏━━━━━━━━━━━━━━━━
-            //           ┗━━━━━━━━━━━━━━━━
-            //━━━━━━━━━━━┳═─═─╗
-            //━━━━━━━━━━━┻─═─═┘
-            auto interval = mIntervals.begin() + first;
-            interval->adjust(interval->start(), i.start());
-            first++; // Don't erase the first interval.
-        }
-        if (trimHead) {
-            // Trim front of last interval.
-            //━━━━━━━━━━━━━━━━┓
-            //━━━━━━━━━━━━━━━━┛
-            //           ┌═─═─┳━━━━━━━━━━━
-            //           ╚─═─═┻━━━━━━━━━━━
-            auto interval = mIntervals.begin() + last;
-            interval->adjust(i.end(), interval->end());
-            last--; // Don't erase the last interval.
-        }
-        if (first <= last) {
-            auto from = mIntervals.begin() + first;
-            auto to = mIntervals.begin() + last + 1;
-            mIntervals.erase(from, to);
-        }
+    if (first == last && trimTail && trimHead) {
+      // i sits within a single interval. Split it into two.
+      //           ┏━━━━━━━━━━━━━━┓
+      //           ┗━━━━━━━━━━━━━━┛
+      //━━━━━━━━━━━┳═─═─═─═─═─═─═─┳━━━━━━━━━━━
+      //━━━━━━━━━━━┻─═─═─═─═─═─═─═┻━━━━━━━━━━━
+      auto interval = mIntervals.begin() + first;
+      mIntervals.insert(interval, *interval);
+      last++;
     }
-    mIntervals.insert(mIntervals.begin() + first, i);
+    if (trimTail) {
+      // Trim end of first interval.
+      //           ┏━━━━━━━━━━━━━━━━
+      //           ┗━━━━━━━━━━━━━━━━
+      //━━━━━━━━━━━┳═─═─╗
+      //━━━━━━━━━━━┻─═─═┘
+      auto interval = mIntervals.begin() + first;
+      interval->adjust(interval->start(), i.start());
+      first++;  // Don't erase the first interval.
+    }
+    if (trimHead) {
+      // Trim front of last interval.
+      //━━━━━━━━━━━━━━━━┓
+      //━━━━━━━━━━━━━━━━┛
+      //           ┌═─═─┳━━━━━━━━━━━
+      //           ╚─═─═┻━━━━━━━━━━━
+      auto interval = mIntervals.begin() + last;
+      interval->adjust(i.end(), interval->end());
+      last--;  // Don't erase the last interval.
+    }
+    if (first <= last) {
+      auto from = mIntervals.begin() + first;
+      auto to = mIntervals.begin() + last + 1;
+      mIntervals.erase(from, to);
+    }
+  }
+  mIntervals.insert(mIntervals.begin() + first, i);
 }
 
-template<typename T>
+template <typename T>
 inline void CustomIntervalList<T>::merge(const T& i) {
-    auto first = rangeFirst(i.start(), mMergeBias);
-    auto last  = rangeLast(i.end(), mMergeBias);
-    auto from = mIntervals.begin() + first;
-    if (first <= last) {
-        auto to = mIntervals.begin() + last;
-        auto low = std::min(from->start(), i.start());
-        auto high = std::max(to->end(), i.end());
-        T* f = &(*from);
-        mIntervals.erase(from, to);
-        f->adjust(low, high);
-    } else {
-        mIntervals.insert(from, i);
-    }
+  auto first = rangeFirst(i.start(), mMergeBias);
+  auto last = rangeLast(i.end(), mMergeBias);
+  auto from = mIntervals.begin() + first;
+  if (first <= last) {
+    auto to = mIntervals.begin() + last;
+    auto low = std::min(from->start(), i.start());
+    auto high = std::max(to->end(), i.end());
+    T* f = &(*from);
+    mIntervals.erase(from, to);
+    f->adjust(low, high);
+  } else {
+    mIntervals.insert(from, i);
+  }
 }
 
-template<typename T>
-inline void CustomIntervalList<T>::setMergeThreshold(interval_unit_type threshold) {
-    mMergeBias = threshold - 1;
+template <typename T>
+inline void CustomIntervalList<T>::setMergeThreshold(
+    interval_unit_type threshold) {
+  mMergeBias = threshold - 1;
 }
 
-template<typename T>
+template <typename T>
 inline void CustomIntervalList<T>::clear() {
-    mIntervals.clear();
+  mIntervals.clear();
 }
 
-template<typename T>
+template <typename T>
 inline uint32_t CustomIntervalList<T>::count() const {
-    return mIntervals.size();
+  return mIntervals.size();
 }
 
-template<typename T>
+template <typename T>
 inline const T* CustomIntervalList<T>::begin() const {
-    if (count() > 0) {
-        return &mIntervals[0];
-    } else {
-        return nullptr;
-    }
+  if (count() > 0) {
+    return &mIntervals[0];
+  } else {
+    return nullptr;
+  }
 }
 
-template<typename T>
+template <typename T>
 inline const T* CustomIntervalList<T>::end() const {
-    size_t c = mIntervals.size();
-    if (c > 0) {
-        return &mIntervals[0] + c;
-    } else {
-        return nullptr;
-    }
+  size_t c = mIntervals.size();
+  if (c > 0) {
+    return &mIntervals[0] + c;
+  } else {
+    return nullptr;
+  }
 }
 
-template<typename T>
+template <typename T>
 inline const T& CustomIntervalList<T>::operator[](size_t pos) const {
   return mIntervals[pos];
 }
 
-template<typename T>
-inline ssize_t CustomIntervalList<T>::rangeFirst(interval_unit_type start, interval_unit_type bias) const {
-    ssize_t l = 0;
-    ssize_t h = mIntervals.size();
-    while (l != h) {
-        ssize_t m = (l + h) / 2;
-        if (mIntervals[m].end() + bias >= start) {
-            h = m;
-        } else {
-            l = m + 1;
-        }
+template <typename T>
+inline ssize_t CustomIntervalList<T>::rangeFirst(
+    interval_unit_type start, interval_unit_type bias) const {
+  ssize_t l = 0;
+  ssize_t h = mIntervals.size();
+  while (l != h) {
+    ssize_t m = (l + h) / 2;
+    if (mIntervals[m].end() + bias >= start) {
+      h = m;
+    } else {
+      l = m + 1;
     }
-    return l;
+  }
+  return l;
 }
 
-template<typename T>
-inline ssize_t CustomIntervalList<T>::rangeLast(interval_unit_type end, interval_unit_type bias) const {
-    ssize_t l = -1;
-    ssize_t h = mIntervals.size() - 1;
-    while (l != h) {
-        ssize_t m = (l + h + 1) / 2;
-        if (mIntervals[m].start() <= end + bias) {
-            l = m;
-        } else {
-            h = m - 1;
-        }
+template <typename T>
+inline ssize_t CustomIntervalList<T>::rangeLast(interval_unit_type end,
+                                                interval_unit_type bias) const {
+  ssize_t l = -1;
+  ssize_t h = mIntervals.size() - 1;
+  while (l != h) {
+    ssize_t m = (l + h + 1) / 2;
+    if (mIntervals[m].start() <= end + bias) {
+      l = m;
+    } else {
+      h = m - 1;
     }
-    return l;
+  }
+  return l;
 }
 
 // IntervalList holds a ascendingly-sorted list of Interval<T>s.
 // See CustomIntervalList for more information.
 template <typename T>
-class IntervalList : public CustomIntervalList< Interval<T> > {};
+class IntervalList : public CustomIntervalList<Interval<T> > {};
 
 }  // namespace core
 

--- a/core/cc/interval_list_test.cpp
+++ b/core/cc/interval_list_test.cpp
@@ -26,122 +26,124 @@ namespace core {
 
 template <typename T>
 ::std::ostream& operator<<(::std::ostream& os, const Interval<T>& interval) {
-    return os << "[" << interval.start() << " - " << interval.end()-1 << "]";
+  return os << "[" << interval.start() << " - " << interval.end() - 1 << "]";
 }
 
 template <typename T>
 ::std::ostream& operator<<(::std::ostream& os, const IntervalList<T>& l) {
-    os << "IntervalList{";
-    for (auto i : l) {
-        os << i;
-    }
-    return os << "}";
+  os << "IntervalList{";
+  for (auto i : l) {
+    os << i;
+  }
+  return os << "}";
 }
 
 namespace test {
 
-Interval<int> I(int first, int last) {
-    return Interval<int>{first, last + 1};
-}
-
+Interval<int> I(int first, int last) { return Interval<int>{first, last + 1}; }
 
 class IntervalListTest : public ::testing::Test, public IntervalList<int> {
-public:
-    inline IntervalList<int>& L() {
-        return *static_cast<IntervalList<int>*>(this);
-    }
+ public:
+  inline IntervalList<int>& L() {
+    return *static_cast<IntervalList<int>*>(this);
+  }
 };
 
 TEST_F(IntervalListTest, IntersectEmpty) {
-    EXPECT_THAT(L().intersect(0, 5), testing::ElementsAre());
+  EXPECT_THAT(L().intersect(0, 5), testing::ElementsAre());
 }
 
 TEST_F(IntervalListTest, Intersect) {
-    merge(I(0x2, 0x4)); // 0
-    merge(I(0x8, 0x9)); // 1
-    merge(I(0xb, 0xc)); // 2
+  merge(I(0x2, 0x4));  // 0
+  merge(I(0x8, 0x9));  // 1
+  merge(I(0xb, 0xc));  // 2
 
-    struct test {
-        Interval<int>              interval;
-        std::vector<Interval<int>> expected;
-    };
-    for (auto t : {
-        test{I(0x0, 0x0), {}},
-        test{I(0x1, 0x1), {}},
-        test{I(0x2, 0x2), {I(0x2, 0x4)}},
-        test{I(0x3, 0x3), {I(0x2, 0x4)}},
-        test{I(0x4, 0x4), {I(0x2, 0x4)}},
-        test{I(0x5, 0x5), {}},
-        test{I(0x6, 0x6), {}},
-        test{I(0x7, 0x7), {}},
-        test{I(0x8, 0x8), {I(0x8, 0x9)}},
-        test{I(0x9, 0x9), {I(0x8, 0x9)}},
-        test{I(0xa, 0xa), {}},
-        test{I(0xb, 0xb), {I(0xb, 0xc)}},
-        test{I(0xc, 0xc), {I(0xb, 0xc)}},
-        test{I(0xd, 0xd), {}},
+  struct test {
+    Interval<int> interval;
+    std::vector<Interval<int>> expected;
+  };
+  for (auto t : {
+           test{I(0x0, 0x0), {}},
+           test{I(0x1, 0x1), {}},
+           test{I(0x2, 0x2), {I(0x2, 0x4)}},
+           test{I(0x3, 0x3), {I(0x2, 0x4)}},
+           test{I(0x4, 0x4), {I(0x2, 0x4)}},
+           test{I(0x5, 0x5), {}},
+           test{I(0x6, 0x6), {}},
+           test{I(0x7, 0x7), {}},
+           test{I(0x8, 0x8), {I(0x8, 0x9)}},
+           test{I(0x9, 0x9), {I(0x8, 0x9)}},
+           test{I(0xa, 0xa), {}},
+           test{I(0xb, 0xb), {I(0xb, 0xc)}},
+           test{I(0xc, 0xc), {I(0xb, 0xc)}},
+           test{I(0xd, 0xd), {}},
 
-        test{I(0x0, 0xe), {I(0x2, 0x4), I(0x8, 0x9), I(0xb, 0xc)}},
-    }) {
-        auto intersection = L().intersect(t.interval.start(), t.interval.end());
-        EXPECT_THAT(intersection, ElementsAreArray(t.expected));
-    }
+           test{I(0x0, 0xe), {I(0x2, 0x4), I(0x8, 0x9), I(0xb, 0xc)}},
+       }) {
+    auto intersection = L().intersect(t.interval.start(), t.interval.end());
+    EXPECT_THAT(intersection, ElementsAreArray(t.expected));
+  }
 }
 
 TEST_F(IntervalListTest, ReplaceEmpty) {
-    replace(I(0x2, 0x4));
-    EXPECT_THAT(L(), ElementsAre(I(0x2, 0x4)));
+  replace(I(0x2, 0x4));
+  EXPECT_THAT(L(), ElementsAre(I(0x2, 0x4)));
 }
 
 TEST_F(IntervalListTest, Replace) {
-    struct test {
-        Interval<int>              interval;
-        std::vector<Interval<int>> expected;
-    };
-    for (auto t : {
-        test{I(0x0, 0x0), {I(0x0, 0x0), I(0x2, 0x4), I(0x8, 0x9), I(0xb, 0xc)}},
-        test{I(0x2, 0x2), {I(0x2, 0x2), I(0x3, 0x4), I(0x8, 0x9), I(0xb, 0xc)}},
-        test{I(0x1, 0x3), {I(0x1, 0x3), I(0x4, 0x4), I(0x8, 0x9), I(0xb, 0xc)}},
-        test{I(0x1, 0x8), {I(0x1, 0x8), I(0x9, 0x9), I(0xb, 0xc)}},
-        test{I(0x2, 0x9), {I(0x2, 0x9), I(0xb, 0xc)}},
-        test{I(0x3, 0xa), {I(0x2, 0x2), I(0x3, 0xa), I(0xb, 0xc)}},
-        test{I(0x4, 0xb), {I(0x2, 0x3), I(0x4, 0xb), I(0xc, 0xc)}},
-        test{I(0x5, 0xc), {I(0x2, 0x4), I(0x5, 0xc)}},
-        test{I(0x5, 0xa), {I(0x2, 0x4), I(0x5, 0xa), I(0xb, 0xc)}},
-        test{I(0x3, 0x3), {I(0x2, 0x2), I(0x3, 0x3), I(0x4, 0x4), I(0x8, 0x9), I(0xb, 0xc)}},
-    }) {
-        clear();
-        merge(I(0x2, 0x4)); // 0
-        merge(I(0x8, 0x9)); // 1
-        merge(I(0xb, 0xc)); // 2
+  struct test {
+    Interval<int> interval;
+    std::vector<Interval<int>> expected;
+  };
+  for (auto t : {
+           test{I(0x0, 0x0),
+                {I(0x0, 0x0), I(0x2, 0x4), I(0x8, 0x9), I(0xb, 0xc)}},
+           test{I(0x2, 0x2),
+                {I(0x2, 0x2), I(0x3, 0x4), I(0x8, 0x9), I(0xb, 0xc)}},
+           test{I(0x1, 0x3),
+                {I(0x1, 0x3), I(0x4, 0x4), I(0x8, 0x9), I(0xb, 0xc)}},
+           test{I(0x1, 0x8), {I(0x1, 0x8), I(0x9, 0x9), I(0xb, 0xc)}},
+           test{I(0x2, 0x9), {I(0x2, 0x9), I(0xb, 0xc)}},
+           test{I(0x3, 0xa), {I(0x2, 0x2), I(0x3, 0xa), I(0xb, 0xc)}},
+           test{I(0x4, 0xb), {I(0x2, 0x3), I(0x4, 0xb), I(0xc, 0xc)}},
+           test{I(0x5, 0xc), {I(0x2, 0x4), I(0x5, 0xc)}},
+           test{I(0x5, 0xa), {I(0x2, 0x4), I(0x5, 0xa), I(0xb, 0xc)}},
+           test{I(0x3, 0x3),
+                {I(0x2, 0x2), I(0x3, 0x3), I(0x4, 0x4), I(0x8, 0x9),
+                 I(0xb, 0xc)}},
+       }) {
+    clear();
+    merge(I(0x2, 0x4));  // 0
+    merge(I(0x8, 0x9));  // 1
+    merge(I(0xb, 0xc));  // 2
 
-        replace(t.interval);
-        EXPECT_THAT(L(), ElementsAreArray(t.expected));
-    }
+    replace(t.interval);
+    EXPECT_THAT(L(), ElementsAreArray(t.expected));
+  }
 }
 
 TEST_F(IntervalListTest, Empty) {
-    EXPECT_EQ(count(), 0);
-    EXPECT_EQ(begin(), end());
+  EXPECT_EQ(count(), 0);
+  EXPECT_EQ(begin(), end());
 }
 
 TEST_F(IntervalListTest, SingleMerge) {
-    merge(I(1, 2));
-    EXPECT_THAT(L(), ElementsAreArray({I(1, 2)}));
+  merge(I(1, 2));
+  EXPECT_THAT(L(), ElementsAreArray({I(1, 2)}));
 }
 
 TEST_F(IntervalListTest, MergeSparseForward) {
-    merge(I(1, 2));
-    merge(I(4, 5));
-    merge(I(7, 8));
-    EXPECT_THAT(L(), ElementsAre(I(1, 2), I(4, 5), I(7, 8)));
+  merge(I(1, 2));
+  merge(I(4, 5));
+  merge(I(7, 8));
+  EXPECT_THAT(L(), ElementsAre(I(1, 2), I(4, 5), I(7, 8)));
 }
 
 TEST_F(IntervalListTest, MergeSparseReverse) {
-    merge(I(7, 8));
-    merge(I(4, 5));
-    merge(I(1, 2));
-    EXPECT_THAT(L(), ElementsAre(I(1, 2), I(4, 5), I(7, 8)));
+  merge(I(7, 8));
+  merge(I(4, 5));
+  merge(I(1, 2));
+  EXPECT_THAT(L(), ElementsAre(I(1, 2), I(4, 5), I(7, 8)));
 }
 
 //   0   1   2   3   4   5   6   7   8   9   A   B   C   D   E
@@ -172,199 +174,199 @@ auto j = I(0x8, 0xc);
 auto k = I(0x0, 0xe);
 
 TEST_F(IntervalListTest, Merge) {
-    struct test {
-        const char*                name;
-        Interval<int>              interval;
-        std::vector<Interval<int>> expected;
-    };
-    for (auto t : {
-        test{"a", a, { I(0x0, 0x0), I(0x2, 0x4), I(0x8, 0x9), I(0xb, 0xc) } },
-        test{"b", b, { I(0x1, 0x4), I(0x8, 0x9), I(0xb, 0xc) } },
-        test{"c", c, { I(0x2, 0x4), I(0x8, 0x9), I(0xb, 0xc) } },
-        test{"d", d, { I(0x2, 0x5), I(0x8, 0x9), I(0xb, 0xc) } },
-        test{"e", e, { I(0x2, 0x4), I(0x7, 0x9), I(0xb, 0xc) } },
-        test{"f", f, { I(0x2, 0x4), I(0x8, 0xc) } },
-        test{"g", g, { I(0x2, 0x4), I(0x8, 0x9), I(0xb, 0xd) } },
-        test{"h", h, { I(0x2, 0x4), I(0x8, 0x9), I(0xb, 0xc), I(0xe, 0xe) } },
-        test{"i", i, { I(0x1, 0x5), I(0x8, 0x9), I(0xb, 0xc) } },
-        test{"j", j, { I(0x2, 0x4), I(0x8, 0xc) } },
-        test{"k", k, { I(0x0, 0xe) } },
-    }) {
-        clear();
-        merge(I(0x2, 0x4)); // 0
-        merge(I(0x8, 0x9)); // 1
-        merge(I(0xb, 0xc)); // 2
+  struct test {
+    const char* name;
+    Interval<int> interval;
+    std::vector<Interval<int>> expected;
+  };
+  for (auto t : {
+           test{"a", a, {I(0x0, 0x0), I(0x2, 0x4), I(0x8, 0x9), I(0xb, 0xc)}},
+           test{"b", b, {I(0x1, 0x4), I(0x8, 0x9), I(0xb, 0xc)}},
+           test{"c", c, {I(0x2, 0x4), I(0x8, 0x9), I(0xb, 0xc)}},
+           test{"d", d, {I(0x2, 0x5), I(0x8, 0x9), I(0xb, 0xc)}},
+           test{"e", e, {I(0x2, 0x4), I(0x7, 0x9), I(0xb, 0xc)}},
+           test{"f", f, {I(0x2, 0x4), I(0x8, 0xc)}},
+           test{"g", g, {I(0x2, 0x4), I(0x8, 0x9), I(0xb, 0xd)}},
+           test{"h", h, {I(0x2, 0x4), I(0x8, 0x9), I(0xb, 0xc), I(0xe, 0xe)}},
+           test{"i", i, {I(0x1, 0x5), I(0x8, 0x9), I(0xb, 0xc)}},
+           test{"j", j, {I(0x2, 0x4), I(0x8, 0xc)}},
+           test{"k", k, {I(0x0, 0xe)}},
+       }) {
+    clear();
+    merge(I(0x2, 0x4));  // 0
+    merge(I(0x8, 0x9));  // 1
+    merge(I(0xb, 0xc));  // 2
 
-        merge(t.interval);
+    merge(t.interval);
 
-        EXPECT_THAT(L(), ElementsAreArray(t.expected));
-    }
+    EXPECT_THAT(L(), ElementsAreArray(t.expected));
+  }
 }
 
 TEST_F(IntervalListTest, MergeThreshold0) {
-    setMergeThreshold(0);
+  setMergeThreshold(0);
 
-    struct test {
-        const char*                name;
-        Interval<int>              interval;
-        std::vector<Interval<int>> expected;
-    };
-    for (auto t : {
-        test{"a", a, { I(0x0, 0x0), I(0x2, 0x4), I(0x8, 0x9), I(0xb, 0xc) } },
-        test{"b", b, { I(0x1, 0x1), I(0x2, 0x4), I(0x8, 0x9), I(0xb, 0xc) } },
-        test{"c", c, { I(0x2, 0x4), I(0x8, 0x9), I(0xb, 0xc) } },
-        test{"d", d, { I(0x2, 0x4), I(0x5, 0x5), I(0x8, 0x9), I(0xb, 0xc) } },
-        test{"e", e, { I(0x2, 0x4), I(0x7, 0x9), I(0xb, 0xc) } },
-        test{"f", f, { I(0x2, 0x4), I(0x8, 0xc) } },
-        test{"g", g, { I(0x2, 0x4), I(0x8, 0x9), I(0xb, 0xd) } },
-        test{"h", h, { I(0x2, 0x4), I(0x8, 0x9), I(0xb, 0xc), I(0xe, 0xe) } },
-        test{"i", i, { I(0x1, 0x5), I(0x8, 0x9), I(0xb, 0xc) } },
-        test{"j", j, { I(0x2, 0x4), I(0x8, 0xc) } },
-        test{"k", k, { I(0x0, 0xe) } },
-    }) {
-        clear();
-        merge(I(0x2, 0x4)); // 0
-        merge(I(0x8, 0x9)); // 1
-        merge(I(0xb, 0xc)); // 2
+  struct test {
+    const char* name;
+    Interval<int> interval;
+    std::vector<Interval<int>> expected;
+  };
+  for (auto t : {
+           test{"a", a, {I(0x0, 0x0), I(0x2, 0x4), I(0x8, 0x9), I(0xb, 0xc)}},
+           test{"b", b, {I(0x1, 0x1), I(0x2, 0x4), I(0x8, 0x9), I(0xb, 0xc)}},
+           test{"c", c, {I(0x2, 0x4), I(0x8, 0x9), I(0xb, 0xc)}},
+           test{"d", d, {I(0x2, 0x4), I(0x5, 0x5), I(0x8, 0x9), I(0xb, 0xc)}},
+           test{"e", e, {I(0x2, 0x4), I(0x7, 0x9), I(0xb, 0xc)}},
+           test{"f", f, {I(0x2, 0x4), I(0x8, 0xc)}},
+           test{"g", g, {I(0x2, 0x4), I(0x8, 0x9), I(0xb, 0xd)}},
+           test{"h", h, {I(0x2, 0x4), I(0x8, 0x9), I(0xb, 0xc), I(0xe, 0xe)}},
+           test{"i", i, {I(0x1, 0x5), I(0x8, 0x9), I(0xb, 0xc)}},
+           test{"j", j, {I(0x2, 0x4), I(0x8, 0xc)}},
+           test{"k", k, {I(0x0, 0xe)}},
+       }) {
+    clear();
+    merge(I(0x2, 0x4));  // 0
+    merge(I(0x8, 0x9));  // 1
+    merge(I(0xb, 0xc));  // 2
 
-        merge(t.interval);
+    merge(t.interval);
 
-        EXPECT_THAT(L(), ElementsAreArray(t.expected));
-    }
+    EXPECT_THAT(L(), ElementsAreArray(t.expected));
+  }
 }
 
 TEST_F(IntervalListTest, MergeThreshold2) {
-    setMergeThreshold(2);
+  setMergeThreshold(2);
 
-    struct test {
-        const char*                name;
-        Interval<int>              interval;
-        std::vector<Interval<int>> expected;
-    };
-    for (auto t : {
-        test{"a", a, { I(0x0, 0x4), I(0x8, 0xc) } },
-        test{"b", b, { I(0x1, 0x4), I(0x8, 0xc) } },
-        test{"c", c, { I(0x2, 0x4), I(0x8, 0xc) } },
-        test{"d", d, { I(0x2, 0x5), I(0x8, 0xc) } },
-        test{"e", e, { I(0x2, 0x4), I(0x7, 0xc) } },
-        test{"f", f, { I(0x2, 0x4), I(0x8, 0xc) } },
-        test{"g", g, { I(0x2, 0x4), I(0x8, 0xd) } },
-        test{"h", h, { I(0x2, 0x4), I(0x8, 0xe) } },
-        test{"i", i, { I(0x1, 0x5), I(0x8, 0xc) } },
-        test{"j", j, { I(0x2, 0x4), I(0x8, 0xc) } },
-        test{"k", k, { I(0x0, 0xe) } },
-    }) {
-        clear();
-        merge(I(0x2, 0x4)); // 0
-        merge(I(0x8, 0x9)); // 1
-        merge(I(0xb, 0xc)); // 2
+  struct test {
+    const char* name;
+    Interval<int> interval;
+    std::vector<Interval<int>> expected;
+  };
+  for (auto t : {
+           test{"a", a, {I(0x0, 0x4), I(0x8, 0xc)}},
+           test{"b", b, {I(0x1, 0x4), I(0x8, 0xc)}},
+           test{"c", c, {I(0x2, 0x4), I(0x8, 0xc)}},
+           test{"d", d, {I(0x2, 0x5), I(0x8, 0xc)}},
+           test{"e", e, {I(0x2, 0x4), I(0x7, 0xc)}},
+           test{"f", f, {I(0x2, 0x4), I(0x8, 0xc)}},
+           test{"g", g, {I(0x2, 0x4), I(0x8, 0xd)}},
+           test{"h", h, {I(0x2, 0x4), I(0x8, 0xe)}},
+           test{"i", i, {I(0x1, 0x5), I(0x8, 0xc)}},
+           test{"j", j, {I(0x2, 0x4), I(0x8, 0xc)}},
+           test{"k", k, {I(0x0, 0xe)}},
+       }) {
+    clear();
+    merge(I(0x2, 0x4));  // 0
+    merge(I(0x8, 0x9));  // 1
+    merge(I(0xb, 0xc));  // 2
 
-        merge(t.interval);
+    merge(t.interval);
 
-        EXPECT_THAT(L(), ElementsAreArray(t.expected));
-    }
+    EXPECT_THAT(L(), ElementsAreArray(t.expected));
+  }
 }
 
 TEST_F(IntervalListTest, MergeThreshold3) {
-    setMergeThreshold(3);
+  setMergeThreshold(3);
 
-    struct test {
-        const char*                name;
-        Interval<int>              interval;
-        std::vector<Interval<int>> expected;
-    };
-    for (auto t : {
-        test{"a", a, { I(0x0, 0x4), I(0x8, 0xc) } },
-        test{"b", b, { I(0x1, 0x4), I(0x8, 0xc) } },
-        test{"c", c, { I(0x2, 0x4), I(0x8, 0xc) } },
-        test{"d", d, { I(0x2, 0xc) } },
-        test{"e", e, { I(0x2, 0xc) } },
-        test{"f", f, { I(0x2, 0x4), I(0x8, 0xc) } },
-        test{"g", g, { I(0x2, 0x4), I(0x8, 0xd) } },
-        test{"h", h, { I(0x2, 0x4), I(0x8, 0xe) } },
-        test{"i", i, { I(0x1, 0xc) } },
-        test{"j", j, { I(0x2, 0x4), I(0x8, 0xc) } },
-        test{"k", k, { I(0x0, 0xe) } },
-    }) {
-        clear();
-        merge(I(0x2, 0x4)); // 0
-        merge(I(0x8, 0x9)); // 1
-        merge(I(0xb, 0xc)); // 2
+  struct test {
+    const char* name;
+    Interval<int> interval;
+    std::vector<Interval<int>> expected;
+  };
+  for (auto t : {
+           test{"a", a, {I(0x0, 0x4), I(0x8, 0xc)}},
+           test{"b", b, {I(0x1, 0x4), I(0x8, 0xc)}},
+           test{"c", c, {I(0x2, 0x4), I(0x8, 0xc)}},
+           test{"d", d, {I(0x2, 0xc)}},
+           test{"e", e, {I(0x2, 0xc)}},
+           test{"f", f, {I(0x2, 0x4), I(0x8, 0xc)}},
+           test{"g", g, {I(0x2, 0x4), I(0x8, 0xd)}},
+           test{"h", h, {I(0x2, 0x4), I(0x8, 0xe)}},
+           test{"i", i, {I(0x1, 0xc)}},
+           test{"j", j, {I(0x2, 0x4), I(0x8, 0xc)}},
+           test{"k", k, {I(0x0, 0xe)}},
+       }) {
+    clear();
+    merge(I(0x2, 0x4));  // 0
+    merge(I(0x8, 0x9));  // 1
+    merge(I(0xb, 0xc));  // 2
 
-        merge(t.interval);
+    merge(t.interval);
 
-        EXPECT_THAT(L(), ElementsAreArray(t.expected));
-    }
+    EXPECT_THAT(L(), ElementsAreArray(t.expected));
+  }
 }
 
 TEST_F(IntervalListTest, MergeThreshold4) {
-    setMergeThreshold(4);
+  setMergeThreshold(4);
 
-    struct test {
-        const char*                name;
-        Interval<int>              interval;
-        std::vector<Interval<int>> expected;
-    };
-    for (auto t : {
-        test{"a", a, { I(0x0, 0xc) } },
-        test{"b", b, { I(0x1, 0xc) } },
-        test{"c", c, { I(0x2, 0xc) } },
-        test{"d", d, { I(0x2, 0xc) } },
-        test{"e", e, { I(0x2, 0xc) } },
-        test{"f", f, { I(0x2, 0xc) } },
-        test{"g", g, { I(0x2, 0xd) } },
-        test{"h", h, { I(0x2, 0xe) } },
-        test{"i", i, { I(0x1, 0xc) } },
-        test{"j", j, { I(0x2, 0xc) } },
-        test{"k", k, { I(0x0, 0xe) } },
-    }) {
-        clear();
-        merge(I(0x2, 0x4)); // 0
-        merge(I(0x8, 0x9)); // 1
-        merge(I(0xb, 0xc)); // 2
+  struct test {
+    const char* name;
+    Interval<int> interval;
+    std::vector<Interval<int>> expected;
+  };
+  for (auto t : {
+           test{"a", a, {I(0x0, 0xc)}},
+           test{"b", b, {I(0x1, 0xc)}},
+           test{"c", c, {I(0x2, 0xc)}},
+           test{"d", d, {I(0x2, 0xc)}},
+           test{"e", e, {I(0x2, 0xc)}},
+           test{"f", f, {I(0x2, 0xc)}},
+           test{"g", g, {I(0x2, 0xd)}},
+           test{"h", h, {I(0x2, 0xe)}},
+           test{"i", i, {I(0x1, 0xc)}},
+           test{"j", j, {I(0x2, 0xc)}},
+           test{"k", k, {I(0x0, 0xe)}},
+       }) {
+    clear();
+    merge(I(0x2, 0x4));  // 0
+    merge(I(0x8, 0x9));  // 1
+    merge(I(0xb, 0xc));  // 2
 
-        merge(t.interval);
+    merge(t.interval);
 
-        EXPECT_THAT(L(), ElementsAreArray(t.expected));
-    }
+    EXPECT_THAT(L(), ElementsAreArray(t.expected));
+  }
 }
 
 TEST_F(IntervalListTest, rangeFirstLast) {
-    merge(I(0x2, 0x4)); // 0
-    merge(I(0x8, 0x9)); // 1
-    merge(I(0xb, 0xc)); // 2
+  merge(I(0x2, 0x4));  // 0
+  merge(I(0x8, 0x9));  // 1
+  merge(I(0xb, 0xc));  // 2
 
-    struct test {
-        const char*   name;
-        Interval<int> interval;
-        int           start;
-        int           end;
-    };
-    for (auto t : {
-        test{"a", a, 0, -1},
-        test{"b", b, 0, 0},
-        test{"c", c, 0, 0},
-        test{"d", d, 0, 0},
-        test{"e", e, 1, 1},
-        test{"f", f, 1, 2},
-        test{"g", g, 2, 2},
-        test{"h", h, 3, 2},
-        test{"i", i, 0, 0},
-        test{"j", j, 1, 2},
-        test{"k", k, 0, 2},
-    }) {
-        int s = rangeFirst(t.interval.start(), 0);
-        int e = rangeLast(t.interval.end(), 0);
-        if (t.start != s) {
-            ADD_FAILURE() << t.name << ": l.rangeFirst(" << t.interval << ") "
-                    "returned " << s << ", expected " << t.start;
-        }
-        if (t.end != e) {
-            ADD_FAILURE() << t.name << ": l.rangeEnd(" << t.interval << ") "
-                    "returned " << e << ", expected " << t.end;
-        }
+  struct test {
+    const char* name;
+    Interval<int> interval;
+    int start;
+    int end;
+  };
+  for (auto t : {
+           test{"a", a, 0, -1},
+           test{"b", b, 0, 0},
+           test{"c", c, 0, 0},
+           test{"d", d, 0, 0},
+           test{"e", e, 1, 1},
+           test{"f", f, 1, 2},
+           test{"g", g, 2, 2},
+           test{"h", h, 3, 2},
+           test{"i", i, 0, 0},
+           test{"j", j, 1, 2},
+           test{"k", k, 0, 2},
+       }) {
+    int s = rangeFirst(t.interval.start(), 0);
+    int e = rangeLast(t.interval.end(), 0);
+    if (t.start != s) {
+      ADD_FAILURE() << t.name << ": l.rangeFirst(" << t.interval
+                    << ") returned " << s << ", expected " << t.start;
     }
+    if (t.end != e) {
+      ADD_FAILURE() << t.name << ": l.rangeEnd(" << t.interval << ") returned "
+                    << e << ", expected " << t.end;
+    }
+  }
 }
 
-} // namespace test
+}  // namespace test
 }  // namespace core

--- a/core/cc/linux/crash_handler.cpp
+++ b/core/cc/linux/crash_handler.cpp
@@ -22,37 +22,39 @@
 
 namespace {
 
-static bool handleCrash(const google_breakpad::MinidumpDescriptor& descriptor, void* crashHandlerPtr, bool succeeded) {
-    core::CrashHandler* crashHandler = reinterpret_cast<core::CrashHandler*>(crashHandlerPtr);
-    std::string minidumpPath(descriptor.path());
-    return crashHandler->handleMinidump(minidumpPath, succeeded);
+static bool handleCrash(const google_breakpad::MinidumpDescriptor& descriptor,
+                        void* crashHandlerPtr, bool succeeded) {
+  core::CrashHandler* crashHandler =
+      reinterpret_cast<core::CrashHandler*>(crashHandlerPtr);
+  std::string minidumpPath(descriptor.path());
+  return crashHandler->handleMinidump(minidumpPath, succeeded);
 }
 
-}
+}  // namespace
 
 namespace core {
 
 namespace {
 const char* GetTempDir() {
-    const char* tmpdir = getenv("TMPDIR");
-    if (!tmpdir) {
-        tmpdir = "/tmp";
-    }
-    return tmpdir;
+  const char* tmpdir = getenv("TMPDIR");
+  if (!tmpdir) {
+    tmpdir = "/tmp";
+  }
+  return tmpdir;
 }
-} // namespace
+}  // namespace
 
-CrashHandler::CrashHandler() :
-    mNextHandlerID(0),
-    mExceptionHandler(new google_breakpad::ExceptionHandler(
-            google_breakpad::MinidumpDescriptor(GetTempDir()),
-            NULL, ::handleCrash, reinterpret_cast<void*>(this), true, -1)) {
-
-    registerHandler(defaultHandler);
+CrashHandler::CrashHandler()
+    : mNextHandlerID(0),
+      mExceptionHandler(new google_breakpad::ExceptionHandler(
+          google_breakpad::MinidumpDescriptor(GetTempDir()), NULL,
+          ::handleCrash, reinterpret_cast<void*>(this), true, -1)) {
+  registerHandler(defaultHandler);
 }
 
-// this prevents unique_ptr<CrashHandler> from causing an incomplete type error from inlining the destructor.
-// The incomplete type is the previously forward declared google_breakpad::ExceptionHandler.
+// this prevents unique_ptr<CrashHandler> from causing an incomplete type error
+// from inlining the destructor. The incomplete type is the previously forward
+// declared google_breakpad::ExceptionHandler.
 CrashHandler::~CrashHandler() = default;
 
-} // namespace core
+}  // namespace core

--- a/core/cc/linux/debugger.cpp
+++ b/core/cc/linux/debugger.cpp
@@ -21,12 +21,10 @@ static volatile bool gIsDebuggerAttached = false;
 namespace core {
 
 void Debugger::waitForAttach() {
-    while (!isAttached()) {}
+  while (!isAttached()) {
+  }
 }
 
-bool Debugger::isAttached() {
-    return gIsDebuggerAttached;
-}
+bool Debugger::isAttached() { return gIsDebuggerAttached; }
 
 }  // namespace core
-

--- a/core/cc/linux/get_gles_proc_address.cpp
+++ b/core/cc/linux/get_gles_proc_address.cpp
@@ -14,60 +14,68 @@
  * limitations under the License.
  */
 
-#include "../dl_loader.h"
 #include "../get_gles_proc_address.h"
+#include "../dl_loader.h"
 #include "../log.h"
 
 #include <dlfcn.h>
 
 namespace {
 
-void* getGlesProcAddress(const char *name, bool bypassLocal) {
-    using namespace core;
-    typedef void* (*GPAPROC)(const char *name);
+void* getGlesProcAddress(const char* name, bool bypassLocal) {
+  using namespace core;
+  typedef void* (*GPAPROC)(const char* name);
 
-    // The mesa driver does bad things with LLVM. Since we also use llvm, 
-    // we can't have the mesa driver do bad things to our code.
-    // Therefore we should preload any versions of llvm that may be required
-    // into the start of our address space.
-    // See: https://github.com/google/gapid/issues/1707 for more information
-    static void* _dummy0 = dlopen("libLLVM-3.0.so.1", RTLD_LAZY | RTLD_DEEPBIND);
-    static void* _dummy1 = dlopen("libLLVM-4.0.so.1", RTLD_LAZY | RTLD_DEEPBIND);
-    static void* _dummy2 = dlopen("libLLVM-5.0.so.1", RTLD_LAZY | RTLD_DEEPBIND);
-    (void)_dummy0;
-    (void)_dummy1;
-    (void)_dummy2;
+  // The mesa driver does bad things with LLVM. Since we also use llvm,
+  // we can't have the mesa driver do bad things to our code.
+  // Therefore we should preload any versions of llvm that may be required
+  // into the start of our address space.
+  // See: https://github.com/google/gapid/issues/1707 for more information
+  static void* _dummy0 = dlopen("libLLVM-3.0.so.1", RTLD_LAZY | RTLD_DEEPBIND);
+  static void* _dummy1 = dlopen("libLLVM-4.0.so.1", RTLD_LAZY | RTLD_DEEPBIND);
+  static void* _dummy2 = dlopen("libLLVM-5.0.so.1", RTLD_LAZY | RTLD_DEEPBIND);
+  (void)_dummy0;
+  (void)_dummy1;
+  (void)_dummy2;
 
-    if (bypassLocal) {
-        // Why .1 ?
-        // See: https://bugs.launchpad.net/ubuntu/+source/python-qt4/+bug/941826
-        static DlLoader libgl("libGL.so.1");
-        if (GPAPROC gpa = reinterpret_cast<GPAPROC>(libgl.lookup("glXGetProcAddress"))) {
-            if (void* proc = gpa(name)) {
-                GAPID_VERBOSE("GetGlesProcAddress(%s, %d) -> 0x%x (via libGL glXGetProcAddress)", name, bypassLocal, proc);
-                return proc;
-            }
-        }
-        if (void* proc = libgl.lookup(name)) {
-            GAPID_VERBOSE("GetGlesProcAddress(%s, %d) -> 0x%x (from libGL dlsym)", name, bypassLocal, proc);
-            return proc;
-        }
-    } else {
-        static DlLoader local(nullptr);
-        if (GPAPROC gpa = reinterpret_cast<GPAPROC>(local.lookup("glXGetProcAddress"))) {
-            if (void* proc = gpa(name)) {
-                GAPID_VERBOSE("GetGlesProcAddress(%s, %d) -> 0x%x (via local glXGetProcAddress)", name, bypassLocal, proc);
-                return proc;
-            }
-        }
-        if (void* proc = local.lookup(name)) {
-            GAPID_VERBOSE("GetGlesProcAddress(%s, %d) -> 0x%x (from local dlsym)", name, bypassLocal, proc);
-            return proc;
-        }
+  if (bypassLocal) {
+    // Why .1 ?
+    // See: https://bugs.launchpad.net/ubuntu/+source/python-qt4/+bug/941826
+    static DlLoader libgl("libGL.so.1");
+    if (GPAPROC gpa =
+            reinterpret_cast<GPAPROC>(libgl.lookup("glXGetProcAddress"))) {
+      if (void* proc = gpa(name)) {
+        GAPID_VERBOSE(
+            "GetGlesProcAddress(%s, %d) -> 0x%x (via libGL glXGetProcAddress)",
+            name, bypassLocal, proc);
+        return proc;
+      }
     }
+    if (void* proc = libgl.lookup(name)) {
+      GAPID_VERBOSE("GetGlesProcAddress(%s, %d) -> 0x%x (from libGL dlsym)",
+                    name, bypassLocal, proc);
+      return proc;
+    }
+  } else {
+    static DlLoader local(nullptr);
+    if (GPAPROC gpa =
+            reinterpret_cast<GPAPROC>(local.lookup("glXGetProcAddress"))) {
+      if (void* proc = gpa(name)) {
+        GAPID_VERBOSE(
+            "GetGlesProcAddress(%s, %d) -> 0x%x (via local glXGetProcAddress)",
+            name, bypassLocal, proc);
+        return proc;
+      }
+    }
+    if (void* proc = local.lookup(name)) {
+      GAPID_VERBOSE("GetGlesProcAddress(%s, %d) -> 0x%x (from local dlsym)",
+                    name, bypassLocal, proc);
+      return proc;
+    }
+  }
 
-    GAPID_DEBUG("GetGlesProcAddress(%s, %d) -> not found", name, bypassLocal);
-    return nullptr;
+  GAPID_DEBUG("GetGlesProcAddress(%s, %d) -> not found", name, bypassLocal);
+  return nullptr;
 }
 
 }  // anonymous namespace
@@ -75,9 +83,6 @@ void* getGlesProcAddress(const char *name, bool bypassLocal) {
 namespace core {
 
 GetGlesProcAddressFunc* GetGlesProcAddress = getGlesProcAddress;
-bool hasGLorGLES() {
-    return DlLoader::can_load("libGL.so.1");
-}
-
+bool hasGLorGLES() { return DlLoader::can_load("libGL.so.1"); }
 
 }  // namespace core

--- a/core/cc/linux/thread.cpp
+++ b/core/cc/linux/thread.cpp
@@ -21,8 +21,8 @@
 namespace core {
 
 Thread Thread::current() {
-    auto thread = pthread_self();
-    return Thread(static_cast<uint64_t>(reinterpret_cast<uintptr_t>(thread)));
+  auto thread = pthread_self();
+  return Thread(static_cast<uint64_t>(reinterpret_cast<uintptr_t>(thread)));
 }
 
 }  // namespace core

--- a/core/cc/lock.h
+++ b/core/cc/lock.h
@@ -19,24 +19,26 @@
 
 namespace core {
 
-// Lock is a RAII helper that calls T::lock() on construction and T::unlock() on destruction.
+// Lock is a RAII helper that calls T::lock() on construction and T::unlock() on
+// destruction.
 template <typename T>
 struct Lock {
-public:
-    inline Lock(T* t);
-    inline ~Lock();
-private:
-    T* _;
+ public:
+  inline Lock(T* t);
+  inline ~Lock();
+
+ private:
+  T* _;
 };
 
 template <typename T>
 inline Lock<T>::Lock(T* t) : _(t) {
-    _->lock();
+  _->lock();
 };
 
 template <typename T>
 inline Lock<T>::~Lock() {
-    _->unlock();
+  _->unlock();
 };
 
 }  // namespace core

--- a/core/cc/log.cpp
+++ b/core/cc/log.cpp
@@ -27,89 +27,96 @@
 #include <string.h>
 
 #include <chrono>
-#include <ctime> // Required for MSVC.
+#include <ctime>  // Required for MSVC.
 
 #if TARGET_OS == GAPID_OS_WINDOWS
 #include "Windows.h"
-#endif // GAPID_OS_WINDOWS
+#endif  // GAPID_OS_WINDOWS
 
 namespace core {
 
 Logger Logger::mInstance = Logger();
 
 void Logger::init(unsigned level, const char* system, const char* path) {
-    mInstance.mLevel = level;
-    mInstance.mSystem = system;
-    if (path != nullptr) {
-        if (FILE* f = fopen(path, "w")) {
-            GAPID_INFO("Logging to %s", path);
-            mInstance.mFiles.push_back(f);
-        } else {
-            GAPID_WARNING("Can't open file for logging (%s): %s", path, strerror(errno));
-        }
+  mInstance.mLevel = level;
+  mInstance.mSystem = system;
+  if (path != nullptr) {
+    if (FILE* f = fopen(path, "w")) {
+      GAPID_INFO("Logging to %s", path);
+      mInstance.mFiles.push_back(f);
+    } else {
+      GAPID_WARNING("Can't open file for logging (%s): %s", path,
+                    strerror(errno));
     }
+  }
 }
 
 Logger::Logger() : mLevel(LOG_LEVEL_INFO), mSystem("") {
-    mFiles.push_back(stdout);
+  mFiles.push_back(stdout);
 }
 
 Logger::~Logger() {
-    for (FILE* file : mFiles) {
-        fclose(file);
-    }
+  for (FILE* file : mFiles) {
+    fclose(file);
+  }
 }
 
-void Logger::logf(unsigned level, const char* file, unsigned line, const char* format, ...) const {
-    va_list args;
-    va_start(args, format);
-    vlogf(level, file, line, format, args);
-    va_end(args);
+void Logger::logf(unsigned level, const char* file, unsigned line,
+                  const char* format, ...) const {
+  va_list args;
+  va_start(args, format);
+  vlogf(level, file, line, format, args);
+  va_end(args);
 }
 
-void Logger::vlogf(unsigned level, const char* src_file, unsigned src_line, const char* format, va_list args) const {
-    // Get the current time with milliseconds precision
-    auto t = std::chrono::system_clock::now();
-    std::time_t now = std::chrono::system_clock::to_time_t(t);
-    std::tm* loc = std::localtime(&now);
-    auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(t.time_since_epoch());
+void Logger::vlogf(unsigned level, const char* src_file, unsigned src_line,
+                   const char* format, va_list args) const {
+  // Get the current time with milliseconds precision
+  auto t = std::chrono::system_clock::now();
+  std::time_t now = std::chrono::system_clock::to_time_t(t);
+  std::tm* loc = std::localtime(&now);
+  auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+      t.time_since_epoch());
 
-#define LOG_COMMON "%02d:%02d:%02d.%03d %c %s: [%s:%u] ", loc->tm_hour, loc->tm_min, loc->tm_sec, \
-    static_cast<int>(ms.count() % 1000), "FEWIDV"[level], mSystem, src_file, src_line 
+#define LOG_COMMON                                                       \
+  "%02d:%02d:%02d.%03d %c %s: [%s:%u] ", loc->tm_hour, loc->tm_min,      \
+      loc->tm_sec, static_cast<int>(ms.count() % 1000), "FEWIDV"[level], \
+      mSystem, src_file, src_line
 
 #if TARGET_OS == GAPID_OS_WINDOWS
-    {
-        va_list args_copy;
-        va_copy(args_copy, args);
-        char buf[2048];
-        snprintf(buf, sizeof(buf), LOG_COMMON);
-        OutputDebugStringA(buf);
-        vsnprintf(buf, sizeof(buf), format, args_copy);
-        OutputDebugStringA(buf);
-        OutputDebugStringA("\r\n");
-    }
-#endif // GAPID_OS_WINDOWS
+  {
+    va_list args_copy;
+    va_copy(args_copy, args);
+    char buf[2048];
+    snprintf(buf, sizeof(buf), LOG_COMMON);
+    OutputDebugStringA(buf);
+    vsnprintf(buf, sizeof(buf), format, args_copy);
+    OutputDebugStringA(buf);
+    OutputDebugStringA("\r\n");
+  }
+#endif  // GAPID_OS_WINDOWS
 
-    for (FILE* file : mFiles) {
-        va_list args_copy;
-        va_copy(args_copy, args);
+  for (FILE* file : mFiles) {
+    va_list args_copy;
+    va_copy(args_copy, args);
 
-        // Print out the common part of the log messages
-        fprintf(file, LOG_COMMON);
+    // Print out the common part of the log messages
+    fprintf(file, LOG_COMMON);
 
-        // Print out the actual log message
-        vfprintf(file, format, args_copy);
+    // Print out the actual log message
+    vfprintf(file, format, args_copy);
 
-        // Always finish with a newline
-        fprintf(file, "\n");
+    // Always finish with a newline
+    fprintf(file, "\n");
 
-        // Flush the log to ensure that every message is written out even if the application crashes
-        fflush(file);
-    }
+    // Flush the log to ensure that every message is written out even if the
+    // application crashes
+    fflush(file);
+  }
 
-    if (level == LOG_LEVEL_FATAL) {
-        exit(EXIT_FAILURE);
-    }
+  if (level == LOG_LEVEL_FATAL) {
+    exit(EXIT_FAILURE);
+  }
 }
 
 }  // namespace core

--- a/core/cc/log.h
+++ b/core/cc/log.h
@@ -23,36 +23,42 @@
 // General logging functions. All logging should be done through these macros.
 //
 // The system supports the following log levels with the specified meanings:
-// * LOG_LEVEL_FATAL:   Serious error. No recovery is possible and the system will die immediately.
-// * LOG_LEVEL_ERROR:   Serious error. We can continue, but it should not happen during normal use.
-// * LOG_LEVEL_WARNING: Possible issue. It is not technically an error, but it is suspicious.
-// * LOG_LEVEL_INFO:    Normal behaviour. Small amount of messages that indicate program progress.
-// * LOG_LEVEL_DEBUG    Used only for debugging. The amount of logging may slow down the program.
-// * LOG_LEVEL_VERBOSE: Very verbose debug logging. It may log excessive amount of information.
+// * LOG_LEVEL_FATAL:   Serious error. No recovery is possible and the system
+//                      will die immediately.
+// * LOG_LEVEL_ERROR:   Serious error. We can continue, but it should not happen
+//                      during normal use.
+// * LOG_LEVEL_WARNING: Possible issue. It is not technically an error, but it
+//                      is suspicious.
+// * LOG_LEVEL_INFO:    Normal behaviour. Small amount of messages that indicate
+//                      program progress.
+// * LOG_LEVEL_DEBUG    Used only for debugging. The amount of logging may slow
+//                      down the program.
+// * LOG_LEVEL_VERBOSE: Very verbose debug logging. It may log excessive amount
+//                      of information.
 
 #include "target.h"
 
 // Levels of logging from least verbose to most verbose.
 // These log levels correspond to Android log levels.
-#define LOG_LEVEL_FATAL   0
-#define LOG_LEVEL_ERROR   1
+#define LOG_LEVEL_FATAL 0
+#define LOG_LEVEL_ERROR 1
 #define LOG_LEVEL_WARNING 2
-#define LOG_LEVEL_INFO    3
-#define LOG_LEVEL_DEBUG   4
+#define LOG_LEVEL_INFO 3
+#define LOG_LEVEL_DEBUG 4
 #define LOG_LEVEL_VERBOSE 5
 
 // If no log level specified then use the default one.
 #ifndef LOG_LEVEL
-#   define LOG_LEVEL LOG_LEVEL_INFO
+#define LOG_LEVEL LOG_LEVEL_INFO
 #endif
 
 #define GAPID_STR(S) GAPID_STR2(S)
 #define GAPID_STR2(S) #S
 
 #if TARGET_OS == GAPID_OS_WINDOWS
-  #define PRIsize "Iu"
+#define PRIsize "Iu"
 #else
-  #define PRIsize "zu"
+#define PRIsize "zu"
 #endif
 
 #if TARGET_OS == GAPID_OS_ANDROID
@@ -61,22 +67,29 @@
 
 #define GAPID_LOGGER_INIT(...)
 #define GAPID_SHOULD_LOG(LEVEL) (LOG_LEVEL >= LEVEL)
-#define GAPID_LOG(LEVEL, ANDROID_LOG_LEVEL, FORMAT, ...)                                          \
-  if GAPID_SHOULD_LOG(LEVEL) {                                                                    \
-    if (LEVEL == LOG_LEVEL_FATAL) {                                                               \
-      __android_log_assert(nullptr, "GAPID", "[%s:%u] " FORMAT,                                   \
-                           __FILE__, __LINE__, ##__VA_ARGS__);                                    \
-    } else {                                                                                      \
-      __android_log_print(ANDROID_LOG_LEVEL, "GAPID", "[%s:%u] " FORMAT,                          \
-                          __FILE__, __LINE__, ##__VA_ARGS__);                                     \
-    }                                                                                             \
-  }
-#define GAPID_FATAL(FORMAT, ...) GAPID_LOG(LOG_LEVEL_FATAL, ANDROID_LOG_FATAL, FORMAT, ##__VA_ARGS__)
-#define GAPID_ERROR(FORMAT, ...) GAPID_LOG(LOG_LEVEL_ERROR, ANDROID_LOG_ERROR, FORMAT, ##__VA_ARGS__)
-#define GAPID_WARNING(FORMAT, ...) GAPID_LOG(LOG_LEVEL_WARNING, ANDROID_LOG_WARN, FORMAT, ##__VA_ARGS__)
-#define GAPID_INFO(FORMAT, ...) GAPID_LOG(LOG_LEVEL_INFO, ANDROID_LOG_INFO, FORMAT, ##__VA_ARGS__)
-#define GAPID_DEBUG(FORMAT, ...) GAPID_LOG(LOG_LEVEL_DEBUG, ANDROID_LOG_DEBUG, FORMAT, ##__VA_ARGS__)
-#define GAPID_VERBOSE(FORMAT, ...) GAPID_LOG(LOG_LEVEL_VERBOSE, ANDROID_LOG_VERBOSE, FORMAT, ##__VA_ARGS__)
+#define GAPID_LOG(LEVEL, ANDROID_LOG_LEVEL, FORMAT, ...)                    \
+  if                                                                        \
+    GAPID_SHOULD_LOG(LEVEL) {                                               \
+      if (LEVEL == LOG_LEVEL_FATAL) {                                       \
+        __android_log_assert(nullptr, "GAPID", "[%s:%u] " FORMAT, __FILE__, \
+                             __LINE__, ##__VA_ARGS__);                      \
+      } else {                                                              \
+        __android_log_print(ANDROID_LOG_LEVEL, "GAPID", "[%s:%u] " FORMAT,  \
+                            __FILE__, __LINE__, ##__VA_ARGS__);             \
+      }                                                                     \
+    }
+#define GAPID_FATAL(FORMAT, ...) \
+  GAPID_LOG(LOG_LEVEL_FATAL, ANDROID_LOG_FATAL, FORMAT, ##__VA_ARGS__)
+#define GAPID_ERROR(FORMAT, ...) \
+  GAPID_LOG(LOG_LEVEL_ERROR, ANDROID_LOG_ERROR, FORMAT, ##__VA_ARGS__)
+#define GAPID_WARNING(FORMAT, ...) \
+  GAPID_LOG(LOG_LEVEL_WARNING, ANDROID_LOG_WARN, FORMAT, ##__VA_ARGS__)
+#define GAPID_INFO(FORMAT, ...) \
+  GAPID_LOG(LOG_LEVEL_INFO, ANDROID_LOG_INFO, FORMAT, ##__VA_ARGS__)
+#define GAPID_DEBUG(FORMAT, ...) \
+  GAPID_LOG(LOG_LEVEL_DEBUG, ANDROID_LOG_DEBUG, FORMAT, ##__VA_ARGS__)
+#define GAPID_VERBOSE(FORMAT, ...) \
+  GAPID_LOG(LOG_LEVEL_VERBOSE, ANDROID_LOG_VERBOSE, FORMAT, ##__VA_ARGS__)
 
 #else  // TARGET_OS == GAPID_OS_ANDROID
 
@@ -86,49 +99,58 @@ namespace core {
 
 // Singleton logger implementation for PCs to write formatted log messages.
 class Logger {
-public:
-    // Initializes the logger to write to the log file at path.
-    static void init(unsigned level, const char* system, const char* path);
+ public:
+  // Initializes the logger to write to the log file at path.
+  static void init(unsigned level, const char* system, const char* path);
 
-    // Write a log message to the log output with the specific log level. The location should
-    // contain the place where the log is written from and the format is a standard C format string
-    // If a message is logged with level LOG_LEVEL_FATAL, the program will terminate after the
-    // message is printed.
-    // Log messages take the form: <time> <level> <system> <file:line> : <message>
-    void logf(unsigned level, const char* file, unsigned line, const char* format, ...) const;
+  // Write a log message to the log output with the specific log level. The
+  // location should contain the place where the log is written from and the
+  // format is a standard C format string If a message is logged with level
+  // LOG_LEVEL_FATAL, the program will terminate after the message is printed.
+  // Log messages take the form: <time> <level> <system> <file:line> : <message>
+  void logf(unsigned level, const char* file, unsigned line, const char* format,
+            ...) const;
 
-    void vlogf(unsigned level, const char* file, unsigned line, const char* format, va_list args) const;
+  void vlogf(unsigned level, const char* file, unsigned line,
+             const char* format, va_list args) const;
 
-    static const Logger& instance() { return mInstance; }
+  static const Logger& instance() { return mInstance; }
 
-    static unsigned level() { return mInstance.mLevel; }
+  static unsigned level() { return mInstance.mLevel; }
 
-private:
-    // mInstance is the single logger instance.
-    static Logger mInstance;
+ private:
+  // mInstance is the single logger instance.
+  static Logger mInstance;
 
-    Logger();
-    ~Logger();
+  Logger();
+  ~Logger();
 
-    unsigned mLevel;
-    const char* mSystem;
-    std::vector<FILE*> mFiles;
+  unsigned mLevel;
+  const char* mSystem;
+  std::vector<FILE*> mFiles;
 };
 
 }  // namespace core
 
 #define GAPID_LOGGER_INIT(...) ::core::Logger::init(__VA_ARGS__)
 #define GAPID_SHOULD_LOG(LEVEL) (::core::Logger::level() >= LEVEL)
-#define GAPID_LOG(LEVEL, FORMAT, ...)                                                             \
-  if GAPID_SHOULD_LOG(LEVEL) {                                                                    \
-    ::core::Logger::instance().logf(LEVEL, __FILE__, __LINE__, FORMAT, ##__VA_ARGS__);            \
-  }
-#define GAPID_FATAL(FORMAT, ...) GAPID_LOG(LOG_LEVEL_FATAL, FORMAT, ##__VA_ARGS__)
-#define GAPID_ERROR(FORMAT, ...) GAPID_LOG(LOG_LEVEL_ERROR, FORMAT, ##__VA_ARGS__)
-#define GAPID_WARNING(FORMAT, ...) GAPID_LOG(LOG_LEVEL_WARNING, FORMAT, ##__VA_ARGS__)
+#define GAPID_LOG(LEVEL, FORMAT, ...)                                    \
+  if                                                                     \
+    GAPID_SHOULD_LOG(LEVEL) {                                            \
+      ::core::Logger::instance().logf(LEVEL, __FILE__, __LINE__, FORMAT, \
+                                      ##__VA_ARGS__);                    \
+    }
+#define GAPID_FATAL(FORMAT, ...) \
+  GAPID_LOG(LOG_LEVEL_FATAL, FORMAT, ##__VA_ARGS__)
+#define GAPID_ERROR(FORMAT, ...) \
+  GAPID_LOG(LOG_LEVEL_ERROR, FORMAT, ##__VA_ARGS__)
+#define GAPID_WARNING(FORMAT, ...) \
+  GAPID_LOG(LOG_LEVEL_WARNING, FORMAT, ##__VA_ARGS__)
 #define GAPID_INFO(FORMAT, ...) GAPID_LOG(LOG_LEVEL_INFO, FORMAT, ##__VA_ARGS__)
-#define GAPID_DEBUG(FORMAT, ...) GAPID_LOG(LOG_LEVEL_DEBUG, FORMAT, ##__VA_ARGS__)
-#define GAPID_VERBOSE(FORMAT, ...) GAPID_LOG(LOG_LEVEL_VERBOSE, FORMAT, ##__VA_ARGS__)
+#define GAPID_DEBUG(FORMAT, ...) \
+  GAPID_LOG(LOG_LEVEL_DEBUG, FORMAT, ##__VA_ARGS__)
+#define GAPID_VERBOSE(FORMAT, ...) \
+  GAPID_LOG(LOG_LEVEL_VERBOSE, FORMAT, ##__VA_ARGS__)
 
 #endif  // TARGET_OS == GAPID_OS_ANDROID
 

--- a/core/cc/mock_connection.h
+++ b/core/cc/mock_connection.h
@@ -32,41 +32,40 @@ namespace core {
 namespace test {
 
 class MockConnection : public Connection {
-public:
-    MockConnection() : read_pos(0), out_limit(-1) {}
-    virtual size_t send(const void* data, size_t size) override {
-        if ((out_limit >= 0)  && (size > out_limit - out.size())) {
-            size = out_limit - out.size();
-        }
-        out.insert(out.end(), (char*)data, (char*)data + size);
-        return size;
+ public:
+  MockConnection() : read_pos(0), out_limit(-1) {}
+  virtual size_t send(const void* data, size_t size) override {
+    if ((out_limit >= 0) && (size > out_limit - out.size())) {
+      size = out_limit - out.size();
     }
-    virtual size_t recv(void* data, size_t size) override {
-        if (size > in.size() - read_pos) {
-            size = in.size() - read_pos;
-        }
-        memcpy(data, &in[read_pos], size);
-        read_pos += size;
-        return size;
+    out.insert(out.end(), (char*)data, (char*)data + size);
+    return size;
+  }
+  virtual size_t recv(void* data, size_t size) override {
+    if (size > in.size() - read_pos) {
+      size = in.size() - read_pos;
     }
+    memcpy(data, &in[read_pos], size);
+    read_pos += size;
+    return size;
+  }
 
-    const char* error() override { return ""; }
-    std::unique_ptr<Connection> accept(int timeoutMs) override {
-        if (connections.size() == 0) {
-            return nullptr;
-        }
-        auto conn = connections.front();
-        connections.pop();
-        return std::unique_ptr<Connection>(conn);
+  const char* error() override { return ""; }
+  std::unique_ptr<Connection> accept(int timeoutMs) override {
+    if (connections.size() == 0) {
+      return nullptr;
     }
-    void close() override {
-    }
+    auto conn = connections.front();
+    connections.pop();
+    return std::unique_ptr<Connection>(conn);
+  }
+  void close() override {}
 
-    std::queue<Connection*> connections;
-    std::vector<uint8_t> in;
-    int read_pos;
-    std::vector<uint8_t> out;
-    int out_limit;
+  std::queue<Connection*> connections;
+  std::vector<uint8_t> in;
+  int read_pos;
+  std::vector<uint8_t> out;
+  int out_limit;
 };
 
 }  // namespace test

--- a/core/cc/null_writer.h
+++ b/core/cc/null_writer.h
@@ -23,11 +23,9 @@ namespace core {
 
 // NullWriter implements StreamWriter, but outputs nothing.
 class NullWriter : public core::StreamWriter {
-  public:
-    uint64_t write(const void* data, uint64_t size) {
-        return size;
-    }
-    ~NullWriter() {}
+ public:
+  uint64_t write(const void* data, uint64_t size) { return size; }
+  ~NullWriter() {}
 };
 
 }  // namespace core

--- a/core/cc/osx/crash_handler_osx.cpp
+++ b/core/cc/osx/crash_handler_osx.cpp
@@ -27,43 +27,43 @@
 
 namespace {
 
-static bool handleCrash(const char* minidumpDir, const char* minidumpId, void* crashHandlerPtr, bool succeeded) {
-    core::CrashHandler* crashHandler = reinterpret_cast<core::CrashHandler*>(crashHandlerPtr);
-    std::string minidumpPath(minidumpDir);
-    minidumpPath.append(minidumpId);
-    minidumpPath.append(".dmp");
-    return crashHandler->handleMinidump(minidumpPath, succeeded);
+static bool handleCrash(const char* minidumpDir, const char* minidumpId,
+                        void* crashHandlerPtr, bool succeeded) {
+  core::CrashHandler* crashHandler =
+      reinterpret_cast<core::CrashHandler*>(crashHandlerPtr);
+  std::string minidumpPath(minidumpDir);
+  minidumpPath.append(minidumpId);
+  minidumpPath.append(".dmp");
+  return crashHandler->handleMinidump(minidumpPath, succeeded);
 }
 
-}
+}  // namespace
 
 namespace core {
 
 namespace {
 const char* GetTempDir() {
-    const char* tmpdir = getenv("TMPDIR");
-    if (!tmpdir) {
-        tmpdir = "/tmp/";
-    }
-    return tmpdir;
+  const char* tmpdir = getenv("TMPDIR");
+  if (!tmpdir) {
+    tmpdir = "/tmp/";
+  }
+  return tmpdir;
 }
-} // namespace
+}  // namespace
 
-CrashHandler::CrashHandler() :
-    mNextHandlerID(0),
-    mExceptionHandler(nullptr) {
-
-    if (!Debugger::isAttached()) {
-        mExceptionHandler = std::unique_ptr<google_breakpad::ExceptionHandler>(
-            new google_breakpad::ExceptionHandler(
-                GetTempDir(), nullptr, ::handleCrash,
-                reinterpret_cast<void*>(this), true, nullptr));
-    }
-    registerHandler(defaultHandler);
+CrashHandler::CrashHandler() : mNextHandlerID(0), mExceptionHandler(nullptr) {
+  if (!Debugger::isAttached()) {
+    mExceptionHandler = std::unique_ptr<google_breakpad::ExceptionHandler>(
+        new google_breakpad::ExceptionHandler(
+            GetTempDir(), nullptr, ::handleCrash, reinterpret_cast<void*>(this),
+            true, nullptr));
+  }
+  registerHandler(defaultHandler);
 }
 
-// this prevents unique_ptr<CrashHandler> from causing an incomplete type error from inlining the destructor.
-// The incomplete type is the previously forward declared google_breakpad::ExceptionHandler.
+// this prevents unique_ptr<CrashHandler> from causing an incomplete type error
+// from inlining the destructor. The incomplete type is the previously forward
+// declared google_breakpad::ExceptionHandler.
 CrashHandler::~CrashHandler() = default;
 
-} // namespace core
+}  // namespace core

--- a/core/cc/osx/debugger.cpp
+++ b/core/cc/osx/debugger.cpp
@@ -18,44 +18,44 @@
 
 #include <assert.h>
 #include <stdbool.h>
+#include <sys/sysctl.h>
 #include <sys/types.h>
 #include <unistd.h>
-#include <sys/sysctl.h>
 
 namespace {
 
 // https://developer.apple.com/library/content/qa/qa1361/_index.html
 static bool AmIBeingDebugged(void)
-    // Returns true if the current process is being debugged (either
-    // running under the debugger or has a debugger attached post facto).
+// Returns true if the current process is being debugged (either
+// running under the debugger or has a debugger attached post facto).
 {
-    int                 junk;
-    int                 mib[4];
-    struct kinfo_proc   info;
-    size_t              size;
+  int junk;
+  int mib[4];
+  struct kinfo_proc info;
+  size_t size;
 
-    // Initialize the flags so that, if sysctl fails for some bizarre
-    // reason, we get a predictable result.
+  // Initialize the flags so that, if sysctl fails for some bizarre
+  // reason, we get a predictable result.
 
-    info.kp_proc.p_flag = 0;
+  info.kp_proc.p_flag = 0;
 
-    // Initialize mib, which tells sysctl the info we want, in this case
-    // we're looking for information about a specific process ID.
+  // Initialize mib, which tells sysctl the info we want, in this case
+  // we're looking for information about a specific process ID.
 
-    mib[0] = CTL_KERN;
-    mib[1] = KERN_PROC;
-    mib[2] = KERN_PROC_PID;
-    mib[3] = getpid();
+  mib[0] = CTL_KERN;
+  mib[1] = KERN_PROC;
+  mib[2] = KERN_PROC_PID;
+  mib[3] = getpid();
 
-    // Call sysctl.
+  // Call sysctl.
 
-    size = sizeof(info);
-    junk = sysctl(mib, sizeof(mib) / sizeof(*mib), &info, &size, NULL, 0);
-    assert(junk == 0);
+  size = sizeof(info);
+  junk = sysctl(mib, sizeof(mib) / sizeof(*mib), &info, &size, NULL, 0);
+  assert(junk == 0);
 
-    // We're being debugged if the P_TRACED flag is set.
+  // We're being debugged if the P_TRACED flag is set.
 
-    return ( (info.kp_proc.p_flag & P_TRACED) != 0 );
+  return ((info.kp_proc.p_flag & P_TRACED) != 0);
 }
 
 }  // anonymous namespace
@@ -63,12 +63,10 @@ static bool AmIBeingDebugged(void)
 namespace core {
 
 void Debugger::waitForAttach() {
-    while (!isAttached()) {}
+  while (!isAttached()) {
+  }
 }
 
-bool Debugger::isAttached() {
-    return AmIBeingDebugged();
-}
+bool Debugger::isAttached() { return AmIBeingDebugged(); }
 
 }  // namespace core
-

--- a/core/cc/osx/get_gles_proc_address.cpp
+++ b/core/cc/osx/get_gles_proc_address.cpp
@@ -14,52 +14,59 @@
  * limitations under the License.
  */
 
-#include "../dl_loader.h"
 #include "../get_gles_proc_address.h"
+#include "../dl_loader.h"
 #include "../log.h"
 
 namespace {
 
 #define FRAMEWORK_ROOT "/System/Library/Frameworks/OpenGL.framework/"
-#define CORE_GRAPHICS "/System/Library/Frameworks/CoreGraphics.framework/CoreGraphics"
+#define CORE_GRAPHICS \
+  "/System/Library/Frameworks/CoreGraphics.framework/CoreGraphics"
 
-void* getGlesProcAddress(const char *name, bool bypassLocal) {
-    using namespace core;
-    if (bypassLocal) {
-        static DlLoader opengl(FRAMEWORK_ROOT "OpenGL");
-        if (void* proc = opengl.lookup(name)) {
-           GAPID_DEBUG("GetGlesProcAddress(%s, true) -> 0x%x (from OpenGL dlsym)", name, proc);
-           return proc;
-        }
-
-        static DlLoader libgl(FRAMEWORK_ROOT "Libraries/libGL.dylib");
-        if (void* proc = libgl.lookup(name)) {
-            GAPID_DEBUG("GetGlesProcAddress(%s, true) -> 0x%x (from libGL dlsym)", name, proc);
-            return proc;
-        }
-
-        static DlLoader libglu(FRAMEWORK_ROOT "Libraries/libGLU.dylib");
-        if (void* proc = libglu.lookup(name)) {
-            GAPID_DEBUG("GetGlesProcAddress(%s, true) -> 0x%x (from libGLU dlsym)", name, proc);
-            return proc;
-        }
-
-        static DlLoader coregraphics(CORE_GRAPHICS);
-        if (void* proc = coregraphics.lookup(name)) {
-            GAPID_DEBUG("GetGlesProcAddress(%s, true) -> 0x%x (from CoreGraphics dlsym)", name, proc);
-            return proc;
-        }
-    } else {
-        static DlLoader local(nullptr);
-        if (void* proc = local.lookup(name)) {
-            GAPID_DEBUG("GetGlesProcAddress(%s, false) -> 0x%x (from local dlsym)", name, proc);
-            return proc;
-        }
-
-        GAPID_DEBUG("GetGlesProcAddress(%s, false) -> not found", name);
+void* getGlesProcAddress(const char* name, bool bypassLocal) {
+  using namespace core;
+  if (bypassLocal) {
+    static DlLoader opengl(FRAMEWORK_ROOT "OpenGL");
+    if (void* proc = opengl.lookup(name)) {
+      GAPID_DEBUG("GetGlesProcAddress(%s, true) -> 0x%x (from OpenGL dlsym)",
+                  name, proc);
+      return proc;
     }
 
-    return nullptr;
+    static DlLoader libgl(FRAMEWORK_ROOT "Libraries/libGL.dylib");
+    if (void* proc = libgl.lookup(name)) {
+      GAPID_DEBUG("GetGlesProcAddress(%s, true) -> 0x%x (from libGL dlsym)",
+                  name, proc);
+      return proc;
+    }
+
+    static DlLoader libglu(FRAMEWORK_ROOT "Libraries/libGLU.dylib");
+    if (void* proc = libglu.lookup(name)) {
+      GAPID_DEBUG("GetGlesProcAddress(%s, true) -> 0x%x (from libGLU dlsym)",
+                  name, proc);
+      return proc;
+    }
+
+    static DlLoader coregraphics(CORE_GRAPHICS);
+    if (void* proc = coregraphics.lookup(name)) {
+      GAPID_DEBUG(
+          "GetGlesProcAddress(%s, true) -> 0x%x (from CoreGraphics dlsym)",
+          name, proc);
+      return proc;
+    }
+  } else {
+    static DlLoader local(nullptr);
+    if (void* proc = local.lookup(name)) {
+      GAPID_DEBUG("GetGlesProcAddress(%s, false) -> 0x%x (from local dlsym)",
+                  name, proc);
+      return proc;
+    }
+
+    GAPID_DEBUG("GetGlesProcAddress(%s, false) -> not found", name);
+  }
+
+  return nullptr;
 }
 
 }  // anonymous namespace
@@ -68,10 +75,10 @@ namespace core {
 
 GetGlesProcAddressFunc* GetGlesProcAddress = getGlesProcAddress;
 bool hasGLorGLES() {
-    return DlLoader::can_load(FRAMEWORK_ROOT "OpenGL") ||
-           DlLoader::can_load(FRAMEWORK_ROOT "Libraries/libGL.dylib") ||
-           DlLoader::can_load(FRAMEWORK_ROOT "Libraries/libGLU.dylib") ||
-           DlLoader::can_load(CORE_GRAPHICS);
+  return DlLoader::can_load(FRAMEWORK_ROOT "OpenGL") ||
+         DlLoader::can_load(FRAMEWORK_ROOT "Libraries/libGL.dylib") ||
+         DlLoader::can_load(FRAMEWORK_ROOT "Libraries/libGLU.dylib") ||
+         DlLoader::can_load(CORE_GRAPHICS);
 }
 
 }  // namespace core

--- a/core/cc/osx/get_vulkan_proc_address.cpp
+++ b/core/cc/osx/get_vulkan_proc_address.cpp
@@ -19,26 +19,30 @@
 
 namespace {
 
-void* getVulkanInstanceProcAddress(size_t instance, const char *name, bool bypassLocal) {
-    GAPID_FATAL("No Vulkan support on macOS");
-    return nullptr;
+void* getVulkanInstanceProcAddress(size_t instance, const char* name,
+                                   bool bypassLocal) {
+  GAPID_FATAL("No Vulkan support on macOS");
+  return nullptr;
 }
 
-void* getVulkanDeviceProcAddress(size_t instance, size_t device, const char *name, bool bypassLocal) {
-    GAPID_FATAL("No Vulkan support on macOS");
-    return nullptr;
+void* getVulkanDeviceProcAddress(size_t instance, size_t device,
+                                 const char* name, bool bypassLocal) {
+  GAPID_FATAL("No Vulkan support on macOS");
+  return nullptr;
 }
 
 void* getVulkanProcAddress(const char* name, bool bypassLocal) {
-    return getVulkanInstanceProcAddress(0u, name, bypassLocal);
+  return getVulkanInstanceProcAddress(0u, name, bypassLocal);
 }
 
 }  // anonymous namespace
 
 namespace core {
 
-GetVulkanInstanceProcAddressFunc* GetVulkanInstanceProcAddress = getVulkanInstanceProcAddress;
-GetVulkanDeviceProcAddressFunc* GetVulkanDeviceProcAddress = getVulkanDeviceProcAddress;
+GetVulkanInstanceProcAddressFunc* GetVulkanInstanceProcAddress =
+    getVulkanInstanceProcAddress;
+GetVulkanDeviceProcAddressFunc* GetVulkanDeviceProcAddress =
+    getVulkanDeviceProcAddress;
 GetVulkanProcAddressFunc* GetVulkanProcAddress = getVulkanProcAddress;
 bool HasVulkanLoader() { return false; }
 }  // namespace core

--- a/core/cc/osx/thread.cpp
+++ b/core/cc/osx/thread.cpp
@@ -21,8 +21,8 @@
 namespace core {
 
 Thread Thread::current() {
-    auto thread = pthread_self();
-    return Thread(static_cast<uint64_t>(reinterpret_cast<uintptr_t>(thread)));
+  auto thread = pthread_self();
+  return Thread(static_cast<uint64_t>(reinterpret_cast<uintptr_t>(thread)));
 }
 
 }  // namespace core

--- a/core/cc/posix/thread.cpp
+++ b/core/cc/posix/thread.cpp
@@ -16,24 +16,24 @@
 
 #include "core/cc/thread.h"
 
+#include <pthread.h>
 #include <cstdint>
 #include <cstdlib>
-#include <pthread.h>
 
 namespace core {
 
-AsyncJob::AsyncJob(const std::function<void()>& function) : mFunction(function) {
-    _ = malloc(sizeof(pthread_t));
-    pthread_t* thread = reinterpret_cast<pthread_t*>(_);
+AsyncJob::AsyncJob(const std::function<void()>& function)
+    : mFunction(function) {
+  _ = malloc(sizeof(pthread_t));
+  pthread_t* thread = reinterpret_cast<pthread_t*>(_);
 
-    pthread_create(thread, nullptr, &AsyncJob::RunJob, this);
+  pthread_create(thread, nullptr, &AsyncJob::RunJob, this);
 }
 
 AsyncJob::~AsyncJob() {
-    pthread_t* thread = reinterpret_cast<pthread_t*>(_);
-    pthread_join(*thread, nullptr);
-    free(_);
+  pthread_t* thread = reinterpret_cast<pthread_t*>(_);
+  pthread_join(*thread, nullptr);
+  free(_);
 }
 
 }  // namespace core
-

--- a/core/cc/semaphore.h
+++ b/core/cc/semaphore.h
@@ -17,44 +17,44 @@
 #ifndef CORE_SEMAPHORE_H
 #define CORE_SEMAPHORE_H
 
-#include <mutex>
 #include <condition_variable>
+#include <mutex>
 
 namespace core {
 
 class Semaphore {
-public:
-    inline Semaphore(unsigned int count = 0);
+ public:
+  inline Semaphore(unsigned int count = 0);
 
-    // acquire takes a counter from the semaphore, blocking until one is 
-    // available.
-    inline void acquire();
+  // acquire takes a counter from the semaphore, blocking until one is
+  // available.
+  inline void acquire();
 
-    // release returns a counter to the semaphore, possibly unblocking a call
-    // to acquire().
-    inline void release();
+  // release returns a counter to the semaphore, possibly unblocking a call
+  // to acquire().
+  inline void release();
 
-private:
-    Semaphore(const Semaphore&) = delete;
-    Semaphore& operator = (const Semaphore&) = delete;
+ private:
+  Semaphore(const Semaphore&) = delete;
+  Semaphore& operator=(const Semaphore&) = delete;
 
-    std::mutex mMutex;
-    std::condition_variable mSignal;
-    int mCount;
+  std::mutex mMutex;
+  std::condition_variable mSignal;
+  int mCount;
 };
 
 Semaphore::Semaphore(unsigned int count /* = 0 */) : mCount(count) {}
 
 inline void Semaphore::acquire() {
-    std::unique_lock<std::mutex> lock(mMutex);
-    mSignal.wait(lock, [this]{ return this->mCount > 0; });
-    --mCount;
+  std::unique_lock<std::mutex> lock(mMutex);
+  mSignal.wait(lock, [this] { return this->mCount > 0; });
+  --mCount;
 }
 
 inline void Semaphore::release() {
-    std::unique_lock<std::mutex> lock(mMutex);
-    ++mCount;
-    mSignal.notify_one();
+  std::unique_lock<std::mutex> lock(mMutex);
+  ++mCount;
+  mSignal.notify_one();
 }
 
 }  // namespace core

--- a/core/cc/socket_connection.cpp
+++ b/core/cc/socket_connection.cpp
@@ -33,8 +33,8 @@
 
 #include <errno.h>
 #include <netdb.h>
-#include <sys/socket.h>
 #include <netinet/in.h>
+#include <sys/socket.h>
 #include <sys/types.h>
 #include <sys/un.h>
 #include <unistd.h>
@@ -53,228 +53,233 @@ int gWinsockUsageCount = 0;
 
 int error() {
 #if TARGET_OS == GAPID_OS_WINDOWS
-    return ::WSAGetLastError();
-#else  // TARGET_OS == GAPID_OS_WINDOWS
-    return errno;
+  return ::WSAGetLastError();
+#else   // TARGET_OS == GAPID_OS_WINDOWS
+  return errno;
 #endif  // TARGET_OS == GAPID_OS_WINDOWS
 }
 
 void close(int fd) {
 #if TARGET_OS == GAPID_OS_WINDOWS
-    ::closesocket(fd);
-#else  // TARGET_OS == GAPID_OS_WINDOWS
-    ::close(fd);
+  ::closesocket(fd);
+#else   // TARGET_OS == GAPID_OS_WINDOWS
+  ::close(fd);
 #endif  // TARGET_OS == GAPID_OS_WINDOWS
 }
 
-size_t recv(int sockfd, void *buf, size_t len, int flags) {
+size_t recv(int sockfd, void* buf, size_t len, int flags) {
 #if TARGET_OS == GAPID_OS_WINDOWS
-    return ::recv(sockfd, static_cast<char*>(buf), static_cast<int>(len), flags);
-#else  // TARGET_OS == GAPID_OS_WINDOWS
-    return ::recv(sockfd, buf, len, flags);
+  return ::recv(sockfd, static_cast<char*>(buf), static_cast<int>(len), flags);
+#else   // TARGET_OS == GAPID_OS_WINDOWS
+  return ::recv(sockfd, buf, len, flags);
 #endif  // TARGET_OS == GAPID_OS_WINDOWS
 }
 
-size_t send(int sockfd, const void *buf, size_t len, int flags) {
+size_t send(int sockfd, const void* buf, size_t len, int flags) {
 #if TARGET_OS == GAPID_OS_WINDOWS
-    return ::send(sockfd, static_cast<const char*>(buf), static_cast<int>(len), flags);
-#else  // TARGET_OS == GAPID_OS_WINDOWS
-    const ssize_t result = len;
-    while(len > 0) {
-        const ssize_t n = ::send(sockfd, buf, len, flags);
-        if (n != -1) {
-            // A signal after some data was transmitted can result in partial send.
-            buf = reinterpret_cast<const char*>(buf) + n;
-            len -= n;
-        } else if (errno == EINTR) {
-            // A signal occurred before any data was transmitted - retry.
-            continue;
-        } else {
-            // Other error.
-            return -1;
-        }
+  return ::send(sockfd, static_cast<const char*>(buf), static_cast<int>(len),
+                flags);
+#else   // TARGET_OS == GAPID_OS_WINDOWS
+  const ssize_t result = len;
+  while (len > 0) {
+    const ssize_t n = ::send(sockfd, buf, len, flags);
+    if (n != -1) {
+      // A signal after some data was transmitted can result in partial send.
+      buf = reinterpret_cast<const char*>(buf) + n;
+      len -= n;
+    } else if (errno == EINTR) {
+      // A signal occurred before any data was transmitted - retry.
+      continue;
+    } else {
+      // Other error.
+      return -1;
     }
-    return result;
+  }
+  return result;
 #endif  // TARGET_OS == GAPID_OS_WINDOWS
 }
 
 int accept(int sockfd, int timeoutMs) {
-    if (timeoutMs != Connection::NO_TIMEOUT) {
-        fd_set set;
-        FD_ZERO(&set);
-        FD_SET(sockfd, &set);
+  if (timeoutMs != Connection::NO_TIMEOUT) {
+    fd_set set;
+    FD_ZERO(&set);
+    FD_SET(sockfd, &set);
 
-        timeval timeout;
-        timeout.tv_sec = timeoutMs / 1000;
-        timeout.tv_usec = (timeoutMs - timeout.tv_sec * 1000) * 1000;
+    timeval timeout;
+    timeout.tv_sec = timeoutMs / 1000;
+    timeout.tv_usec = (timeoutMs - timeout.tv_sec * 1000) * 1000;
 
-        switch (select(sockfd + 1, &set, NULL, NULL, &timeout)) {
-            case -1:
-                GAPID_WARNING("Error from select(): %s", strerror(error()));
-                return ACCEPT_ERROR;
-            case 0:
-                return ACCEPT_TIMEOUT;
-            default:
-                break;
-        }
+    switch (select(sockfd + 1, &set, NULL, NULL, &timeout)) {
+      case -1:
+        GAPID_WARNING("Error from select(): %s", strerror(error()));
+        return ACCEPT_ERROR;
+      case 0:
+        return ACCEPT_TIMEOUT;
+      default:
+        break;
     }
+  }
 
-    return static_cast<int>(::accept(sockfd, nullptr, nullptr));
+  return static_cast<int>(::accept(sockfd, nullptr, nullptr));
 }
 
-int getaddrinfo(const char *node, const char *service, const struct addrinfo *hints,
-                struct addrinfo **res) {
-    return ::getaddrinfo(node, service, hints, res);
+int getaddrinfo(const char* node, const char* service,
+                const struct addrinfo* hints, struct addrinfo** res) {
+  return ::getaddrinfo(node, service, hints, res);
 }
 
-void freeaddrinfo(struct addrinfo *res) {
-    ::freeaddrinfo(res);
-}
+void freeaddrinfo(struct addrinfo* res) { ::freeaddrinfo(res); }
 
-int setsockopt(int sockfd, int level, int optname, const void *optval, size_t optlen) {
+int setsockopt(int sockfd, int level, int optname, const void* optval,
+               size_t optlen) {
 #if TARGET_OS == GAPID_OS_WINDOWS
-    return ::setsockopt(sockfd, level, optname, static_cast<const char*>(optval),
-            static_cast<int>(optlen));
-#else  // TARGET_OS == GAPID_OS_WINDOWS
-    return ::setsockopt(sockfd, level, optname, optval, optlen);
+  return ::setsockopt(sockfd, level, optname, static_cast<const char*>(optval),
+                      static_cast<int>(optlen));
+#else   // TARGET_OS == GAPID_OS_WINDOWS
+  return ::setsockopt(sockfd, level, optname, optval, optlen);
 #endif  // TARGET_OS == GAPID_OS_WINDOWS
 }
 
 int socket(int domain, int type, int protocol) {
-    return static_cast<int>(::socket(domain, type, protocol));
+  return static_cast<int>(::socket(domain, type, protocol));
 }
 
-int listen(int sockfd, int backlog) {
-    return ::listen(sockfd, backlog);
-}
+int listen(int sockfd, int backlog) { return ::listen(sockfd, backlog); }
 
-int bind(int sockfd, const struct sockaddr *addr, size_t addrlen) {
+int bind(int sockfd, const struct sockaddr* addr, size_t addrlen) {
 #if TARGET_OS == GAPID_OS_WINDOWS
-    return ::bind(sockfd, addr, static_cast<int>(addrlen));
-#else  // TARGET_OS == GAPID_OS_WINDOWS
-    return ::bind(sockfd, addr, addrlen);
+  return ::bind(sockfd, addr, static_cast<int>(addrlen));
+#else   // TARGET_OS == GAPID_OS_WINDOWS
+  return ::bind(sockfd, addr, addrlen);
 #endif  // TARGET_OS == GAPID_OS_WINDOWS
 }
 
-int getsockname(int sockfd, struct sockaddr *addr, socklen_t* addrlen) {
+int getsockname(int sockfd, struct sockaddr* addr, socklen_t* addrlen) {
 #if TARGET_OS == GAPID_OS_WINDOWS
-    return ::getsockname(sockfd, addr, static_cast<int*>(addrlen));
-#else  // TARGET_OS == GAPID_OS_WINDOWS
-    return ::getsockname(sockfd, addr, addrlen);
+  return ::getsockname(sockfd, addr, static_cast<int*>(addrlen));
+#else   // TARGET_OS == GAPID_OS_WINDOWS
+  return ::getsockname(sockfd, addr, addrlen);
 #endif  // TARGET_OS == GAPID_OS_WINDOWS
 }
 
 }  // anonymous namespace
 
-SocketConnection::SocketConnection(int socket) : mSocket(socket) {
-}
+SocketConnection::SocketConnection(int socket) : mSocket(socket) {}
 
-SocketConnection::~SocketConnection() {
-    core::close(mSocket);
-}
+SocketConnection::~SocketConnection() { core::close(mSocket); }
 
 size_t SocketConnection::send(const void* data, size_t size) {
-    return core::send(mSocket, data, size, 0);
+  return core::send(mSocket, data, size, 0);
 }
 
 size_t SocketConnection::recv(void* data, size_t size) {
-    return core::recv(mSocket, data, size, MSG_WAITALL);
+  return core::recv(mSocket, data, size, MSG_WAITALL);
 }
 
-const char* SocketConnection::error() {
-    return strerror(core::error());
-}
+const char* SocketConnection::error() { return strerror(core::error()); }
 
 void SocketConnection::close() {
-    core::close(mSocket);
-    mSocket = -1;
+  core::close(mSocket);
+  mSocket = -1;
 }
 
-std::unique_ptr<Connection> SocketConnection::accept(int timeoutMs /* = NO_TIMEOUT */) {
-    int clientSocket = core::accept(mSocket, timeoutMs);
-    switch (clientSocket) {
-        case ACCEPT_ERROR:
-            GAPID_WARNING("Failed to accept incoming connection: %s", strerror(core::error()));
-            return nullptr;
-        case ACCEPT_TIMEOUT:
-            GAPID_INFO("Timeout accepting incoming connection");
-            return nullptr;
-        default:
-            return std::unique_ptr<Connection>(new SocketConnection(clientSocket));
-    }
+std::unique_ptr<Connection> SocketConnection::accept(
+    int timeoutMs /* = NO_TIMEOUT */) {
+  int clientSocket = core::accept(mSocket, timeoutMs);
+  switch (clientSocket) {
+    case ACCEPT_ERROR:
+      GAPID_WARNING("Failed to accept incoming connection: %s",
+                    strerror(core::error()));
+      return nullptr;
+    case ACCEPT_TIMEOUT:
+      GAPID_INFO("Timeout accepting incoming connection");
+      return nullptr;
+    default:
+      return std::unique_ptr<Connection>(new SocketConnection(clientSocket));
+  }
 }
 
-std::unique_ptr<Connection> SocketConnection::createSocket(
-        const char* hostname, const char* port) {
-    // Network initializer to ensure that the network driver is initialized during the lifetime of
-    // the create function. If the connection created successfully then the new connection will
-    // hold a reference to a networkInitializer struct to ensure that the network is initialized
-    NetworkInitializer networkInitializer;
+std::unique_ptr<Connection> SocketConnection::createSocket(const char* hostname,
+                                                           const char* port) {
+  // Network initializer to ensure that the network driver is initialized during
+  // the lifetime of the create function. If the connection created successfully
+  // then the new connection will hold a reference to a networkInitializer
+  // struct to ensure that the network is initialized
+  NetworkInitializer networkInitializer;
 
-    struct addrinfo* addr;
-    struct addrinfo hints{};
-    hints.ai_family = AF_INET;
-    hints.ai_socktype = SOCK_STREAM;
+  struct addrinfo* addr;
+  struct addrinfo hints {};
+  hints.ai_family = AF_INET;
+  hints.ai_socktype = SOCK_STREAM;
 
-    const int getaddrinfoRes = core::getaddrinfo(hostname, port, &hints, &addr);
-    if (0 != getaddrinfoRes) {
-        GAPID_WARNING("getaddrinfo() failed: %d - %s.", getaddrinfoRes, strerror(core::error()));
-        return nullptr;
+  const int getaddrinfoRes = core::getaddrinfo(hostname, port, &hints, &addr);
+  if (0 != getaddrinfoRes) {
+    GAPID_WARNING("getaddrinfo() failed: %d - %s.", getaddrinfoRes,
+                  strerror(core::error()));
+    return nullptr;
+  }
+  auto addrDeleter = [](struct addrinfo* ptr) {
+    core::freeaddrinfo(ptr);
+  };  // deferred.
+  std::unique_ptr<struct addrinfo, decltype(addrDeleter)> addrScopeGuard(
+      addr, addrDeleter);
+
+  const int sock =
+      core::socket(addr->ai_family, addr->ai_socktype, addr->ai_protocol);
+  if (-1 == sock) {
+    GAPID_WARNING("socket() failed: %s.", strerror(core::error()));
+    return nullptr;
+  }
+  auto socketCloser = [](const int* ptr) { core::close(*ptr); };  // deferred.
+  std::unique_ptr<const int, decltype(socketCloser)> sockScopeGuard(
+      &sock, socketCloser);
+
+  const int one = 1;
+  if (-1 == core::setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, (const char*)&one,
+                             sizeof(int))) {
+    GAPID_WARNING("setsockopt() failed: %s", strerror(core::error()));
+    return nullptr;
+  }
+
+  if (-1 == core::bind(sock, addr->ai_addr, addr->ai_addrlen)) {
+    GAPID_WARNING("bind() failed: %s.", strerror(core::error()));
+    return nullptr;
+  }
+  struct sockaddr_in sin;
+  socklen_t len = sizeof(sin);
+  if (-1 == core::getsockname(sock, (struct sockaddr*)&sin, &len)) {
+    GAPID_WARNING("getsockname() failed: %s.", strerror(core::error()));
+    return nullptr;
+  }
+
+  if (-1 == core::listen(sock, 10)) {
+    GAPID_WARNING("listen() failed: %s.", strerror(core::error()));
+    return nullptr;
+  }
+
+  // The following message is parsed by launchers to detect the selected port.
+  // DO NOT CHANGE!
+  printf("Bound on port '%d'\n", ntohs(sin.sin_port));
+  fflush(stdout);  // Force the message for piped readers
+
+  const char* portFile = getenv("GAPII_PORT_FILE");
+  if (portFile != nullptr) {
+    FILE* f = fopen(portFile, "w");
+    if (f != nullptr) {
+      fprintf(f, "Bound on port '%d'", ntohs(sin.sin_port));
+      fclose(f);
     }
-    auto addrDeleter = [](struct addrinfo* ptr) { core::freeaddrinfo(ptr); };  // deferred.
-    std::unique_ptr<struct addrinfo, decltype(addrDeleter)> addrScopeGuard(addr, addrDeleter);
+  }
 
-    const int sock = core::socket(addr->ai_family, addr->ai_socktype, addr->ai_protocol);
-    if (-1 == sock) {
-        GAPID_WARNING("socket() failed: %s.", strerror(core::error()));
-        return nullptr;
-    }
-    auto socketCloser = [](const int* ptr) { core::close(*ptr); };  // deferred.
-    std::unique_ptr<const int, decltype(socketCloser)> sockScopeGuard(&sock, socketCloser);
-
-    const int one = 1;
-    if (-1 == core::setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, (const char*)&one, sizeof(int))) {
-        GAPID_WARNING("setsockopt() failed: %s", strerror(core::error()));
-        return nullptr;
-    }
-
-    if (-1 == core::bind(sock, addr->ai_addr, addr->ai_addrlen)) {
-        GAPID_WARNING("bind() failed: %s.", strerror(core::error()));
-        return nullptr;
-    }
-    struct sockaddr_in sin;
-    socklen_t len = sizeof(sin);
-    if (-1 == core::getsockname(sock, (struct sockaddr *)&sin, &len)) {
-        GAPID_WARNING("getsockname() failed: %s.", strerror(core::error()));
-        return nullptr;
-    }
-
-    if (-1 == core::listen(sock, 10)) {
-        GAPID_WARNING("listen() failed: %s.", strerror(core::error()));
-        return nullptr;
-    }
-
-    // The following message is parsed by launchers to detect the selected port. DO NOT CHANGE!
-    printf("Bound on port '%d'\n", ntohs(sin.sin_port));
-    fflush(stdout); // Force the message for piped readers
-
-    const char* portFile = getenv("GAPII_PORT_FILE");
-    if (portFile != nullptr) {
-        FILE* f = fopen(portFile, "w");
-        if (f != nullptr) {
-            fprintf(f, "Bound on port '%d'", ntohs(sin.sin_port));
-            fclose(f);
-        }
-    }
-
-    sockScopeGuard.release();
-    return std::unique_ptr<Connection>(new SocketConnection(sock));
+  sockScopeGuard.release();
+  return std::unique_ptr<Connection>(new SocketConnection(sock));
 }
 
 uint32_t SocketConnection::getFreePort(const char* hostname) {
-  // Network initializer to ensure that the network driver is initialized during the lifetime of
-  // the create function. If the connection created successfully then the new connection will
-  // hold a reference to a networkInitializer struct to ensure that the network is initialized
+  // Network initializer to ensure that the network driver is initialized during
+  // the lifetime of the create function. If the connection created successfully
+  // then the new connection will hold a reference to a networkInitializer
+  // struct to ensure that the network is initialized
   NetworkInitializer networkInitializer;
 
   struct addrinfo* addr;
@@ -332,66 +337,72 @@ uint32_t SocketConnection::getFreePort(const char* hostname) {
 std::unique_ptr<Connection> SocketConnection::createPipe(const char* pipename,
                                                          bool abstract) {
 #if TARGET_OS == GAPID_OS_WINDOWS
-    // AF_UNIX is not supported on Windows.
-    return nullptr;
+  // AF_UNIX is not supported on Windows.
+  return nullptr;
 #else  // TARGET_OS == GAPID_OS_WINDOWS
-    const int sock = core::socket(AF_UNIX, SOCK_STREAM, 0);
-    if (-1 == sock) {
-        GAPID_WARNING("socket() failed: %s.", strerror(core::error()));
-        return nullptr;
-    }
-    auto socketCloser = [](const int* ptr) { core::close(*ptr); };  // deferred.
-    std::unique_ptr<const int, decltype(socketCloser)> sockScopeGuard(&sock, socketCloser);
+  const int sock = core::socket(AF_UNIX, SOCK_STREAM, 0);
+  if (-1 == sock) {
+    GAPID_WARNING("socket() failed: %s.", strerror(core::error()));
+    return nullptr;
+  }
+  auto socketCloser = [](const int* ptr) { core::close(*ptr); };  // deferred.
+  std::unique_ptr<const int, decltype(socketCloser)> sockScopeGuard(
+      &sock, socketCloser);
 
-    // In order to create a socket in the abstract namespace (no filesystem link), sun_path must
-    // start with a null byte followed by the abstract socket name. Abstract sockets/pipes are a
-    // non-portable Linux extension available on Android, described in Linux's man unix(7).
+  // In order to create a socket in the abstract namespace (no filesystem link),
+  // sun_path must start with a null byte followed by the abstract socket name.
+  // Abstract sockets/pipes are a non-portable Linux extension available on
+  // Android, described in Linux's man unix(7).
 
 #if (TARGET_OS != GAPID_OS_LINUX) && (TARGET_OS != GAPID_OS_ANDROID)
-    if (abstract) {
-        GAPID_WARNING("Abstract pipe '%s' creation unsupported for this platform. "
-            "Falling back to non-abstract.", pipename);
-        abstract = false;
-    }
+  if (abstract) {
+    GAPID_WARNING(
+        "Abstract pipe '%s' creation unsupported for this platform. "
+        "Falling back to non-abstract.",
+        pipename);
+    abstract = false;
+  }
 #endif
 
-    struct sockaddr_un pipe{};
-    pipe.sun_family = AF_UNIX;
-    strncpy(pipe.sun_path + (abstract ? 1 : 0), pipename, sizeof(pipe.sun_path)-2);
-    const size_t pipelen = sizeof(pipe.sun_family) + strlen(pipename) + (abstract ? 1 : 0);
+  struct sockaddr_un pipe {};
+  pipe.sun_family = AF_UNIX;
+  strncpy(pipe.sun_path + (abstract ? 1 : 0), pipename,
+          sizeof(pipe.sun_path) - 2);
+  const size_t pipelen =
+      sizeof(pipe.sun_family) + strlen(pipename) + (abstract ? 1 : 0);
 
-    if (-1 == core::bind(sock, (struct sockaddr*)&pipe, pipelen)) {
-        GAPID_WARNING("bind() failed: %s.", strerror(core::error()));
-        return nullptr;
-    }
+  if (-1 == core::bind(sock, (struct sockaddr*)&pipe, pipelen)) {
+    GAPID_WARNING("bind() failed: %s.", strerror(core::error()));
+    return nullptr;
+  }
 
-    if (-1 == core::listen(sock, 10)) {
-        GAPID_WARNING("listen() failed: %s.", strerror(core::error()));
-        return nullptr;
-    }
+  if (-1 == core::listen(sock, 10)) {
+    GAPID_WARNING("listen() failed: %s.", strerror(core::error()));
+    return nullptr;
+  }
 
-    sockScopeGuard.release();
-    return std::unique_ptr<Connection>(new SocketConnection(sock));
+  sockScopeGuard.release();
+  return std::unique_ptr<Connection>(new SocketConnection(sock));
 #endif  // TARGET_OS == GAPID_OS_WINDOWS
 }
 
 SocketConnection::NetworkInitializer::NetworkInitializer() {
 #if TARGET_OS == GAPID_OS_WINDOWS
-    if (gWinsockUsageCount++ == 0) {
-        WSADATA wsaData;
-        int wsaInitRes = ::WSAStartup(MAKEWORD(2, 2), &wsaData);
-        if (wsaInitRes != 0) {
-            GAPID_FATAL("WSAStartup failed with error code: %d", wsaInitRes);
-        }
+  if (gWinsockUsageCount++ == 0) {
+    WSADATA wsaData;
+    int wsaInitRes = ::WSAStartup(MAKEWORD(2, 2), &wsaData);
+    if (wsaInitRes != 0) {
+      GAPID_FATAL("WSAStartup failed with error code: %d", wsaInitRes);
     }
+  }
 #endif  // TARGET_OS == GAPID_OS_WINDOWS
 }
 
 SocketConnection::NetworkInitializer::~NetworkInitializer() {
 #if TARGET_OS == GAPID_OS_WINDOWS
-    if (--gWinsockUsageCount == 0) {
-        ::WSACleanup();
-    }
+  if (--gWinsockUsageCount == 0) {
+    ::WSACleanup();
+  }
 #endif  // TARGET_OS == GAPID_OS_WINDOWS
 }
 

--- a/core/cc/socket_connection.h
+++ b/core/cc/socket_connection.h
@@ -26,46 +26,51 @@ namespace core {
 
 // Connection object using a native socket
 class SocketConnection : public Connection {
-public:
-    ~SocketConnection();
+ public:
+  ~SocketConnection();
 
-    // Creates a new socket connection listening on the specified hostname and port. Returns a
-    // connection object on successful open or a nullptr if opening the connection is unsuccessful
-    static std::unique_ptr<Connection> createSocket(const char* hostname, const char* port);
+  // Creates a new socket connection listening on the specified hostname and
+  // port. Returns a connection object on successful open or a nullptr if
+  // opening the connection is unsuccessful
+  static std::unique_ptr<Connection> createSocket(const char* hostname,
+                                                  const char* port);
 
-    // Returns a free port to use with the given hostname. In case of error,
-    // returns 0
-    static uint32_t getFreePort(const char* hostname);
+  // Returns a free port to use with the given hostname. In case of error,
+  // returns 0
+  static uint32_t getFreePort(const char* hostname);
 
-    // Creates a new pipe connection listening on the specified UNIX pipename, without
-    // pipe creation on the local file system if abstract is true. Returns a connection object
-    // on successful open or a nullptr if opening the connection is unsuccessful
-    static std::unique_ptr<Connection> createPipe(const char* pipename, bool abstract);
+  // Creates a new pipe connection listening on the specified UNIX pipename,
+  // without pipe creation on the local file system if abstract is true. Returns
+  // a connection object on successful open or a nullptr if opening the
+  // connection is unsuccessful
+  static std::unique_ptr<Connection> createPipe(const char* pipename,
+                                                bool abstract);
 
-    // Implementation of the Connection interface
-    size_t send(const void* data, size_t size) override;
-    size_t recv(void* data, size_t size) override;
-    const char* error() override;
-    std::unique_ptr<Connection> accept(int timeoutMs = NO_TIMEOUT) override;
+  // Implementation of the Connection interface
+  size_t send(const void* data, size_t size) override;
+  size_t recv(void* data, size_t size) override;
+  const char* error() override;
+  std::unique_ptr<Connection> accept(int timeoutMs = NO_TIMEOUT) override;
 
-    void close() override;
-private:
-    // Private constructor used only by the static create function
-    explicit SocketConnection(int socket);
+  void close() override;
 
-    // Network initializer class to handle the initialization of the network driver. A socket
-    // function can be called only if there is at least one active network initializer is in
-    // the system
-    struct NetworkInitializer {
-        NetworkInitializer();
-        ~NetworkInitializer();
-    };
+ private:
+  // Private constructor used only by the static create function
+  explicit SocketConnection(int socket);
 
-    // The underlying socket for the connection
-    int mSocket;
+  // Network initializer class to handle the initialization of the network
+  // driver. A socket function can be called only if there is at least one
+  // active network initializer is in the system
+  struct NetworkInitializer {
+    NetworkInitializer();
+    ~NetworkInitializer();
+  };
 
-    // Network initializer instance lasts for the lifetime of the connection
-    NetworkInitializer mNetworkInitializer;
+  // The underlying socket for the connection
+  int mSocket;
+
+  // Network initializer instance lasts for the lifetime of the connection
+  NetworkInitializer mNetworkInitializer;
 };
 
 }  // namespace core

--- a/core/cc/static_array.h
+++ b/core/cc/static_array.h
@@ -30,14 +30,13 @@ struct CStaticArray {
 // from T[N].
 template <typename T, int N>
 class StaticArray : protected CStaticArray<T, N> {
-public:
-
+ public:
   inline StaticArray();
   inline StaticArray(const CStaticArray<T, N>& other);
   inline StaticArray(T arr[N]);
   inline StaticArray(std::initializer_list<T> l);
 
-  template<typename ...ARGS>
+  template <typename... ARGS>
   static inline StaticArray<T, N> create(ARGS&&...);
 
   static inline StaticArray<T, N> create(std::initializer_list<T> l);
@@ -50,79 +49,79 @@ public:
 
 template <typename T, int N>
 inline StaticArray<T, N>::StaticArray() {
-    for (int i = 0; i < N; i++) {
-        this->mData[i] = T();
-    }
+  for (int i = 0; i < N; i++) {
+    this->mData[i] = T();
+  }
 }
 
 template <typename T, int N>
 inline StaticArray<T, N>::StaticArray(const CStaticArray<T, N>& other) {
-    for (int i = 0; i < N; i++) {
-        this->mData[i] = other.mData[i];
-    }
+  for (int i = 0; i < N; i++) {
+    this->mData[i] = other.mData[i];
+  }
 }
 
 template <typename T, int N>
 inline StaticArray<T, N>::StaticArray(T arr[N]) {
-    for (int i = 0; i < N; i++) {
-        this->mData[i] = arr[i];
-    }
+  for (int i = 0; i < N; i++) {
+    this->mData[i] = arr[i];
+  }
 }
 
 template <typename T, int N>
 inline StaticArray<T, N>::StaticArray(std::initializer_list<T> l) {
-    GAPID_ASSERT(l.size() == N);
-    for (int i = 0; i < N; i++) {
-        this->mData[i] = l.begin()[i];
-    }
+  GAPID_ASSERT(l.size() == N);
+  for (int i = 0; i < N; i++) {
+    this->mData[i] = l.begin()[i];
+  }
 }
 
-#define NEW_UNINITIALIZED(name)  \
-    const size_t align = alignof(T); \
-    uint8_t buffer[sizeof(StaticArray<T, N>) + align]; \
-    uintptr_t unaligned = reinterpret_cast<uintptr_t>(buffer); \
-    uintptr_t aligned = (unaligned + align - 1) & ~(align - 1); \
-    StaticArray<T, N>& name = *reinterpret_cast<StaticArray<T, N>*>(aligned);
+#define NEW_UNINITIALIZED(name)                               \
+  const size_t align = alignof(T);                            \
+  uint8_t buffer[sizeof(StaticArray<T, N>) + align];          \
+  uintptr_t unaligned = reinterpret_cast<uintptr_t>(buffer);  \
+  uintptr_t aligned = (unaligned + align - 1) & ~(align - 1); \
+  StaticArray<T, N>& name = *reinterpret_cast<StaticArray<T, N>*>(aligned);
 
 template <typename T, int N>
-template <typename ...ARGS>
+template <typename... ARGS>
 inline StaticArray<T, N> StaticArray<T, N>::create(ARGS&&... args) {
-    NEW_UNINITIALIZED(out);
-    for (int i = 0; i < N; i++) {
-        new(&out.mData[i]) T(std::forward<ARGS>(args)...);
-    }
-    return out;
+  NEW_UNINITIALIZED(out);
+  for (int i = 0; i < N; i++) {
+    new (&out.mData[i]) T(std::forward<ARGS>(args)...);
+  }
+  return out;
 }
 
 template <typename T, int N>
 inline StaticArray<T, N> StaticArray<T, N>::create(std::initializer_list<T> l) {
-    GAPID_ASSERT(l.size() == N);
-    NEW_UNINITIALIZED(out);
-    for (int i = 0; i < N; i++) {
-        new(&out.mData[i]) T(l.begin()[i]);
-    }
-    return out;
+  GAPID_ASSERT(l.size() == N);
+  NEW_UNINITIALIZED(out);
+  for (int i = 0; i < N; i++) {
+    new (&out.mData[i]) T(l.begin()[i]);
+  }
+  return out;
 }
 
 template <typename T, int N>
 inline StaticArray<T, N> StaticArray<T, N>::create(T arr[N]) {
-    NEW_UNINITIALIZED(out);
-    for (int i = 0; i < N; i++) {
-        new(&out.mData[i]) T(arr[i]);
-    }
-    return out;
+  NEW_UNINITIALIZED(out);
+  for (int i = 0; i < N; i++) {
+    new (&out.mData[i]) T(arr[i]);
+  }
+  return out;
 }
 
 #undef NEW_UNINITIALIZED
 
 template <typename T, int N>
 inline StaticArray<T, N>::operator T*() {
-    return &this->mData[0];
+  return &this->mData[0];
 }
 
 template <typename T, int N>
 inline StaticArray<T, N>::operator const T*() const {
-    return &this->mData[0];
+  return &this->mData[0];
 }
 
 }  // namespace core

--- a/core/cc/stream_reader.h
+++ b/core/cc/stream_reader.h
@@ -23,25 +23,26 @@ namespace core {
 
 // StreamReader is a pure-virtual interface used to read from data streams.
 class StreamReader {
-public:
-    // read attempts to read max_size bytes to the pointer data, blocking until
-    // the data is available. Returns the number of bytes successfully read,
-    // which may be less than size if the stream was closed or there was an
-    // error.
-    virtual uint64_t read(void* data, uint64_t max_size) = 0;
+ public:
+  // read attempts to read max_size bytes to the pointer data, blocking until
+  // the data is available. Returns the number of bytes successfully read,
+  // which may be less than size if the stream was closed or there was an
+  // error.
+  virtual uint64_t read(void* data, uint64_t max_size) = 0;
 
-    // read attempts to read the s from the stream, returning true on success or
-    // false if the read was partial or a complete failure.
-    // Note: T must be a plain-old-data type.
-    template <typename T> inline bool read(T& s);
+  // read attempts to read the s from the stream, returning true on success or
+  // false if the read was partial or a complete failure.
+  // Note: T must be a plain-old-data type.
+  template <typename T>
+  inline bool read(T& s);
 
-protected:
-    virtual ~StreamReader() {}
+ protected:
+  virtual ~StreamReader() {}
 };
 
 template <typename T>
 inline bool StreamReader::read(T& s) {
-    return read(&s, sizeof(s)) == sizeof(s);
+  return read(&s, sizeof(s)) == sizeof(s);
 }
 
 }  // namespace core

--- a/core/cc/stream_writer.h
+++ b/core/cc/stream_writer.h
@@ -23,25 +23,26 @@ namespace core {
 
 // StreamWriter is a pure-virtual interface used to write data streams.
 class StreamWriter {
-public:
-    // write attempts to write size bytes from data to the stream, blocking
-    // until all data is written. Returns the number of bytes successfully
-    // written, which may be less than size if the stream was closed or there
-    // was an error.
-    virtual uint64_t write(const void* data, uint64_t size) = 0;
+ public:
+  // write attempts to write size bytes from data to the stream, blocking
+  // until all data is written. Returns the number of bytes successfully
+  // written, which may be less than size if the stream was closed or there
+  // was an error.
+  virtual uint64_t write(const void* data, uint64_t size) = 0;
 
-    // write attempts to write the bytes of s to the stream, returning true on
-    // success or false if the write was partial or a complete failure.
-    // Note: T must be a plain-old-data type.
-    template <typename T> inline bool write(const T& s);
+  // write attempts to write the bytes of s to the stream, returning true on
+  // success or false if the write was partial or a complete failure.
+  // Note: T must be a plain-old-data type.
+  template <typename T>
+  inline bool write(const T& s);
 
-protected:
-    virtual ~StreamWriter() {}
+ protected:
+  virtual ~StreamWriter() {}
 };
 
 template <typename T>
 inline bool StreamWriter::write(const T& s) {
-    return write(&s, sizeof(s)) == sizeof(s);
+  return write(&s, sizeof(s)) == sizeof(s);
 }
 
 }  // namespace core

--- a/core/cc/string_writer.h
+++ b/core/cc/string_writer.h
@@ -25,20 +25,20 @@ class StreamWriter;
 
 // StringWriter is a pure virtual class used to write strings to a StreamWriter.
 class StringWriter {
-public:
-    typedef std::shared_ptr<StringWriter> SPtr;
+ public:
+  typedef std::shared_ptr<StringWriter> SPtr;
 
-    // write attempts to write the string 'data' to the underlying stream,
-    // returning false upon failure.  'data' may be in an unknown state past
-    // this call, as implementations of this interface may use move semantics
-    // as a memory optimization.
-    virtual bool write(std::string& data) = 0;
+  // write attempts to write the string 'data' to the underlying stream,
+  // returning false upon failure.  'data' may be in an unknown state past
+  // this call, as implementations of this interface may use move semantics
+  // as a memory optimization.
+  virtual bool write(std::string& data) = 0;
 
-    // flush flushes out all of the pending in the steam
-    virtual void flush() = 0;
+  // flush flushes out all of the pending in the steam
+  virtual void flush() = 0;
 
-protected:
-    virtual ~StringWriter() {}
+ protected:
+  virtual ~StringWriter() {}
 };
 
 }  // namespace core

--- a/core/cc/supported_abis.h
+++ b/core/cc/supported_abis.h
@@ -24,15 +24,15 @@ namespace core {
 // Must match the definitions in core/os/device/abi.go.
 inline const char* supportedABIs() {
 #ifdef __x86_64
-    return "x86-64";
+  return "x86-64";
 #elif defined __i386
-    return "x86";
+  return "x86";
 #elif defined __ARM_ARCH_7A__
-    return "armeabi-v7a";
+  return "armeabi-v7a";
 #elif defined __aarch64__
-    return "arm64-v8a armeabi-v7a";
+  return "arm64-v8a armeabi-v7a";
 #else
-#   error "Unrecognised target architecture"
+#error "Unrecognised target architecture"
 #endif
 }
 

--- a/core/cc/target.h
+++ b/core/cc/target.h
@@ -17,8 +17,8 @@
 #ifndef CORE_TARGET_H
 #define CORE_TARGET_H
 
-#define GAPID_OS_LINUX   1
-#define GAPID_OS_OSX     2
+#define GAPID_OS_LINUX 1
+#define GAPID_OS_OSX 2
 #define GAPID_OS_WINDOWS 3
 #define GAPID_OS_ANDROID 4
 
@@ -28,70 +28,71 @@
 #define ANDROID_ONLY(x)
 
 #if defined(TARGET_OS_LINUX)
-#   define TARGET_OS GAPID_OS_LINUX
-#   define STDCALL
-#   define EXPORT __attribute__ ((visibility ("default")))
-#   define PATH_DELIMITER '/'
-#   define PATH_DELIMITER_STR "/"
-#   undef  LINUX_ONLY
-#   define LINUX_ONLY(x) x
+#define TARGET_OS GAPID_OS_LINUX
+#define STDCALL
+#define EXPORT __attribute__((visibility("default")))
+#define PATH_DELIMITER '/'
+#define PATH_DELIMITER_STR "/"
+#undef LINUX_ONLY
+#define LINUX_ONLY(x) x
 #endif
 
 #if defined(TARGET_OS_OSX)
-#   define TARGET_OS GAPID_OS_OSX
-#   define STDCALL
-#   define EXPORT __attribute__ ((visibility ("default")))
-#   define PATH_DELIMITER '/'
-#   define PATH_DELIMITER_STR "/"
-#   undef  OSX_ONLY
-#   define OSX_ONLY(x) x
-#   include <stdint.h>
-    using size_val = uint64_t;
+#define TARGET_OS GAPID_OS_OSX
+#define STDCALL
+#define EXPORT __attribute__((visibility("default")))
+#define PATH_DELIMITER '/'
+#define PATH_DELIMITER_STR "/"
+#undef OSX_ONLY
+#define OSX_ONLY(x) x
+#include <stdint.h>
+using size_val = uint64_t;
 #else  // defined(TARGET_OS_OSX)
-#   include <stddef.h>
-    using size_val = size_t;
+#include <stddef.h>
+using size_val = size_t;
 #endif
 
 #if defined(TARGET_OS_ANDROID)
-#   define TARGET_OS GAPID_OS_ANDROID
-#   define STDCALL
-#   define EXPORT __attribute__ ((visibility ("default")))
-#   define PATH_DELIMITER '/'
-#   define PATH_DELIMITER_STR "/"
-#   undef  ANDROID_ONLY
-#   define ANDROID_ONLY(x) x
+#define TARGET_OS GAPID_OS_ANDROID
+#define STDCALL
+#define EXPORT __attribute__((visibility("default")))
+#define PATH_DELIMITER '/'
+#define PATH_DELIMITER_STR "/"
+#undef ANDROID_ONLY
+#define ANDROID_ONLY(x) x
 #endif
 
 #if defined(TARGET_OS_WINDOWS)
-#   define TARGET_OS GAPID_OS_WINDOWS
-#   define STDCALL __stdcall
-#   define EXPORT __declspec(dllexport)
-#   define PATH_DELIMITER '\\'
-#   define PATH_DELIMITER_STR "\\"
-#   undef  WINDOWS_ONLY
-#   define WINDOWS_ONLY(x) x
+#define TARGET_OS GAPID_OS_WINDOWS
+#define STDCALL __stdcall
+#define EXPORT __declspec(dllexport)
+#define PATH_DELIMITER '\\'
+#define PATH_DELIMITER_STR "\\"
+#undef WINDOWS_ONLY
+#define WINDOWS_ONLY(x) x
 #endif
 
 #ifndef TARGET_OS
-#   error "OS not defined correctly."
-#   error "Exactly one of the following macro have to be defined:" \
+#error "OS not defined correctly."
+#error \
+    "Exactly one of the following macro have to be defined:" \
            "TARGET_OS_LINUX, TARGET_OS_OSX, TARGET_OS_WINDOWS, TARGET_OS_ANDROID"
 #endif
 
-#ifdef _MSC_VER // MSVC
-#   define ftruncate _chsize
-#   define alignof __alignof
-#   define _ALLOW_KEYWORD_MACROS 1
-#   define LIKELY(expr) expr
-#   define UNLIKELY(expr) expr
+#ifdef _MSC_VER  // MSVC
+#define ftruncate _chsize
+#define alignof __alignof
+#define _ALLOW_KEYWORD_MACROS 1
+#define LIKELY(expr) expr
+#define UNLIKELY(expr) expr
 #if !defined(__GNUC__)
-    // MSVC itself does not have ssize_t, although
-    // msys mingw does.
-    typedef long long ssize_t;
-#endif //!defined(__GNUC__)
-#else // _MSC_VER
-#   define LIKELY(expr) __builtin_expect(expr, true)
-#   define UNLIKELY(expr) __builtin_expect(expr, false)
-#endif // _MSC_VER
+// MSVC itself does not have ssize_t, although
+// msys mingw does.
+typedef long long ssize_t;
+#endif  //! defined(__GNUC__)
+#else   // _MSC_VER
+#define LIKELY(expr) __builtin_expect(expr, true)
+#define UNLIKELY(expr) __builtin_expect(expr, false)
+#endif  // _MSC_VER
 
 #endif  // CORE_TARGET_H

--- a/core/cc/thread.h
+++ b/core/cc/thread.h
@@ -24,37 +24,35 @@ namespace core {
 
 // Thread represents a single thread of execution in the process.
 class Thread {
-public:
-    // current returns the Thread representing the current thread of execution.
-    static Thread current();
+ public:
+  // current returns the Thread representing the current thread of execution.
+  static Thread current();
 
-    // id returns the process-unique identifier for the Thread.
-    inline uint64_t id() const;
+  // id returns the process-unique identifier for the Thread.
+  inline uint64_t id() const;
 
-private:
-    inline Thread(uint64_t id);
+ private:
+  inline Thread(uint64_t id);
 
-    uint64_t mId;
+  uint64_t mId;
 };
 
 inline Thread::Thread(uint64_t id) : mId(id) {}
 
-inline uint64_t Thread::id() const {
-    return mId;
-}
+inline uint64_t Thread::id() const { return mId; }
 
 class AsyncJob {
-    public:
-        AsyncJob(const std::function<void()>& function);
-        ~AsyncJob(); // Waits on the thread to finish.
-    private:
-    static void* RunJob(void* _data) {
-        AsyncJob* job = reinterpret_cast<AsyncJob*>(_data);
-        job->mFunction();
-        return nullptr;
-    }
-    std::function<void()> mFunction;
-    void* _; // A pointer to the OS thread object.
+ public:
+  AsyncJob(const std::function<void()>& function);
+  ~AsyncJob();  // Waits on the thread to finish.
+ private:
+  static void* RunJob(void* _data) {
+    AsyncJob* job = reinterpret_cast<AsyncJob*>(_data);
+    job->mFunction();
+    return nullptr;
+  }
+  std::function<void()> mFunction;
+  void* _;  // A pointer to the OS thread object.
 };
 
 }  // namespace core

--- a/core/cc/timer.h
+++ b/core/cc/timer.h
@@ -21,17 +21,18 @@
 
 namespace core {
 
-// Timer provides a timer that measures monotonic time between calls to Start() and Stop().
+// Timer provides a timer that measures monotonic time between calls to Start()
+// and Stop().
 class Timer {
-public:
-    // Begin the timer.
-    void Start();
+ public:
+  // Begin the timer.
+  void Start();
 
-    // Stop the timer and report the time in nanoseconds since Start was called.
-    uint64_t Stop();
+  // Stop the timer and report the time in nanoseconds since Start was called.
+  uint64_t Stop();
 
-private:
-  uint64_t mStartTime; // Units dependent on platform.
+ private:
+  uint64_t mStartTime;  // Units dependent on platform.
 };
 
 }  // namespace core

--- a/core/cc/trace.h
+++ b/core/cc/trace.h
@@ -24,7 +24,6 @@
 #endif  // TARGET_OS == GAPID_OS_ANDROID
 #endif  // GAPID_USE_TRACING
 
-
 #ifndef GAPID_TRACE_MACROS_DEFINED
 #define GAPID_TRACE_CALL()
 #define GAPID_TRACE_NAME(name)

--- a/core/cc/vector.h
+++ b/core/cc/vector.h
@@ -25,119 +25,111 @@ namespace core {
 
 // Vector is a fixed-capacity container of plain-old-data elements of type T.
 // Do not use elements that require destruction in this container.
-template<typename T>
+template <typename T>
 class Vector {
-public:
-    // Default constructor.
-    // Vector is unusable until it is assigned from a Vector constructed using one of the other
-    // constructors.
-    Vector();
+ public:
+  // Default constructor.
+  // Vector is unusable until it is assigned from a Vector constructed using one
+  // of the other constructors.
+  Vector();
 
-    // Constructs a vector pre-sized to count and with the first element at the specified address.
-    // The vector's capacity is fixed to count.
-    Vector(T* first, size_t count);
+  // Constructs a vector pre-sized to count and with the first element at the
+  // specified address. The vector's capacity is fixed to count.
+  Vector(T* first, size_t count);
 
-    // Constructs a vector pre-sized to count and with the first element at the specified address.
-    // The vector's capacity is fixed to capacity.
-    Vector(T* first, size_t count, size_t capacity);
+  // Constructs a vector pre-sized to count and with the first element at the
+  // specified address. The vector's capacity is fixed to capacity.
+  Vector(T* first, size_t count, size_t capacity);
 
-    // clear sets the vector count to 0.
-    inline void clear();
+  // clear sets the vector count to 0.
+  inline void clear();
 
-    // append grows the vector by 1 by appending el to the end of the vector.
-    // It is a fatal error if the vector has no more capacity.
-    inline void append(const T& el);
+  // append grows the vector by 1 by appending el to the end of the vector.
+  // It is a fatal error if the vector has no more capacity.
+  inline void append(const T& el);
 
-    // append grows the vector and appends all elements from the other vector.
-    // It is a fatal error if the vector has no more capacity.
-    inline void append(const Vector<T>& other);
+  // append grows the vector and appends all elements from the other vector.
+  // It is a fatal error if the vector has no more capacity.
+  inline void append(const Vector<T>& other);
 
-    // data returns the pointer to the first element in the vector.
-    // If the vector is empty, then data returns nullptr.
-    inline T* data() const;
+  // data returns the pointer to the first element in the vector.
+  // If the vector is empty, then data returns nullptr.
+  inline T* data() const;
 
-    // count returns the number of elements in the vector.
-    inline size_t count() const;
+  // count returns the number of elements in the vector.
+  inline size_t count() const;
 
-    // Returns a reference to a single element in the slice.
-    inline T& operator[](size_t index) const;
+  // Returns a reference to a single element in the slice.
+  inline T& operator[](size_t index) const;
 
-    // Support for range-based for looping
-    inline T* begin() const;
-    inline T* end() const;
+  // Support for range-based for looping
+  inline T* begin() const;
+  inline T* end() const;
 
-private:
-    T*     mBase;     // Address of the first element in the vector.
-    size_t mCapacity; // Maximum number of elements this vector can hold.
-    size_t mCount;    // Number of elements in the vector.
+ private:
+  T* mBase;          // Address of the first element in the vector.
+  size_t mCapacity;  // Maximum number of elements this vector can hold.
+  size_t mCount;     // Number of elements in the vector.
 };
 
-template<typename T>
-Vector<T>::Vector()
-        : mBase(nullptr)
-        , mCapacity(0)
-        , mCount(0)
-{}
+template <typename T>
+Vector<T>::Vector() : mBase(nullptr), mCapacity(0), mCount(0) {}
 
-template<typename T>
+template <typename T>
 Vector<T>::Vector(T* first, size_t count)
-        : mBase(first)
-        , mCapacity(count)
-        , mCount(count) {}
+    : mBase(first), mCapacity(count), mCount(count) {}
 
-template<typename T>
+template <typename T>
 Vector<T>::Vector(T* first, size_t count, size_t capacity)
-        : mBase(first)
-        , mCapacity(capacity)
-        , mCount(count) {
-    GAPID_ASSERT(count <= capacity);
+    : mBase(first), mCapacity(capacity), mCount(count) {
+  GAPID_ASSERT(count <= capacity);
 }
 
-template<typename T>
+template <typename T>
 inline void Vector<T>::clear() {
-    mCount = 0;
+  mCount = 0;
 }
 
-template<typename T>
+template <typename T>
 inline void Vector<T>::append(const T& el) {
-    GAPID_ASSERT(mCount < mCapacity);
-    new(&mBase[mCount]) T(el);
-    mCount++;
+  GAPID_ASSERT(mCount < mCapacity);
+  new (&mBase[mCount]) T(el);
+  mCount++;
 }
 
-template<typename T>
+template <typename T>
 inline void Vector<T>::append(const Vector<T>& other) {
-    for (auto it : other) {
-        append(it);
-    }
+  for (auto it : other) {
+    append(it);
+  }
 }
 
-template<typename T>
+template <typename T>
 inline T* Vector<T>::data() const {
-    return mCount > 0 ? mBase : nullptr;
+  return mCount > 0 ? mBase : nullptr;
 }
 
-template<typename T>
+template <typename T>
 inline size_t Vector<T>::count() const {
-    return mCount;
+  return mCount;
 }
 
 // Returns a reference to a single element in the slice.
-template<typename T>
+template <typename T>
 inline T& Vector<T>::operator[](size_t index) const {
-    GAPID_ASSERT(index < mCount);
-    return mBase[index];
+  GAPID_ASSERT(index < mCount);
+  return mBase[index];
 }
 
 // Support for range-based for looping
-template<typename T>
+template <typename T>
 inline T* Vector<T>::begin() const {
-    return mBase;
+  return mBase;
 }
 
-template<typename T>
+template <typename T>
 inline T* Vector<T>::end() const {
-    return mBase + mCount;
+  return mBase + mCount;
 }
 
 }  // namespace core

--- a/core/cc/vulkan_ptr_types.h
+++ b/core/cc/vulkan_ptr_types.h
@@ -37,26 +37,26 @@
 #include "core/cc/target.h"
 
 #if defined(TARGET_OS_WINDOWS)
-    // On Windows, Vulkan commands use the stdcall convention
-    #define VKAPI_ATTR
-    #define VKAPI_CALL __stdcall
-    #define VKAPI_PTR  VKAPI_CALL
+// On Windows, Vulkan commands use the stdcall convention
+#define VKAPI_ATTR
+#define VKAPI_CALL __stdcall
+#define VKAPI_PTR VKAPI_CALL
 #elif defined(TARGET_OS_ANDROID) && defined(__ARM_ARCH_7A__)
-    // On Android/ARMv7a, Vulkan functions use the armeabi-v7a-hard calling
-    // convention, even if the application's native code is compiled with the
-    // armeabi-v7a calling convention.
-    #define VKAPI_ATTR __attribute__((pcs("aapcs-vfp")))
-    #define VKAPI_CALL
-    #define VKAPI_PTR  VKAPI_ATTR
+// On Android/ARMv7a, Vulkan functions use the armeabi-v7a-hard calling
+// convention, even if the application's native code is compiled with the
+// armeabi-v7a calling convention.
+#define VKAPI_ATTR __attribute__((pcs("aapcs-vfp")))
+#define VKAPI_CALL
+#define VKAPI_PTR VKAPI_ATTR
 #else
-    // On other platforms, use the default calling convention
-    #define VKAPI_ATTR
-    #define VKAPI_CALL
-    #define VKAPI_PTR
+// On other platforms, use the default calling convention
+#define VKAPI_ATTR
+#define VKAPI_CALL
+#define VKAPI_PTR
 #endif
 
 #define VULKAN_API_ATTR VKAPI_ATTR
 #define VULKAN_API_CALL VKAPI_CALL
-#define VULKAN_API_PTR  VKAPI_PTR
+#define VULKAN_API_PTR VKAPI_PTR
 
 #endif

--- a/core/cc/windows/debugger.cpp
+++ b/core/cc/windows/debugger.cpp
@@ -21,13 +21,11 @@
 namespace core {
 
 void Debugger::waitForAttach() {
-    while (!isAttached()) {}
-    DebugBreak();
+  while (!isAttached()) {
+  }
+  DebugBreak();
 }
 
-bool Debugger::isAttached() {
-    return IsDebuggerPresent();
-}
+bool Debugger::isAttached() { return IsDebuggerPresent(); }
 
 }  // namespace core
-

--- a/core/cc/windows/get_gles_proc_address.cpp
+++ b/core/cc/windows/get_gles_proc_address.cpp
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-#include "../dl_loader.h"
 #include "../get_gles_proc_address.h"
+#include "../dl_loader.h"
 #include "../log.h"
-#include "../target.h" // STDCALL
+#include "../target.h"  // STDCALL
 
-#include <string>
 #include <sstream>
+#include <string>
 
 #include <windows.h>
 #include <wingdi.h>
@@ -28,32 +28,37 @@
 namespace {
 
 std::string systemOpengl32Path() {
-    char sysdir[MAX_PATH];
-    GetSystemDirectoryA(sysdir, MAX_PATH-1);
+  char sysdir[MAX_PATH];
+  GetSystemDirectoryA(sysdir, MAX_PATH - 1);
 
-    std::stringstream path;
-    path << sysdir << "\\opengl32.dll";
-    return path.str();
+  std::stringstream path;
+  path << sysdir << "\\opengl32.dll";
+  return path.str();
 }
 
 void* getGlesProcAddress(const char* name, bool bypassLocal) {
-    using namespace core;
-    typedef void* (*GPAPROC)(const char *name);
+  using namespace core;
+  typedef void* (*GPAPROC)(const char* name);
 
-    static DlLoader opengl(bypassLocal ? systemOpengl32Path().c_str() : "opengl32.dll");
-    if (GPAPROC gpa = reinterpret_cast<GPAPROC>(opengl.lookup("wglGetProcAddress"))) {
-        if (void* proc = gpa(name)) {
-            GAPID_DEBUG("GetGlesProcAddress(%s, %d) -> 0x%x (via opengl32 wglGetProcAddress)", name, bypassLocal, proc);
-            return proc;
-        }
+  static DlLoader opengl(bypassLocal ? systemOpengl32Path().c_str()
+                                     : "opengl32.dll");
+  if (GPAPROC gpa =
+          reinterpret_cast<GPAPROC>(opengl.lookup("wglGetProcAddress"))) {
+    if (void* proc = gpa(name)) {
+      GAPID_DEBUG(
+          "GetGlesProcAddress(%s, %d) -> 0x%x (via opengl32 wglGetProcAddress)",
+          name, bypassLocal, proc);
+      return proc;
     }
-    if (void* proc = opengl.lookup(name)) {
-        GAPID_DEBUG("GetGlesProcAddress(%s, %d) -> 0x%x (from opengl32 symbol)", name, bypassLocal, proc);
-        return proc;
-    }
+  }
+  if (void* proc = opengl.lookup(name)) {
+    GAPID_DEBUG("GetGlesProcAddress(%s, %d) -> 0x%x (from opengl32 symbol)",
+                name, bypassLocal, proc);
+    return proc;
+  }
 
-    GAPID_DEBUG("GetGlesProcAddress(%s, %d) -> not found", name, bypassLocal);
-    return nullptr;
+  GAPID_DEBUG("GetGlesProcAddress(%s, %d) -> not found", name, bypassLocal);
+  return nullptr;
 }
 
 }  // anonymous namespace
@@ -61,8 +66,6 @@ void* getGlesProcAddress(const char* name, bool bypassLocal) {
 namespace core {
 
 GetGlesProcAddressFunc* GetGlesProcAddress = getGlesProcAddress;
-bool hasGLorGLES() {
-    return DlLoader::can_load(systemOpengl32Path().c_str());
-}
+bool hasGLorGLES() { return DlLoader::can_load(systemOpengl32Path().c_str()); }
 
 }  // namespace core

--- a/core/cc/windows/thread.cpp
+++ b/core/cc/windows/thread.cpp
@@ -21,22 +21,22 @@
 namespace core {
 
 Thread Thread::current() {
-    auto thread = GetCurrentThreadId();
-    return Thread(static_cast<uint64_t>(thread));
+  auto thread = GetCurrentThreadId();
+  return Thread(static_cast<uint64_t>(thread));
 }
 
-AsyncJob::AsyncJob(const std::function<void()>& function) : mFunction(function) {
-    LPTHREAD_START_ROUTINE start = [](void* _this) -> long unsigned int {
-        AsyncJob::RunJob(_this);
-        return 0;
-    };
-    _ = reinterpret_cast<void*>(CreateThread(nullptr,
-        0, start, this, 0, nullptr));
+AsyncJob::AsyncJob(const std::function<void()>& function)
+    : mFunction(function) {
+  LPTHREAD_START_ROUTINE start = [](void* _this) -> long unsigned int {
+    AsyncJob::RunJob(_this);
+    return 0;
+  };
+  _ = reinterpret_cast<void*>(
+      CreateThread(nullptr, 0, start, this, 0, nullptr));
 }
 
 AsyncJob::~AsyncJob() {
-    WaitForSingleObject(reinterpret_cast<HANDLE>(_), INFINITE);
+  WaitForSingleObject(reinterpret_cast<HANDLE>(_), INFINITE);
 }
-
 
 }  // namespace core

--- a/core/image/astc/astc.h
+++ b/core/image/astc/astc.h
@@ -20,13 +20,9 @@ extern "C" {
 
 void init_astc();
 
-void decompress_astc(uint8_t* in,
-                     uint8_t* out,
-                     uint32_t width,
-                     uint32_t height,
-                     uint32_t block_width,
-                     uint32_t block_height);
+void decompress_astc(uint8_t* in, uint8_t* out, uint32_t width, uint32_t height,
+                     uint32_t block_width, uint32_t block_height);
 
 #ifdef __cplusplus
-} // extern "C"
+}  // extern "C"
 #endif

--- a/core/memory/arena/cc/arena.cpp
+++ b/core/memory/arena/cc/arena.cpp
@@ -16,8 +16,8 @@
 
 #include "arena.h"
 
-#include "core/cc/target.h"
 #include "core/cc/assert.h"
+#include "core/cc/target.h"
 
 #include <algorithm>
 #include <cassert>
@@ -174,7 +174,8 @@ void* Arena::allocate(uint32_t size, uint32_t align) {
     } else {
       chunk_header* val = 0;
       // If we can't actually allocate memory that is a problem.
-      val = static_cast<chunk_header*>(allocate_aligned(kChunkSize, kChunkSize));
+      val =
+          static_cast<chunk_header*>(allocate_aligned(kChunkSize, kChunkSize));
       data.current_chunk = reinterpret_cast<uint8_t*>(val);
       chunks_.push_back(val);
       val->block_size = block_size;
@@ -286,13 +287,15 @@ void Arena::dump_allocator_stats() const {
 
   GAPID_ERROR("----------------- ARENA STATS -----------------");
   GAPID_ERROR("Num Chunks: %35zu", chunks_.size());
-  GAPID_ERROR("Num Dedicated Allocations: %20zu", dedicated_allocations_.size());
+  GAPID_ERROR("Num Dedicated Allocations: %20zu",
+              dedicated_allocations_.size());
   GAPID_ERROR("Total Memory Reserved: %24" PRIu32,
               total_chunk_memory + total_dedicated_memory);
   GAPID_ERROR("Total Memory Reserved [Chunks]: %15" PRIu32, total_chunk_memory);
   GAPID_ERROR("Total Memory Reserved [Dedicated]: %12" PRIu32,
               total_dedicated_memory);
-  GAPID_ERROR("Total Memory Used [Chunks]: %19" PRIu32, total_used_chunk_memory);
+  GAPID_ERROR("Total Memory Used [Chunks]: %19" PRIu32,
+              total_used_chunk_memory);
   GAPID_ERROR("Total Memory Used [Dedicated]: %16" PRIu32,
               total_used_dedicated_memory);
   GAPID_ERROR("Memory Overhead [Headers]: %20" PRIu32, total_header_memory);
@@ -315,8 +318,8 @@ void Arena::dump_allocator_stats() const {
          node = node->next) {
       freelist_count += 1;
     }
-    GAPID_ERROR("Freelist [%6" PRIu32 "]: %28" PRIu32, 1 << (kMinBlockSizePower + i),
-                freelist_count);
+    GAPID_ERROR("Freelist [%6" PRIu32 "]: %28" PRIu32,
+                1 << (kMinBlockSizePower + i), freelist_count);
     i++;
   }
   GAPID_ERROR("-----------------------------------------------");
@@ -346,32 +349,28 @@ void Arena::unprotect() {
 
 extern "C" {
 
-arena* arena_create() {
-    return reinterpret_cast<arena*>(new core::Arena());
-}
+arena* arena_create() { return reinterpret_cast<arena*>(new core::Arena()); }
 
-void arena_destroy(arena* a) {
-    delete reinterpret_cast<core::Arena*>(a);
-}
+void arena_destroy(arena* a) { delete reinterpret_cast<core::Arena*>(a); }
 
 void* arena_alloc(arena* a, uint32_t size, uint32_t align) {
-    return reinterpret_cast<core::Arena*>(a)->allocate(size, align);
+  return reinterpret_cast<core::Arena*>(a)->allocate(size, align);
 }
 
 void* arena_realloc(arena* a, void* ptr, uint32_t size, uint32_t align) {
-    return reinterpret_cast<core::Arena*>(a)->reallocate(ptr, size, align);
+  return reinterpret_cast<core::Arena*>(a)->reallocate(ptr, size, align);
 }
 
 void arena_free(arena* a, void* ptr) {
-    reinterpret_cast<core::Arena*>(a)->free(ptr);
+  reinterpret_cast<core::Arena*>(a)->free(ptr);
 }
 
 // arena_stats returns statistics of the current state of the arena.
-void arena_stats(arena* a, size_t* num_allocations, size_t* num_bytes_allocated) {
-    auto arena = reinterpret_cast<core::Arena*>(a);
-    *num_allocations = arena->num_allocations();
-    *num_bytes_allocated = arena->num_bytes_allocated();
+void arena_stats(arena* a, size_t* num_allocations,
+                 size_t* num_bytes_allocated) {
+  auto arena = reinterpret_cast<core::Arena*>(a);
+  *num_allocations = arena->num_allocations();
+  *num_bytes_allocated = arena->num_bytes_allocated();
 }
 
-} // extern "C"
-
+}  // extern "C"

--- a/core/memory/arena/cc/arena.h
+++ b/core/memory/arena/cc/arena.h
@@ -15,8 +15,8 @@
 #ifndef CORE_ARENA_H
 #define CORE_ARENA_H
 
-#include <stdint.h>
 #include <stddef.h>
+#include <stdint.h>
 
 #ifdef __cplusplus
 
@@ -64,102 +64,101 @@ struct chunk_header {
 // If there are any outstanding allocations when the Arena is destructed then
 // these allocations are automatically freed.
 class Arena {
-public:
-    Arena();
-    ~Arena();
+ public:
+  Arena();
+  ~Arena();
 
-    // allocates a contiguous block of memory of at least the requested size and
-    // alignment. This is internally synchronized and may be called from
-    // multiple threads at once.
-    void* allocate(uint32_t size, uint32_t align);
+  // allocates a contiguous block of memory of at least the requested size and
+  // alignment. This is internally synchronized and may be called from
+  // multiple threads at once.
+  void* allocate(uint32_t size, uint32_t align);
 
-    // reallocates a block of memory previously allocated by this arena.
-    // Data held in the previous allocation will be copied to the reallocated
-    // address, but data may be trimmed if the new size is smaller than the
-    // previous allocation.
-    // This is internally synchronized and may be called from multiple
-    // threads at once.
-    void* reallocate(void* ptr, uint32_t size, uint32_t align);
+  // reallocates a block of memory previously allocated by this arena.
+  // Data held in the previous allocation will be copied to the reallocated
+  // address, but data may be trimmed if the new size is smaller than the
+  // previous allocation.
+  // This is internally synchronized and may be called from multiple
+  // threads at once.
+  void* reallocate(void* ptr, uint32_t size, uint32_t align);
 
-    // free releases the memory previously allocated by this arena.
-    // Once the memory is freed, it must not be used.
-    // This is internalyl synchronized and may be called from multiple
-    // threads at once.
-    void free(void* ptr);
+  // free releases the memory previously allocated by this arena.
+  // Once the memory is freed, it must not be used.
+  // This is internalyl synchronized and may be called from multiple
+  // threads at once.
+  void free(void* ptr);
 
-    // create constructs and returns a pointer to a new T.
-    // This is internally synchronized and may be called from multiple
-    // threads at once.
-    template<typename T, typename... ARGS>
-    inline T* create(ARGS&&... args);
+  // create constructs and returns a pointer to a new T.
+  // This is internally synchronized and may be called from multiple
+  // threads at once.
+  template <typename T, typename... ARGS>
+  inline T* create(ARGS&&... args);
 
-    // destroy destructs an object constructed with create<T>().
-    // This is internally synchronized and may be called from multiple
-    // threads at once.
-    template<typename T>
-    inline void destroy(T* ptr);
+  // destroy destructs an object constructed with create<T>().
+  // This is internally synchronized and may be called from multiple
+  // threads at once.
+  template <typename T>
+  inline void destroy(T* ptr);
 
-    // returns the total number of allocations owned by this arena.
-    size_t num_allocations() const;
+  // returns the total number of allocations owned by this arena.
+  size_t num_allocations() const;
 
-    // returns the total number of bytes allocated by this arena.
-    size_t num_bytes_allocated() const;
+  // returns the total number of bytes allocated by this arena.
+  size_t num_bytes_allocated() const;
 
-    // Dumps allocator stats to GAPID_ERROR.
-    void dump_allocator_stats() const;
+  // Dumps allocator stats to GAPID_ERROR.
+  void dump_allocator_stats() const;
 
-    // protects all of the memory in the arena. None of the memory
-    // that was created by this arena may be written to after this
-    // point.
-    // No allocation / free operations may be in progress while this
-    // is happening, futhermore, allocate/free may not be called
-    // after the arena is protected.
-    void protect();
+  // protects all of the memory in the arena. None of the memory
+  // that was created by this arena may be written to after this
+  // point.
+  // No allocation / free operations may be in progress while this
+  // is happening, futhermore, allocate/free may not be called
+  // after the arena is protected.
+  void protect();
 
-    // unprotects all of the memory in the arena.
-    void unprotect();
+  // unprotects all of the memory in the arena.
+  void unprotect();
 
-   private:
-    void lock() const {
-      uint32_t l = 0;
-      while (!lock_.compare_exchange_weak(l, 1, std::memory_order_acquire)) {
-        l = 0;
-      }
+ private:
+  void lock() const {
+    uint32_t l = 0;
+    while (!lock_.compare_exchange_weak(l, 1, std::memory_order_acquire)) {
+      l = 0;
     }
-    void unlock() const { lock_.store(0, std::memory_order_release); }
+  }
+  void unlock() const { lock_.store(0, std::memory_order_release); }
 
-    // chunks_ contains every chunk that has ever been allocated.
-    std::list<chunk_header*> chunks_;
-    // dedicated_allocations_ contains data about every allocation
-    // that was too large for a block.
-    std::unordered_map<uint8_t*, uint32_t> dedicated_allocations_;
-    // blocks_ contains all of the freelists and blocksize specific information.
-    std::array<block_data, kMaxBlockSizePower - kMinBlockSizePower + 1> blocks_;
-    // lock_ is a simple atomic lock spinlock for locking. We have this lock
-    // only for very brief periods of time.
-    // We mark this mutable, so we can use lock/unlock in
-    // num_allocations/num_bytes_allocated.
-    mutable std::atomic<uint32_t> lock_;
+  // chunks_ contains every chunk that has ever been allocated.
+  std::list<chunk_header*> chunks_;
+  // dedicated_allocations_ contains data about every allocation
+  // that was too large for a block.
+  std::unordered_map<uint8_t*, uint32_t> dedicated_allocations_;
+  // blocks_ contains all of the freelists and blocksize specific information.
+  std::array<block_data, kMaxBlockSizePower - kMinBlockSizePower + 1> blocks_;
+  // lock_ is a simple atomic lock spinlock for locking. We have this lock
+  // only for very brief periods of time.
+  // We mark this mutable, so we can use lock/unlock in
+  // num_allocations/num_bytes_allocated.
+  mutable std::atomic<uint32_t> lock_;
 
-    // page_size_ is needed for protecting memory.
-    uint32_t page_size_;
-    // protected_ is true when the memory in this allocator has been
-    // protected.
-    bool protected_;
+  // page_size_ is needed for protecting memory.
+  uint32_t page_size_;
+  // protected_ is true when the memory in this allocator has been
+  // protected.
+  bool protected_;
 };
 
-template<typename T, typename... ARGS>
+template <typename T, typename... ARGS>
 inline T* Arena::create(ARGS&&... args) {
-    auto buf = allocate(sizeof(T), alignof(T));
-    return new(buf) T(std::forward<ARGS>(args)...);
+  auto buf = allocate(sizeof(T), alignof(T));
+  return new (buf) T(std::forward<ARGS>(args)...);
 }
 
-template<typename T>
+template <typename T>
 inline void Arena::destroy(T* ptr) {
-    ptr->~T();
-    free(ptr);
+  ptr->~T();
+  free(ptr);
 }
-
 
 }  // namespace core
 
@@ -189,10 +188,11 @@ void* arena_realloc(arena* arena, void* ptr, uint32_t size, uint32_t align);
 void arena_free(arena* arena, void* ptr);
 
 // arena_stats returns statistics of the current state of the arena.
-void arena_stats(arena* arena, size_t* num_allocations, size_t* num_bytes_allocated);
+void arena_stats(arena* arena, size_t* num_allocations,
+                 size_t* num_bytes_allocated);
 
 #ifdef __cplusplus
-} // extern "C"
+}  // extern "C"
 #endif
 
-#endif //  CORE_ARENA_H
+#endif  //  CORE_ARENA_H

--- a/core/memory_tracker/cc/memory_protections.h
+++ b/core/memory_tracker/cc/memory_protections.h
@@ -14,10 +14,8 @@
  * limitations under the License.
  */
 
-
 #ifndef GAPII_MEMORY_PROTECTIONS_H
 #define GAPII_MEMORY_PROTECTIONS_H
-
 
 namespace gapii {
 namespace track_memory {
@@ -29,7 +27,7 @@ enum class PageProtections {
   kReadWrite = 0x1 | 0x2
 };
 
-} // namespace track_memory
-} // namespace gapii
+}  // namespace track_memory
+}  // namespace gapii
 
-#endif // GAPII_MEMORY_PROTECTIONS_H
+#endif  // GAPII_MEMORY_PROTECTIONS_H

--- a/core/memory_tracker/cc/memory_tracker.h
+++ b/core/memory_tracker/cc/memory_tracker.h
@@ -31,7 +31,7 @@
 #undef COHERENT_TRACKING_ENABLED
 #define COHERENT_TRACKING_ENABLED 0
 #endif
-#endif // COHERENT_TRACKING_ENABLED
+#endif  // COHERENT_TRACKING_ENABLED
 
 #if COHERENT_TRACKING_ENABLED
 
@@ -220,7 +220,8 @@ class SignalSafe : public SpinLockGuarded<OwnerTy, MemberFuncPtrTy> {
   auto operator()(Args&&... args) ->
       typename std::result_of<MemberFuncPtrTy(OwnerTy*, Args&&...)>::type {
     SignalBlocker g(sig_);
-    return this->SpinLockGuardedFunctor::template operator()<Args...>(std::forward<Args>(args)...);
+    return this->SpinLockGuardedFunctor::template operator()<Args...>(
+        std::forward<Args>(args)...);
   }
 
  protected:
@@ -300,7 +301,7 @@ class DirtyPageTable {
 
 // MemoryTrackerImpl utilizes Segfault signal on Linux to track accesses to
 // memories.
-template<typename SpecificMemoryTracker>
+template <typename SpecificMemoryTracker>
 class MemoryTrackerImpl : public SpecificMemoryTracker {
  public:
   using derived_tracker_type = SpecificMemoryTracker;
@@ -406,17 +407,16 @@ class MemoryTrackerImpl : public SpecificMemoryTracker {
     bool succeeded = true;
     std::for_each(pages.begin(), pages.end(), [this, &succeeded](void* p) {
       if (IsInRanges(reinterpret_cast<uintptr_t>(p), ranges_, true)) {
-        succeeded &=
-            set_protection(p, page_size_, track_read_ ? PageProtections::kNone : PageProtections::kRead) == 0;
+        succeeded &= set_protection(p, page_size_,
+                                    track_read_ ? PageProtections::kNone
+                                                : PageProtections::kRead) == 0;
       }
     });
     return succeeded;
   }
 
   // Dummy function that we can pass down to the specific memory tracker.
-  bool DoHandleSegfault(void* v) {
-    return HandleSegfault(v);
-  }
+  bool DoHandleSegfault(void* v) { return HandleSegfault(v); }
 
   // Returns a vector of dirty pages addresses that overlaps a memory range
   // specified with |start| and |size|. Then clears all the records of dirty
@@ -433,8 +433,8 @@ class MemoryTrackerImpl : public SpecificMemoryTracker {
   bool track_read_;  // A flag to indicate whether to track read operations on
                      // the tracking memory ranges.
 
-  const size_t page_size_;          // Size of a memory page in byte
-  SpinLock l_;  // Spin lock to guard the accesses of shared data
+  const size_t page_size_;  // Size of a memory page in byte
+  SpinLock l_;              // Spin lock to guard the accesses of shared data
   std::map<uintptr_t, size_t> ranges_;  // Memory ranges registered for tracking
   DirtyPageTable dirty_pages_;          // Storage of dirty pages
 
@@ -443,8 +443,9 @@ class MemoryTrackerImpl : public SpecificMemoryTracker {
 
 // SignalSafe wrapped methods that access shared data and cannot be
 // interrupted by SIGSEGV signal.
-#define SIGNAL_SAFE(function) \
-  SignalSafe<MemoryTrackerImpl, decltype(&MemoryTrackerImpl::function##Impl)> function;
+#define SIGNAL_SAFE(function)                                                 \
+  SignalSafe<MemoryTrackerImpl, decltype(&MemoryTrackerImpl::function##Impl)> \
+      function;
   SIGNAL_SAFE(AddTrackingRange);
   SIGNAL_SAFE(RemoveTrackingRange);
   SIGNAL_SAFE(GetDirtyPagesInRange);
@@ -457,8 +458,9 @@ class MemoryTrackerImpl : public SpecificMemoryTracker {
 #undef SIGNAL_SAFE
 
 // SpinLockGuarded wrapped methods that access critical region.
-#define LOCKED(function)                                                   \
-  SpinLockGuarded<MemoryTrackerImpl, decltype(&MemoryTrackerImpl::function##Impl)> \
+#define LOCKED(function)                                        \
+  SpinLockGuarded<MemoryTrackerImpl,                            \
+                  decltype(&MemoryTrackerImpl::function##Impl)> \
       function;
   LOCKED(HandleSegfault);
 #undef LOCKED
@@ -467,10 +469,10 @@ class MemoryTrackerImpl : public SpecificMemoryTracker {
 }  // namespace gapii
 
 #if IS_POSIX
-#include  "core/memory_tracker/cc/posix/memory_tracker.inc"
+#include "core/memory_tracker/cc/posix/memory_tracker.inc"
 #else
-#include  "core/memory_tracker/cc/windows/memory_tracker.inc"
+#include "core/memory_tracker/cc/windows/memory_tracker.inc"
 #endif
 
-#endif // COHERENT_TRACKING_ENABLED
+#endif  // COHERENT_TRACKING_ENABLED
 #endif  // GAPII_MEMORY_TRACKER_H

--- a/core/memory_tracker/cc/memory_tracker_test.cpp
+++ b/core/memory_tracker/cc/memory_tracker_test.cpp
@@ -204,7 +204,7 @@ class TestFixture : public ::testing::Test {
                                      // functions.
 };
 TestFixture* TestFixture::unique_test_ = nullptr;
-}
+}  // namespace
 
 // A helper function to ease void* pointer + offset calculation.
 void* VoidPointerAdd(void* addr, ssize_t offset) {
@@ -442,7 +442,7 @@ class DirtyPageTableForTest : public DirtyPageTable {
   const std::list<uintptr_t>::iterator& current() const { return current_; }
   size_t stored() const { return stored_; }
 };
-}
+}  // namespace
 
 TEST(DirtyPageTableTest, Init) {
   DirtyPageTableForTest t;
@@ -699,7 +699,7 @@ class AlignedMemory {
  private:
   void* mem_;
 };
-}
+}  // namespace
 
 // Allocates one page of memory, adds the memory range to the memory tracker,
 // touches the allocated memory, the tracker should record the touched page.
@@ -898,8 +898,7 @@ template <int SIG>
 class SilentSignal {
  public:
   SilentSignal() : succeeded_(false), old_sigaction_{0} {
-    succeeded_ =
-        RegisterSignalHandler(SIG, IgnoreSignal, &old_sigaction_);
+    succeeded_ = RegisterSignalHandler(SIG, IgnoreSignal, &old_sigaction_);
   }
   ~SilentSignal() {
     if (succeeded_) {
@@ -916,12 +915,12 @@ class SilentSignal {
 
 // To silently ignore a SIGSEGV signal, the permission of the fault page
 // will be set to read-write before return.
-template<>
+template <>
 void SilentSignal<SIGSEGV>::IgnoreSignal(int, siginfo_t* info, void*) {
   void* page_start = GetAlignedAddress(info->si_addr, getpagesize());
   mprotect(page_start, getpagesize(), PROT_READ | PROT_WRITE);
 }
-}
+}  // namespace
 
 TEST(MemoryTrackerTest, RegisterAndUnregister) {
   SilentSignal<SIGSEGV> ss;
@@ -936,8 +935,7 @@ TEST(MemoryTrackerTest, RegisterAndUnregister) {
   EXPECT_TRUE(t.EnableMemoryTracker());
   // Register segfault handler with the same tracker in another thread should
   // also return true.
-  std::thread another_thread(
-      [&t]() { EXPECT_TRUE(t.EnableMemoryTracker()); });
+  std::thread another_thread([&t]() { EXPECT_TRUE(t.EnableMemoryTracker()); });
   another_thread.join();
 
   EXPECT_TRUE(t.AddTrackingRange(m.mem(), t.page_size()));

--- a/core/memory_tracker/cc/posix/memory_tracker.h
+++ b/core/memory_tracker/cc/posix/memory_tracker.h
@@ -19,21 +19,24 @@
 
 #include "core/memory_tracker/cc/memory_protections.h"
 
-#include <cstdint>
 #include <pthread.h>
 #include <signal.h>
 #include <stdlib.h>
 #include <sys/mman.h>
 #include <unistd.h>
-
+#include <cstdint>
 
 namespace gapii {
 namespace track_memory {
 
 inline bool set_protection(void* p, size_t size, PageProtections prot) {
-  uint32_t protections = (prot == PageProtections::kRead) ? PROT_READ :
-                    (prot == PageProtections::kWrite) ? PROT_WRITE :
-                (prot == PageProtections::kReadWrite) ? PROT_READ | PROT_WRITE: 0;
+  uint32_t protections = (prot == PageProtections::kRead)
+                             ? PROT_READ
+                             : (prot == PageProtections::kWrite)
+                                   ? PROT_WRITE
+                                   : (prot == PageProtections::kReadWrite)
+                                         ? PROT_READ | PROT_WRITE
+                                         : 0;
   return mprotect(p, size, protections);
 }
 
@@ -58,11 +61,9 @@ class SignalBlocker {
   sigset_t old_set_;
 };
 
-inline uint32_t GetPageSize() {
-  return getpagesize();
-}
+inline uint32_t GetPageSize() { return getpagesize(); }
 
-} // namespace track_memory
-} // namespace gapii
+}  // namespace track_memory
+}  // namespace gapii
 
-#endif // GAPII_MEMORY_TRACKER_POSIX_H
+#endif  // GAPII_MEMORY_TRACKER_POSIX_H

--- a/core/memory_tracker/cc/windows/memory_tracker.h
+++ b/core/memory_tracker/cc/windows/memory_tracker.h
@@ -20,17 +20,20 @@
 #include "core/memory_tracker/cc/memory_protections.h"
 
 #include <Windows.h>
-#include <cstdint>
 #include <atomic>
+#include <cstdint>
 
 namespace gapii {
 namespace track_memory {
 
 inline bool set_protection(void* p, size_t size, PageProtections prot) {
-  DWORD protections = (prot == PageProtections::kRead) ? PAGE_READONLY :
-                    (prot == PageProtections::kWrite) ? PAGE_READWRITE :
-                (prot == PageProtections::kReadWrite) ?PAGE_READWRITE: 0;
-  return VirtualProtect(p, size, protections, nullptr); 
+  DWORD protections =
+      (prot == PageProtections::kRead)
+          ? PAGE_READONLY
+          : (prot == PageProtections::kWrite)
+                ? PAGE_READWRITE
+                : (prot == PageProtections::kReadWrite) ? PAGE_READWRITE : 0;
+  return VirtualProtect(p, size, protections, nullptr);
 }
 
 #define IS_POSIX 0
@@ -38,7 +41,7 @@ inline bool set_protection(void* p, size_t size, PageProtections prot) {
 class SignalBlocker {
  public:
   SignalBlocker(int) {}
-  ~SignalBlocker() { }
+  ~SignalBlocker() {}
   // Not copyable, not movable.
   SignalBlocker(const SignalBlocker&) = delete;
   SignalBlocker(SignalBlocker&&) = delete;
@@ -58,7 +61,7 @@ inline uint32_t GetPageSize() {
   return si.dwPageSize;
 }
 
-} // namespace track_memory
-} // namespace gapii
+}  // namespace track_memory
+}  // namespace gapii
 
-#endif // GAPII_MEMORY_TRACKER_WINDOWS_H
+#endif  // GAPII_MEMORY_TRACKER_WINDOWS_H

--- a/core/os/device/deviceinfo/cc/android/egl_lite.h
+++ b/core/os/device/deviceinfo/cc/android/egl_lite.h
@@ -26,42 +26,53 @@ typedef void* EGLDisplay;
 typedef void* EGLNativeDisplayType;
 typedef void* EGLSurface;
 
-const EGLint EGL_PBUFFER_BIT               = 0x0001;
-const EGLint EGL_OPENGL_ES2_BIT            = 0x0004;
+const EGLint EGL_PBUFFER_BIT = 0x0001;
+const EGLint EGL_OPENGL_ES2_BIT = 0x0004;
 
-const EGLint EGL_TRUE                      = 0x0001;
-const EGLint EGL_SUCCESS                   = 0x3000;
-const EGLint EGL_BUFFER_SIZE               = 0x3020;
-const EGLint EGL_ALPHA_SIZE                = 0x3021;
-const EGLint EGL_BLUE_SIZE                 = 0x3022;
-const EGLint EGL_GREEN_SIZE                = 0x3023;
-const EGLint EGL_RED_SIZE                  = 0x3024;
-const EGLint EGL_DEPTH_SIZE                = 0x3025;
-const EGLint EGL_STENCIL_SIZE              = 0x3026;
-const EGLint EGL_CONFIG_ID                 = 0x3028;
-const EGLint EGL_SURFACE_TYPE              = 0x3033;
-const EGLint EGL_NONE                      = 0x3038;
-const EGLint EGL_RENDERABLE_TYPE           = 0x3040;
-const EGLint EGL_HEIGHT                    = 0x3056;
-const EGLint EGL_WIDTH                     = 0x3057;
-const EGLint EGL_SWAP_BEHAVIOR             = 0x3093;
-const EGLint EGL_BUFFER_PRESERVED          = 0x3094;
-const EGLint EGL_CONTEXT_CLIENT_VERSION    = 0x3098;
-const EGLint EGL_OPENGL_ES_API             = 0x30A0;
+const EGLint EGL_TRUE = 0x0001;
+const EGLint EGL_SUCCESS = 0x3000;
+const EGLint EGL_BUFFER_SIZE = 0x3020;
+const EGLint EGL_ALPHA_SIZE = 0x3021;
+const EGLint EGL_BLUE_SIZE = 0x3022;
+const EGLint EGL_GREEN_SIZE = 0x3023;
+const EGLint EGL_RED_SIZE = 0x3024;
+const EGLint EGL_DEPTH_SIZE = 0x3025;
+const EGLint EGL_STENCIL_SIZE = 0x3026;
+const EGLint EGL_CONFIG_ID = 0x3028;
+const EGLint EGL_SURFACE_TYPE = 0x3033;
+const EGLint EGL_NONE = 0x3038;
+const EGLint EGL_RENDERABLE_TYPE = 0x3040;
+const EGLint EGL_HEIGHT = 0x3056;
+const EGLint EGL_WIDTH = 0x3057;
+const EGLint EGL_SWAP_BEHAVIOR = 0x3093;
+const EGLint EGL_BUFFER_PRESERVED = 0x3094;
+const EGLint EGL_CONTEXT_CLIENT_VERSION = 0x3098;
+const EGLint EGL_OPENGL_ES_API = 0x30A0;
 
 const EGLNativeDisplayType EGL_DEFAULT_DISPLAY = nullptr;
-const EGLContext           EGL_NO_CONTEXT      = 0;
+const EGLContext EGL_NO_CONTEXT = 0;
 
 typedef EGLBoolean (*PFNEGLBINDAPI)(EGLenum api);
-typedef EGLBoolean (*PFNEGLCHOOSECONFIG)(EGLDisplay display, const EGLint* attrib_list, EGLConfig* configs, EGLint config_size, EGLint* num_config);
-typedef EGLBoolean (*PFNEGLDESTROYCONTEXT)(EGLDisplay display, EGLContext context);
-typedef EGLBoolean (*PFNEGLDESTROYSURFACE)(EGLDisplay display, EGLSurface surface);
-typedef EGLBoolean (*PFNEGLINITIALIZE)(EGLDisplay dpy, EGLint* major, EGLint* minor);
-typedef EGLBoolean (*PFNEGLMAKECURRENT)(EGLDisplay display, EGLSurface draw, EGLSurface read, EGLContext context);
+typedef EGLBoolean (*PFNEGLCHOOSECONFIG)(EGLDisplay display,
+                                         const EGLint* attrib_list,
+                                         EGLConfig* configs, EGLint config_size,
+                                         EGLint* num_config);
+typedef EGLBoolean (*PFNEGLDESTROYCONTEXT)(EGLDisplay display,
+                                           EGLContext context);
+typedef EGLBoolean (*PFNEGLDESTROYSURFACE)(EGLDisplay display,
+                                           EGLSurface surface);
+typedef EGLBoolean (*PFNEGLINITIALIZE)(EGLDisplay dpy, EGLint* major,
+                                       EGLint* minor);
+typedef EGLBoolean (*PFNEGLMAKECURRENT)(EGLDisplay display, EGLSurface draw,
+                                        EGLSurface read, EGLContext context);
 typedef EGLBoolean (*PFNEGLTERMINATE)(EGLDisplay display);
-typedef EGLContext (*PFNEGLCREATECONTEXT)(EGLDisplay display, EGLConfig config, EGLContext share_context, const EGLint* attrib_list);
+typedef EGLContext (*PFNEGLCREATECONTEXT)(EGLDisplay display, EGLConfig config,
+                                          EGLContext share_context,
+                                          const EGLint* attrib_list);
 typedef EGLDisplay (*PFNEGLGETDISPLAY)(EGLNativeDisplayType native_display);
 typedef EGLint (*PFNEGLGETERROR)();
-typedef EGLSurface (*PFNEGLCREATEPBUFFERSURFACE)(EGLDisplay display, EGLConfig config, const EGLint* attrib_list);
+typedef EGLSurface (*PFNEGLCREATEPBUFFERSURFACE)(EGLDisplay display,
+                                                 EGLConfig config,
+                                                 const EGLint* attrib_list);
 
 #endif  // GAPID_CORE_OS_DEVICEINFO_ANDROID_EGL_LITE

--- a/core/os/device/deviceinfo/cc/android/jni.cpp
+++ b/core/os/device/deviceinfo/cc/android/jni.cpp
@@ -20,15 +20,16 @@
 
 extern "C" {
 
-jbyteArray Java_com_google_android_gapid_DeviceInfoService_getDeviceInfo(JNIEnv* env) {
-    JavaVM* vm = nullptr;
-    env->GetJavaVM(&vm);
-    auto device_instance = get_device_instance(vm);
-    auto out = env->NewByteArray(device_instance.size);
-    auto data = reinterpret_cast<jbyte*>(device_instance.data);
-    env->SetByteArrayRegion(out, 0, device_instance.size, data);
-    free_device_instance(device_instance);
-    return out;
+jbyteArray Java_com_google_android_gapid_DeviceInfoService_getDeviceInfo(
+    JNIEnv* env) {
+  JavaVM* vm = nullptr;
+  env->GetJavaVM(&vm);
+  auto device_instance = get_device_instance(vm);
+  auto out = env->NewByteArray(device_instance.size);
+  auto data = reinterpret_cast<jbyte*>(device_instance.data);
+  env->SetByteArrayRegion(out, 0, device_instance.size, data);
+  free_device_instance(device_instance);
+  return out;
 }
 
 }  // extern "C"

--- a/core/os/device/deviceinfo/cc/android/query.cpp
+++ b/core/os/device/deviceinfo/cc/android/query.cpp
@@ -20,8 +20,8 @@
 #include "../query.h"
 
 #include "core/cc/assert.h"
-#include "core/cc/log.h"
 #include "core/cc/get_gles_proc_address.h"
+#include "core/cc/log.h"
 
 #include <cstring>
 
@@ -29,10 +29,10 @@
 #include <jni.h>
 
 #define LOG_ERR(...) \
-    __android_log_print(ANDROID_LOG_ERROR, "GAPID", __VA_ARGS__);
+  __android_log_print(ANDROID_LOG_ERROR, "GAPID", __VA_ARGS__);
 
 #define LOG_WARN(...) \
-    __android_log_print(ANDROID_LOG_WARN, "GAPID", __VA_ARGS__);
+  __android_log_print(ANDROID_LOG_WARN, "GAPID", __VA_ARGS__);
 
 typedef int GLint;
 typedef unsigned int GLuint;
@@ -41,88 +41,88 @@ typedef uint8_t GLubyte;
 namespace {
 
 device::DataTypeLayout* new_dt_layout(int size, int alignment) {
-    auto out = new device::DataTypeLayout();
-    out->set_size(size);
-    out->set_alignment(alignment);
-    return out;
+  auto out = new device::DataTypeLayout();
+  out->set_size(size);
+  out->set_alignment(alignment);
+  return out;
 }
 
 void abiByName(const std::string name, device::ABI* abi) {
-    abi->set_name(name);
-    abi->set_os(device::Android);
+  abi->set_name(name);
+  abi->set_os(device::Android);
 
-    if (name == "armeabi" || name == "armeabi-v7a") {
-        // http://infocenter.arm.com/help/topic/com.arm.doc.ihi0042f/IHI0042F_aapcs.pdf
-        // 4 DATA TYPES AND ALIGNMENT
-        auto memory_layout = new device::MemoryLayout();
-        memory_layout->set_allocated_pointer(new_dt_layout(4, 4));
-        memory_layout->set_allocated_integer(new_dt_layout(4, 4));
-        memory_layout->set_allocated_size(new_dt_layout(4, 4));
-        memory_layout->set_allocated_char_(new_dt_layout(1, 1));
-        memory_layout->set_allocated_i64(new_dt_layout(8, 8));
-        memory_layout->set_allocated_i32(new_dt_layout(4, 4));
-        memory_layout->set_allocated_i16(new_dt_layout(2, 2));
-        memory_layout->set_allocated_i8(new_dt_layout(1, 1));
-        memory_layout->set_allocated_f64(new_dt_layout(8, 8));
-        memory_layout->set_allocated_f32(new_dt_layout(4, 4));
-        memory_layout->set_allocated_f16(new_dt_layout(2, 2));
-        memory_layout->set_endian(device::LittleEndian);
-        abi->set_allocated_memorylayout(memory_layout);
-        abi->set_architecture(device::ARMv7a);
-    } else if (name == "arm64-v8a") {
-        // http://infocenter.arm.com/help/topic/com.arm.doc.ihi0055b/IHI0055B_aapcs64.pdf
-        // 4 DATA TYPES AND ALIGNMENT
-        auto memory_layout = new device::MemoryLayout();
-        memory_layout->set_allocated_pointer(new_dt_layout(8, 8));
-        memory_layout->set_allocated_integer(new_dt_layout(8, 8));
-        memory_layout->set_allocated_size(new_dt_layout(8, 8));
-        memory_layout->set_allocated_char_(new_dt_layout(1, 1));
-        memory_layout->set_allocated_i64(new_dt_layout(8, 8));
-        memory_layout->set_allocated_i32(new_dt_layout(4, 4));
-        memory_layout->set_allocated_i16(new_dt_layout(2, 2));
-        memory_layout->set_allocated_i8(new_dt_layout(1, 1));
-        memory_layout->set_allocated_f64(new_dt_layout(8, 8));
-        memory_layout->set_allocated_f32(new_dt_layout(4, 4));
-        memory_layout->set_allocated_f16(new_dt_layout(2, 2));
-        memory_layout->set_endian(device::LittleEndian);
-        abi->set_allocated_memorylayout(memory_layout);
-        abi->set_architecture(device::ARMv8a);
-    } else if (name == "x86") {
-        // https://en.wikipedia.org/wiki/Data_structure_alignment#Typical_alignment_of_C_structs_on_x86
-        auto memory_layout = new device::MemoryLayout();
-        memory_layout->set_allocated_pointer(new_dt_layout(4, 4));
-        memory_layout->set_allocated_integer(new_dt_layout(4, 4));
-        memory_layout->set_allocated_size(new_dt_layout(4, 4));
-        memory_layout->set_allocated_char_(new_dt_layout(1, 1));
-        memory_layout->set_allocated_i64(new_dt_layout(8, 4));
-        memory_layout->set_allocated_i32(new_dt_layout(4, 4));
-        memory_layout->set_allocated_i16(new_dt_layout(2, 2));
-        memory_layout->set_allocated_i8(new_dt_layout(1, 1));
-        memory_layout->set_allocated_f64(new_dt_layout(8, 4));
-        memory_layout->set_allocated_f32(new_dt_layout(4, 4));
-        memory_layout->set_allocated_f16(new_dt_layout(2, 2));
-        memory_layout->set_endian(device::LittleEndian);
-        abi->set_allocated_memorylayout(memory_layout);
-        abi->set_architecture(device::X86);
-    } else if (name == "x86_64") {
-        auto memory_layout = new device::MemoryLayout();
-        memory_layout->set_allocated_pointer(new_dt_layout(8, 8));
-        memory_layout->set_allocated_integer(new_dt_layout(4, 4));
-        memory_layout->set_allocated_size(new_dt_layout(8, 8));
-        memory_layout->set_allocated_char_(new_dt_layout(1, 1));
-        memory_layout->set_allocated_i64(new_dt_layout(8, 4));
-        memory_layout->set_allocated_i32(new_dt_layout(4, 4));
-        memory_layout->set_allocated_i16(new_dt_layout(2, 2));
-        memory_layout->set_allocated_i8(new_dt_layout(1, 1));
-        memory_layout->set_allocated_f64(new_dt_layout(8, 4));
-        memory_layout->set_allocated_f32(new_dt_layout(4, 4));
-        memory_layout->set_allocated_f16(new_dt_layout(2, 2));
-        memory_layout->set_endian(device::LittleEndian);
-        abi->set_allocated_memorylayout(memory_layout);
-        abi->set_architecture(device::X86_64);
-    } else {
-        LOG_WARN("Unrecognised ABI: %s", name.c_str());
-    }
+  if (name == "armeabi" || name == "armeabi-v7a") {
+    // http://infocenter.arm.com/help/topic/com.arm.doc.ihi0042f/IHI0042F_aapcs.pdf
+    // 4 DATA TYPES AND ALIGNMENT
+    auto memory_layout = new device::MemoryLayout();
+    memory_layout->set_allocated_pointer(new_dt_layout(4, 4));
+    memory_layout->set_allocated_integer(new_dt_layout(4, 4));
+    memory_layout->set_allocated_size(new_dt_layout(4, 4));
+    memory_layout->set_allocated_char_(new_dt_layout(1, 1));
+    memory_layout->set_allocated_i64(new_dt_layout(8, 8));
+    memory_layout->set_allocated_i32(new_dt_layout(4, 4));
+    memory_layout->set_allocated_i16(new_dt_layout(2, 2));
+    memory_layout->set_allocated_i8(new_dt_layout(1, 1));
+    memory_layout->set_allocated_f64(new_dt_layout(8, 8));
+    memory_layout->set_allocated_f32(new_dt_layout(4, 4));
+    memory_layout->set_allocated_f16(new_dt_layout(2, 2));
+    memory_layout->set_endian(device::LittleEndian);
+    abi->set_allocated_memorylayout(memory_layout);
+    abi->set_architecture(device::ARMv7a);
+  } else if (name == "arm64-v8a") {
+    // http://infocenter.arm.com/help/topic/com.arm.doc.ihi0055b/IHI0055B_aapcs64.pdf
+    // 4 DATA TYPES AND ALIGNMENT
+    auto memory_layout = new device::MemoryLayout();
+    memory_layout->set_allocated_pointer(new_dt_layout(8, 8));
+    memory_layout->set_allocated_integer(new_dt_layout(8, 8));
+    memory_layout->set_allocated_size(new_dt_layout(8, 8));
+    memory_layout->set_allocated_char_(new_dt_layout(1, 1));
+    memory_layout->set_allocated_i64(new_dt_layout(8, 8));
+    memory_layout->set_allocated_i32(new_dt_layout(4, 4));
+    memory_layout->set_allocated_i16(new_dt_layout(2, 2));
+    memory_layout->set_allocated_i8(new_dt_layout(1, 1));
+    memory_layout->set_allocated_f64(new_dt_layout(8, 8));
+    memory_layout->set_allocated_f32(new_dt_layout(4, 4));
+    memory_layout->set_allocated_f16(new_dt_layout(2, 2));
+    memory_layout->set_endian(device::LittleEndian);
+    abi->set_allocated_memorylayout(memory_layout);
+    abi->set_architecture(device::ARMv8a);
+  } else if (name == "x86") {
+    // https://en.wikipedia.org/wiki/Data_structure_alignment#Typical_alignment_of_C_structs_on_x86
+    auto memory_layout = new device::MemoryLayout();
+    memory_layout->set_allocated_pointer(new_dt_layout(4, 4));
+    memory_layout->set_allocated_integer(new_dt_layout(4, 4));
+    memory_layout->set_allocated_size(new_dt_layout(4, 4));
+    memory_layout->set_allocated_char_(new_dt_layout(1, 1));
+    memory_layout->set_allocated_i64(new_dt_layout(8, 4));
+    memory_layout->set_allocated_i32(new_dt_layout(4, 4));
+    memory_layout->set_allocated_i16(new_dt_layout(2, 2));
+    memory_layout->set_allocated_i8(new_dt_layout(1, 1));
+    memory_layout->set_allocated_f64(new_dt_layout(8, 4));
+    memory_layout->set_allocated_f32(new_dt_layout(4, 4));
+    memory_layout->set_allocated_f16(new_dt_layout(2, 2));
+    memory_layout->set_endian(device::LittleEndian);
+    abi->set_allocated_memorylayout(memory_layout);
+    abi->set_architecture(device::X86);
+  } else if (name == "x86_64") {
+    auto memory_layout = new device::MemoryLayout();
+    memory_layout->set_allocated_pointer(new_dt_layout(8, 8));
+    memory_layout->set_allocated_integer(new_dt_layout(4, 4));
+    memory_layout->set_allocated_size(new_dt_layout(8, 8));
+    memory_layout->set_allocated_char_(new_dt_layout(1, 1));
+    memory_layout->set_allocated_i64(new_dt_layout(8, 4));
+    memory_layout->set_allocated_i32(new_dt_layout(4, 4));
+    memory_layout->set_allocated_i16(new_dt_layout(2, 2));
+    memory_layout->set_allocated_i8(new_dt_layout(1, 1));
+    memory_layout->set_allocated_f64(new_dt_layout(8, 4));
+    memory_layout->set_allocated_f32(new_dt_layout(4, 4));
+    memory_layout->set_allocated_f16(new_dt_layout(2, 2));
+    memory_layout->set_endian(device::LittleEndian);
+    abi->set_allocated_memorylayout(memory_layout);
+    abi->set_architecture(device::X86_64);
+  } else {
+    LOG_WARN("Unrecognised ABI: %s", name.c_str());
+  }
 }
 
 }  // anonymous namespace
@@ -130,303 +130,309 @@ void abiByName(const std::string name, device::ABI* abi) {
 namespace query {
 
 struct Context {
-    char mError[512];
-    EGLDisplay mDisplay;
-    EGLSurface mSurface;
-    EGLContext mContext;
-    int mNumCores;
-    std::string mHost;
-    std::string mSerial;
-    std::string mHardware;
-    std::string mOSName;
-    std::string mOSBuild;
-    int mOSVersion;
-    int mOSVersionMajor;
-    int mOSVersionMinor;
-    std::vector<std::string> mSupportedABIs;
-    device::Architecture mCpuArchitecture;
+  char mError[512];
+  EGLDisplay mDisplay;
+  EGLSurface mSurface;
+  EGLContext mContext;
+  int mNumCores;
+  std::string mHost;
+  std::string mSerial;
+  std::string mHardware;
+  std::string mOSName;
+  std::string mOSBuild;
+  int mOSVersion;
+  int mOSVersionMajor;
+  int mOSVersionMinor;
+  std::vector<std::string> mSupportedABIs;
+  device::Architecture mCpuArchitecture;
 };
 
 static Context gContext;
 static int gContextRefCount = 0;
 
 void destroyContext() {
-    if (--gContextRefCount > 0) {
-        return;
-    }
+  if (--gContextRefCount > 0) {
+    return;
+  }
 
-    auto eglDestroyContext = reinterpret_cast<PFNEGLDESTROYCONTEXT>(core::GetGlesProcAddress("eglDestroyContext", true));
-    auto eglDestroySurface = reinterpret_cast<PFNEGLDESTROYSURFACE>(core::GetGlesProcAddress("eglDestroySurface", true));
-    auto eglTerminate = reinterpret_cast<PFNEGLTERMINATE>(core::GetGlesProcAddress("eglTerminate", true));
+  auto eglDestroyContext = reinterpret_cast<PFNEGLDESTROYCONTEXT>(
+      core::GetGlesProcAddress("eglDestroyContext", true));
+  auto eglDestroySurface = reinterpret_cast<PFNEGLDESTROYSURFACE>(
+      core::GetGlesProcAddress("eglDestroySurface", true));
+  auto eglTerminate = reinterpret_cast<PFNEGLTERMINATE>(
+      core::GetGlesProcAddress("eglTerminate", true));
 
-    if (gContext.mContext) {
-        eglDestroyContext(gContext.mDisplay, gContext.mContext);
-        gContext.mContext = 0;
-    }
-    if (gContext.mSurface) {
-        eglDestroySurface(gContext.mDisplay, gContext.mSurface);
-        gContext.mSurface = 0;
-    }
-    if (gContext.mDisplay) {
-        eglTerminate(gContext.mDisplay);
-        gContext.mDisplay = nullptr;
-    }
+  if (gContext.mContext) {
+    eglDestroyContext(gContext.mDisplay, gContext.mContext);
+    gContext.mContext = 0;
+  }
+  if (gContext.mSurface) {
+    eglDestroySurface(gContext.mDisplay, gContext.mSurface);
+    gContext.mSurface = 0;
+  }
+  if (gContext.mDisplay) {
+    eglTerminate(gContext.mDisplay);
+    gContext.mDisplay = nullptr;
+  }
 }
 
 bool createContext(void* platform_data) {
-    if (gContextRefCount++ > 0) {
-        return true;
-    }
+  if (gContextRefCount++ > 0) {
+    return true;
+  }
 
-    gContext.mDisplay = nullptr;
-    gContext.mSurface = nullptr;
-    gContext.mContext = nullptr;
-    gContext.mNumCores = 0;
+  gContext.mDisplay = nullptr;
+  gContext.mSurface = nullptr;
+  gContext.mContext = nullptr;
+  gContext.mNumCores = 0;
 
-    if (platform_data == nullptr) {
-        snprintf(gContext.mError, sizeof(gContext.mError),
-                "platform_data was nullptr");
-        return false;
-    }
+  if (platform_data == nullptr) {
+    snprintf(gContext.mError, sizeof(gContext.mError),
+             "platform_data was nullptr");
+    return false;
+  }
 
-#define RESOLVE(name, pfun) \
-    auto name = reinterpret_cast<pfun>(core::GetGlesProcAddress(#name, true)); \
-    GAPID_ASSERT(name != nullptr)
+#define RESOLVE(name, pfun)                                                  \
+  auto name = reinterpret_cast<pfun>(core::GetGlesProcAddress(#name, true)); \
+  GAPID_ASSERT(name != nullptr)
 
-    RESOLVE(eglGetError,             PFNEGLGETERROR);
-    RESOLVE(eglInitialize,           PFNEGLINITIALIZE);
-    RESOLVE(eglBindAPI,              PFNEGLBINDAPI);
-    RESOLVE(eglChooseConfig,         PFNEGLCHOOSECONFIG);
-    RESOLVE(eglCreateContext,        PFNEGLCREATECONTEXT);
-    RESOLVE(eglCreatePbufferSurface, PFNEGLCREATEPBUFFERSURFACE);
-    RESOLVE(eglMakeCurrent,          PFNEGLMAKECURRENT);
-    RESOLVE(eglGetDisplay,           PFNEGLGETDISPLAY);
+  RESOLVE(eglGetError, PFNEGLGETERROR);
+  RESOLVE(eglInitialize, PFNEGLINITIALIZE);
+  RESOLVE(eglBindAPI, PFNEGLBINDAPI);
+  RESOLVE(eglChooseConfig, PFNEGLCHOOSECONFIG);
+  RESOLVE(eglCreateContext, PFNEGLCREATECONTEXT);
+  RESOLVE(eglCreatePbufferSurface, PFNEGLCREATEPBUFFERSURFACE);
+  RESOLVE(eglMakeCurrent, PFNEGLMAKECURRENT);
+  RESOLVE(eglGetDisplay, PFNEGLGETDISPLAY);
 
 #undef RESOLVE
 
-#define CHECK(x) \
-    x; \
-    { \
-        EGLint error = eglGetError(); \
-        if (error != EGL_SUCCESS) { \
-            snprintf(gContext.mError, sizeof(gContext.mError), \
-                     "EGL error: 0x%x when executing:\n   " #x, error); \
-            destroyContext(); \
-            return false; \
-        } \
-    }
+#define CHECK(x)                                                  \
+  x;                                                              \
+  {                                                               \
+    EGLint error = eglGetError();                                 \
+    if (error != EGL_SUCCESS) {                                   \
+      snprintf(gContext.mError, sizeof(gContext.mError),          \
+               "EGL error: 0x%x when executing:\n   " #x, error); \
+      destroyContext();                                           \
+      return false;                                               \
+    }                                                             \
+  }
 
-    CHECK(auto display = eglGetDisplay(EGL_DEFAULT_DISPLAY));
+  CHECK(auto display = eglGetDisplay(EGL_DEFAULT_DISPLAY));
 
-    CHECK(eglInitialize(display, nullptr, nullptr));
+  CHECK(eglInitialize(display, nullptr, nullptr));
 
-    gContext.mDisplay = display;
+  gContext.mDisplay = display;
 
-    CHECK(eglBindAPI(EGL_OPENGL_ES_API));
+  CHECK(eglBindAPI(EGL_OPENGL_ES_API));
 
-    // Find a supported EGL context config.
-    int r = 8, g = 8, b = 8, a = 8, d = 24, s = 8;
-    const int configAttribList[] = {
-        EGL_RED_SIZE, r,
-        EGL_GREEN_SIZE, g,
-        EGL_BLUE_SIZE, b,
-        EGL_ALPHA_SIZE, a,
-        EGL_BUFFER_SIZE, r+g+b+a,
-        EGL_DEPTH_SIZE, d,
-        EGL_STENCIL_SIZE, s,
-        EGL_SURFACE_TYPE, EGL_PBUFFER_BIT,
-        EGL_RENDERABLE_TYPE, EGL_OPENGL_ES2_BIT,
-        EGL_NONE
-    };
+  // Find a supported EGL context config.
+  int r = 8, g = 8, b = 8, a = 8, d = 24, s = 8;
+  const int configAttribList[] = {
+      // clang-format off
+      EGL_RED_SIZE, r,
+      EGL_GREEN_SIZE, g,
+      EGL_BLUE_SIZE, b,
+      EGL_ALPHA_SIZE, a,
+      EGL_BUFFER_SIZE, r+g+b+a,
+      EGL_DEPTH_SIZE, d,
+      EGL_STENCIL_SIZE, s,
+      EGL_SURFACE_TYPE, EGL_PBUFFER_BIT,
+      EGL_RENDERABLE_TYPE, EGL_OPENGL_ES2_BIT,
+      EGL_NONE
+      // clang-format on
+  };
 
-    int one = 1;
-    EGLConfig eglConfig;
+  int one = 1;
+  EGLConfig eglConfig;
 
-    CHECK(eglChooseConfig(display, configAttribList, &eglConfig, 1, &one));
+  CHECK(eglChooseConfig(display, configAttribList, &eglConfig, 1, &one));
 
-    // Create an EGL context.
-    const int contextAttribList[] = {
-        EGL_CONTEXT_CLIENT_VERSION, 2,
-        EGL_NONE
-    };
+  // Create an EGL context.
+  const int contextAttribList[] = {EGL_CONTEXT_CLIENT_VERSION, 2, EGL_NONE};
 
-    CHECK(gContext.mContext = eglCreateContext(display, eglConfig, EGL_NO_CONTEXT, contextAttribList));
+  CHECK(gContext.mContext = eglCreateContext(display, eglConfig, EGL_NO_CONTEXT,
+                                             contextAttribList));
 
-    const int surfaceAttribList[] = {
-        EGL_WIDTH, 16,
-        EGL_HEIGHT, 16,
-        EGL_NONE
-    };
+  const int surfaceAttribList[] = {
+      // clang-format off
+      EGL_WIDTH, 16,
+      EGL_HEIGHT, 16,
+      EGL_NONE
+      // clang-format on
+  };
 
-    CHECK(gContext.mSurface = eglCreatePbufferSurface(display, eglConfig, surfaceAttribList));
+  CHECK(gContext.mSurface =
+            eglCreatePbufferSurface(display, eglConfig, surfaceAttribList));
 
-    CHECK(eglMakeCurrent(display, gContext.mSurface, gContext.mSurface, gContext.mContext));
+  CHECK(eglMakeCurrent(display, gContext.mSurface, gContext.mSurface,
+                       gContext.mContext));
 
 #undef CHECK
 
-#define CHECK(x) \
-    if (!x) { \
-        snprintf(gContext.mError, sizeof(gContext.mError), \
-                 "JNI error:\n   " #x); \
-        destroyContext(); \
-        return false; \
-    }
+#define CHECK(x)                                                              \
+  if (!x) {                                                                   \
+    snprintf(gContext.mError, sizeof(gContext.mError), "JNI error:\n   " #x); \
+    destroyContext();                                                         \
+    return false;                                                             \
+  }
 
-    JavaVM* vm = reinterpret_cast<JavaVM*>(platform_data);
-    JNIEnv* env = nullptr;
-    auto res = vm->GetEnv(reinterpret_cast<void**>(&env), JNI_VERSION_1_6);
-    bool shouldDetach = false;
-    switch (res) {
+  JavaVM* vm = reinterpret_cast<JavaVM*>(platform_data);
+  JNIEnv* env = nullptr;
+  auto res = vm->GetEnv(reinterpret_cast<void**>(&env), JNI_VERSION_1_6);
+  bool shouldDetach = false;
+  switch (res) {
     case JNI_OK:
-        break;
+      break;
     case JNI_EDETACHED:
-        res = vm->AttachCurrentThread(&env, nullptr);
-        if (res != 0) {
-            snprintf(gContext.mError, sizeof(gContext.mError),
-                    "Failed to attach thread to JavaVM. (%d)", res);
-            destroyContext();
-            return false;
-        }
-        shouldDetach = true;
-        break;
-    default:
+      res = vm->AttachCurrentThread(&env, nullptr);
+      if (res != 0) {
         snprintf(gContext.mError, sizeof(gContext.mError),
-                "Failed to get Java env. (%d)", res);
+                 "Failed to attach thread to JavaVM. (%d)", res);
         destroyContext();
         return false;
-    }
+      }
+      shouldDetach = true;
+      break;
+    default:
+      snprintf(gContext.mError, sizeof(gContext.mError),
+               "Failed to get Java env. (%d)", res);
+      destroyContext();
+      return false;
+  }
 
-    Class build(env, "android/os/Build");
-    CHECK(build.get_field("SUPPORTED_ABIS", gContext.mSupportedABIs));
-    CHECK(build.get_field("HOST", gContext.mHost));
-    CHECK(build.get_field("SERIAL", gContext.mSerial));
-    CHECK(build.get_field("HARDWARE", gContext.mHardware));
-    CHECK(build.get_field("DISPLAY", gContext.mOSBuild));
+  Class build(env, "android/os/Build");
+  CHECK(build.get_field("SUPPORTED_ABIS", gContext.mSupportedABIs));
+  CHECK(build.get_field("HOST", gContext.mHost));
+  CHECK(build.get_field("SERIAL", gContext.mSerial));
+  CHECK(build.get_field("HARDWARE", gContext.mHardware));
+  CHECK(build.get_field("DISPLAY", gContext.mOSBuild));
 
-    Class version(env, "android/os/Build$VERSION");
-    CHECK(version.get_field("RELEASE", gContext.mOSName));
-    CHECK(version.get_field("SDK_INT", gContext.mOSVersion));
+  Class version(env, "android/os/Build$VERSION");
+  CHECK(version.get_field("RELEASE", gContext.mOSName));
+  CHECK(version.get_field("SDK_INT", gContext.mOSVersion));
 
-    if (shouldDetach) {
-        vm->DetachCurrentThread();
-    }
+  if (shouldDetach) {
+    vm->DetachCurrentThread();
+  }
 
 #undef CHECK
 
-    if (gContext.mSupportedABIs.size() > 0) {
-        auto primaryABI = gContext.mSupportedABIs[0];
-        if (primaryABI == "armeabi" || primaryABI == "armeabi-v7a") {
-            gContext.mCpuArchitecture = device::ARMv7a;
-        } else if (primaryABI == "arm64-v8a") {
-            gContext.mCpuArchitecture = device::ARMv8a;
-        } else if (primaryABI == "x86") {
-            gContext.mCpuArchitecture = device::X86;
-        } else if (primaryABI == "x86_64") {
-            gContext.mCpuArchitecture = device::X86_64;
-        } else {
-            LOG_WARN("Unrecognised ABI: %s", primaryABI.c_str());
-        }
+  if (gContext.mSupportedABIs.size() > 0) {
+    auto primaryABI = gContext.mSupportedABIs[0];
+    if (primaryABI == "armeabi" || primaryABI == "armeabi-v7a") {
+      gContext.mCpuArchitecture = device::ARMv7a;
+    } else if (primaryABI == "arm64-v8a") {
+      gContext.mCpuArchitecture = device::ARMv8a;
+    } else if (primaryABI == "x86") {
+      gContext.mCpuArchitecture = device::X86;
+    } else if (primaryABI == "x86_64") {
+      gContext.mCpuArchitecture = device::X86_64;
+    } else {
+      LOG_WARN("Unrecognised ABI: %s", primaryABI.c_str());
     }
+  }
 
-    switch (gContext.mOSVersion) {
-        case 27:  // Oreo
-            gContext.mOSVersionMajor = 8;
-            gContext.mOSVersionMinor = 1;
-            break;
-        case 26:  // Oreo
-            gContext.mOSVersionMajor = 8;
-            gContext.mOSVersionMinor = 0;
-            break;
-        case 25:  // Nougat
-            gContext.mOSVersionMajor = 7;
-            gContext.mOSVersionMinor = 1;
-            break;
-        case 24:  // Nougat
-            gContext.mOSVersionMajor = 7;
-            gContext.mOSVersionMinor = 0;
-            break;
-        case 23:  // Marshmallow
-            gContext.mOSVersionMajor = 6;
-            gContext.mOSVersionMinor = 0;
-            break;
-        case 22:  // Lollipop
-            gContext.mOSVersionMajor = 5;
-            gContext.mOSVersionMinor = 1;
-            break;
-        case 21:  // Lollipop
-            gContext.mOSVersionMajor = 5;
-            gContext.mOSVersionMinor = 0;
-            break;
-        case 19:  // KitKat
-            gContext.mOSVersionMajor = 4;
-            gContext.mOSVersionMinor = 4;
-            break;
-        case 18:  // Jelly Bean
-            gContext.mOSVersionMajor = 4;
-            gContext.mOSVersionMinor = 3;
-            break;
-        case 17:  // Jelly Bean
-            gContext.mOSVersionMajor = 4;
-            gContext.mOSVersionMinor = 2;
-            break;
-        case 16:  // Jelly Bean
-            gContext.mOSVersionMajor = 4;
-            gContext.mOSVersionMinor = 1;
-            break;
-        case 15:  // Ice Cream Sandwich
-        case 14:  // Ice Cream Sandwich
-            gContext.mOSVersionMajor = 4;
-            gContext.mOSVersionMinor = 0;
-            break;
-        case 13:  // Honeycomb
-            gContext.mOSVersionMajor = 3;
-            gContext.mOSVersionMinor = 2;
-            break;
-        case 12:  // Honeycomb
-            gContext.mOSVersionMajor = 3;
-            gContext.mOSVersionMinor = 1;
-            break;
-        case 11:  // Honeycomb
-            gContext.mOSVersionMajor = 3;
-            gContext.mOSVersionMinor = 0;
-            break;
-        case 10:  // Gingerbread
-        case 9:   // Gingerbread
-            gContext.mOSVersionMajor = 2;
-            gContext.mOSVersionMinor = 3;
-            break;
-        case 8:   // Froyo
-            gContext.mOSVersionMajor = 2;
-            gContext.mOSVersionMinor = 2;
-            break;
-        case 7:   // Eclair
-            gContext.mOSVersionMajor = 2;
-            gContext.mOSVersionMinor = 1;
-            break;
-        case 6:   // Eclair
-        case 5:   // Eclair
-            gContext.mOSVersionMajor = 2;
-            gContext.mOSVersionMinor = 0;
-            break;
-        case 4:   // Donut
-            gContext.mOSVersionMajor = 1;
-            gContext.mOSVersionMinor = 6;
-            break;
-        case 3:   // Cupcake
-            gContext.mOSVersionMajor = 1;
-            gContext.mOSVersionMinor = 5;
-            break;
-        case 2:   // (no code name)
-            gContext.mOSVersionMajor = 1;
-            gContext.mOSVersionMinor = 1;
-            break;
-        case 1:   // (no code name)
-            gContext.mOSVersionMajor = 1;
-            gContext.mOSVersionMinor = 0;
-            break;
-    }
+  switch (gContext.mOSVersion) {
+    case 27:  // Oreo
+      gContext.mOSVersionMajor = 8;
+      gContext.mOSVersionMinor = 1;
+      break;
+    case 26:  // Oreo
+      gContext.mOSVersionMajor = 8;
+      gContext.mOSVersionMinor = 0;
+      break;
+    case 25:  // Nougat
+      gContext.mOSVersionMajor = 7;
+      gContext.mOSVersionMinor = 1;
+      break;
+    case 24:  // Nougat
+      gContext.mOSVersionMajor = 7;
+      gContext.mOSVersionMinor = 0;
+      break;
+    case 23:  // Marshmallow
+      gContext.mOSVersionMajor = 6;
+      gContext.mOSVersionMinor = 0;
+      break;
+    case 22:  // Lollipop
+      gContext.mOSVersionMajor = 5;
+      gContext.mOSVersionMinor = 1;
+      break;
+    case 21:  // Lollipop
+      gContext.mOSVersionMajor = 5;
+      gContext.mOSVersionMinor = 0;
+      break;
+    case 19:  // KitKat
+      gContext.mOSVersionMajor = 4;
+      gContext.mOSVersionMinor = 4;
+      break;
+    case 18:  // Jelly Bean
+      gContext.mOSVersionMajor = 4;
+      gContext.mOSVersionMinor = 3;
+      break;
+    case 17:  // Jelly Bean
+      gContext.mOSVersionMajor = 4;
+      gContext.mOSVersionMinor = 2;
+      break;
+    case 16:  // Jelly Bean
+      gContext.mOSVersionMajor = 4;
+      gContext.mOSVersionMinor = 1;
+      break;
+    case 15:  // Ice Cream Sandwich
+    case 14:  // Ice Cream Sandwich
+      gContext.mOSVersionMajor = 4;
+      gContext.mOSVersionMinor = 0;
+      break;
+    case 13:  // Honeycomb
+      gContext.mOSVersionMajor = 3;
+      gContext.mOSVersionMinor = 2;
+      break;
+    case 12:  // Honeycomb
+      gContext.mOSVersionMajor = 3;
+      gContext.mOSVersionMinor = 1;
+      break;
+    case 11:  // Honeycomb
+      gContext.mOSVersionMajor = 3;
+      gContext.mOSVersionMinor = 0;
+      break;
+    case 10:  // Gingerbread
+    case 9:   // Gingerbread
+      gContext.mOSVersionMajor = 2;
+      gContext.mOSVersionMinor = 3;
+      break;
+    case 8:  // Froyo
+      gContext.mOSVersionMajor = 2;
+      gContext.mOSVersionMinor = 2;
+      break;
+    case 7:  // Eclair
+      gContext.mOSVersionMajor = 2;
+      gContext.mOSVersionMinor = 1;
+      break;
+    case 6:  // Eclair
+    case 5:  // Eclair
+      gContext.mOSVersionMajor = 2;
+      gContext.mOSVersionMinor = 0;
+      break;
+    case 4:  // Donut
+      gContext.mOSVersionMajor = 1;
+      gContext.mOSVersionMinor = 6;
+      break;
+    case 3:  // Cupcake
+      gContext.mOSVersionMajor = 1;
+      gContext.mOSVersionMinor = 5;
+      break;
+    case 2:  // (no code name)
+      gContext.mOSVersionMajor = 1;
+      gContext.mOSVersionMinor = 1;
+      break;
+    case 1:  // (no code name)
+      gContext.mOSVersionMajor = 1;
+      gContext.mOSVersionMinor = 0;
+      break;
+  }
 
-    return true;
+  return true;
 }
 
 const char* contextError() { return gContext.mError; }
@@ -436,23 +442,23 @@ bool hasGLorGLES() { return true; }
 int numABIs() { return gContext.mSupportedABIs.size(); }
 
 device::ABI* currentABI() {
-    device::ABI* out = new device::ABI();
+  device::ABI* out = new device::ABI();
 #if defined(__arm__)
-    abiByName("armeabi", out);
+  abiByName("armeabi", out);
 #elif defined(__aarch64__)
-    abiByName("arm64-v8a", out);
+  abiByName("arm64-v8a", out);
 #elif defined(__i686__)
-    abiByName("x86", out);
+  abiByName("x86", out);
 #elif defined(__x86_64__)
-    abiByName("x86_64", out);
+  abiByName("x86_64", out);
 #else
-#   error "Unknown ABI"
+#error "Unknown ABI"
 #endif
-    return out;
+  return out;
 }
 
 void abi(int idx, device::ABI* abi) {
-    return abiByName(gContext.mSupportedABIs[idx], abi);
+  return abiByName(gContext.mSupportedABIs[idx], abi);
 }
 
 int cpuNumCores() { return gContext.mNumCores; }
@@ -467,7 +473,7 @@ const char* gpuName() { return ""; }
 
 const char* gpuVendor() { return ""; }
 
-const char* instanceName()  { return gContext.mSerial.c_str(); }
+const char* instanceName() { return gContext.mSerial.c_str(); }
 
 const char* hardwareName() { return gContext.mHardware.c_str(); }
 

--- a/core/os/device/deviceinfo/cc/cpu.cpp
+++ b/core/os/device/deviceinfo/cc/cpu.cpp
@@ -25,55 +25,48 @@
 namespace query {
 
 const char* cpuName() {
-    static union {
-        uint32_t reg[12];
-        char str[49];
-    };
-    if (__get_cpuid(0x80000002, &reg[0], &reg[1], &reg[2],  &reg[3]) &&
-        __get_cpuid(0x80000003, &reg[4], &reg[5], &reg[6],  &reg[7]) &&
-        __get_cpuid(0x80000004, &reg[8], &reg[9], &reg[10], &reg[11])) {
-
-        return str;
-    }
-    return "";
+  static union {
+    uint32_t reg[12];
+    char str[49];
+  };
+  if (__get_cpuid(0x80000002, &reg[0], &reg[1], &reg[2], &reg[3]) &&
+      __get_cpuid(0x80000003, &reg[4], &reg[5], &reg[6], &reg[7]) &&
+      __get_cpuid(0x80000004, &reg[8], &reg[9], &reg[10], &reg[11])) {
+    return str;
+  }
+  return "";
 }
 
 const char* cpuVendor() {
-    static union {
-        uint32_t reg[3];
-        char str[13];
-    };
-    uint32_t eax = 0;
-    if (__get_cpuid(0, &eax, &reg[0], &reg[2], &reg[1])) {
-        return str;
-    }
-    return "";
+  static union {
+    uint32_t reg[3];
+    char str[13];
+  };
+  uint32_t eax = 0;
+  if (__get_cpuid(0, &eax, &reg[0], &reg[2], &reg[1])) {
+    return str;
+  }
+  return "";
 }
 
-device::Architecture cpuArchitecture() {
-    return device::X86_64;
-}
+device::Architecture cpuArchitecture() { return device::X86_64; }
 
 }  // namespace query
-#else // !defined(_MSC_VER) || defined(__GNUC__)
+#else  // !defined(_MSC_VER) || defined(__GNUC__)
 // If we are using MSVC (rather than MSYS) we cannot use __get_cpuid
 namespace query {
 
-const char* cpuName() {
-    return "";
-}
+const char* cpuName() { return ""; }
 
-const char* cpuVendor() {
-    return "";
-}
+const char* cpuVendor() { return ""; }
 
 device::Architecture cpuArchitecture() {
 #ifdef _WIN64
-    return device::X86_64;
+  return device::X86_64;
 #elif defined _WIN32
-    return device::X86;
+  return device::X86;
 #endif
 }
-}
+}  // namespace query
 #endif
 #endif

--- a/core/os/device/deviceinfo/cc/gl.cpp
+++ b/core/os/device/deviceinfo/cc/gl.cpp
@@ -14,76 +14,84 @@
  * limitations under the License.
  */
 
-#include "query.h"
 #include "gl_lite.h"
+#include "query.h"
 
 #include "core/cc/assert.h"
-#include "core/cc/log.h"
 #include "core/cc/get_gles_proc_address.h"
+#include "core/cc/log.h"
 
 #include <sstream>
 
 namespace query {
 
 const char* safe_string(void* x) {
-    return (x != nullptr) ? reinterpret_cast<const char*>(x) : "";
+  return (x != nullptr) ? reinterpret_cast<const char*>(x) : "";
 }
 
 void glDriver(device::OpenGLDriver* driver) {
-    GLint major_version = 2;
-    GLint minor_version = 0;
-    GLint uniformbufferalignment = 1;
-    GLint maxtransformfeedbackseparateattribs = 0;
-    GLint maxtransformfeedbackinterleavedcomponents = 0;
+  GLint major_version = 2;
+  GLint minor_version = 0;
+  GLint uniformbufferalignment = 1;
+  GLint maxtransformfeedbackseparateattribs = 0;
+  GLint maxtransformfeedbackinterleavedcomponents = 0;
 
-    auto glGetIntegerv = reinterpret_cast<PFNGLGETINTEGERV>(core::GetGlesProcAddress("glGetIntegerv", true));
-    auto glGetError = reinterpret_cast<PFNGLGETERROR>(core::GetGlesProcAddress("glGetError", true));
-    auto glGetString = reinterpret_cast<PFNGLGETSTRING>(core::GetGlesProcAddress("glGetString", true));
-    auto glGetStringi = reinterpret_cast<PFNGLGETSTRINGI>(core::GetGlesProcAddress("glGetStringi", true));
+  auto glGetIntegerv = reinterpret_cast<PFNGLGETINTEGERV>(
+      core::GetGlesProcAddress("glGetIntegerv", true));
+  auto glGetError = reinterpret_cast<PFNGLGETERROR>(
+      core::GetGlesProcAddress("glGetError", true));
+  auto glGetString = reinterpret_cast<PFNGLGETSTRING>(
+      core::GetGlesProcAddress("glGetString", true));
+  auto glGetStringi = reinterpret_cast<PFNGLGETSTRINGI>(
+      core::GetGlesProcAddress("glGetStringi", true));
 
-    GAPID_ASSERT(glGetError != nullptr);
-    GAPID_ASSERT(glGetString != nullptr);
+  GAPID_ASSERT(glGetError != nullptr);
+  GAPID_ASSERT(glGetString != nullptr);
 
-    glGetIntegerv(GL_UNIFORM_BUFFER_OFFSET_ALIGNMENT, &uniformbufferalignment);
-    glGetIntegerv(GL_MAX_TRANSFORM_FEEDBACK_SEPARATE_ATTRIBS, &maxtransformfeedbackseparateattribs);
-    glGetIntegerv(GL_MAX_TRANSFORM_FEEDBACK_INTERLEAVED_COMPONENTS, &maxtransformfeedbackinterleavedcomponents);
+  glGetIntegerv(GL_UNIFORM_BUFFER_OFFSET_ALIGNMENT, &uniformbufferalignment);
+  glGetIntegerv(GL_MAX_TRANSFORM_FEEDBACK_SEPARATE_ATTRIBS,
+                &maxtransformfeedbackseparateattribs);
+  glGetIntegerv(GL_MAX_TRANSFORM_FEEDBACK_INTERLEAVED_COMPONENTS,
+                &maxtransformfeedbackinterleavedcomponents);
 
-    glGetError();  // Clear error state.
-    glGetIntegerv(GL_MAJOR_VERSION, &major_version);
-    glGetIntegerv(GL_MINOR_VERSION, &minor_version);
-    if (glGetError() != GL_NO_ERROR) {
-        // GL_MAJOR_VERSION/GL_MINOR_VERSION were introduced in GLES 3.0,
-        // so if the commands returned error we assume it is GLES 2.0.
-        major_version = 2;
-        minor_version = 0;
+  glGetError();  // Clear error state.
+  glGetIntegerv(GL_MAJOR_VERSION, &major_version);
+  glGetIntegerv(GL_MINOR_VERSION, &minor_version);
+  if (glGetError() != GL_NO_ERROR) {
+    // GL_MAJOR_VERSION/GL_MINOR_VERSION were introduced in GLES 3.0,
+    // so if the commands returned error we assume it is GLES 2.0.
+    major_version = 2;
+    minor_version = 0;
+  }
+
+  if (major_version >= 3) {
+    GAPID_ASSERT(glGetIntegerv != nullptr);
+    GAPID_ASSERT(glGetStringi != nullptr);
+
+    int32_t c = 0;
+    glGetIntegerv(GL_NUM_EXTENSIONS, &c);
+    for (int32_t i = 0; i < c; i++) {
+      driver->add_extensions(safe_string(glGetStringi(GL_EXTENSIONS, i)));
     }
-
-    if (major_version >= 3) {
-        GAPID_ASSERT(glGetIntegerv != nullptr);
-        GAPID_ASSERT(glGetStringi != nullptr);
-
-        int32_t c = 0;
-        glGetIntegerv(GL_NUM_EXTENSIONS, &c);
-        for (int32_t i = 0; i < c; i++) {
-            driver->add_extensions(safe_string(glGetStringi(GL_EXTENSIONS, i)));
-        }
-    } else {
-        std::string extensions = safe_string(glGetString(GL_EXTENSIONS));
-        if (glGetError() == GL_NO_ERROR) {
-            std::istringstream iss(extensions);
-            std::string extension;
-            while (std::getline(iss, extension, ' ')) {
-                driver->add_extensions(extension);
-            }
-        }
+  } else {
+    std::string extensions = safe_string(glGetString(GL_EXTENSIONS));
+    if (glGetError() == GL_NO_ERROR) {
+      std::istringstream iss(extensions);
+      std::string extension;
+      while (std::getline(iss, extension, ' ')) {
+        driver->add_extensions(extension);
+      }
     }
+  }
 
-    driver->set_renderer(safe_string(glGetString(GL_RENDERER)));
-    driver->set_vendor(safe_string(glGetString(GL_VENDOR)));
-    driver->set_version(safe_string(glGetString(GL_VERSION)));
-    driver->set_uniformbufferalignment(uniformbufferalignment);
-    driver->set_maxtransformfeedbackseparateattribs(maxtransformfeedbackseparateattribs);
-    driver->set_maxtransformfeedbackinterleavedcomponents(maxtransformfeedbackinterleavedcomponents);
+  driver->set_renderer(safe_string(glGetString(GL_RENDERER)));
+  driver->set_vendor(safe_string(glGetString(GL_VENDOR)));
+  driver->set_version(safe_string(glGetString(GL_VERSION)));
+  driver->set_uniformbufferalignment(uniformbufferalignment);
+  driver->set_maxtransformfeedbackseparateattribs(
+      maxtransformfeedbackseparateattribs);
+  driver->set_maxtransformfeedbackinterleavedcomponents(
+      maxtransformfeedbackinterleavedcomponents);
 }
 
 }  // namespace query

--- a/core/os/device/deviceinfo/cc/gl_lite.h
+++ b/core/os/device/deviceinfo/cc/gl_lite.h
@@ -24,16 +24,16 @@ typedef int GLint;
 
 const GLint GL_UNIFORM_BUFFER_OFFSET_ALIGNMENT = 0x8A34;
 
-const GLint GL_NO_ERROR       = 0x0000;
-const GLint GL_VENDOR         = 0x1F00;
-const GLint GL_RENDERER       = 0x1F01;
-const GLint GL_VERSION        = 0x1F02;
-const GLint GL_EXTENSIONS     = 0x1F03;
-const GLint GL_MINOR_VERSION  = 0x821C;
-const GLint GL_MAJOR_VERSION  = 0x821B;
+const GLint GL_NO_ERROR = 0x0000;
+const GLint GL_VENDOR = 0x1F00;
+const GLint GL_RENDERER = 0x1F01;
+const GLint GL_VERSION = 0x1F02;
+const GLint GL_EXTENSIONS = 0x1F03;
+const GLint GL_MINOR_VERSION = 0x821C;
+const GLint GL_MAJOR_VERSION = 0x821B;
 const GLint GL_NUM_EXTENSIONS = 0x821D;
 const GLint GL_MAX_TRANSFORM_FEEDBACK_INTERLEAVED_COMPONENTS = 0x8C8A;
-const GLint GL_MAX_TRANSFORM_FEEDBACK_SEPARATE_ATTRIBS       = 0x8C8B;
+const GLint GL_MAX_TRANSFORM_FEEDBACK_SEPARATE_ATTRIBS = 0x8C8B;
 
 typedef void (*PFNGLGETINTEGERV)(GLenum param, GLint* values);
 typedef GLenum (*PFNGLGETERROR)();

--- a/core/os/device/deviceinfo/cc/instance.cpp
+++ b/core/os/device/deviceinfo/cc/instance.cpp
@@ -20,32 +20,28 @@
 extern "C" {
 
 device_instance get_device_instance(void* platform_data) {
-    device_instance out = {};
+  device_instance out = {};
 
-    query::Option query_opt;
-    query_opt.vulkan.set_query_layers_and_extensions(true)
-        .set_query_physical_devices(true);
-    auto instance = query::getDeviceInstance(query_opt, platform_data);
-    if (!instance) {
-        return out;
-    }
-
-    // Reserialize the instance with the ID field.
-    out.size = instance->ByteSize();
-    out.data = new uint8_t[out.size];
-    instance->SerializeToArray(out.data, out.size);
-
-    delete instance;
-
+  query::Option query_opt;
+  query_opt.vulkan.set_query_layers_and_extensions(true)
+      .set_query_physical_devices(true);
+  auto instance = query::getDeviceInstance(query_opt, platform_data);
+  if (!instance) {
     return out;
+  }
+
+  // Reserialize the instance with the ID field.
+  out.size = instance->ByteSize();
+  out.data = new uint8_t[out.size];
+  instance->SerializeToArray(out.data, out.size);
+
+  delete instance;
+
+  return out;
 }
 
-const char* get_device_instance_error() {
-    return query::contextError();
-}
+const char* get_device_instance_error() { return query::contextError(); }
 
-void free_device_instance(device_instance di) {
-    delete[] di.data;
-}
+void free_device_instance(device_instance di) { delete[] di.data; }
 
-} // extern "C"
+}  // extern "C"

--- a/core/os/device/deviceinfo/cc/instance.h
+++ b/core/os/device/deviceinfo/cc/instance.h
@@ -17,16 +17,16 @@
 #ifndef DEVICEINFO_INSTANCE_H
 #define DEVICEINFO_INSTANCE_H
 
-#include <stdint.h>
 #include <stddef.h>
+#include <stdint.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 typedef struct {
-    uint8_t* data;
-    size_t size;
+  uint8_t* data;
+  size_t size;
 } device_instance;
 
 device_instance get_device_instance(void* platform_data);
@@ -34,7 +34,7 @@ const char* get_device_instance_error();
 void free_device_instance(device_instance);
 
 #ifdef __cplusplus
-} // extern "C"
+}  // extern "C"
 #endif
 
 #endif  // DEVICEINFO_INSTANCE_H

--- a/core/os/device/deviceinfo/cc/linux/query.cpp
+++ b/core/os/device/deviceinfo/cc/linux/query.cpp
@@ -16,14 +16,14 @@
 
 #include "../query.h"
 
-#include "core/cc/gl/versions.h"
-#include "core/cc/get_gles_proc_address.h"
 #include "core/cc/dl_loader.h"
+#include "core/cc/get_gles_proc_address.h"
+#include "core/cc/gl/versions.h"
 
-#include <X11/Xresource.h>
 #include <GL/glx.h>
-#include <cstring>
+#include <X11/Xresource.h>
 #include <string.h>
+#include <cstring>
 
 #include <sys/utsname.h>
 #include <unistd.h>
@@ -39,196 +39,226 @@
 namespace query {
 
 struct Context {
-    char mError[512];
-    Display* mDisplay;
-    GLXFBConfig* mFBConfigs;
-    GLXContext mGlCtx;
-    GLXPbuffer mPbuffer;
-    int mNumCores;
-    utsname mUbuf;
-    char mHostName[512];
+  char mError[512];
+  Display* mDisplay;
+  GLXFBConfig* mFBConfigs;
+  GLXContext mGlCtx;
+  GLXPbuffer mPbuffer;
+  int mNumCores;
+  utsname mUbuf;
+  char mHostName[512];
 };
 
 static Context gContext;
 static int gContextRefCount = 0;
 
-typedef GLXFBConfig* (*pfn_glXChooseFBConfig)(Display* dpy, int screen, const int* attrib_list, int* nelements);
-typedef GLXContext (*pfn_glXCreateNewContext)(Display* dpy, GLXFBConfig config, int render_type, GLXContext shader_list, bool direct);
-typedef GLXPbuffer (*pfn_glXCreatePbuffer)(Display* dpy, GLXFBConfig config, const int* attrib_list);
-typedef void (*pfn_glXDestroyPbuffer)(Display*  dpy, GLXPbuffer  pbuf);
-typedef void (*pfn_glXDestroyContext)(Display *  dpy, GLXContext  ctx);
-typedef Bool (*pfn_glXMakeContextCurrent)(Display *dpy, GLXDrawable draw, GLXDrawable read, GLXContext ctx);
-typedef GLXContext (*pfn_glXCreateContextAttribsARB)(Display *dpy, GLXFBConfig config, GLXContext share_context,
-                                                     Bool direct, const int *attrib_list);
+typedef GLXFBConfig* (*pfn_glXChooseFBConfig)(Display* dpy, int screen,
+                                              const int* attrib_list,
+                                              int* nelements);
+typedef GLXContext (*pfn_glXCreateNewContext)(Display* dpy, GLXFBConfig config,
+                                              int render_type,
+                                              GLXContext shader_list,
+                                              bool direct);
+typedef GLXPbuffer (*pfn_glXCreatePbuffer)(Display* dpy, GLXFBConfig config,
+                                           const int* attrib_list);
+typedef void (*pfn_glXDestroyPbuffer)(Display* dpy, GLXPbuffer pbuf);
+typedef void (*pfn_glXDestroyContext)(Display* dpy, GLXContext ctx);
+typedef Bool (*pfn_glXMakeContextCurrent)(Display* dpy, GLXDrawable draw,
+                                          GLXDrawable read, GLXContext ctx);
+typedef GLXContext (*pfn_glXCreateContextAttribsARB)(Display* dpy,
+                                                     GLXFBConfig config,
+                                                     GLXContext share_context,
+                                                     Bool direct,
+                                                     const int* attrib_list);
 
-typedef int(*pfn_XFree) (void*);
-typedef int(*pfn_XCloseDisplay)(Display*);
+typedef int (*pfn_XFree)(void*);
+typedef int (*pfn_XCloseDisplay)(Display*);
 typedef Display* (*pfn_XOpenDisplay)(_Xconst char*);
-typedef XErrorHandler (*pfn_XSetErrorHandler) (XErrorHandler);
+typedef XErrorHandler (*pfn_XSetErrorHandler)(XErrorHandler);
 
 void destroyContext() {
-    if (--gContextRefCount > 0) {
-        return;
-    }
+  if (--gContextRefCount > 0) {
+    return;
+  }
 
-    if (!core::DlLoader::can_load("libX11.so")) {
-        return;
-    }
+  if (!core::DlLoader::can_load("libX11.so")) {
+    return;
+  }
 
-    if (!core::hasGLorGLES()) {
-        return;
-    }
+  if (!core::hasGLorGLES()) {
+    return;
+  }
 
-    core::DlLoader libX("libX11.so");
-    pfn_XFree fn_XFree = (pfn_XFree)libX.lookup("XFree");
-    pfn_XCloseDisplay fn_XCloseDisplay = (pfn_XCloseDisplay)libX.lookup("XCloseDisplay");
+  core::DlLoader libX("libX11.so");
+  pfn_XFree fn_XFree = (pfn_XFree)libX.lookup("XFree");
+  pfn_XCloseDisplay fn_XCloseDisplay =
+      (pfn_XCloseDisplay)libX.lookup("XCloseDisplay");
 
-    pfn_glXDestroyPbuffer fn_glXDestroyPbuffer = (pfn_glXDestroyPbuffer)core::GetGlesProcAddress("glXDestroyPbuffer", true);
-    pfn_glXDestroyContext fn_glXDestroyContext = (pfn_glXDestroyContext)core::GetGlesProcAddress("glXDestroyContext", true);
+  pfn_glXDestroyPbuffer fn_glXDestroyPbuffer =
+      (pfn_glXDestroyPbuffer)core::GetGlesProcAddress("glXDestroyPbuffer",
+                                                      true);
+  pfn_glXDestroyContext fn_glXDestroyContext =
+      (pfn_glXDestroyContext)core::GetGlesProcAddress("glXDestroyContext",
+                                                      true);
 
-    if (gContext.mPbuffer && fn_glXDestroyPbuffer) {
-        (*fn_glXDestroyPbuffer)(gContext.mDisplay, gContext.mPbuffer);
-        gContext.mPbuffer = 0;
-    }
-    if (gContext.mGlCtx && fn_glXDestroyContext) {
-        (*fn_glXDestroyContext)(gContext.mDisplay, gContext.mGlCtx);
-        gContext.mGlCtx = nullptr;
-    }
-    if (gContext.mFBConfigs) {
-        fn_XFree(gContext.mFBConfigs);
-        gContext.mFBConfigs = nullptr;
-    }
-    if (gContext.mDisplay) {
-        fn_XCloseDisplay(gContext.mDisplay);
-        gContext.mDisplay = nullptr;
-    }
+  if (gContext.mPbuffer && fn_glXDestroyPbuffer) {
+    (*fn_glXDestroyPbuffer)(gContext.mDisplay, gContext.mPbuffer);
+    gContext.mPbuffer = 0;
+  }
+  if (gContext.mGlCtx && fn_glXDestroyContext) {
+    (*fn_glXDestroyContext)(gContext.mDisplay, gContext.mGlCtx);
+    gContext.mGlCtx = nullptr;
+  }
+  if (gContext.mFBConfigs) {
+    fn_XFree(gContext.mFBConfigs);
+    gContext.mFBConfigs = nullptr;
+  }
+  if (gContext.mDisplay) {
+    fn_XCloseDisplay(gContext.mDisplay);
+    gContext.mDisplay = nullptr;
+  }
 }
 
 void createGlContext() {
-    if (!core::hasGLorGLES()) {
-        return;
-    }
-    auto fn_glXChooseFBConfig= (pfn_glXChooseFBConfig)core::GetGlesProcAddress("glXChooseFBConfig", true);
-    auto fn_glXCreateNewContext = (pfn_glXCreateNewContext)core::GetGlesProcAddress("glXCreateNewContext", true);
-    auto fn_glXCreatePbuffer = (pfn_glXCreatePbuffer)core::GetGlesProcAddress("glXCreatePbuffer", true);
-    auto fn_glXMakeContextCurrent = (pfn_glXMakeContextCurrent)core::GetGlesProcAddress("glXMakeContextCurrent", true);
-    auto fn_glXCreateContextAttribsARB = (pfn_glXCreateContextAttribsARB)core::GetGlesProcAddress("glXCreateContextAttribsARB", true);
+  if (!core::hasGLorGLES()) {
+    return;
+  }
+  auto fn_glXChooseFBConfig = (pfn_glXChooseFBConfig)core::GetGlesProcAddress(
+      "glXChooseFBConfig", true);
+  auto fn_glXCreateNewContext =
+      (pfn_glXCreateNewContext)core::GetGlesProcAddress("glXCreateNewContext",
+                                                        true);
+  auto fn_glXCreatePbuffer =
+      (pfn_glXCreatePbuffer)core::GetGlesProcAddress("glXCreatePbuffer", true);
+  auto fn_glXMakeContextCurrent =
+      (pfn_glXMakeContextCurrent)core::GetGlesProcAddress(
+          "glXMakeContextCurrent", true);
+  auto fn_glXCreateContextAttribsARB =
+      (pfn_glXCreateContextAttribsARB)core::GetGlesProcAddress(
+          "glXCreateContextAttribsARB", true);
 
-    if (!fn_glXChooseFBConfig || !fn_glXCreateNewContext || !fn_glXCreatePbuffer || !fn_glXMakeContextCurrent) {
-        return;
-    }
+  if (!fn_glXChooseFBConfig || !fn_glXCreateNewContext ||
+      !fn_glXCreatePbuffer || !fn_glXMakeContextCurrent) {
+    return;
+  }
 
-    if (!core::DlLoader::can_load("libX11.so")) {
-        return;
-    }
+  if (!core::DlLoader::can_load("libX11.so")) {
+    return;
+  }
 
-    core::DlLoader libX("libX11.so");
+  core::DlLoader libX("libX11.so");
 
-    pfn_XOpenDisplay fn_XOpenDisplay = (pfn_XOpenDisplay)libX.lookup("XOpenDisplay");
-    pfn_XSetErrorHandler fn_XSetErrorHandler = (pfn_XSetErrorHandler)libX.lookup("XSetErrorHandler");
+  pfn_XOpenDisplay fn_XOpenDisplay =
+      (pfn_XOpenDisplay)libX.lookup("XOpenDisplay");
+  pfn_XSetErrorHandler fn_XSetErrorHandler =
+      (pfn_XSetErrorHandler)libX.lookup("XSetErrorHandler");
 
-    gContext.mDisplay = fn_XOpenDisplay(nullptr);
+  gContext.mDisplay = fn_XOpenDisplay(nullptr);
+  if (gContext.mDisplay == nullptr) {
+    // Default display was not found. This may be because we're executing in
+    // the bazel sandbox. Attempt to connect to the 0'th display instead.
+    gContext.mDisplay = fn_XOpenDisplay(":0");
     if (gContext.mDisplay == nullptr) {
-        // Default display was not found. This may be because we're executing in
-        // the bazel sandbox. Attempt to connect to the 0'th display instead.
-        gContext.mDisplay = fn_XOpenDisplay(":0");
-        if (gContext.mDisplay == nullptr) {
-            return;
-        }
+      return;
     }
+  }
 
-    const int visualAttribs[] = {
-        GLX_RED_SIZE, 8,
-        GLX_GREEN_SIZE, 8,
-        GLX_BLUE_SIZE, 8,
-        GLX_ALPHA_SIZE, 8,
-        GLX_DEPTH_SIZE, 24,
-        GLX_STENCIL_SIZE, 8,
-        GLX_RENDER_TYPE, GLX_RGBA_BIT,
-        GLX_DRAWABLE_TYPE, GLX_PBUFFER_BIT,
-        None
-    };
-    int fbConfigsCount = 0;
-    gContext.mFBConfigs = (*fn_glXChooseFBConfig)(gContext.mDisplay,
-                                            DefaultScreen(gContext.mDisplay),
-                                            visualAttribs,
-                                            &fbConfigsCount);
-    if (!gContext.mFBConfigs) {
-        return;
+  const int visualAttribs[] = {
+      // clang-format off
+      GLX_RED_SIZE, 8,
+      GLX_GREEN_SIZE, 8,
+      GLX_BLUE_SIZE, 8,
+      GLX_ALPHA_SIZE, 8,
+      GLX_DEPTH_SIZE, 24,
+      GLX_STENCIL_SIZE, 8,
+      GLX_RENDER_TYPE, GLX_RGBA_BIT,
+      GLX_DRAWABLE_TYPE, GLX_PBUFFER_BIT,
+      None
+      // clang-format on
+  };
+  int fbConfigsCount = 0;
+  gContext.mFBConfigs = (*fn_glXChooseFBConfig)(
+      gContext.mDisplay, DefaultScreen(gContext.mDisplay), visualAttribs,
+      &fbConfigsCount);
+  if (!gContext.mFBConfigs) {
+    return;
+  }
+
+  GLXFBConfig fbConfig = gContext.mFBConfigs[0];
+
+  if (fn_glXCreateContextAttribsARB == nullptr) {
+    gContext.mGlCtx = (*fn_glXCreateNewContext)(gContext.mDisplay, fbConfig,
+                                                GLX_RGBA_TYPE, nullptr, True);
+  } else {
+    // Prevent X from taking down the process if the GL version is not
+    // supported.
+    auto oldHandler =
+        fn_XSetErrorHandler([](Display*, XErrorEvent*) -> int { return 0; });
+    for (auto gl_version : core::gl::sVersionSearchOrder) {
+      // List of name-value pairs.
+      const int contextAttribs[] = {
+          // clang-format off
+          GLX_RENDER_TYPE, GLX_RGBA_TYPE,
+          GLX_CONTEXT_MAJOR_VERSION_ARB, gl_version.major,
+          GLX_CONTEXT_MINOR_VERSION_ARB, gl_version.minor,
+          GLX_CONTEXT_FLAGS_ARB, GLX_CONTEXT_DEBUG_BIT_ARB,
+          GLX_CONTEXT_PROFILE_MASK_ARB, GLX_CONTEXT_CORE_PROFILE_BIT_ARB,
+          None,
+          // clang-format on
+      };
+      gContext.mGlCtx =
+          fn_glXCreateContextAttribsARB(gContext.mDisplay, fbConfig, nullptr,
+                                        /* direct */ True, contextAttribs);
+      if (gContext.mGlCtx != nullptr) {
+        break;
+      }
     }
+    fn_XSetErrorHandler(oldHandler);
+  }
 
-    GLXFBConfig fbConfig = gContext.mFBConfigs[0];
+  if (!gContext.mGlCtx) {
+    return;
+  }
 
-    if (fn_glXCreateContextAttribsARB == nullptr) {
-        gContext.mGlCtx = (*fn_glXCreateNewContext)(gContext.mDisplay,
-                                                fbConfig,
-                                                GLX_RGBA_TYPE,
-                                                nullptr,
-                                                True);
-    } else {
-        // Prevent X from taking down the process if the GL version is not supported.
-        auto oldHandler = fn_XSetErrorHandler([](Display*, XErrorEvent*)->int{ return 0; });
-        for (auto gl_version : core::gl::sVersionSearchOrder) {
-            // List of name-value pairs.
-            const int contextAttribs[] = {
-                GLX_RENDER_TYPE, GLX_RGBA_TYPE,
-                GLX_CONTEXT_MAJOR_VERSION_ARB, gl_version.major,
-                GLX_CONTEXT_MINOR_VERSION_ARB, gl_version.minor,
-                GLX_CONTEXT_FLAGS_ARB, GLX_CONTEXT_DEBUG_BIT_ARB,
-                GLX_CONTEXT_PROFILE_MASK_ARB, GLX_CONTEXT_CORE_PROFILE_BIT_ARB,
-                None,
-            };
-            gContext.mGlCtx = fn_glXCreateContextAttribsARB(
-                gContext.mDisplay, fbConfig, nullptr, /* direct */ True, contextAttribs);
-            if (gContext.mGlCtx != nullptr) {
-                break;
-            }
-        }
-        fn_XSetErrorHandler(oldHandler);
-    }
+  const int pbufferAttribs[] = {GLX_PBUFFER_WIDTH, 32, GLX_PBUFFER_HEIGHT, 32,
+                                None};
 
-    if (!gContext.mGlCtx) {
-        return;
-    }
+  gContext.mPbuffer =
+      fn_glXCreatePbuffer(gContext.mDisplay, fbConfig, pbufferAttribs);
+  if (!gContext.mPbuffer) {
+    return;
+  }
 
-    const int pbufferAttribs[] = {
-        GLX_PBUFFER_WIDTH, 32, GLX_PBUFFER_HEIGHT, 32, None
-    };
-
-    gContext.mPbuffer = fn_glXCreatePbuffer(gContext.mDisplay, fbConfig, pbufferAttribs);
-    if (!gContext.mPbuffer) {
-        return;
-    }
-
-    fn_glXMakeContextCurrent(gContext.mDisplay, gContext.mPbuffer, gContext.mPbuffer, gContext.mGlCtx);
+  fn_glXMakeContextCurrent(gContext.mDisplay, gContext.mPbuffer,
+                           gContext.mPbuffer, gContext.mGlCtx);
 }
 
 bool createContext(void* platform_data) {
-    if (gContextRefCount++ > 0) {
-        return true;
-    }
-
-    memset(&gContext, 0, sizeof(gContext));
-
-    if (uname(&gContext.mUbuf) != 0) {
-		snprintf(gContext.mError, sizeof(gContext.mError),
-				 "uname returned error: %d", errno);
-        destroyContext();
-        return false;
-    }
-
-    gContext.mNumCores = sysconf(_SC_NPROCESSORS_CONF);
-
-    if (gethostname(gContext.mHostName, sizeof(gContext.mHostName)) != 0) {
-		snprintf(gContext.mError, sizeof(gContext.mError),
-				 "gethostname returned error: %d", errno);
-        destroyContext();
-        return false;
-    }
-
-    createGlContext();
-
+  if (gContextRefCount++ > 0) {
     return true;
+  }
+
+  memset(&gContext, 0, sizeof(gContext));
+
+  if (uname(&gContext.mUbuf) != 0) {
+    snprintf(gContext.mError, sizeof(gContext.mError),
+             "uname returned error: %d", errno);
+    destroyContext();
+    return false;
+  }
+
+  gContext.mNumCores = sysconf(_SC_NPROCESSORS_CONF);
+
+  if (gethostname(gContext.mHostName, sizeof(gContext.mHostName)) != 0) {
+    snprintf(gContext.mError, sizeof(gContext.mError),
+             "gethostname returned error: %d", errno);
+    destroyContext();
+    return false;
+  }
+
+  createGlContext();
+
+  return true;
 }
 
 const char* contextError() { return gContext.mError; }
@@ -238,16 +268,16 @@ bool hasGLorGLES() { return gContext.mGlCtx != nullptr; }
 int numABIs() { return 1; }
 
 void abi(int idx, device::ABI* abi) {
-    abi->set_name("x86_64");
-    abi->set_os(device::Linux);
-    abi->set_architecture(device::X86_64);
-    abi->set_allocated_memorylayout(currentMemoryLayout());
+  abi->set_name("x86_64");
+  abi->set_os(device::Linux);
+  abi->set_architecture(device::X86_64);
+  abi->set_allocated_memorylayout(currentMemoryLayout());
 }
 
 device::ABI* currentABI() {
-    auto out = new device::ABI();
-    abi(0, out);
-    return out;
+  auto out = new device::ABI();
+  abi(0, out);
+  return out;
 }
 
 int cpuNumCores() { return gContext.mNumCores; }

--- a/core/os/device/deviceinfo/cc/query.cpp
+++ b/core/os/device/deviceinfo/cc/query.cpp
@@ -112,7 +112,8 @@ void buildDeviceInstance(const query::Option& opt, void* platform_data,
     }
     if (opt.vulkan.query_physical_devices()) {
       query::vkPhysicalDevices(vulkan_driver);
-      if (strlen(backupName) == 0 && vulkan_driver->physicaldevices_size() > 0) {
+      if (strlen(backupName) == 0 &&
+          vulkan_driver->physicaldevices_size() > 0) {
         backupName = vulkan_driver->physicaldevices(0).devicename().c_str();
       }
     }
@@ -166,11 +167,11 @@ void buildDeviceInstance(const query::Option& opt, void* platform_data,
   bool blacklist = false;
   if (std::string(gpuName).find("Vega") != std::string::npos &&
       std::string(query::osName()).find("Windows 10") != std::string::npos) {
-      blacklist = true;
+    blacklist = true;
   }
 
   if (!blacklist) {
-     query::destroyContext();
+    query::destroyContext();
   }
 
   *out = instance;

--- a/core/os/device/deviceinfo/cc/vk.cpp
+++ b/core/os/device/deviceinfo/cc/vk.cpp
@@ -41,11 +41,11 @@ bool hasVulkanLoader() { return core::HasVulkanLoader(); }
     }                                                   \
   }
 
-#define RETURN_IF_NOT_RESOLVED(FuncName)                        \
-  if (FuncName == nullptr) {                                    \
-    GAPID_WARNING("Failed at resolving: " #FuncName             \
+#define RETURN_IF_NOT_RESOLVED(FuncName)               \
+  if (FuncName == nullptr) {                           \
+    GAPID_WARNING("Failed at resolving: " #FuncName    \
                   " for getting Vulkan Driver info."); \
-    return false;                                               \
+    return false;                                      \
   }
 
 bool vkLayersAndExtensions(
@@ -92,7 +92,8 @@ bool vkLayersAndExtensions(
     driver->add_layers();
     driver->mutable_layers(driver->layers_size() - 1)->set_name(l.layerName);
     for (size_t j = 0; j < ext_props.size(); j++) {
-      driver->mutable_layers(driver->layers_size() - 1)->add_extensions(ext_props[j].extensionName);
+      driver->mutable_layers(driver->layers_size() - 1)
+          ->add_extensions(ext_props[j].extensionName);
     }
   }
   // For implicit layers and ICD extensions

--- a/core/os/device/deviceinfo/cc/windows/query.cpp
+++ b/core/os/device/deviceinfo/cc/windows/query.cpp
@@ -18,177 +18,180 @@
 
 #include "core/cc/get_gles_proc_address.h"
 
+#include <GL/gl.h>
 #include <windows.h>
 #include <wingdi.h>
-#include <GL/gl.h>
 
 namespace {
 
 static const char* wndClassName = TEXT("opengl-dummy-window");
 
 WNDCLASSEX registerWindowClass() {
-    WNDCLASSEX wc;
-    memset(&wc, 0, sizeof(wc));
-    wc.cbSize        = sizeof(wc);
-// We must use CS_OWNDC here if we are to use this window with GL.
-// https://www.khronos.org/opengl/wiki/Creating_an_OpenGL_Context_(WGL)#The_Window_Itself
-    wc.style         = CS_OWNDC;
-    wc.lpfnWndProc   = DefWindowProc;
-    wc.hInstance     = GetModuleHandle(0);
-    wc.hCursor       = LoadCursor(0, IDC_ARROW);
-    wc.lpszMenuName  = TEXT("");
-    wc.lpszClassName = wndClassName;
-    RegisterClassEx(&wc);
-    return wc;
+  WNDCLASSEX wc;
+  memset(&wc, 0, sizeof(wc));
+  wc.cbSize = sizeof(wc);
+  // We must use CS_OWNDC here if we are to use this window with GL.
+  // https://www.khronos.org/opengl/wiki/Creating_an_OpenGL_Context_(WGL)#The_Window_Itself
+  wc.style = CS_OWNDC;
+  wc.lpfnWndProc = DefWindowProc;
+  wc.hInstance = GetModuleHandle(0);
+  wc.hCursor = LoadCursor(0, IDC_ARROW);
+  wc.lpszMenuName = TEXT("");
+  wc.lpszClassName = wndClassName;
+  RegisterClassEx(&wc);
+  return wc;
 }
 
-} // anonymous namespace
+}  // anonymous namespace
 
 namespace query {
 
-typedef HGLRC (CALLBACK* pfn_wglCreateContext)(HDC);
-typedef BOOL (CALLBACK* pfn_wglMakeCurrent)(HDC, HGLRC);
-typedef BOOL (CALLBACK* pfn_wglDeleteContext)(HGLRC);
+typedef HGLRC(CALLBACK* pfn_wglCreateContext)(HDC);
+typedef BOOL(CALLBACK* pfn_wglMakeCurrent)(HDC, HGLRC);
+typedef BOOL(CALLBACK* pfn_wglDeleteContext)(HGLRC);
 
 struct Context {
-    char mError[512];
-    HWND mWnd;
-    HDC mHDC;
-    HGLRC mGlCtx;
-    int mNumCores;
-    char mHostName[MAX_COMPUTERNAME_LENGTH*4+1]; // Stored as UTF-8
-    OSVERSIONINFOEX mOsVersion;
-    const char* mOsName;
+  char mError[512];
+  HWND mWnd;
+  HDC mHDC;
+  HGLRC mGlCtx;
+  int mNumCores;
+  char mHostName[MAX_COMPUTERNAME_LENGTH * 4 + 1];  // Stored as UTF-8
+  OSVERSIONINFOEX mOsVersion;
+  const char* mOsName;
 
-    pfn_wglCreateContext wglCreateContext;
-    pfn_wglMakeCurrent wglMakeCurrent;
-    pfn_wglDeleteContext wglDeleteContext;
+  pfn_wglCreateContext wglCreateContext;
+  pfn_wglMakeCurrent wglMakeCurrent;
+  pfn_wglDeleteContext wglDeleteContext;
 };
 
 static Context gContext;
 static int gContextRefCount = 0;
 
 void destroyContext() {
-    if (--gContextRefCount > 0) {
-        return;
-    }
+  if (--gContextRefCount > 0) {
+    return;
+  }
 
-    if (gContext.mWnd != nullptr) {
-        DestroyWindow(gContext.mWnd);
-    }
-    if (gContext.mGlCtx != nullptr) {
-        gContext.wglMakeCurrent(gContext.mHDC, 0);
-        gContext.wglDeleteContext(gContext.mGlCtx);
-    }
+  if (gContext.mWnd != nullptr) {
+    DestroyWindow(gContext.mWnd);
+  }
+  if (gContext.mGlCtx != nullptr) {
+    gContext.wglMakeCurrent(gContext.mHDC, 0);
+    gContext.wglDeleteContext(gContext.mGlCtx);
+  }
 }
 
 void createGlContext() {
-    gContext.wglCreateContext = (pfn_wglCreateContext)core::GetGlesProcAddress("wglCreateContext", true);
-    gContext.wglMakeCurrent = (pfn_wglMakeCurrent)core::GetGlesProcAddress("wglMakeCurrent", true);
-    gContext.wglDeleteContext = (pfn_wglDeleteContext)core::GetGlesProcAddress("wglDeleteContext", true);
+  gContext.wglCreateContext =
+      (pfn_wglCreateContext)core::GetGlesProcAddress("wglCreateContext", true);
+  gContext.wglMakeCurrent =
+      (pfn_wglMakeCurrent)core::GetGlesProcAddress("wglMakeCurrent", true);
+  gContext.wglDeleteContext =
+      (pfn_wglDeleteContext)core::GetGlesProcAddress("wglDeleteContext", true);
 
-    if (gContext.wglCreateContext == nullptr ||
-        gContext.wglMakeCurrent == nullptr ||
-        gContext.wglDeleteContext == nullptr) {
-
-        return;
-    }
-
-    WNDCLASSEX wc = registerWindowClass();
-    gContext.mWnd = CreateWindow(wndClassName, TEXT(""), WS_POPUP, 0, 0, 8, 8, 0, 0, GetModuleHandle(0), 0);
-    if (gContext.mWnd == nullptr) {
-        return;
-    }
-
-    PIXELFORMATDESCRIPTOR pfd;
-    memset(&pfd, 0, sizeof(pfd));
-    pfd.nSize = sizeof(PIXELFORMATDESCRIPTOR);
-    pfd.nVersion = 1;
-    pfd.dwFlags = PFD_DRAW_TO_WINDOW | PFD_SUPPORT_OPENGL;
-    pfd.iPixelType = PFD_TYPE_RGBA;
-    pfd.cRedBits = 8;
-    pfd.cGreenBits = 8;
-    pfd.cBlueBits = 8;
-    pfd.cAlphaBits = 8;
-    pfd.cDepthBits = 24;
-    pfd.cStencilBits = 8;
-    pfd.cColorBits = 32;
-    pfd.iLayerType = PFD_MAIN_PLANE;
-    gContext.mHDC = GetDC(gContext.mWnd);
-    SetPixelFormat(gContext.mHDC, ChoosePixelFormat(gContext.mHDC, &pfd), &pfd);
-    gContext.mGlCtx = gContext.wglCreateContext(gContext.mHDC);
-    if (gContext.mGlCtx != nullptr) {
-        gContext.wglMakeCurrent(gContext.mHDC, gContext.mGlCtx);
-    }
-
+  if (gContext.wglCreateContext == nullptr ||
+      gContext.wglMakeCurrent == nullptr ||
+      gContext.wglDeleteContext == nullptr) {
     return;
+  }
+
+  WNDCLASSEX wc = registerWindowClass();
+  gContext.mWnd = CreateWindow(wndClassName, TEXT(""), WS_POPUP, 0, 0, 8, 8, 0,
+                               0, GetModuleHandle(0), 0);
+  if (gContext.mWnd == nullptr) {
+    return;
+  }
+
+  PIXELFORMATDESCRIPTOR pfd;
+  memset(&pfd, 0, sizeof(pfd));
+  pfd.nSize = sizeof(PIXELFORMATDESCRIPTOR);
+  pfd.nVersion = 1;
+  pfd.dwFlags = PFD_DRAW_TO_WINDOW | PFD_SUPPORT_OPENGL;
+  pfd.iPixelType = PFD_TYPE_RGBA;
+  pfd.cRedBits = 8;
+  pfd.cGreenBits = 8;
+  pfd.cBlueBits = 8;
+  pfd.cAlphaBits = 8;
+  pfd.cDepthBits = 24;
+  pfd.cStencilBits = 8;
+  pfd.cColorBits = 32;
+  pfd.iLayerType = PFD_MAIN_PLANE;
+  gContext.mHDC = GetDC(gContext.mWnd);
+  SetPixelFormat(gContext.mHDC, ChoosePixelFormat(gContext.mHDC, &pfd), &pfd);
+  gContext.mGlCtx = gContext.wglCreateContext(gContext.mHDC);
+  if (gContext.mGlCtx != nullptr) {
+    gContext.wglMakeCurrent(gContext.mHDC, gContext.mGlCtx);
+  }
+
+  return;
 }
 
 bool createContext(void* platform_data) {
-    if (gContextRefCount++ > 0) {
-        return true;
-    }
-
-    createGlContext();
-
-    gContext.mOsVersion.dwOSVersionInfoSize = sizeof(gContext.mOsVersion);
-    GetVersionEx((OSVERSIONINFO*)(&gContext.mOsVersion));
-    int major = gContext.mOsVersion.dwMajorVersion;
-    int minor = gContext.mOsVersion.dwMinorVersion;
-    int point = gContext.mOsVersion.dwBuildNumber;
-    bool isNTWorkstation = (gContext.mOsVersion.wProductType == VER_NT_WORKSTATION);
-
-    if (major == 10 && isNTWorkstation) {
-        gContext.mOsName = "Windows 10";
-    } else if (major == 10 && !isNTWorkstation) {
-        gContext.mOsName = "Windows Server 2016 Technical Preview";
-    } else if (major == 6 && minor == 3 && isNTWorkstation) {
-        gContext.mOsName = "Windows 8.1";
-    } else if (major == 6 && minor == 3 && !isNTWorkstation) {
-        gContext.mOsName = "Windows Server 2012 R2";
-    } else if (major == 6 && minor == 2 && isNTWorkstation) {
-        gContext.mOsName = "Windows 8";
-    } else if (major == 6 && minor == 2 && !isNTWorkstation) {
-        gContext.mOsName = "Windows Server 2012";
-    } else if (major == 6 && minor == 1 && isNTWorkstation) {
-        gContext.mOsName = "Windows 7";
-    } else if (major == 6 && minor == 1 && !isNTWorkstation) {
-        gContext.mOsName = "Windows Server 2008 R2";
-    } else if (major == 6 && minor == 0 && isNTWorkstation) {
-        gContext.mOsName = "Windows Vista";
-    } else if (major == 6 && minor == 0 && !isNTWorkstation) {
-        gContext.mOsName = "Windows Server 2008";
-    } else if (major == 5 && minor == 1) {
-        gContext.mOsName = "Windows XP";
-    } else if (major == 5 && minor == 0) {
-        gContext.mOsName = "Windows 2000";
-    } else {
-        gContext.mOsName = "";
-    }
-
-    SYSTEM_INFO sysInfo;
-    GetSystemInfo(&sysInfo);
-    gContext.mNumCores = sysInfo.dwNumberOfProcessors;
-
-    DWORD size = MAX_COMPUTERNAME_LENGTH + 1;
-    WCHAR host_wide[MAX_COMPUTERNAME_LENGTH + 1];
-    if (!GetComputerNameW(host_wide, &size)) {
-        snprintf(gContext.mError, sizeof(gContext.mError),
-                 "Couldn't get host name: %d", GetLastError());
-        return false;
-    }
-    WideCharToMultiByte(
-        CP_UTF8,                    // CodePage
-        0,                          // dwFlags
-        host_wide,                  // lpWideCharStr
-        -1,                         // cchWideChar
-        gContext.mHostName,         // lpMultiByteStr
-        sizeof(gContext.mHostName), // cbMultiByte
-        nullptr,                    // lpDefaultChar
-        nullptr                     // lpUsedDefaultChar
-    );
-
+  if (gContextRefCount++ > 0) {
     return true;
+  }
+
+  createGlContext();
+
+  gContext.mOsVersion.dwOSVersionInfoSize = sizeof(gContext.mOsVersion);
+  GetVersionEx((OSVERSIONINFO*)(&gContext.mOsVersion));
+  int major = gContext.mOsVersion.dwMajorVersion;
+  int minor = gContext.mOsVersion.dwMinorVersion;
+  int point = gContext.mOsVersion.dwBuildNumber;
+  bool isNTWorkstation =
+      (gContext.mOsVersion.wProductType == VER_NT_WORKSTATION);
+
+  if (major == 10 && isNTWorkstation) {
+    gContext.mOsName = "Windows 10";
+  } else if (major == 10 && !isNTWorkstation) {
+    gContext.mOsName = "Windows Server 2016 Technical Preview";
+  } else if (major == 6 && minor == 3 && isNTWorkstation) {
+    gContext.mOsName = "Windows 8.1";
+  } else if (major == 6 && minor == 3 && !isNTWorkstation) {
+    gContext.mOsName = "Windows Server 2012 R2";
+  } else if (major == 6 && minor == 2 && isNTWorkstation) {
+    gContext.mOsName = "Windows 8";
+  } else if (major == 6 && minor == 2 && !isNTWorkstation) {
+    gContext.mOsName = "Windows Server 2012";
+  } else if (major == 6 && minor == 1 && isNTWorkstation) {
+    gContext.mOsName = "Windows 7";
+  } else if (major == 6 && minor == 1 && !isNTWorkstation) {
+    gContext.mOsName = "Windows Server 2008 R2";
+  } else if (major == 6 && minor == 0 && isNTWorkstation) {
+    gContext.mOsName = "Windows Vista";
+  } else if (major == 6 && minor == 0 && !isNTWorkstation) {
+    gContext.mOsName = "Windows Server 2008";
+  } else if (major == 5 && minor == 1) {
+    gContext.mOsName = "Windows XP";
+  } else if (major == 5 && minor == 0) {
+    gContext.mOsName = "Windows 2000";
+  } else {
+    gContext.mOsName = "";
+  }
+
+  SYSTEM_INFO sysInfo;
+  GetSystemInfo(&sysInfo);
+  gContext.mNumCores = sysInfo.dwNumberOfProcessors;
+
+  DWORD size = MAX_COMPUTERNAME_LENGTH + 1;
+  WCHAR host_wide[MAX_COMPUTERNAME_LENGTH + 1];
+  if (!GetComputerNameW(host_wide, &size)) {
+    snprintf(gContext.mError, sizeof(gContext.mError),
+             "Couldn't get host name: %d", GetLastError());
+    return false;
+  }
+  WideCharToMultiByte(CP_UTF8,                     // CodePage
+                      0,                           // dwFlags
+                      host_wide,                   // lpWideCharStr
+                      -1,                          // cchWideChar
+                      gContext.mHostName,          // lpMultiByteStr
+                      sizeof(gContext.mHostName),  // cbMultiByte
+                      nullptr,                     // lpDefaultChar
+                      nullptr                      // lpUsedDefaultChar
+  );
+
+  return true;
 }
 
 const char* contextError() { return gContext.mError; }
@@ -198,16 +201,16 @@ bool hasGLorGLES() { return gContext.mGlCtx != nullptr; }
 int numABIs() { return 1; }
 
 void abi(int idx, device::ABI* abi) {
-    abi->set_name("x86_64");
-    abi->set_os(device::Windows);
-    abi->set_architecture(device::X86_64);
-    abi->set_allocated_memorylayout(currentMemoryLayout());
+  abi->set_name("x86_64");
+  abi->set_os(device::Windows);
+  abi->set_architecture(device::X86_64);
+  abi->set_allocated_memorylayout(currentMemoryLayout());
 }
 
 device::ABI* currentABI() {
-    auto out = new device::ABI();
-    abi(0, out);
-    return out;
+  auto out = new device::ABI();
+  abi(0, out);
+  return out;
 }
 
 int cpuNumCores() { return gContext.mNumCores; }
@@ -232,4 +235,4 @@ int osMinor() { return gContext.mOsVersion.dwMinorVersion; }
 
 int osPoint() { return gContext.mOsVersion.dwBuildNumber; }
 
-} // namespace query
+}  // namespace query

--- a/core/vulkan/cc/include/vulkan/vk_layer.h
+++ b/core/vulkan/cc/include/vulkan/vk_layer.h
@@ -43,8 +43,8 @@
 #pragma once
 
 #include "vulkan.h"
-#if defined (_WIN32)
-#define VK_LAYER_EXPORT  __declspec(dllexport)
+#if defined(_WIN32)
+#define VK_LAYER_EXPORT __declspec(dllexport)
 #elif defined(__GNUC__) && __GNUC__ >= 4
 #define VK_LAYER_EXPORT __attribute__((visibility("default")))
 #elif defined(__SUNPRO_C) && (__SUNPRO_C >= 0x590)
@@ -54,202 +54,197 @@
 #endif
 
 typedef struct VkLayerDispatchTable_ {
-    PFN_vkGetDeviceProcAddr GetDeviceProcAddr;
-    PFN_vkDestroyDevice DestroyDevice;
-    PFN_vkGetDeviceQueue GetDeviceQueue;
-    PFN_vkQueueSubmit QueueSubmit;
-    PFN_vkQueueWaitIdle QueueWaitIdle;
-    PFN_vkDeviceWaitIdle DeviceWaitIdle;
-    PFN_vkAllocateMemory AllocateMemory;
-    PFN_vkFreeMemory FreeMemory;
-    PFN_vkMapMemory MapMemory;
-    PFN_vkUnmapMemory UnmapMemory;
-    PFN_vkFlushMappedMemoryRanges FlushMappedMemoryRanges;
-    PFN_vkInvalidateMappedMemoryRanges InvalidateMappedMemoryRanges;
-    PFN_vkGetDeviceMemoryCommitment GetDeviceMemoryCommitment;
-    PFN_vkGetImageSparseMemoryRequirements GetImageSparseMemoryRequirements;
-    PFN_vkGetImageMemoryRequirements GetImageMemoryRequirements;
-    PFN_vkGetBufferMemoryRequirements GetBufferMemoryRequirements;
-    PFN_vkBindImageMemory BindImageMemory;
-    PFN_vkBindBufferMemory BindBufferMemory;
-    PFN_vkQueueBindSparse QueueBindSparse;
-    PFN_vkCreateFence CreateFence;
-    PFN_vkDestroyFence DestroyFence;
-    PFN_vkGetFenceStatus GetFenceStatus;
-    PFN_vkResetFences ResetFences;
-    PFN_vkWaitForFences WaitForFences;
-    PFN_vkCreateSemaphore CreateSemaphore;
-    PFN_vkDestroySemaphore DestroySemaphore;
-    PFN_vkCreateEvent CreateEvent;
-    PFN_vkDestroyEvent DestroyEvent;
-    PFN_vkGetEventStatus GetEventStatus;
-    PFN_vkSetEvent SetEvent;
-    PFN_vkResetEvent ResetEvent;
-    PFN_vkCreateQueryPool CreateQueryPool;
-    PFN_vkDestroyQueryPool DestroyQueryPool;
-    PFN_vkGetQueryPoolResults GetQueryPoolResults;
-    PFN_vkCreateBuffer CreateBuffer;
-    PFN_vkDestroyBuffer DestroyBuffer;
-    PFN_vkCreateBufferView CreateBufferView;
-    PFN_vkDestroyBufferView DestroyBufferView;
-    PFN_vkCreateImage CreateImage;
-    PFN_vkDestroyImage DestroyImage;
-    PFN_vkGetImageSubresourceLayout GetImageSubresourceLayout;
-    PFN_vkCreateImageView CreateImageView;
-    PFN_vkDestroyImageView DestroyImageView;
-    PFN_vkCreateShaderModule CreateShaderModule;
-    PFN_vkDestroyShaderModule DestroyShaderModule;
-    PFN_vkCreatePipelineCache CreatePipelineCache;
-    PFN_vkDestroyPipelineCache DestroyPipelineCache;
-    PFN_vkGetPipelineCacheData GetPipelineCacheData;
-    PFN_vkMergePipelineCaches MergePipelineCaches;
-    PFN_vkCreateGraphicsPipelines CreateGraphicsPipelines;
-    PFN_vkCreateComputePipelines CreateComputePipelines;
-    PFN_vkDestroyPipeline DestroyPipeline;
-    PFN_vkCreatePipelineLayout CreatePipelineLayout;
-    PFN_vkDestroyPipelineLayout DestroyPipelineLayout;
-    PFN_vkCreateSampler CreateSampler;
-    PFN_vkDestroySampler DestroySampler;
-    PFN_vkCreateDescriptorSetLayout CreateDescriptorSetLayout;
-    PFN_vkDestroyDescriptorSetLayout DestroyDescriptorSetLayout;
-    PFN_vkCreateDescriptorPool CreateDescriptorPool;
-    PFN_vkDestroyDescriptorPool DestroyDescriptorPool;
-    PFN_vkResetDescriptorPool ResetDescriptorPool;
-    PFN_vkAllocateDescriptorSets AllocateDescriptorSets;
-    PFN_vkFreeDescriptorSets FreeDescriptorSets;
-    PFN_vkUpdateDescriptorSets UpdateDescriptorSets;
-    PFN_vkCreateFramebuffer CreateFramebuffer;
-    PFN_vkDestroyFramebuffer DestroyFramebuffer;
-    PFN_vkCreateRenderPass CreateRenderPass;
-    PFN_vkDestroyRenderPass DestroyRenderPass;
-    PFN_vkGetRenderAreaGranularity GetRenderAreaGranularity;
-    PFN_vkCreateCommandPool CreateCommandPool;
-    PFN_vkDestroyCommandPool DestroyCommandPool;
-    PFN_vkResetCommandPool ResetCommandPool;
-    PFN_vkAllocateCommandBuffers AllocateCommandBuffers;
-    PFN_vkFreeCommandBuffers FreeCommandBuffers;
-    PFN_vkBeginCommandBuffer BeginCommandBuffer;
-    PFN_vkEndCommandBuffer EndCommandBuffer;
-    PFN_vkResetCommandBuffer ResetCommandBuffer;
-    PFN_vkCmdBindPipeline CmdBindPipeline;
-    PFN_vkCmdBindDescriptorSets CmdBindDescriptorSets;
-    PFN_vkCmdBindVertexBuffers CmdBindVertexBuffers;
-    PFN_vkCmdBindIndexBuffer CmdBindIndexBuffer;
-    PFN_vkCmdSetViewport CmdSetViewport;
-    PFN_vkCmdSetScissor CmdSetScissor;
-    PFN_vkCmdSetLineWidth CmdSetLineWidth;
-    PFN_vkCmdSetDepthBias CmdSetDepthBias;
-    PFN_vkCmdSetBlendConstants CmdSetBlendConstants;
-    PFN_vkCmdSetDepthBounds CmdSetDepthBounds;
-    PFN_vkCmdSetStencilCompareMask CmdSetStencilCompareMask;
-    PFN_vkCmdSetStencilWriteMask CmdSetStencilWriteMask;
-    PFN_vkCmdSetStencilReference CmdSetStencilReference;
-    PFN_vkCmdDraw CmdDraw;
-    PFN_vkCmdDrawIndexed CmdDrawIndexed;
-    PFN_vkCmdDrawIndirect CmdDrawIndirect;
-    PFN_vkCmdDrawIndexedIndirect CmdDrawIndexedIndirect;
-    PFN_vkCmdDispatch CmdDispatch;
-    PFN_vkCmdDispatchIndirect CmdDispatchIndirect;
-    PFN_vkCmdCopyBuffer CmdCopyBuffer;
-    PFN_vkCmdCopyImage CmdCopyImage;
-    PFN_vkCmdBlitImage CmdBlitImage;
-    PFN_vkCmdCopyBufferToImage CmdCopyBufferToImage;
-    PFN_vkCmdCopyImageToBuffer CmdCopyImageToBuffer;
-    PFN_vkCmdUpdateBuffer CmdUpdateBuffer;
-    PFN_vkCmdFillBuffer CmdFillBuffer;
-    PFN_vkCmdClearColorImage CmdClearColorImage;
-    PFN_vkCmdClearDepthStencilImage CmdClearDepthStencilImage;
-    PFN_vkCmdClearAttachments CmdClearAttachments;
-    PFN_vkCmdResolveImage CmdResolveImage;
-    PFN_vkCmdSetEvent CmdSetEvent;
-    PFN_vkCmdResetEvent CmdResetEvent;
-    PFN_vkCmdWaitEvents CmdWaitEvents;
-    PFN_vkCmdPipelineBarrier CmdPipelineBarrier;
-    PFN_vkCmdBeginQuery CmdBeginQuery;
-    PFN_vkCmdEndQuery CmdEndQuery;
-    PFN_vkCmdResetQueryPool CmdResetQueryPool;
-    PFN_vkCmdWriteTimestamp CmdWriteTimestamp;
-    PFN_vkCmdCopyQueryPoolResults CmdCopyQueryPoolResults;
-    PFN_vkCmdPushConstants CmdPushConstants;
-    PFN_vkCmdBeginRenderPass CmdBeginRenderPass;
-    PFN_vkCmdNextSubpass CmdNextSubpass;
-    PFN_vkCmdEndRenderPass CmdEndRenderPass;
-    PFN_vkCmdExecuteCommands CmdExecuteCommands;
-    PFN_vkCreateSwapchainKHR CreateSwapchainKHR;
-    PFN_vkDestroySwapchainKHR DestroySwapchainKHR;
-    PFN_vkGetSwapchainImagesKHR GetSwapchainImagesKHR;
-    PFN_vkAcquireNextImageKHR AcquireNextImageKHR;
-    PFN_vkQueuePresentKHR QueuePresentKHR;
+  PFN_vkGetDeviceProcAddr GetDeviceProcAddr;
+  PFN_vkDestroyDevice DestroyDevice;
+  PFN_vkGetDeviceQueue GetDeviceQueue;
+  PFN_vkQueueSubmit QueueSubmit;
+  PFN_vkQueueWaitIdle QueueWaitIdle;
+  PFN_vkDeviceWaitIdle DeviceWaitIdle;
+  PFN_vkAllocateMemory AllocateMemory;
+  PFN_vkFreeMemory FreeMemory;
+  PFN_vkMapMemory MapMemory;
+  PFN_vkUnmapMemory UnmapMemory;
+  PFN_vkFlushMappedMemoryRanges FlushMappedMemoryRanges;
+  PFN_vkInvalidateMappedMemoryRanges InvalidateMappedMemoryRanges;
+  PFN_vkGetDeviceMemoryCommitment GetDeviceMemoryCommitment;
+  PFN_vkGetImageSparseMemoryRequirements GetImageSparseMemoryRequirements;
+  PFN_vkGetImageMemoryRequirements GetImageMemoryRequirements;
+  PFN_vkGetBufferMemoryRequirements GetBufferMemoryRequirements;
+  PFN_vkBindImageMemory BindImageMemory;
+  PFN_vkBindBufferMemory BindBufferMemory;
+  PFN_vkQueueBindSparse QueueBindSparse;
+  PFN_vkCreateFence CreateFence;
+  PFN_vkDestroyFence DestroyFence;
+  PFN_vkGetFenceStatus GetFenceStatus;
+  PFN_vkResetFences ResetFences;
+  PFN_vkWaitForFences WaitForFences;
+  PFN_vkCreateSemaphore CreateSemaphore;
+  PFN_vkDestroySemaphore DestroySemaphore;
+  PFN_vkCreateEvent CreateEvent;
+  PFN_vkDestroyEvent DestroyEvent;
+  PFN_vkGetEventStatus GetEventStatus;
+  PFN_vkSetEvent SetEvent;
+  PFN_vkResetEvent ResetEvent;
+  PFN_vkCreateQueryPool CreateQueryPool;
+  PFN_vkDestroyQueryPool DestroyQueryPool;
+  PFN_vkGetQueryPoolResults GetQueryPoolResults;
+  PFN_vkCreateBuffer CreateBuffer;
+  PFN_vkDestroyBuffer DestroyBuffer;
+  PFN_vkCreateBufferView CreateBufferView;
+  PFN_vkDestroyBufferView DestroyBufferView;
+  PFN_vkCreateImage CreateImage;
+  PFN_vkDestroyImage DestroyImage;
+  PFN_vkGetImageSubresourceLayout GetImageSubresourceLayout;
+  PFN_vkCreateImageView CreateImageView;
+  PFN_vkDestroyImageView DestroyImageView;
+  PFN_vkCreateShaderModule CreateShaderModule;
+  PFN_vkDestroyShaderModule DestroyShaderModule;
+  PFN_vkCreatePipelineCache CreatePipelineCache;
+  PFN_vkDestroyPipelineCache DestroyPipelineCache;
+  PFN_vkGetPipelineCacheData GetPipelineCacheData;
+  PFN_vkMergePipelineCaches MergePipelineCaches;
+  PFN_vkCreateGraphicsPipelines CreateGraphicsPipelines;
+  PFN_vkCreateComputePipelines CreateComputePipelines;
+  PFN_vkDestroyPipeline DestroyPipeline;
+  PFN_vkCreatePipelineLayout CreatePipelineLayout;
+  PFN_vkDestroyPipelineLayout DestroyPipelineLayout;
+  PFN_vkCreateSampler CreateSampler;
+  PFN_vkDestroySampler DestroySampler;
+  PFN_vkCreateDescriptorSetLayout CreateDescriptorSetLayout;
+  PFN_vkDestroyDescriptorSetLayout DestroyDescriptorSetLayout;
+  PFN_vkCreateDescriptorPool CreateDescriptorPool;
+  PFN_vkDestroyDescriptorPool DestroyDescriptorPool;
+  PFN_vkResetDescriptorPool ResetDescriptorPool;
+  PFN_vkAllocateDescriptorSets AllocateDescriptorSets;
+  PFN_vkFreeDescriptorSets FreeDescriptorSets;
+  PFN_vkUpdateDescriptorSets UpdateDescriptorSets;
+  PFN_vkCreateFramebuffer CreateFramebuffer;
+  PFN_vkDestroyFramebuffer DestroyFramebuffer;
+  PFN_vkCreateRenderPass CreateRenderPass;
+  PFN_vkDestroyRenderPass DestroyRenderPass;
+  PFN_vkGetRenderAreaGranularity GetRenderAreaGranularity;
+  PFN_vkCreateCommandPool CreateCommandPool;
+  PFN_vkDestroyCommandPool DestroyCommandPool;
+  PFN_vkResetCommandPool ResetCommandPool;
+  PFN_vkAllocateCommandBuffers AllocateCommandBuffers;
+  PFN_vkFreeCommandBuffers FreeCommandBuffers;
+  PFN_vkBeginCommandBuffer BeginCommandBuffer;
+  PFN_vkEndCommandBuffer EndCommandBuffer;
+  PFN_vkResetCommandBuffer ResetCommandBuffer;
+  PFN_vkCmdBindPipeline CmdBindPipeline;
+  PFN_vkCmdBindDescriptorSets CmdBindDescriptorSets;
+  PFN_vkCmdBindVertexBuffers CmdBindVertexBuffers;
+  PFN_vkCmdBindIndexBuffer CmdBindIndexBuffer;
+  PFN_vkCmdSetViewport CmdSetViewport;
+  PFN_vkCmdSetScissor CmdSetScissor;
+  PFN_vkCmdSetLineWidth CmdSetLineWidth;
+  PFN_vkCmdSetDepthBias CmdSetDepthBias;
+  PFN_vkCmdSetBlendConstants CmdSetBlendConstants;
+  PFN_vkCmdSetDepthBounds CmdSetDepthBounds;
+  PFN_vkCmdSetStencilCompareMask CmdSetStencilCompareMask;
+  PFN_vkCmdSetStencilWriteMask CmdSetStencilWriteMask;
+  PFN_vkCmdSetStencilReference CmdSetStencilReference;
+  PFN_vkCmdDraw CmdDraw;
+  PFN_vkCmdDrawIndexed CmdDrawIndexed;
+  PFN_vkCmdDrawIndirect CmdDrawIndirect;
+  PFN_vkCmdDrawIndexedIndirect CmdDrawIndexedIndirect;
+  PFN_vkCmdDispatch CmdDispatch;
+  PFN_vkCmdDispatchIndirect CmdDispatchIndirect;
+  PFN_vkCmdCopyBuffer CmdCopyBuffer;
+  PFN_vkCmdCopyImage CmdCopyImage;
+  PFN_vkCmdBlitImage CmdBlitImage;
+  PFN_vkCmdCopyBufferToImage CmdCopyBufferToImage;
+  PFN_vkCmdCopyImageToBuffer CmdCopyImageToBuffer;
+  PFN_vkCmdUpdateBuffer CmdUpdateBuffer;
+  PFN_vkCmdFillBuffer CmdFillBuffer;
+  PFN_vkCmdClearColorImage CmdClearColorImage;
+  PFN_vkCmdClearDepthStencilImage CmdClearDepthStencilImage;
+  PFN_vkCmdClearAttachments CmdClearAttachments;
+  PFN_vkCmdResolveImage CmdResolveImage;
+  PFN_vkCmdSetEvent CmdSetEvent;
+  PFN_vkCmdResetEvent CmdResetEvent;
+  PFN_vkCmdWaitEvents CmdWaitEvents;
+  PFN_vkCmdPipelineBarrier CmdPipelineBarrier;
+  PFN_vkCmdBeginQuery CmdBeginQuery;
+  PFN_vkCmdEndQuery CmdEndQuery;
+  PFN_vkCmdResetQueryPool CmdResetQueryPool;
+  PFN_vkCmdWriteTimestamp CmdWriteTimestamp;
+  PFN_vkCmdCopyQueryPoolResults CmdCopyQueryPoolResults;
+  PFN_vkCmdPushConstants CmdPushConstants;
+  PFN_vkCmdBeginRenderPass CmdBeginRenderPass;
+  PFN_vkCmdNextSubpass CmdNextSubpass;
+  PFN_vkCmdEndRenderPass CmdEndRenderPass;
+  PFN_vkCmdExecuteCommands CmdExecuteCommands;
+  PFN_vkCreateSwapchainKHR CreateSwapchainKHR;
+  PFN_vkDestroySwapchainKHR DestroySwapchainKHR;
+  PFN_vkGetSwapchainImagesKHR GetSwapchainImagesKHR;
+  PFN_vkAcquireNextImageKHR AcquireNextImageKHR;
+  PFN_vkQueuePresentKHR QueuePresentKHR;
 } VkLayerDispatchTable;
 
 typedef struct VkLayerInstanceDispatchTable_ {
-    PFN_vkGetInstanceProcAddr GetInstanceProcAddr;
-    PFN_vkDestroyInstance DestroyInstance;
-    PFN_vkEnumeratePhysicalDevices EnumeratePhysicalDevices;
-    PFN_vkGetPhysicalDeviceFeatures GetPhysicalDeviceFeatures;
-    PFN_vkGetPhysicalDeviceImageFormatProperties
-        GetPhysicalDeviceImageFormatProperties;
-    PFN_vkGetPhysicalDeviceFormatProperties GetPhysicalDeviceFormatProperties;
-    PFN_vkGetPhysicalDeviceSparseImageFormatProperties
-        GetPhysicalDeviceSparseImageFormatProperties;
-    PFN_vkGetPhysicalDeviceProperties GetPhysicalDeviceProperties;
-    PFN_vkGetPhysicalDeviceQueueFamilyProperties
-        GetPhysicalDeviceQueueFamilyProperties;
-    PFN_vkGetPhysicalDeviceMemoryProperties GetPhysicalDeviceMemoryProperties;
-    PFN_vkEnumerateDeviceExtensionProperties EnumerateDeviceExtensionProperties;
-    PFN_vkEnumerateDeviceLayerProperties EnumerateDeviceLayerProperties;
-    PFN_vkDestroySurfaceKHR DestroySurfaceKHR;
-    PFN_vkGetPhysicalDeviceSurfaceSupportKHR GetPhysicalDeviceSurfaceSupportKHR;
-    PFN_vkGetPhysicalDeviceSurfaceCapabilitiesKHR
-        GetPhysicalDeviceSurfaceCapabilitiesKHR;
-    PFN_vkGetPhysicalDeviceSurfaceFormatsKHR GetPhysicalDeviceSurfaceFormatsKHR;
-    PFN_vkGetPhysicalDeviceSurfacePresentModesKHR
-        GetPhysicalDeviceSurfacePresentModesKHR;
-    PFN_vkCreateDebugReportCallbackEXT CreateDebugReportCallbackEXT;
-    PFN_vkDestroyDebugReportCallbackEXT DestroyDebugReportCallbackEXT;
-    PFN_vkDebugReportMessageEXT DebugReportMessageEXT;
+  PFN_vkGetInstanceProcAddr GetInstanceProcAddr;
+  PFN_vkDestroyInstance DestroyInstance;
+  PFN_vkEnumeratePhysicalDevices EnumeratePhysicalDevices;
+  PFN_vkGetPhysicalDeviceFeatures GetPhysicalDeviceFeatures;
+  PFN_vkGetPhysicalDeviceImageFormatProperties
+      GetPhysicalDeviceImageFormatProperties;
+  PFN_vkGetPhysicalDeviceFormatProperties GetPhysicalDeviceFormatProperties;
+  PFN_vkGetPhysicalDeviceSparseImageFormatProperties
+      GetPhysicalDeviceSparseImageFormatProperties;
+  PFN_vkGetPhysicalDeviceProperties GetPhysicalDeviceProperties;
+  PFN_vkGetPhysicalDeviceQueueFamilyProperties
+      GetPhysicalDeviceQueueFamilyProperties;
+  PFN_vkGetPhysicalDeviceMemoryProperties GetPhysicalDeviceMemoryProperties;
+  PFN_vkEnumerateDeviceExtensionProperties EnumerateDeviceExtensionProperties;
+  PFN_vkEnumerateDeviceLayerProperties EnumerateDeviceLayerProperties;
+  PFN_vkDestroySurfaceKHR DestroySurfaceKHR;
+  PFN_vkGetPhysicalDeviceSurfaceSupportKHR GetPhysicalDeviceSurfaceSupportKHR;
+  PFN_vkGetPhysicalDeviceSurfaceCapabilitiesKHR
+      GetPhysicalDeviceSurfaceCapabilitiesKHR;
+  PFN_vkGetPhysicalDeviceSurfaceFormatsKHR GetPhysicalDeviceSurfaceFormatsKHR;
+  PFN_vkGetPhysicalDeviceSurfacePresentModesKHR
+      GetPhysicalDeviceSurfacePresentModesKHR;
+  PFN_vkCreateDebugReportCallbackEXT CreateDebugReportCallbackEXT;
+  PFN_vkDestroyDebugReportCallbackEXT DestroyDebugReportCallbackEXT;
+  PFN_vkDebugReportMessageEXT DebugReportMessageEXT;
 #ifdef VK_USE_PLATFORM_MIR_KHR
-    PFN_vkCreateMirSurfaceKHR CreateMirSurfaceKHR;
-    PFN_vkGetPhysicalDeviceMirPresentationSupportKHR
-        GetPhysicalDeviceMirPresentationSupportKHR;
+  PFN_vkCreateMirSurfaceKHR CreateMirSurfaceKHR;
+  PFN_vkGetPhysicalDeviceMirPresentationSupportKHR
+      GetPhysicalDeviceMirPresentationSupportKHR;
 #endif
 #ifdef VK_USE_PLATFORM_WAYLAND_KHR
-    PFN_vkCreateWaylandSurfaceKHR CreateWaylandSurfaceKHR;
-    PFN_vkGetPhysicalDeviceWaylandPresentationSupportKHR
-        GetPhysicalDeviceWaylandPresentationSupportKHR;
+  PFN_vkCreateWaylandSurfaceKHR CreateWaylandSurfaceKHR;
+  PFN_vkGetPhysicalDeviceWaylandPresentationSupportKHR
+      GetPhysicalDeviceWaylandPresentationSupportKHR;
 #endif
 #ifdef VK_USE_PLATFORM_WIN32_KHR
-    PFN_vkCreateWin32SurfaceKHR CreateWin32SurfaceKHR;
-    PFN_vkGetPhysicalDeviceWin32PresentationSupportKHR
-        GetPhysicalDeviceWin32PresentationSupportKHR;
+  PFN_vkCreateWin32SurfaceKHR CreateWin32SurfaceKHR;
+  PFN_vkGetPhysicalDeviceWin32PresentationSupportKHR
+      GetPhysicalDeviceWin32PresentationSupportKHR;
 #endif
 #ifdef VK_USE_PLATFORM_XCB_KHR
-    PFN_vkCreateXcbSurfaceKHR CreateXcbSurfaceKHR;
-    PFN_vkGetPhysicalDeviceXcbPresentationSupportKHR
-        GetPhysicalDeviceXcbPresentationSupportKHR;
+  PFN_vkCreateXcbSurfaceKHR CreateXcbSurfaceKHR;
+  PFN_vkGetPhysicalDeviceXcbPresentationSupportKHR
+      GetPhysicalDeviceXcbPresentationSupportKHR;
 #endif
 #ifdef VK_USE_PLATFORM_XLIB_KHR
-    PFN_vkCreateXlibSurfaceKHR CreateXlibSurfaceKHR;
-    PFN_vkGetPhysicalDeviceXlibPresentationSupportKHR
-        GetPhysicalDeviceXlibPresentationSupportKHR;
+  PFN_vkCreateXlibSurfaceKHR CreateXlibSurfaceKHR;
+  PFN_vkGetPhysicalDeviceXlibPresentationSupportKHR
+      GetPhysicalDeviceXlibPresentationSupportKHR;
 #endif
 #ifdef VK_USE_PLATFORM_ANDROID_KHR
-    PFN_vkCreateAndroidSurfaceKHR CreateAndroidSurfaceKHR;
+  PFN_vkCreateAndroidSurfaceKHR CreateAndroidSurfaceKHR;
 #endif
-    PFN_vkGetPhysicalDeviceDisplayPropertiesKHR
-        GetPhysicalDeviceDisplayPropertiesKHR;
-    PFN_vkGetPhysicalDeviceDisplayPlanePropertiesKHR
-        GetPhysicalDeviceDisplayPlanePropertiesKHR;
-    PFN_vkGetDisplayPlaneSupportedDisplaysKHR
-        GetDisplayPlaneSupportedDisplaysKHR;
-    PFN_vkGetDisplayModePropertiesKHR
-        GetDisplayModePropertiesKHR;
-    PFN_vkCreateDisplayModeKHR
-        CreateDisplayModeKHR;
-    PFN_vkGetDisplayPlaneCapabilitiesKHR
-        GetDisplayPlaneCapabilitiesKHR;
-    PFN_vkCreateDisplayPlaneSurfaceKHR
-        CreateDisplayPlaneSurfaceKHR;
+  PFN_vkGetPhysicalDeviceDisplayPropertiesKHR
+      GetPhysicalDeviceDisplayPropertiesKHR;
+  PFN_vkGetPhysicalDeviceDisplayPlanePropertiesKHR
+      GetPhysicalDeviceDisplayPlanePropertiesKHR;
+  PFN_vkGetDisplayPlaneSupportedDisplaysKHR GetDisplayPlaneSupportedDisplaysKHR;
+  PFN_vkGetDisplayModePropertiesKHR GetDisplayModePropertiesKHR;
+  PFN_vkCreateDisplayModeKHR CreateDisplayModeKHR;
+  PFN_vkGetDisplayPlaneCapabilitiesKHR GetDisplayPlaneCapabilitiesKHR;
+  PFN_vkCreateDisplayPlaneSurfaceKHR CreateDisplayPlaneSurfaceKHR;
 } VkLayerInstanceDispatchTable;
 
 // ------------------------------------------------------------------------------------------------
@@ -261,13 +256,13 @@ typedef struct VkLayerInstanceDispatchTable_ {
  * then VkLayerFunction indicates struct type pointed to by pNext
  */
 typedef enum VkLayerFunction_ {
-    VK_LAYER_LINK_INFO = 0,
-    VK_LOADER_DATA_CALLBACK = 1
+  VK_LAYER_LINK_INFO = 0,
+  VK_LOADER_DATA_CALLBACK = 1
 } VkLayerFunction;
 
 typedef struct VkLayerInstanceLink_ {
-    struct VkLayerInstanceLink_ *pNext;
-    PFN_vkGetInstanceProcAddr pfnNextGetInstanceProcAddr;
+  struct VkLayerInstanceLink_ *pNext;
+  PFN_vkGetInstanceProcAddr pfnNextGetInstanceProcAddr;
 } VkLayerInstanceLink;
 
 /*
@@ -278,37 +273,37 @@ typedef struct VkLayerInstanceLink_ {
  * exact instance being used.
  */
 typedef struct VkLayerDeviceInfo_ {
-    void *device_info;
-    PFN_vkGetInstanceProcAddr pfnNextGetInstanceProcAddr;
+  void *device_info;
+  PFN_vkGetInstanceProcAddr pfnNextGetInstanceProcAddr;
 } VkLayerDeviceInfo;
 
-typedef VkResult (VKAPI_PTR *PFN_vkSetInstanceLoaderData)(VkInstance instance,
-        void *object);
-typedef VkResult (VKAPI_PTR *PFN_vkSetDeviceLoaderData)(VkDevice device,
-        void *object);
+typedef VkResult(VKAPI_PTR *PFN_vkSetInstanceLoaderData)(VkInstance instance,
+                                                         void *object);
+typedef VkResult(VKAPI_PTR *PFN_vkSetDeviceLoaderData)(VkDevice device,
+                                                       void *object);
 
 typedef struct {
-    VkStructureType sType; // VK_STRUCTURE_TYPE_LOADER_INSTANCE_CREATE_INFO
-    const void *pNext;
-    VkLayerFunction function;
-    union {
-        VkLayerInstanceLink *pLayerInfo;
-        PFN_vkSetInstanceLoaderData pfnSetInstanceLoaderData;
-    } u;
+  VkStructureType sType;  // VK_STRUCTURE_TYPE_LOADER_INSTANCE_CREATE_INFO
+  const void *pNext;
+  VkLayerFunction function;
+  union {
+    VkLayerInstanceLink *pLayerInfo;
+    PFN_vkSetInstanceLoaderData pfnSetInstanceLoaderData;
+  } u;
 } VkLayerInstanceCreateInfo;
 
 typedef struct VkLayerDeviceLink_ {
-    struct VkLayerDeviceLink_ *pNext;
-    PFN_vkGetInstanceProcAddr pfnNextGetInstanceProcAddr;
-    PFN_vkGetDeviceProcAddr pfnNextGetDeviceProcAddr;
+  struct VkLayerDeviceLink_ *pNext;
+  PFN_vkGetInstanceProcAddr pfnNextGetInstanceProcAddr;
+  PFN_vkGetDeviceProcAddr pfnNextGetDeviceProcAddr;
 } VkLayerDeviceLink;
 
 typedef struct {
-    VkStructureType sType; // VK_STRUCTURE_TYPE_LOADER_DEVICE_CREATE_INFO
-    const void *pNext;
-    VkLayerFunction function;
-    union {
-        VkLayerDeviceLink *pLayerInfo;
-        PFN_vkSetDeviceLoaderData pfnSetDeviceLoaderData;
-    } u;
+  VkStructureType sType;  // VK_STRUCTURE_TYPE_LOADER_DEVICE_CREATE_INFO
+  const void *pNext;
+  VkLayerFunction function;
+  union {
+    VkLayerDeviceLink *pLayerInfo;
+    PFN_vkSetDeviceLoaderData pfnSetDeviceLoaderData;
+  } u;
 } VkLayerDeviceCreateInfo;

--- a/core/vulkan/cc/include/vulkan/vk_platform.h
+++ b/core/vulkan/cc/include/vulkan/vk_platform.h
@@ -32,6 +32,7 @@
 ** See the License for the specific language governing permissions and
 ** limitations under the License.
 */
+// clang-format off
 
 
 #ifndef VK_PLATFORM_H_

--- a/core/vulkan/cc/include/vulkan/vulkan.h
+++ b/core/vulkan/cc/include/vulkan/vulkan.h
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+// clang-format off
 
 #ifndef VULKAN_H_
 #define VULKAN_H_ 1

--- a/core/vulkan/vk_virtual_swapchain/cc/layer.h
+++ b/core/vulkan/vk_virtual_swapchain/cc/layer.h
@@ -31,9 +31,10 @@ namespace swapchain {
 // handle should share the same dispatch table key. E.g. VkCommandBuffer is a
 // child dispatchable handle of VkDevice, all the VkCommandBuffer dispatching
 // functions are actually device functions (resolved by VkGetDeviceProcAddress).
-// Ref: https://github.com/KhronosGroup/Vulkan-LoaderAndValidationLayers/blob/master/loader/LoaderAndLayerInterface.md#creating-new-dispatchable-objects,
-static inline void set_dispatch_from_parent(void* child, void* parent) {
-  *((const void**)child) = *((const void**)parent);
+// Ref:
+// https://github.com/KhronosGroup/Vulkan-LoaderAndValidationLayers/blob/master/loader/LoaderAndLayerInterface.md#creating-new-dispatchable-objects,
+static inline void set_dispatch_from_parent(void *child, void *parent) {
+  *((const void **)child) = *((const void **)parent);
 }
 
 // All of the instance data that is needed for book-keeping in a layer.
@@ -121,7 +122,8 @@ struct QueueData {
 // All context functions return a context token.
 // Any data within a ContextToken is only valid
 // for the lifetime of the ContextToken.
-template <typename T> struct ContextToken {
+template <typename T>
+struct ContextToken {
   ContextToken(T &object, threading::mutex &locker)
       : object_(object), context_lock_(locker) {}
 
@@ -140,7 +142,7 @@ template <typename T> struct ContextToken {
   T *operator->() { return &object_; }
   T &operator*() { return object_; }
 
-private:
+ private:
   T &object_;
   std::unique_lock<threading::mutex> context_lock_;
 };
@@ -201,8 +203,8 @@ struct Context {
                                    std::move(locker));
   }
 
-  ContextToken<PhysicalDeviceData>
-  GetPhysicalDeviceData(VkPhysicalDevice physical_device) {
+  ContextToken<PhysicalDeviceData> GetPhysicalDeviceData(
+      VkPhysicalDevice physical_device) {
     std::unique_lock<threading::mutex> locker(physical_device_lock_);
     return ContextToken<PhysicalDeviceData>(
         physical_device_data_map_.at(physical_device), std::move(locker));
@@ -214,7 +216,7 @@ struct Context {
                                     std::move(locker));
   }
 
-private:
+ private:
   // Map of instances to their data. Our other option would be
   // to wrap the instance object, but then we have to handle every possible
   // instance function.
@@ -250,6 +252,6 @@ private:
 
 Context &GetGlobalContext();
 
-} // swapchain
+}  // namespace swapchain
 
-#endif // VK_VIRTUAL_SWAPCHAIN_LAYER_H
+#endif  // VK_VIRTUAL_SWAPCHAIN_LAYER_H

--- a/core/vulkan/vk_virtual_swapchain/cc/swapchain.cpp
+++ b/core/vulkan/vk_virtual_swapchain/cc/swapchain.cpp
@@ -15,9 +15,9 @@
  */
 
 #include "swapchain.h"
-#include "virtual_swapchain.h"
 #include <cassert>
 #include <vector>
+#include "virtual_swapchain.h"
 
 namespace swapchain {
 
@@ -99,7 +99,6 @@ VKAPI_ATTR VkResult VKAPI_CALL vkGetPhysicalDeviceSurfaceSupportKHR(
 VKAPI_ATTR VkResult VKAPI_CALL vkGetPhysicalDeviceSurfaceCapabilitiesKHR(
     VkPhysicalDevice physicalDevice, VkSurfaceKHR surface,
     VkSurfaceCapabilitiesKHR *pSurfaceCapabilities) {
-
   // It would be illegal for the program to call VkDestroyInstance here.
   // We do not need to lock the map for the whole time, just
   // long enough to get the data out. unordered_map guarantees that
@@ -128,7 +127,7 @@ VKAPI_ATTR VkResult VKAPI_CALL vkGetPhysicalDeviceSurfaceCapabilitiesKHR(
   // TODO(awoloszyn): Handle all of the composite types.
 
   pSurfaceCapabilities->supportedUsageFlags =
-      VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT|VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
+      VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
   // TODO(awoloszyn): Find a good set of formats that we can use
   // for rendering.
 
@@ -180,7 +179,6 @@ VKAPI_ATTR VkResult VKAPI_CALL vkGetPhysicalDeviceSurfacePresentModesKHR(
 VKAPI_ATTR VkResult VKAPI_CALL vkCreateSwapchainKHR(
     VkDevice device, const VkSwapchainCreateInfoKHR *pCreateInfo,
     const VkAllocationCallbacks *pAllocator, VkSwapchainKHR *pSwapchain) {
-
   DeviceData &dev_dat = *GetGlobalContext().GetDeviceData(device);
   PhysicalDeviceData &pdd =
       *GetGlobalContext().GetPhysicalDeviceData(dev_dat.physicalDevice);
@@ -196,8 +194,7 @@ VKAPI_ATTR VkResult VKAPI_CALL vkCreateSwapchainKHR(
 
   size_t queue = 0;
   for (; queue < queue_properties.size(); ++queue) {
-    if (queue_properties[queue].queueFlags & VK_QUEUE_GRAPHICS_BIT)
-      break;
+    if (queue_properties[queue].queueFlags & VK_QUEUE_GRAPHICS_BIT) break;
   }
 
   assert(queue < queue_properties.size());
@@ -292,17 +289,16 @@ VKAPI_ATTR VkResult VKAPI_CALL vkAcquireNextImageKHR(
 
   bool has_semaphore = semaphore != VK_NULL_HANDLE;
 
-  VkSubmitInfo info{VK_STRUCTURE_TYPE_SUBMIT_INFO, // sType
-                    nullptr,                       // pNext
-                    0,                             // waitSemaphoreCount
-                    nullptr,                       // waitSemaphores
-                    nullptr,                       // waitDstStageMask
-                    0,                             // commandBufferCount
-                    nullptr,                       // pCommandBuffers
-                    (has_semaphore ? 1u : 0u),     // semaphoreCount
-                    (has_semaphore ? &semaphore : nullptr)}; // pSemaphores
+  VkSubmitInfo info{VK_STRUCTURE_TYPE_SUBMIT_INFO,  // sType
+                    nullptr,                        // pNext
+                    0,                              // waitSemaphoreCount
+                    nullptr,                        // waitSemaphores
+                    nullptr,                        // waitDstStageMask
+                    0,                              // commandBufferCount
+                    nullptr,                        // pCommandBuffers
+                    (has_semaphore ? 1u : 0u),      // semaphoreCount
+                    (has_semaphore ? &semaphore : nullptr)};  // pSemaphores
   return swapchain::vkQueueSubmit(q, 1, &info, fence);
-
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL
@@ -319,15 +315,15 @@ vkQueuePresentKHR(VkQueue queue, const VkPresentInfoKHR *pPresentInfo) {
         reinterpret_cast<VirtualSwapchain *>(pPresentInfo->pSwapchains[i]);
 
     VkSubmitInfo submitInfo{
-        VK_STRUCTURE_TYPE_SUBMIT_INFO,                    // sType
-        nullptr,                                          // nullptr
-        i == 0 ? pPresentInfo->waitSemaphoreCount : 0,    // waitSemaphoreCount
-        i == 0 ? pPresentInfo->pWaitSemaphores : nullptr, // pWaitSemaphores
-        i == 0 ? pipeline_stages.data() : nullptr,        // pWaitDstStageMask
-        1,                                                // commandBufferCount
-        &swp->GetCommandBuffer(image_index),              // pCommandBuffers
-        0,                                                // semaphoreCount
-        nullptr                                           // pSemaphores
+        VK_STRUCTURE_TYPE_SUBMIT_INFO,                     // sType
+        nullptr,                                           // nullptr
+        i == 0 ? pPresentInfo->waitSemaphoreCount : 0,     // waitSemaphoreCount
+        i == 0 ? pPresentInfo->pWaitSemaphores : nullptr,  // pWaitSemaphores
+        i == 0 ? pipeline_stages.data() : nullptr,         // pWaitDstStageMask
+        1,                                                 // commandBufferCount
+        &swp->GetCommandBuffer(image_index),               // pCommandBuffers
+        0,                                                 // semaphoreCount
+        nullptr                                            // pSemaphores
     };
 
     res |= GetGlobalContext().GetQueueData(queue)->vkQueueSubmit(
@@ -344,8 +340,8 @@ VKAPI_ATTR VkResult VKAPI_CALL vkQueueSubmit(VkQueue queue,
                                              VkFence fence) {
   // We actually DO have to lock here, we may share this queue with
   // vkAcquireNextImageKHR, which is not externally synchronized on Queue.
-  return GetGlobalContext().GetQueueData(queue)->vkQueueSubmit(queue, submitCount,
-                                                        pSubmits, fence);
+  return GetGlobalContext().GetQueueData(queue)->vkQueueSubmit(
+      queue, submitCount, pSubmits, fence);
 }
 
 // The following 3 functions are special. We would normally not have to
@@ -363,7 +359,6 @@ VKAPI_ATTR void VKAPI_CALL vkCmdPipelineBarrier(
     const VkBufferMemoryBarrier *pBufferMemoryBarriers,
     uint32_t imageMemoryBarrierCount,
     const VkImageMemoryBarrier *pImageMemoryBarriers) {
-
   std::vector<VkImageMemoryBarrier> imageBarriers(imageMemoryBarrierCount);
   for (size_t i = 0; i < imageMemoryBarrierCount; ++i) {
     imageBarriers[i] = pImageMemoryBarriers[i];
@@ -394,7 +389,6 @@ VKAPI_ATTR void VKAPI_CALL vkCmdWaitEvents(
     const VkBufferMemoryBarrier *pBufferMemoryBarriers,
     uint32_t imageMemoryBarrierCount,
     const VkImageMemoryBarrier *pImageMemoryBarriers) {
-
   std::vector<VkImageMemoryBarrier> imageBarriers(imageMemoryBarrierCount);
   for (size_t i = 0; i < imageMemoryBarrierCount; ++i) {
     imageBarriers[i] = pImageMemoryBarriers[i];
@@ -436,4 +430,4 @@ VKAPI_ATTR VkResult VKAPI_CALL vkCreateRenderPass(
       GetGlobalContext().GetDeviceData(device)->vkCreateRenderPass;
   return func(device, &intercepted, pAllocator, pRenderPass);
 }
-} // swapchain
+}  // namespace swapchain

--- a/core/vulkan/vk_virtual_swapchain/cc/swapchain.h
+++ b/core/vulkan/vk_virtual_swapchain/cc/swapchain.h
@@ -27,7 +27,7 @@ void RegisterInstance(VkInstance instance, const InstanceData &data);
 static const uint32_t VIRTUAL_SWAPCHAIN_CREATE_PNEXT = 0xFFFFFFAA;
 struct CreateNext {
   uint32_t sType;
-  void* pNext;
+  void *pNext;
 };
 
 // All of the following functions are the same as the Vulkan functions
@@ -69,9 +69,8 @@ VKAPI_ATTR VkResult VKAPI_CALL vkAcquireNextImageKHR(
     VkDevice device, VkSwapchainKHR swapchain, uint64_t timeout,
     VkSemaphore semaphore, VkFence fence, uint32_t *pImageIndex);
 
-VKAPI_ATTR void VKAPI_CALL
-vkSetSwapchainCallback(VkSwapchainKHR swapchain,
-                       void callback(void *, uint8_t *, size_t), void *);
+VKAPI_ATTR void VKAPI_CALL vkSetSwapchainCallback(
+    VkSwapchainKHR swapchain, void callback(void *, uint8_t *, size_t), void *);
 
 VKAPI_ATTR VkResult VKAPI_CALL
 vkQueuePresentKHR(VkQueue queue, const VkPresentInfoKHR *pPresentInfo);
@@ -108,5 +107,5 @@ VKAPI_ATTR void VKAPI_CALL vkCmdWaitEvents(
 VKAPI_ATTR VkResult VKAPI_CALL vkCreateRenderPass(
     VkDevice device, const VkRenderPassCreateInfo *pCreateInfo,
     const VkAllocationCallbacks *pAllocator, VkRenderPass *pRenderPass);
-} // swapchain
-#endif // VK_VIRTUAL_SWAPCHAIN_SWAPCHAIN_H_
+}  // namespace swapchain
+#endif  // VK_VIRTUAL_SWAPCHAIN_SWAPCHAIN_H_

--- a/core/vulkan/vk_virtual_swapchain/cc/threading.h
+++ b/core/vulkan/vk_virtual_swapchain/cc/threading.h
@@ -32,7 +32,7 @@ namespace swapchain {
 namespace threading {
 
 class mutex {
-public:
+ public:
   mutex(const mutex &) = delete;
   mutex &operator=(const mutex &) = delete;
   mutex() {
@@ -73,7 +73,7 @@ public:
   pthread_mutex_t &native_handle() { return mutex_; }
 #endif
 
-private:
+ private:
 #ifdef _WIN32
   CRITICAL_SECTION mutex_;
 #else
@@ -84,7 +84,7 @@ private:
 enum class cv_status { timeout, no_timeout };
 
 class condition_variable {
-public:
+ public:
   condition_variable(const condition_variable &) = delete;
   condition_variable &operator=(const condition_variable &) = delete;
   condition_variable() {
@@ -151,7 +151,7 @@ public:
 #endif
   }
 
-private:
+ private:
 #ifdef _WIN32
   CONDITION_VARIABLE condition_;
 #else
@@ -159,6 +159,6 @@ private:
 #endif
 };
 
-} // threading
-} // swapchain
-#endif // VK_VIRTUAL_SWAPCHAIN_THREADING_H_
+}  // namespace threading
+}  // namespace swapchain
+#endif  // VK_VIRTUAL_SWAPCHAIN_THREADING_H_

--- a/core/vulkan/vk_virtual_swapchain/cc/virtual_swapchain.cpp
+++ b/core/vulkan/vk_virtual_swapchain/cc/virtual_swapchain.cpp
@@ -17,8 +17,8 @@
 #include "virtual_swapchain.h"
 #include <cassert>
 #include <chrono>
-#include <functional>
 #include <fstream>
+#include <functional>
 #include <iomanip>
 #include <iostream>
 #include <sstream>
@@ -28,9 +28,9 @@ namespace {
 
 // Determines what heap memory should be allocated from, given
 // a set of bits.
-int32_t
-FindMemoryType(const VkPhysicalDeviceMemoryProperties *memory_properties,
-               uint32_t memoryTypeBits, VkMemoryPropertyFlags properties) {
+int32_t FindMemoryType(
+    const VkPhysicalDeviceMemoryProperties *memory_properties,
+    uint32_t memoryTypeBits, VkMemoryPropertyFlags properties) {
   for (uint32_t i = 0; i < memory_properties->memoryTypeCount; ++i) {
     if ((memoryTypeBits & (1 << i)) &&
         ((memory_properties->memoryTypes[i].propertyFlags & properties) ==
@@ -41,7 +41,7 @@ FindMemoryType(const VkPhysicalDeviceMemoryProperties *memory_properties,
 }
 
 void null_callback(void *, uint8_t *, size_t) {}
-}
+}  // namespace
 
 namespace swapchain {
 VirtualSwapchain::VirtualSwapchain(
@@ -70,184 +70,179 @@ VirtualSwapchain::VirtualSwapchain(
       always_get_acquired_image_(always_get_acquired_image) {
   VkPhysicalDeviceMemoryProperties properties = *memory_properties;
   build_swapchain_image_data_ = [this, properties, pAllocator]() {
-      SwapchainImageData image_data;
+    SwapchainImageData image_data;
 
-      static const VkFenceCreateInfo fence_info{
-          VK_STRUCTURE_TYPE_FENCE_CREATE_INFO, nullptr, 0};
-      const VkImageCreateInfo image_create_info{
-          VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO, // sType
-          nullptr,                             // pNext
-          0,                                   // flags
-          VK_IMAGE_TYPE_2D,                    // imageType
-          swapchain_info_.imageFormat,         // format
-          VkExtent3D{swapchain_info_.imageExtent.width,
-                     swapchain_info_.imageExtent.height, 1}, // extent
-          1,                                                 // mipLevels
-          swapchain_info_.imageArrayLayers,                  // arrayLayers
-          VK_SAMPLE_COUNT_1_BIT,                             // samples
-          VK_IMAGE_TILING_OPTIMAL,                           // tiling
-          swapchain_info_.imageUsage | VK_IMAGE_USAGE_TRANSFER_SRC_BIT, // usage
-          swapchain_info_.imageSharingMode,      // sharingmode
-          swapchain_info_.queueFamilyIndexCount, // queueFamilyIndexCount
-          swapchain_info_.pQueueFamilyIndices,   // queueFamilyIndices
-          VK_IMAGE_LAYOUT_UNDEFINED,             // initialLayout
-      };
-      // The size of the buffer that we need is surprisingly easy.
-      // Pixel-width * width * height. The GPU will copy into the
-      // buffer with the stride we provide.
-      // All we want to do here is create a buffer that we can copy
-      // the image into.
-      // TODO(awolosyn): Currently we know the format is VK_FORMAT_R8G8B8A8_UNORM
-      // Handle more formats later if we have other swapchain formats we care
-      // about.
+    static const VkFenceCreateInfo fence_info{
+        VK_STRUCTURE_TYPE_FENCE_CREATE_INFO, nullptr, 0};
+    const VkImageCreateInfo image_create_info{
+        VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO,  // sType
+        nullptr,                              // pNext
+        0,                                    // flags
+        VK_IMAGE_TYPE_2D,                     // imageType
+        swapchain_info_.imageFormat,          // format
+        VkExtent3D{swapchain_info_.imageExtent.width,
+                   swapchain_info_.imageExtent.height, 1},  // extent
+        1,                                                  // mipLevels
+        swapchain_info_.imageArrayLayers,                   // arrayLayers
+        VK_SAMPLE_COUNT_1_BIT,                              // samples
+        VK_IMAGE_TILING_OPTIMAL,                            // tiling
+        swapchain_info_.imageUsage | VK_IMAGE_USAGE_TRANSFER_SRC_BIT,  // usage
+        swapchain_info_.imageSharingMode,       // sharingmode
+        swapchain_info_.queueFamilyIndexCount,  // queueFamilyIndexCount
+        swapchain_info_.pQueueFamilyIndices,    // queueFamilyIndices
+        VK_IMAGE_LAYOUT_UNDEFINED,              // initialLayout
+    };
+    // The size of the buffer that we need is surprisingly easy.
+    // Pixel-width * width * height. The GPU will copy into the
+    // buffer with the stride we provide.
+    // All we want to do here is create a buffer that we can copy
+    // the image into.
+    // TODO(awolosyn): Currently we know the format is VK_FORMAT_R8G8B8A8_UNORM
+    // Handle more formats later if we have other swapchain formats we care
+    // about.
 
-      // maximum non-coherent-command-size is 128 bytes
-      // This means we can write subsequent layers on 128-byte
-      // boundaries
-      size_t buffer_memory_size =
-          ((ImageByteSize() + 127) & ~127) * swapchain_info_.imageArrayLayers;
+    // maximum non-coherent-command-size is 128 bytes
+    // This means we can write subsequent layers on 128-byte
+    // boundaries
+    size_t buffer_memory_size =
+        ((ImageByteSize() + 127) & ~127) * swapchain_info_.imageArrayLayers;
 
-      const VkBufferCreateInfo buffer_create_info{
-          VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO, // sType
-          nullptr,                              // pNext
-          0,                                    // flags
-          buffer_memory_size,                   // size
-          VK_BUFFER_USAGE_TRANSFER_DST_BIT,     // usage
-          VK_SHARING_MODE_EXCLUSIVE,            // sharingMode
-          0,                                    // queueFamilyIndexCount
-          nullptr                               // pQueueFamilyIndices
+    const VkBufferCreateInfo buffer_create_info{
+        VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO,  // sType
+        nullptr,                               // pNext
+        0,                                     // flags
+        buffer_memory_size,                    // size
+        VK_BUFFER_USAGE_TRANSFER_DST_BIT,      // usage
+        VK_SHARING_MODE_EXCLUSIVE,             // sharingMode
+        0,                                     // queueFamilyIndexCount
+        nullptr                                // pQueueFamilyIndices
+    };
+
+    VkCommandPoolCreateInfo command_pool_info{
+        VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO,       // sType
+        nullptr,                                          // pNext
+        VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT,  // flags
+        queue_                                            // queueFamilyIndex
+    };
+
+    functions_->vkCreateCommandPool(device_, &command_pool_info, pAllocator,
+                                    &command_pool_);
+
+    VkCommandBufferAllocateInfo command_buffer_info{
+        VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO,  // sType
+        nullptr,                                         // pNext
+        command_pool_,                                   // commandPool
+        VK_COMMAND_BUFFER_LEVEL_PRIMARY,                 // level
+        1                                                // count
+    };
+
+    // Create the command buffer
+    functions_->vkAllocateCommandBuffers(device_, &command_buffer_info,
+                                         &image_data.command_buffer_);
+    set_dispatch_from_parent(image_data.command_buffer_, device_);
+
+    // Create the fence
+    {
+      functions_->vkCreateFence(device_, &fence_info, pAllocator,
+                                &image_data.fence_);
+      functions_->vkResetFences(device_, 1, &image_data.fence_);
+    }
+
+    // Create the buffer
+    {
+      functions_->vkCreateBuffer(device_, &buffer_create_info, pAllocator,
+                                 &image_data.buffer_);
+      // Create device-memory for the buffer
+      {
+        VkMemoryRequirements reqs;
+        functions_->vkGetBufferMemoryRequirements(device_, image_data.buffer_,
+                                                  &reqs);
+
+        uint32_t memory_type =
+            FindMemoryType(&properties, reqs.memoryTypeBits,
+                           VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT);
+        VkMemoryAllocateInfo buffer_memory_info{
+            VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO,  // sType
+            nullptr,                                 // pNext
+            reqs.size,                               // allocationSize
+            memory_type                              // memoryTypeIndex
         };
 
-      VkCommandPoolCreateInfo command_pool_info{
-          VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO,      // sType
-          nullptr,                                         // pNext
-          VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT, // flags
-          queue_                                           // queueFamilyIndex
-      };
-
-      functions_->vkCreateCommandPool(device_, &command_pool_info, pAllocator,
-                                      &command_pool_);
-
-      VkCommandBufferAllocateInfo command_buffer_info{
-          VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO, // sType
-          nullptr,                                        // pNext
-          command_pool_,                                  // commandPool
-          VK_COMMAND_BUFFER_LEVEL_PRIMARY,                // level
-          1                                               // count
-      };
-
-      // Create the command buffer
-      functions_->vkAllocateCommandBuffers(device_, &command_buffer_info,
-                                           &image_data.command_buffer_);
-      set_dispatch_from_parent(image_data.command_buffer_, device_);
-
-      // Create the fence
-      {
-
-          functions_->vkCreateFence(device_, &fence_info, pAllocator,
-                                    &image_data.fence_);
-          functions_->vkResetFences(device_, 1, &image_data.fence_);
+        functions_->vkAllocateMemory(device_, &buffer_memory_info, pAllocator,
+                                     &image_data.buffer_memory_);
+        functions_->vkBindBufferMemory(device_, image_data.buffer_,
+                                       image_data.buffer_memory_, 0);
       }
+    }
 
-      // Create the buffer
+    // Create the image
+    {
+      functions_->vkCreateImage(device_, &image_create_info, pAllocator,
+                                &image_data.image_);
+      // Create device-memory for the image
       {
-          functions_->vkCreateBuffer(device_, &buffer_create_info, pAllocator,
-                                     &image_data.buffer_);
-          // Create device-memory for the buffer
-          {
-              VkMemoryRequirements reqs;
-              functions_->vkGetBufferMemoryRequirements(
-                  device_, image_data.buffer_, &reqs);
+        VkMemoryRequirements reqs;
+        functions_->vkGetImageMemoryRequirements(device_, image_data.image_,
+                                                 &reqs);
+        uint32_t memory_type =
+            FindMemoryType(&properties, reqs.memoryTypeBits, 0);
 
-              uint32_t memory_type =
-                  FindMemoryType(&properties, reqs.memoryTypeBits,
-                                 VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT);
-              VkMemoryAllocateInfo buffer_memory_info{
-                  VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO, // sType
-                  nullptr,                                // pNext
-                  reqs.size,                              // allocationSize
-                  memory_type                             // memoryTypeIndex
-              };
+        VkMemoryAllocateInfo image_memory_info{
+            VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO,  // sType
+            nullptr,                                 // pNext
+            reqs.size,                               // allocationSize
+            memory_type                              // memoryTypeIndex
+        };
 
-              functions_->vkAllocateMemory(device_, &buffer_memory_info,
-                                           pAllocator,
-                                           &image_data.buffer_memory_);
-              functions_->vkBindBufferMemory(device_, image_data.buffer_,
-                                             image_data.buffer_memory_, 0);
-          }
+        functions_->vkAllocateMemory(device_, &image_memory_info, pAllocator,
+                                     &image_data.image_memory_);
+        functions_->vkBindImageMemory(device_, image_data.image_,
+                                      image_data.image_memory_, 0);
       }
+    }
 
-      // Create the image
-      {
+    VkBufferMemoryBarrier dest_barrier{
+        VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER,  // sType
+        nullptr,                                  // pNext
+        VK_ACCESS_TRANSFER_WRITE_BIT,             // srcAccessMask
+        VK_ACCESS_HOST_READ_BIT,                  // dstAccessMask
+        VK_QUEUE_FAMILY_IGNORED,                  // srcQueueFamilyIndex
+        VK_QUEUE_FAMILY_IGNORED,                  // dstQueueFamilyIndex
+        image_data.buffer_,                       // buffer
+        0,                                        // offset
+        VK_WHOLE_SIZE                             // size
+    };
 
-          functions_->vkCreateImage(device_, &image_create_info, pAllocator,
-                                    &image_data.image_);
-          // Create device-memory for the image
-          {
-              VkMemoryRequirements reqs;
-              functions_->vkGetImageMemoryRequirements(
-                  device_, image_data.image_, &reqs);
-              uint32_t memory_type =
-                  FindMemoryType(&properties, reqs.memoryTypeBits, 0);
+    VkBufferImageCopy region{
+        0,  // Start of the buffer
+        0,  // bufferRowLength Tightly packed buffer
+        0,  // bufferImageHeight same
+        VkImageSubresourceLayers{
+            VK_IMAGE_ASPECT_COLOR_BIT,          // aspectMask
+            0,                                  // mipLevel
+            0,                                  // baseArrayLayer
+            swapchain_info_.imageArrayLayers},  // imageSubresourceLayers
+        VkOffset3D{0, 0, 0},
+        VkExtent3D{swapchain_info_.imageExtent.width,
+                   swapchain_info_.imageExtent.height, 1}};
 
-              VkMemoryAllocateInfo image_memory_info{
-                  VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO, // sType
-                  nullptr,                                // pNext
-                  reqs.size,                              // allocationSize
-                  memory_type                             // memoryTypeIndex
-              };
+    VkCommandBufferBeginInfo cbegin{
+        VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO,  // sType
+        nullptr,                                      // pNext
+        0,                                            // flags
+        nullptr                                       // pInheritanceInfo
+    };
 
-              functions_->vkAllocateMemory(device_, &image_memory_info, pAllocator,
-                                           &image_data.image_memory_);
-              functions_->vkBindImageMemory(device_, image_data.image_,
-                                            image_data.image_memory_, 0);
-          }
-      }
+    functions_->vkBeginCommandBuffer(image_data.command_buffer_, &cbegin);
+    functions_->vkCmdCopyImageToBuffer(
+        image_data.command_buffer_, image_data.image_,
+        VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, image_data.buffer_, 1, &region);
+    functions_->vkCmdPipelineBarrier(
+        image_data.command_buffer_, VK_PIPELINE_STAGE_TRANSFER_BIT,
+        VK_PIPELINE_STAGE_HOST_BIT, 0, 0, nullptr, 1, &dest_barrier, 0, 0);
+    functions_->vkEndCommandBuffer(image_data.command_buffer_);
 
-      VkBufferMemoryBarrier dest_barrier{
-          VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER, // sType
-          nullptr,                                 // pNext
-          VK_ACCESS_TRANSFER_WRITE_BIT,            // srcAccessMask
-          VK_ACCESS_HOST_READ_BIT,                 // dstAccessMask
-          VK_QUEUE_FAMILY_IGNORED,                 // srcQueueFamilyIndex
-          VK_QUEUE_FAMILY_IGNORED,                 // dstQueueFamilyIndex
-          image_data.buffer_,                      // buffer
-          0,                                       // offset
-          VK_WHOLE_SIZE                            // size
-      };
-
-      VkBufferImageCopy region{
-          0, // Start of the buffer
-          0, // bufferRowLength Tightly packed buffer
-          0, // bufferImageHeight same
-          VkImageSubresourceLayers{
-              VK_IMAGE_ASPECT_COLOR_BIT,          // aspectMask
-              0,                                  // mipLevel
-              0,                                  // baseArrayLayer
-              swapchain_info_.imageArrayLayers},  // imageSubresourceLayers
-          VkOffset3D{0, 0, 0},
-          VkExtent3D{swapchain_info_.imageExtent.width,
-                     swapchain_info_.imageExtent.height, 1}
-      };
-
-      VkCommandBufferBeginInfo cbegin{
-          VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO, // sType
-          nullptr,                                     // pNext
-          0,                                           // flags
-          nullptr                                      // pInheritanceInfo
-      };
-
-      functions_->vkBeginCommandBuffer(image_data.command_buffer_, &cbegin);
-      functions_->vkCmdCopyImageToBuffer(image_data.command_buffer_,
-                                         image_data.image_,
-                                         VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
-                                         image_data.buffer_, 1, &region);
-      functions_->vkCmdPipelineBarrier(
-          image_data.command_buffer_, VK_PIPELINE_STAGE_TRANSFER_BIT,
-          VK_PIPELINE_STAGE_HOST_BIT, 0, 0, nullptr, 1, &dest_barrier, 0, 0);
-      functions_->vkEndCommandBuffer(image_data.command_buffer_);
-
-      return image_data;
+    return image_data;
   };
 
   // Populate the swapchain image data vector
@@ -309,8 +304,7 @@ void VirtualSwapchain::CopyThreadFunc() {
           if (should_close_.load()) {
             // One last check to see if there are any more pending images.
             // If not we can return.
-            if (!pending_images_.empty())
-              break;
+            if (!pending_images_.empty()) break;
             return;
           }
         }
@@ -321,18 +315,18 @@ void VirtualSwapchain::CopyThreadFunc() {
 
     VkResult ret = functions_->vkWaitForFences(
         device_, 1, &image_data_[pending_image].fence_, false, UINT64_MAX);
-    (void)ret; // TODO: Check this?
+    (void)ret;  // TODO: Check this?
     functions_->vkResetFences(device_, 1, &image_data_[pending_image].fence_);
 
     void *mapped_value;
     functions_->vkMapMemory(device_, image_data_[pending_image].buffer_memory_,
                             0, VK_WHOLE_SIZE, 0, &mapped_value);
     VkMappedMemoryRange range{
-        VK_STRUCTURE_TYPE_MAPPED_MEMORY_RANGE,     // sType
-        nullptr,                                   // pNext
-        image_data_[pending_image].buffer_memory_, // memory
-        0,                                         // offset
-        VK_WHOLE_SIZE,                             // size
+        VK_STRUCTURE_TYPE_MAPPED_MEMORY_RANGE,      // sType
+        nullptr,                                    // pNext
+        image_data_[pending_image].buffer_memory_,  // memory
+        0,                                          // offset
+        VK_WHOLE_SIZE,                              // size
     };
     functions_->vkInvalidateMappedMemoryRanges(device_, 1, &range);
 
@@ -348,9 +342,9 @@ void VirtualSwapchain::CopyThreadFunc() {
   }
 }
 
-bool VirtualSwapchain::GetImage(uint64_t timeout, uint32_t* image) {
+bool VirtualSwapchain::GetImage(uint64_t timeout, uint32_t *image) {
   // A helper function that tries to get a free image.
-  auto try_get_image_index = [&](uint32_t* index) {
+  auto try_get_image_index = [&](uint32_t *index) {
     uint32_t i = 0;
     if (always_get_acquired_image_) {
       for (auto iter = free_images_.begin(); iter != free_images_.end();
@@ -363,8 +357,7 @@ bool VirtualSwapchain::GetImage(uint64_t timeout, uint32_t* image) {
       }
       return false;
     } else {
-      if (free_images_.empty())
-        return false;
+      if (free_images_.empty()) return false;
       *index = free_images_[0];
       free_images_.pop_front();
       return true;
@@ -374,8 +367,7 @@ bool VirtualSwapchain::GetImage(uint64_t timeout, uint32_t* image) {
   auto wakeup = std::chrono::nanoseconds(timeout);
   while (true) {
     std::unique_lock<threading::mutex> sl(free_images_lock_);
-    if (try_get_image_index(image))
-      return true;
+    if (try_get_image_index(image)) return true;
     if (timeout == UINT64_MAX) {
       free_images_condition_.wait(sl);
     } else {
@@ -398,4 +390,4 @@ uint32_t VirtualSwapchain::ImageByteSize() const {
   // more dynamic.
   return width_ * height_ * 4;
 }
-} // swapchain
+}  // namespace swapchain

--- a/core/vulkan/vk_virtual_swapchain/cc/virtual_swapchain.h
+++ b/core/vulkan/vk_virtual_swapchain/cc/virtual_swapchain.h
@@ -17,19 +17,19 @@
 #ifndef VK_VIRTUAL_SWAPCHAIN_VIRTUAL_SWAPCHAIN_H_
 #define VK_VIRTUAL_SWAPCHAIN_VIRTUAL_SWAPCHAIN_H_
 
-#include "layer.h"
+#include <vulkan/vulkan.h>
 #include <atomic>
 #include <deque>
-#include <mutex>
 #include <functional>
-#include <vulkan/vulkan.h>
+#include <mutex>
+#include "layer.h"
 
 namespace swapchain {
 
 // The VirtualSwapchain is the bulk of the data for handling
 // all of the images/synchronization/buffers for our swapchain.
 class VirtualSwapchain {
-public:
+ public:
   // pending_image_timeout_in_milliseconds_ can be configured based on your
   // application. By default it is 10ms. This tells the secondary thread
   // how long it should wait if no image has been submitted to see if
@@ -99,7 +99,7 @@ public:
     always_get_acquired_image_ = always_get_acquired_image;
   }
 
-private:
+ private:
   const VkSwapchainCreateInfoKHR swapchain_info_;
   // This is the entry-point to our secondary thread.
   // It is responsible for keeping track of copies, and calling the
@@ -109,34 +109,34 @@ private:
   uint32_t ImageByteSize() const;
   // All of the data associated with a single swapchain VkImage.
   struct SwapchainImageData {
-    VkImage image_;               // The image itself.
-    VkDeviceMemory image_memory_; // The device memory allocated to this image.
+    VkImage image_;                // The image itself.
+    VkDeviceMemory image_memory_;  // The device memory allocated to this image.
 
-    VkBuffer buffer_; // The buffer to copy the image contents into.
-    VkDeviceMemory buffer_memory_; // The memory for the buffer.
+    VkBuffer buffer_;  // The buffer to copy the image contents into.
+    VkDeviceMemory buffer_memory_;  // The memory for the buffer.
 
-    VkFence fence_; // The fence to signal when the copy is complete.
+    VkFence fence_;  // The fence to signal when the copy is complete.
     VkCommandBuffer
-        command_buffer_; // The command_buffer that contains the copy commands.
+        command_buffer_;  // The command_buffer that contains the copy commands.
   };
 
   // In our constructor we rely on num_images_ being
   // initialized first, so don't move anything above it.
-  uint32_t num_images_; // The number of images requested.
+  uint32_t num_images_;  // The number of images requested.
 
-  uint32_t width_;  // The width of our swapchain.
-  uint32_t height_; // The height of our swapchain.
+  uint32_t width_;   // The width of our swapchain.
+  uint32_t height_;  // The height of our swapchain.
   std::deque<SwapchainImageData>
-      image_data_; // All of the data for each requested swapchain image.
+      image_data_;  // All of the data for each requested swapchain image.
   std::deque<uint32_t>
-      pending_images_; // Indices into image_data_ for all images that
-                       // have been submitted but not processed yet.
+      pending_images_;  // Indices into image_data_ for all images that
+                        // have been submitted but not processed yet.
   std::deque<uint32_t>
-      free_images_; // Indices into image_data_ for all images that
-                    // are not currently in use.
-  VkDevice device_; // The device that this swapchain belongs to.
+      free_images_;  // Indices into image_data_ for all images that
+                     // are not currently in use.
+  VkDevice device_;  // The device that this swapchain belongs to.
   VkCommandPool
-      command_pool_; // The command_pool that we are allocating buffers from.
+      command_pool_;  // The command_pool that we are allocating buffers from.
 
   // If should_close_ == true then the next time we wake up we should
   // terminate our thread.
@@ -153,27 +153,28 @@ private:
   // Leave the mutexes above their associated condition_variables.
   // On windows if you delete the mutex first, bad things happen somtimes.
   threading::mutex
-      pending_images_lock_; // The lock for modifying our pending images list.
+      pending_images_lock_;  // The lock for modifying our pending images list.
 
-  threading::condition_variable pending_images_condition_; // Condition variable
-                                                           // to wait for
-                                                           // pending_images_ to
-                                                           // contain an image.
+  threading::condition_variable
+      pending_images_condition_;  // Condition variable
+                                  // to wait for
+                                  // pending_images_ to
+                                  // contain an image.
 
   threading::mutex
-      free_images_lock_; // The lock for modifying our free images list.
+      free_images_lock_;  // The lock for modifying our free images list.
 
-  threading::condition_variable free_images_condition_; // The condition
-                                                        // variable to wait on
-                                                        // for free_images_ to
-                                                        // contain an image.
+  threading::condition_variable free_images_condition_;  // The condition
+                                                         // variable to wait on
+                                                         // for free_images_ to
+                                                         // contain an image.
 
-  void (*callback_)(void *, uint8_t *, size_t); // The user-supplied callback.
-  void *callback_user_data_; // The user-data to pass to this callback.
+  void (*callback_)(void *, uint8_t *, size_t);  // The user-supplied callback.
+  void *callback_user_data_;  // The user-data to pass to this callback.
 
-  const uint32_t queue_; // the queue that we need to use to signal things
-  const DeviceData *
-      functions_; // All of the resolved function pointers that we need to call.
+  const uint32_t queue_;  // the queue that we need to use to signal things
+  const DeviceData *functions_;  // All of the resolved function pointers that
+                                 // we need to call.
 
   // This is how many milliseconds we should wait for an image before waking up
   // and seeing if we should shut down.
@@ -187,6 +188,6 @@ private:
   // Function to build swapchain images
   std::function<SwapchainImageData()> build_swapchain_image_data_;
 };
-} // swapchain
+}  // namespace swapchain
 
-#endif //  VK_VIRTUAL_SWAPCHAIN_VIRTUAL_SWAPCHAIN_H_
+#endif  //  VK_VIRTUAL_SWAPCHAIN_VIRTUAL_SWAPCHAIN_H_

--- a/gapii/cc/android/gvr_install.h
+++ b/gapii/cc/android/gvr_install.h
@@ -26,6 +26,6 @@ class GvrImports;
 // install_gvr installs interceptor hooks into all the GVR functions.
 bool install_gvr(Installer* installer, void* gvr_lib, GvrImports* imports);
 
-} // namespace gapii
+}  // namespace gapii
 
-#endif // GAPII_ANDROID_GVR_INSTALL_H
+#endif  // GAPII_ANDROID_GVR_INSTALL_H

--- a/gapii/cc/android/installer.cpp
+++ b/gapii/cc/android/installer.cpp
@@ -21,8 +21,8 @@
 #include "core/cc/get_gles_proc_address.h"
 #include "core/cc/log.h"
 
-#include <cstring>
 #include <dlfcn.h>
+#include <cstring>
 
 #include <unordered_map>
 
@@ -33,7 +33,6 @@
 #endif
 
 #define NELEM(x) (sizeof(x) / sizeof(x[0]))
-
 
 extern "C" {
 // For this to function on Android the entry-point names for GetDeviceProcAddr
@@ -48,7 +47,6 @@ extern void gapid_vkEnumerateInstanceExtensionProperties();
 extern void gapid_vkEnumerateDeviceLayerProperties();
 extern void gapid_vkEnumerateDeviceExtensionProperties();
 }
-
 
 namespace {
 
@@ -67,57 +65,51 @@ namespace {
 // have been initialized yet.
 //
 
-typedef void* (InitializeInterceptorFunc)();
-typedef void (TerminateInterceptorFunc)(void *interceptor);
-typedef bool (InterceptFunctionFunc)(void* interceptor,
-                                     void* old_function,
-                                     const void* new_function,
-                                     void** callback_function,
-                                     void (*error_callback)(void*, const char*),
-                                     void* error_callback_baton);
+typedef void*(InitializeInterceptorFunc)();
+typedef void(TerminateInterceptorFunc)(void* interceptor);
+typedef bool(InterceptFunctionFunc)(void* interceptor, void* old_function,
+                                    const void* new_function,
+                                    void** callback_function,
+                                    void (*error_callback)(void*, const char*),
+                                    void* error_callback_baton);
 
-InitializeInterceptorFunc*             gInitializeInterceptor = nullptr;
-TerminateInterceptorFunc*              gTerminateInterceptor = nullptr;
-void*                                  gInterceptor = nullptr;
-InterceptFunctionFunc*                 gInterceptFunction = nullptr;
+InitializeInterceptorFunc* gInitializeInterceptor = nullptr;
+TerminateInterceptorFunc* gTerminateInterceptor = nullptr;
+void* gInterceptor = nullptr;
+InterceptFunctionFunc* gInterceptFunction = nullptr;
 std::unordered_map<std::string, void*> gCallbacks;
-const char*                            gDriverPaths[] = {
-  SYSTEM_LIB_PATH "libhwgl.so", // Huawei specific, must be first.
-  SYSTEM_LIB_PATH "libGLES.so",
-  SYSTEM_LIB_PATH "libEGL.so",
-  SYSTEM_LIB_PATH "libGLESv1_CM.so",
-  SYSTEM_LIB_PATH "libGLESv2.so",
-  SYSTEM_LIB_PATH "libGLESv3.so",
+const char* gDriverPaths[] = {
+    SYSTEM_LIB_PATH "libhwgl.so",  // Huawei specific, must be first.
+    SYSTEM_LIB_PATH "libGLES.so",      SYSTEM_LIB_PATH "libEGL.so",
+    SYSTEM_LIB_PATH "libGLESv1_CM.so", SYSTEM_LIB_PATH "libGLESv2.so",
+    SYSTEM_LIB_PATH "libGLESv3.so",
 };
 
 void* resolveCallback(const char* name, bool bypassLocal) {
-    if (void* ptr = gCallbacks[name]) {
-        return ptr;
-    }
-    if(strcmp(name, "gapid_vkGetDeviceProcAddr") == 0) {
-        return reinterpret_cast<void*>(&gapid_vkGetDeviceProcAddr);
-    }
-    else if(strcmp(name, "gapid_vkGetInstanceProcAddr") == 0) {
-        return reinterpret_cast<void*>(&gapid_vkGetInstanceProcAddr);
-    }
-    else if(strcmp(name, "gapid_vkEnumerateInstanceLayerProperties") == 0) {
-        return reinterpret_cast<void*>(&gapid_vkEnumerateInstanceLayerProperties);
-    }
-    else if(strcmp(name, "gapid_vkEnumerateInstanceExtensionProperties") == 0) {
-        return reinterpret_cast<void*>(&gapid_vkEnumerateInstanceExtensionProperties);
-    }
-    else if(strcmp(name, "gapid_vkEnumerateDeviceLayerProperties") == 0) {
-        return reinterpret_cast<void*>(&gapid_vkEnumerateDeviceLayerProperties);
-    }
-    else if(strcmp(name, "gapid_vkEnumerateDeviceExtensionProperties") == 0) {
-        return reinterpret_cast<void*>(&gapid_vkEnumerateDeviceExtensionProperties);
-    }
-    GAPID_WARNING("%s was requested, but cannot be traced.", name);
-    return nullptr;
+  if (void* ptr = gCallbacks[name]) {
+    return ptr;
+  }
+  if (strcmp(name, "gapid_vkGetDeviceProcAddr") == 0) {
+    return reinterpret_cast<void*>(&gapid_vkGetDeviceProcAddr);
+  } else if (strcmp(name, "gapid_vkGetInstanceProcAddr") == 0) {
+    return reinterpret_cast<void*>(&gapid_vkGetInstanceProcAddr);
+  } else if (strcmp(name, "gapid_vkEnumerateInstanceLayerProperties") == 0) {
+    return reinterpret_cast<void*>(&gapid_vkEnumerateInstanceLayerProperties);
+  } else if (strcmp(name, "gapid_vkEnumerateInstanceExtensionProperties") ==
+             0) {
+    return reinterpret_cast<void*>(
+        &gapid_vkEnumerateInstanceExtensionProperties);
+  } else if (strcmp(name, "gapid_vkEnumerateDeviceLayerProperties") == 0) {
+    return reinterpret_cast<void*>(&gapid_vkEnumerateDeviceLayerProperties);
+  } else if (strcmp(name, "gapid_vkEnumerateDeviceExtensionProperties") == 0) {
+    return reinterpret_cast<void*>(&gapid_vkEnumerateDeviceExtensionProperties);
+  }
+  GAPID_WARNING("%s was requested, but cannot be traced.", name);
+  return nullptr;
 }
 
 void recordInterceptorError(void*, const char* message) {
-    GAPID_WARNING("Interceptor error: %s", message);
+  GAPID_WARNING("Interceptor error: %s", message);
 }
 
 }  // anonymous namespace
@@ -125,122 +117,121 @@ void recordInterceptorError(void*, const char* message) {
 namespace gapii {
 
 Installer::Installer(const char* libInterceptorPath) {
-    GAPID_INFO("Installing GAPII hooks...")
+  GAPID_INFO("Installing GAPII hooks...")
 
-    auto lib = dlopen(libInterceptorPath, RTLD_NOW);
-    if (lib == nullptr) {
-        GAPID_FATAL("Couldn't load interceptor library from: %s: %s", libInterceptorPath, dlerror());
-    }
+  auto lib = dlopen(libInterceptorPath, RTLD_NOW);
+  if (lib == nullptr) {
+    GAPID_FATAL("Couldn't load interceptor library from: %s: %s",
+                libInterceptorPath, dlerror());
+  }
 
-    gInitializeInterceptor = reinterpret_cast<InitializeInterceptorFunc*>(dlsym(lib, "InitializeInterceptor"));
-    gTerminateInterceptor = reinterpret_cast<TerminateInterceptorFunc*>(dlsym(lib, "TerminateInterceptor"));
-    gInterceptFunction = reinterpret_cast<InterceptFunctionFunc*>(dlsym(lib, "InterceptFunction"));
+  gInitializeInterceptor = reinterpret_cast<InitializeInterceptorFunc*>(
+      dlsym(lib, "InitializeInterceptor"));
+  gTerminateInterceptor = reinterpret_cast<TerminateInterceptorFunc*>(
+      dlsym(lib, "TerminateInterceptor"));
+  gInterceptFunction =
+      reinterpret_cast<InterceptFunctionFunc*>(dlsym(lib, "InterceptFunction"));
 
-    if (gInitializeInterceptor == nullptr ||
-        gTerminateInterceptor == nullptr ||
-        gInterceptFunction == nullptr) {
-        GAPID_FATAL("Couldn't resolve the interceptor methods. "
-                "Did you forget to load libinterceptor.so before libgapii.so?\n"
-                "gInitializeInterceptor = %p\n"
-                "gTerminateInterceptor  = %p\n"
-                "gInterceptFunction     = %p\n",
-                gInitializeInterceptor, gTerminateInterceptor, gInterceptFunction);
-    }
+  if (gInitializeInterceptor == nullptr || gTerminateInterceptor == nullptr ||
+      gInterceptFunction == nullptr) {
+    GAPID_FATAL(
+        "Couldn't resolve the interceptor methods. "
+        "Did you forget to load libinterceptor.so before libgapii.so?\n"
+        "gInitializeInterceptor = %p\n"
+        "gTerminateInterceptor  = %p\n"
+        "gInterceptFunction     = %p\n",
+        gInitializeInterceptor, gTerminateInterceptor, gInterceptFunction);
+  }
 
-    GAPID_INFO("Interceptor functions resolved")
+  GAPID_INFO("Interceptor functions resolved")
 
-    GAPID_INFO("Calling gInitializeInterceptor at %p...", gInitializeInterceptor);
-    gInterceptor = gInitializeInterceptor();
-    GAPID_ASSERT(gInterceptor != nullptr);
+  GAPID_INFO("Calling gInitializeInterceptor at %p...", gInitializeInterceptor);
+  gInterceptor = gInitializeInterceptor();
+  GAPID_ASSERT(gInterceptor != nullptr);
 
-    // Patch the driver to trampoline to the spy for all OpenGL ES functions.
-    GAPID_INFO("Installing OpenGL ES hooks...");
-    install_gles();
+  // Patch the driver to trampoline to the spy for all OpenGL ES functions.
+  GAPID_INFO("Installing OpenGL ES hooks...");
+  install_gles();
 
-    // Switch to using the callbacks instead of the patched driver functions.
-    core::GetGlesProcAddress = resolveCallback;
+  // Switch to using the callbacks instead of the patched driver functions.
+  core::GetGlesProcAddress = resolveCallback;
 
-    GAPID_INFO("OpenGL ES hooks successfully installed");
+  GAPID_INFO("OpenGL ES hooks successfully installed");
 }
 
-Installer::~Installer() {
-    gTerminateInterceptor(gInterceptor);
-}
+Installer::~Installer() { gTerminateInterceptor(gInterceptor); }
 
 void* Installer::install(void* func_import, const void* func_export) {
-    void* callback = nullptr;
-    if (!gInterceptFunction(gInterceptor,
-                            func_import,
-                            func_export,
-                            &callback,
-                            &recordInterceptorError,
-                            nullptr)) {
-        return nullptr;
-    }
-    return callback;
+  void* callback = nullptr;
+  if (!gInterceptFunction(gInterceptor, func_import, func_export, &callback,
+                          &recordInterceptorError, nullptr)) {
+    return nullptr;
+  }
+  return callback;
 }
 
 void Installer::install_gles() {
-    // Start by loading all the drivers.
-    void* drivers[NELEM(gDriverPaths)];
-    for (int i = 0; i < NELEM(gDriverPaths); ++i) {
-        drivers[i] = dlopen(gDriverPaths[i], RTLD_NOW | RTLD_LOCAL);
-    }
+  // Start by loading all the drivers.
+  void* drivers[NELEM(gDriverPaths)];
+  for (int i = 0; i < NELEM(gDriverPaths); ++i) {
+    drivers[i] = dlopen(gDriverPaths[i], RTLD_NOW | RTLD_LOCAL);
+  }
 
-    struct func {
-        const char* name;
-        void* func_export;
-    };
+  struct func {
+    const char* name;
+    void* func_export;
+  };
 
-    // Now resolve all the imported functions. We do this early so that
-    // the function resolver doesn't end up using patched functions.
-    std::unordered_map<void*, func> functions;
-    for (int i = 0; gapii::kGLESExports[i].mName != nullptr; ++i) {
-        const char* name = gapii::kGLESExports[i].mName;
-        void* func_export = gapii::kGLESExports[i].mFunc;
-        bool import_found = false;
-        if (drivers[0] != nullptr) { // libhwgl.so
-            // Huawei implements all functions in this library with prefix,
-            // all GL functions in libGLES*.so are just trampolines to his.
-            // However, we do not support trampoline interception for now,
-            // so try to intercept the internal implementation instead.
-            std::string hwName = "hw_" + std::string(name);
-            if (void* func_import = dlsym(drivers[0], hwName.c_str())) {
-                import_found = true;
-                functions[func_import] = func{name, func_export};
-                continue; // Do not do any other lookups.
-            }
-        }
-        for (int i = 1; i < NELEM(gDriverPaths); ++i) {
-            if (void* func_import = dlsym(drivers[i], name)) {
-                import_found = true;
-                functions[func_import] = func{name, func_export};
-            }
-        }
-        if (void* func_import = core::GetGlesProcAddress(name, true)) {
-            import_found = true;
-            functions[func_import] = func{name, func_export};
-        }
-        if (!import_found) {
-            // Don't export this function if the driver didn't export it.
-            gapii::kGLESExports[i].mFunc = nullptr;
-        }
+  // Now resolve all the imported functions. We do this early so that
+  // the function resolver doesn't end up using patched functions.
+  std::unordered_map<void*, func> functions;
+  for (int i = 0; gapii::kGLESExports[i].mName != nullptr; ++i) {
+    const char* name = gapii::kGLESExports[i].mName;
+    void* func_export = gapii::kGLESExports[i].mFunc;
+    bool import_found = false;
+    if (drivers[0] != nullptr) {  // libhwgl.so
+      // Huawei implements all functions in this library with prefix,
+      // all GL functions in libGLES*.so are just trampolines to his.
+      // However, we do not support trampoline interception for now,
+      // so try to intercept the internal implementation instead.
+      std::string hwName = "hw_" + std::string(name);
+      if (void* func_import = dlsym(drivers[0], hwName.c_str())) {
+        import_found = true;
+        functions[func_import] = func{name, func_export};
+        continue;  // Do not do any other lookups.
+      }
     }
+    for (int i = 1; i < NELEM(gDriverPaths); ++i) {
+      if (void* func_import = dlsym(drivers[i], name)) {
+        import_found = true;
+        functions[func_import] = func{name, func_export};
+      }
+    }
+    if (void* func_import = core::GetGlesProcAddress(name, true)) {
+      import_found = true;
+      functions[func_import] = func{name, func_export};
+    }
+    if (!import_found) {
+      // Don't export this function if the driver didn't export it.
+      gapii::kGLESExports[i].mFunc = nullptr;
+    }
+  }
 
-    // Now patch each of the functions.
-    for (auto it : functions) {
-        void* func_import = it.first;
-        void* func_export = it.second.func_export;
-        const char* name = it.second.name;
-        GAPID_DEBUG("Patching '%s' at %p with %p...", name, func_import, func_export);
-        if (auto callback = install(func_import, func_export)) {
-            GAPID_DEBUG("Replaced function %s at %p with %p (callback %p)",
-                    name, func_import, func_export, callback);
-            gCallbacks[name] = callback;
-        } else {
-            GAPID_ERROR("Couldn't intercept function %s at %p", name, func_import);
-        }
+  // Now patch each of the functions.
+  for (auto it : functions) {
+    void* func_import = it.first;
+    void* func_export = it.second.func_export;
+    const char* name = it.second.name;
+    GAPID_DEBUG("Patching '%s' at %p with %p...", name, func_import,
+                func_export);
+    if (auto callback = install(func_import, func_export)) {
+      GAPID_DEBUG("Replaced function %s at %p with %p (callback %p)", name,
+                  func_import, func_export, callback);
+      gCallbacks[name] = callback;
+    } else {
+      GAPID_ERROR("Couldn't intercept function %s at %p", name, func_import);
     }
+  }
 }
 
-} // namespace gapii
+}  // namespace gapii

--- a/gapii/cc/android/installer.h
+++ b/gapii/cc/android/installer.h
@@ -20,19 +20,19 @@
 namespace gapii {
 
 class Installer {
-public:
-    Installer(const char* libInterceptorPath);
-    ~Installer();
+ public:
+  Installer(const char* libInterceptorPath);
+  ~Installer();
 
-    // install_function installs a hook into func_import to call func_export.
-    // The returned function allows func_export to call back to the original
-    // function that was at func_import.
-    void* install(void* func_import, const void* func_export);
+  // install_function installs a hook into func_import to call func_export.
+  // The returned function allows func_export to call back to the original
+  // function that was at func_import.
+  void* install(void* func_import, const void* func_export);
 
-private:
-    void install_gles();
+ private:
+  void install_gles();
 };
 
-} // namespace gapii
+}  // namespace gapii
 
-#endif // GAPII_ANDROID_INSTALLER_H
+#endif  // GAPII_ANDROID_INSTALLER_H

--- a/gapii/cc/call_observer.h
+++ b/gapii/cc/call_observer.h
@@ -42,259 +42,268 @@ class SpyBase;
 // to be created at the beginning of each intercepted API function call and
 // deleted at the end.
 class CallObserver : public context_t {
-public:
-    template<class T>
-    using enable_if_encodable = typename std::enable_if<std::is_member_function_pointer<decltype(&T::encode)>::value>::type;
+ public:
+  template <class T>
+  using enable_if_encodable = typename std::enable_if<
+      std::is_member_function_pointer<decltype(&T::encode)>::value>::type;
 
-    typedef std::function<void(slice_t*)> OnSliceEncodedCallback;
+  typedef std::function<void(slice_t*)> OnSliceEncodedCallback;
 
-    CallObserver(SpyBase* spy_p, CallObserver* parent, uint8_t api);
+  CallObserver(SpyBase* spy_p, CallObserver* parent, uint8_t api);
 
-    ~CallObserver();
+  ~CallObserver();
 
-    inline CallObserver* getParent() { return mParent; }
+  inline CallObserver* getParent() { return mParent; }
 
-    // setCurrentCommandName sets the name of the current command that is being
-    // observed by this observer. The storage of cmd_name must remain valid for
-    // the lifetime of this observer object, ideally it should be static
-    // string.
-    void setCurrentCommandName(const char* cmd_name) {
-        mCurrentCommandName = cmd_name;
+  // setCurrentCommandName sets the name of the current command that is being
+  // observed by this observer. The storage of cmd_name must remain valid for
+  // the lifetime of this observer object, ideally it should be static
+  // string.
+  void setCurrentCommandName(const char* cmd_name) {
+    mCurrentCommandName = cmd_name;
+  }
+
+  const char* getCurrentCommandName() { return mCurrentCommandName; }
+
+  // Get or set the GL error code for this call.
+  GLenum_Error getError() { return mError; }
+  void setError(GLenum_Error err) { mError = err; }
+
+  // getCurrentThread returns the current thread identifier.
+  inline uint64_t getCurrentThread() { return mCurrentThread; }
+
+  // Returns the unique reference identifier for the given object address,
+  // and true when the address is seen for the first time.
+  // Nullptr address is always mapped to identifier 0.
+  inline std::pair<uint64_t, bool> reference_id(const void* address) {
+    auto it = mSeenReferences.emplace(address, mSeenReferences.size());
+    return std::pair<uint64_t, bool>(it.first->second, it.second);
+  }
+
+  // on_slice_encoded sets the callback to be invoked when slice_encoded is
+  // called.
+  inline void on_slice_encoded(OnSliceEncodedCallback f) {
+    mOnSliceEncoded = f;
+  }
+
+  // slice_encoded should be called whenever a slice is encoded.
+  inline void slice_encoded(slice_t* slice) {
+    if (mOnSliceEncoded) {
+      mOnSliceEncoded(slice);
     }
+  }
 
-    const char* getCurrentCommandName() { return mCurrentCommandName; }
+  // arena returns the active memory arena.
+  core::Arena* arena() const;
 
-    // Get or set the GL error code for this call.
-    GLenum_Error getError() { return mError; }
-    void setError(GLenum_Error err) { mError = err; }
+  // read is called to make a read memory observation of size bytes, starting
+  // at base. It only records the range of the read memory, the actual
+  // copying of the data is deferred until the data is to be sent.
+  void read(const void* base, uint64_t size);
 
-    // getCurrentThread returns the current thread identifier.
-    inline uint64_t getCurrentThread() { return mCurrentThread; }
+  // write is called to make a write memory observation of size bytes,
+  // starting at base. It only records the range of the write memory, the
+  // actual copying of the data is deferred until the data is to be sent.
+  void write(const void* base, uint64_t size);
 
-    // Returns the unique reference identifier for the given object address,
-    // and true when the address is seen for the first time.
-    // Nullptr address is always mapped to identifier 0.
-    inline std::pair<uint64_t, bool> reference_id(const void* address) {
-        auto it = mSeenReferences.emplace(address, mSeenReferences.size());
-        return std::pair<uint64_t, bool>(it.first->second, it.second);
-    }
+  // read records the memory range for the given slice as a read operation.
+  // The actual copying of the data is deferred until the data is to be sent.
+  template <typename T>
+  inline void read(const gapil::Slice<T>& slice);
 
-    // on_slice_encoded sets the callback to be invoked when slice_encoded is
-    // called.
-    inline void on_slice_encoded(OnSliceEncodedCallback f) { mOnSliceEncoded = f; }
+  // read records and returns the i'th element from the slice src. The actual
+  // copying of the data is deferred until the data is to be sent.
+  template <typename T>
+  inline T read(const gapil::Slice<T>& src, uint64_t i);
 
-    // slice_encoded should be called whenever a slice is encoded.
-    inline void slice_encoded(slice_t* slice) { if (mOnSliceEncoded) { mOnSliceEncoded(slice); } }
+  // write records the memory for the given slice as a write operation. The
+  // actual copying of the data is deferred until the data is to be sent.
+  template <typename T>
+  inline void write(const gapil::Slice<T>& slice);
 
-    // arena returns the active memory arena.
-    core::Arena* arena() const;
+  // write records a value to i'th element in the slice dst. The actual
+  // copying of the data is deferred until the data is to be sent.
+  template <typename T>
+  inline void write(const gapil::Slice<T>& dst, uint64_t i, const T& value);
 
-    // read is called to make a read memory observation of size bytes, starting
-    // at base. It only records the range of the read memory, the actual
-    // copying of the data is deferred until the data is to be sent.
-    void read(const void* base, uint64_t size);
+  // copy copies N elements from src to dst, where N is the smaller of
+  // src.count() and dst.count().
+  // copy observes the sub-slice of src as a read operation.  The sub-slice
+  // of dst is returned so that the write observation can be made after the
+  // call to the imported function.
+  template <typename T>
+  inline gapil::Slice<T> copy(const gapil::Slice<T>& dst,
+                              const gapil::Slice<T>& src);
 
-    // write is called to make a write memory observation of size bytes,
-    // starting at base. It only records the range of the write memory, the
-    // actual copying of the data is deferred until the data is to be sent.
-    void write(const void* base, uint64_t size);
+  // clone observes src as a read operation and returns a copy of src in a
+  // new Pool.
+  template <typename T>
+  inline gapil::Slice<T> clone(const gapil::Slice<T>& src);
 
-    // read records the memory range for the given slice as a read operation.
-    // The actual copying of the data is deferred until the data is to be sent.
-    template <typename T>
-    inline void read(const gapil::Slice<T>& slice);
+  // string returns a gapil::String from the null-terminated string str.
+  // str is observed as a read operation.
+  gapil::String string(const char* str);
 
-    // read records and returns the i'th element from the slice src. The actual
-    // copying of the data is deferred until the data is to be sent.
-    template <typename T>
-    inline T read(const gapil::Slice<T>& src, uint64_t i);
+  // string returns a gapil::String from the gapil::Slice<char> slice.
+  // slice is observed as a read operation.
+  gapil::String string(const gapil::Slice<char>& slice);
 
-    // write records the memory for the given slice as a write operation. The
-    // actual copying of the data is deferred until the data is to be sent.
-    template <typename T>
-    inline void write(const gapil::Slice<T>& slice);
+  // encoder returns the PackEncoder currently in use.
+  inline PackEncoder::SPtr encoder();
 
-    // write records a value to i'th element in the slice dst. The actual
-    // copying of the data is deferred until the data is to be sent.
-    template <typename T>
-    inline void write(const gapil::Slice<T>& dst, uint64_t i, const T& value);
+  // enter encodes cmd as a group. All encodables will be encoded to this
+  // group until exit() is called.
+  void enter(const ::google::protobuf::Message* cmd);
 
-    // copy copies N elements from src to dst, where N is the smaller of
-    // src.count() and dst.count().
-    // copy observes the sub-slice of src as a read operation.  The sub-slice
-    // of dst is returned so that the write observation can be made after the
-    // call to the imported function.
-    template <typename T>
-    inline gapil::Slice<T> copy(const gapil::Slice<T>& dst, const gapil::Slice<T>& src);
+  // encode encodes cmd the proto message to the PackEncoder.
+  void encode(const ::google::protobuf::Message* cmd);
 
-    // clone observes src as a read operation and returns a copy of src in a
-    // new Pool.
-    template <typename T>
-    inline gapil::Slice<T> clone(const gapil::Slice<T>& src);
+  // encodeAndDelete encodes the proto message to the PackEncoder and then
+  // deletes the message.
+  void encodeAndDelete(::google::protobuf::Message* cmd);
 
-    // string returns a gapil::String from the null-terminated string str.
-    // str is observed as a read operation.
-    gapil::String string(const char* str);
+  // enter encodes the encodable to the PackEncoder. All encodables will be
+  // encoded to this group until exit() is called.
+  template <typename T, typename = enable_if_encodable<T> >
+  inline void enter(const T& obj);
 
-    // string returns a gapil::String from the gapil::Slice<char> slice.
-    // slice is observed as a read operation.
-    gapil::String string(const gapil::Slice<char>& slice);
+  // encode encodes the encodable to the PackEncoder.
+  template <typename T, typename = enable_if_encodable<T> >
+  inline void encode(const T& obj);
 
-    // encoder returns the PackEncoder currently in use.
-    inline PackEncoder::SPtr encoder();
+  // exit returns encoding to the group bound before calling enter().
+  void exit();
 
-    // enter encodes cmd as a group. All encodables will be encoded to this
-    // group until exit() is called.
-    void enter(const ::google::protobuf::Message* cmd);
+  // observePending observes and encodes all the pending memory observations.
+  // The list of pending memory observations is cleared on returning.
+  void observePending();
 
-    // encode encodes cmd the proto message to the PackEncoder.
-    void encode(const ::google::protobuf::Message* cmd);
+ private:
+  // shouldObserve returns true if the given slice is located in application
+  // pool and we are supposed to observe application pool.
+  template <class T>
+  bool shouldObserve(const gapil::Slice<T>& slice) const {
+    return mObserveApplicationPool && slice.is_app_pool();
+  }
 
-    // encodeAndDelete encodes the proto message to the PackEncoder and then
-    // deletes the message.
-    void encodeAndDelete(::google::protobuf::Message* cmd);
+  // Make a slice on a new Pool.
+  template <typename T>
+  inline gapil::Slice<T> make(uint64_t count);
 
-    // enter encodes the encodable to the PackEncoder. All encodables will be
-    // encoded to this group until exit() is called.
-    template<typename T, typename = enable_if_encodable<T> >
-    inline void enter(const T& obj);
+  // A pointer to the spy instance.
+  SpyBase* mSpy;
 
-    // encode encodes the encodable to the PackEncoder.
-    template<typename T, typename = enable_if_encodable<T> >
-    inline void encode(const T& obj);
+  // A pointer to the parent CallObserver.
+  CallObserver* mParent;
 
-    // exit returns encoding to the group bound before calling enter().
-    void exit();
+  // The encoder stack.
+  std::stack<PackEncoder::SPtr> mEncoderStack;
 
-    // observePending observes and encodes all the pending memory observations.
-    // The list of pending memory observations is cleared on returning.
-    void observePending();
+  // A map of object pointer to encoded reference identifier.
+  std::unordered_map<const void*, uint64_t> mSeenReferences;
 
-private:
-    // shouldObserve returns true if the given slice is located in application
-    // pool and we are supposed to observe application pool.
-    template <class T>
-    bool shouldObserve(const gapil::Slice<T>& slice) const {
-        return mObserveApplicationPool && slice.is_app_pool();
-    }
+  // A pointer to the static array that contains the current command name.
+  const char* mCurrentCommandName;
 
-    // Make a slice on a new Pool.
-    template <typename T>
-    inline gapil::Slice<T> make(uint64_t count);
+  // True if we should observe the application poool.
+  bool mObserveApplicationPool;
 
-    // A pointer to the spy instance.
-    SpyBase* mSpy;
+  // The list of pending reads or writes observations that are yet to be made.
+  core::IntervalList<uintptr_t> mPendingObservations;
 
-    // A pointer to the parent CallObserver.
-    CallObserver* mParent;
+  // Record GL error which was raised during this call.
+  GLenum_Error mError;
 
-    // The encoder stack.
-    std::stack<PackEncoder::SPtr> mEncoderStack;
+  // The current API that this call-observer is observing.
+  uint8_t mApi;
 
-    // A map of object pointer to encoded reference identifier.
-    std::unordered_map<const void*, uint64_t> mSeenReferences;
+  // Whether or not we should be tracing with this call observer
+  bool mShouldTrace;
 
-    // A pointer to the static array that contains the current command name.
-    const char* mCurrentCommandName;
+  // The current thread id.
+  uint64_t mCurrentThread;
 
-    // True if we should observe the application poool.
-    bool mObserveApplicationPool;
-
-    // The list of pending reads or writes observations that are yet to be made.
-    core::IntervalList<uintptr_t> mPendingObservations;
-
-    // Record GL error which was raised during this call.
-    GLenum_Error mError;
-
-    // The current API that this call-observer is observing.
-    uint8_t mApi;
-
-    // Whether or not we should be tracing with this call observer
-    bool mShouldTrace;
-
-    // The current thread id.
-    uint64_t mCurrentThread;
-
-    // Callback invoked whenever slice_encoded() is called.
-    OnSliceEncodedCallback mOnSliceEncoded;
+  // Callback invoked whenever slice_encoded() is called.
+  OnSliceEncodedCallback mOnSliceEncoded;
 };
 
 template <typename T>
 inline void CallObserver::read(const gapil::Slice<T>& slice) {
-    if (shouldObserve(slice)) {
-        read(slice.begin(), slice.count() * sizeof(T));
-    }
+  if (shouldObserve(slice)) {
+    read(slice.begin(), slice.count() * sizeof(T));
+  }
 }
 
 template <typename T>
 inline T CallObserver::read(const gapil::Slice<T>& src, uint64_t index) {
-    T& elem = src[index];
-    if (shouldObserve(src)) {
-        read(&elem, sizeof(T));
-    }
-    return elem;
+  T& elem = src[index];
+  if (shouldObserve(src)) {
+    read(&elem, sizeof(T));
+  }
+  return elem;
 }
 
 template <typename T>
 inline void CallObserver::write(const gapil::Slice<T>& slice) {
-    if (shouldObserve(slice)) {
-        write(slice.begin(), slice.count() * sizeof(T));
-    }
+  if (shouldObserve(slice)) {
+    write(slice.begin(), slice.count() * sizeof(T));
+  }
 }
 
 template <typename T>
 inline void CallObserver::write(const gapil::Slice<T>& dst, uint64_t index,
                                 const T& value) {
-    if (!shouldObserve(
-            dst)) {  // The spy must not mutate data in the application pool.
-        dst[index] = value;
-    } else {
-        write(&dst[index], sizeof(T));
-    }
+  if (!shouldObserve(
+          dst)) {  // The spy must not mutate data in the application pool.
+    dst[index] = value;
+  } else {
+    write(&dst[index], sizeof(T));
+  }
 }
 
 template <typename T>
-inline gapil::Slice<T> CallObserver::copy(const gapil::Slice<T>& dst, const gapil::Slice<T>& src) {
-    read(src);
-    if (!shouldObserve(
-            dst)) {  // The spy must not mutate data in the application pool.
-        uint64_t c = (src.count() < dst.count()) ? src.count() : dst.count();
-        src.copy(dst, 0, c, 0);
-    }
-    return dst;
+inline gapil::Slice<T> CallObserver::copy(const gapil::Slice<T>& dst,
+                                          const gapil::Slice<T>& src) {
+  read(src);
+  if (!shouldObserve(
+          dst)) {  // The spy must not mutate data in the application pool.
+    uint64_t c = (src.count() < dst.count()) ? src.count() : dst.count();
+    src.copy(dst, 0, c, 0);
+  }
+  return dst;
 }
 
 template <typename T>
 inline gapil::Slice<T> CallObserver::clone(const gapil::Slice<T>& src) {
-    auto dst = make<T>(src.count());
-    // Make sure that we actually fill the data the first time.
-    // If we use ::copy(), then the copy will only happen if
-    // the observer is active.
-    read(src);
-    src.copy(dst, 0, src.count(), 0);
-    return dst;
+  auto dst = make<T>(src.count());
+  // Make sure that we actually fill the data the first time.
+  // If we use ::copy(), then the copy will only happen if
+  // the observer is active.
+  read(src);
+  src.copy(dst, 0, src.count(), 0);
+  return dst;
 }
 
 template <typename T>
 inline gapil::Slice<T> CallObserver::make(uint64_t count) {
-    return gapil::Slice<T>::create(this, count);
+  return gapil::Slice<T>::create(this, count);
 }
 
-inline PackEncoder::SPtr CallObserver::encoder() {
-    return mEncoderStack.top();
-}
+inline PackEncoder::SPtr CallObserver::encoder() { return mEncoderStack.top(); }
 
-template<typename T, typename /* = enable_if_encodable<T> */ >
+template <typename T, typename /* = enable_if_encodable<T> */>
 inline void CallObserver::enter(const T& obj) {
-    auto group = reinterpret_cast<PackEncoder*>(obj.encode(this, true));
-    GAPID_ASSERT_MSG(group != nullptr, "encode() for group did not return sub-encoder");
-    mEncoderStack.push(PackEncoder::SPtr(group));
+  auto group = reinterpret_cast<PackEncoder*>(obj.encode(this, true));
+  GAPID_ASSERT_MSG(group != nullptr,
+                   "encode() for group did not return sub-encoder");
+  mEncoderStack.push(PackEncoder::SPtr(group));
 }
 
-template<typename T, typename /* = enable_if_encodable<T> */ >
+template <typename T, typename /* = enable_if_encodable<T> */>
 inline void CallObserver::encode(const T& obj) {
-    auto group = obj.encode(this, false);
-    GAPID_ASSERT_MSG(group == nullptr, "encode() for non-group returned sub-encoder");
+  auto group = obj.encode(this, false);
+  GAPID_ASSERT_MSG(group == nullptr,
+                   "encode() for non-group returned sub-encoder");
 }
 
 }  // namespace gapii

--- a/gapii/cc/chunk_writer.cpp
+++ b/gapii/cc/chunk_writer.cpp
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-
 #include "chunk_writer.h"
 
 #include "core/cc/stream_writer.h"
@@ -25,65 +24,65 @@ using ::google::protobuf::io::CodedOutputStream;
 
 namespace {
 
-constexpr size_t kBufferSize = 32*1024;
+constexpr size_t kBufferSize = 32 * 1024;
 
 class ChunkWriterImpl : public gapii::ChunkWriter {
-public:
-    ChunkWriterImpl(const std::shared_ptr<core::StreamWriter>& writer, bool paranoid = false);
+ public:
+  ChunkWriterImpl(const std::shared_ptr<core::StreamWriter>& writer,
+                  bool paranoid = false);
 
-    ~ChunkWriterImpl();
+  ~ChunkWriterImpl();
 
-    virtual bool write(std::string& s) override;
-    virtual void flush() override;
+  virtual bool write(std::string& s) override;
+  virtual void flush() override;
 
-private:
+ private:
+  std::string mBuffer;
 
-    std::string mBuffer;
+  std::shared_ptr<core::StreamWriter> mWriter;
 
-    std::shared_ptr<core::StreamWriter> mWriter;
+  bool mStreamGood;
 
-    bool mStreamGood;
-
-    bool mNoBuffer;
+  bool mNoBuffer;
 };
 
-ChunkWriterImpl::ChunkWriterImpl(const std::shared_ptr<core::StreamWriter>& writer, bool no_buffer)
-        : mWriter(writer)
-        , mStreamGood(true)
-        , mNoBuffer(no_buffer){
-}
+ChunkWriterImpl::ChunkWriterImpl(
+    const std::shared_ptr<core::StreamWriter>& writer, bool no_buffer)
+    : mWriter(writer), mStreamGood(true), mNoBuffer(no_buffer) {}
 
 ChunkWriterImpl::~ChunkWriterImpl() {
-    if (mBuffer.size() && mStreamGood) {
-        flush();
-    }
+  if (mBuffer.size() && mStreamGood) {
+    flush();
+  }
 }
 
 bool ChunkWriterImpl::write(std::string& s) {
-    if (mStreamGood) {
-        mBuffer.append(s);
+  if (mStreamGood) {
+    mBuffer.append(s);
 
-        if(mNoBuffer || (mBuffer.size() >= kBufferSize)) {
-            flush();
-        }
+    if (mNoBuffer || (mBuffer.size() >= kBufferSize)) {
+      flush();
     }
+  }
 
-    return mStreamGood;
+  return mStreamGood;
 }
 
 void ChunkWriterImpl::flush() {
-    size_t bufferSize = mBuffer.size();
-    mStreamGood = mWriter->write(mBuffer.data(), mBuffer.size()) == bufferSize;
-    mBuffer.clear();
+  size_t bufferSize = mBuffer.size();
+  mStreamGood = mWriter->write(mBuffer.data(), mBuffer.size()) == bufferSize;
+  mBuffer.clear();
 }
 
-} // anonymous namespace
+}  // anonymous namespace
 
 namespace gapii {
 
-// create returns a shared pointer to a ChunkWriter that writes to stream_writer.
-ChunkWriter::SPtr ChunkWriter::create(const std::shared_ptr<core::StreamWriter>& stream_writer, bool no_buffer) {
-    return ChunkWriter::SPtr(new ChunkWriterImpl(stream_writer, no_buffer));
+// create returns a shared pointer to a ChunkWriter that writes to
+// stream_writer.
+ChunkWriter::SPtr ChunkWriter::create(
+    const std::shared_ptr<core::StreamWriter>& stream_writer, bool no_buffer) {
+  return ChunkWriter::SPtr(new ChunkWriterImpl(stream_writer, no_buffer));
 }
 
-} // namespace gapii
+}  // namespace gapii

--- a/gapii/cc/chunk_writer.h
+++ b/gapii/cc/chunk_writer.h
@@ -23,11 +23,12 @@ namespace gapii {
 
 // ChunkWriter is used to write chunk strings to a core::StreamWriter.
 class ChunkWriter : public core::StringWriter {
-public:
-    static SPtr create(const std::shared_ptr<core::StreamWriter>& stream_writer, bool no_buffer = false);
+ public:
+  static SPtr create(const std::shared_ptr<core::StreamWriter>& stream_writer,
+                     bool no_buffer = false);
 
-protected:
-    ~ChunkWriter() = default;
+ protected:
+  ~ChunkWriter() = default;
 };
 
 }  // namespace gapii

--- a/gapii/cc/connection_header.cpp
+++ b/gapii/cc/connection_header.cpp
@@ -22,55 +22,52 @@
 namespace gapii {
 
 ConnectionHeader::ConnectionHeader()
-    : mVersion(0)
-    , mObserveFrameFrequency(0)
-    , mObserveDrawFrequency(0)
-    , mStartFrame(0)
-    , mNumFrames(0)
-    , mAPIs(0xFFFFFFFF)
-    , mFlags(0)
-    , mGvrHandle(0) {}
+    : mVersion(0),
+      mObserveFrameFrequency(0),
+      mObserveDrawFrequency(0),
+      mStartFrame(0),
+      mNumFrames(0),
+      mAPIs(0xFFFFFFFF),
+      mFlags(0),
+      mGvrHandle(0) {}
 
 bool ConnectionHeader::read(core::StreamReader* reader) {
-    if (!reader->read(mMagic)) {
-        return false;
-    }
-    if (mMagic[0] != 's'
-     || mMagic[1] != 'p'
-     || mMagic[2] != 'y'
-     || mMagic[3] != '0') {
-        GAPID_WARNING("ConnectionHeader magic was not as expected. Got %c%c%c%c",
-            mMagic[0], mMagic[1], mMagic[2], mMagic[3]);
-        return false;
-     }
+  if (!reader->read(mMagic)) {
+    return false;
+  }
+  if (mMagic[0] != 's' || mMagic[1] != 'p' || mMagic[2] != 'y' ||
+      mMagic[3] != '0') {
+    GAPID_WARNING("ConnectionHeader magic was not as expected. Got %c%c%c%c",
+                  mMagic[0], mMagic[1], mMagic[2], mMagic[3]);
+    return false;
+  }
 
-    // TODO: Endian-swap data if GAPII is running on a big-endian architecture.
+  // TODO: Endian-swap data if GAPII is running on a big-endian architecture.
 
-    if (!reader->read(mVersion)) {
-        return false;
-    }
+  if (!reader->read(mVersion)) {
+    return false;
+  }
 
-    const int kMinSupportedVersion = 1;
-    const int kMaxSupportedVersion = 1;
+  const int kMinSupportedVersion = 1;
+  const int kMaxSupportedVersion = 1;
 
-    if (mVersion < kMinSupportedVersion || mVersion > kMaxSupportedVersion) {
-        GAPID_WARNING("Unsupported ConnectionHeader version %d. Only understand [%d to %d].",
-                mVersion, kMinSupportedVersion, kMaxSupportedVersion);
-        return false;
-    }
-    if (!reader->read(mObserveFrameFrequency) ||
-        !reader->read(mObserveDrawFrequency) ||
-        !reader->read(mStartFrame) ||
-        !reader->read(mNumFrames) ||
-        !reader->read(mAPIs) ||
-        !reader->read(mFlags) ||
-        !reader->read(mGvrHandle) ||
-        !reader->read(mLibInterceptorPath)) {
-        return false;
-    }
+  if (mVersion < kMinSupportedVersion || mVersion > kMaxSupportedVersion) {
+    GAPID_WARNING(
+        "Unsupported ConnectionHeader version %d. Only understand [%d to %d].",
+        mVersion, kMinSupportedVersion, kMaxSupportedVersion);
+    return false;
+  }
+  if (!reader->read(mObserveFrameFrequency) ||
+      !reader->read(mObserveDrawFrequency) || !reader->read(mStartFrame) ||
+      !reader->read(mNumFrames) || !reader->read(mAPIs) ||
+      !reader->read(mFlags) || !reader->read(mGvrHandle) ||
+      !reader->read(mLibInterceptorPath)) {
+    return false;
+  }
 
-    // Insert new version handling here. Don't forget to bump kMaxSupportedVersion!
-    return true;
+  // Insert new version handling here. Don't forget to bump
+  // kMaxSupportedVersion!
+  return true;
 }
 
-} // namespace gapii
+}  // namespace gapii

--- a/gapii/cc/connection_header.h
+++ b/gapii/cc/connection_header.h
@@ -33,36 +33,36 @@ namespace gapii {
 // All fields are encoded little-endian with no compression, regardless of
 // architecture.
 class ConnectionHeader {
-public:
-    ConnectionHeader();
+ public:
+  ConnectionHeader();
 
-    static const size_t MAX_PATH = 512;
+  static const size_t MAX_PATH = 512;
 
-    // Fakes no support for PCS, forcing the app to share shader source.
-    static const uint32_t FLAG_DISABLE_PRECOMPILED_SHADERS = 0x00000001;
-    // Driver errors are queried after each call and stored as extras.
-    static const uint32_t FLAG_RECORD_ERROR_STATE          = 0x10000000;
-    // Defers the start frame until a message is receieved over the network.
-    static const uint32_t FLAG_DEFER_START                 = 0x00000010;
-    // Disables buffering of the output stream
-    static const uint32_t FLAG_NO_BUFFER                   = 0x00000020;
+  // Fakes no support for PCS, forcing the app to share shader source.
+  static const uint32_t FLAG_DISABLE_PRECOMPILED_SHADERS = 0x00000001;
+  // Driver errors are queried after each call and stored as extras.
+  static const uint32_t FLAG_RECORD_ERROR_STATE = 0x10000000;
+  // Defers the start frame until a message is receieved over the network.
+  static const uint32_t FLAG_DEFER_START = 0x00000010;
+  // Disables buffering of the output stream
+  static const uint32_t FLAG_NO_BUFFER = 0x00000020;
 
-    // read reads the ConnectionHeader from the provided stream, returning true
-    // on success or false on error.
-    bool read(core::StreamReader* reader);
+  // read reads the ConnectionHeader from the provided stream, returning true
+  // on success or false on error.
+  bool read(core::StreamReader* reader);
 
-    uint8_t  mMagic[4];                     // 's', 'p', 'y', '0'
-    uint32_t mVersion;                      // 1
-    uint32_t mObserveFrameFrequency;        // non-zero == enabled.
-    uint32_t mObserveDrawFrequency;         // non-zero == enabled.
-    uint32_t mStartFrame;                   // non-zero == Frame to start at.
-    uint32_t mNumFrames;                    // non-zero == Number of frames to capture.
-    uint32_t mAPIs;                         // Bitset of APIS to enable.
-    uint32_t mFlags;                        // Combination of FLAG_XX bits.
-    uint64_t mGvrHandle;                    // Handle of GVR library.
-    char     mLibInterceptorPath[MAX_PATH]; // Path of libinterceptor.so.
+  uint8_t mMagic[4];                // 's', 'p', 'y', '0'
+  uint32_t mVersion;                // 1
+  uint32_t mObserveFrameFrequency;  // non-zero == enabled.
+  uint32_t mObserveDrawFrequency;   // non-zero == enabled.
+  uint32_t mStartFrame;             // non-zero == Frame to start at.
+  uint32_t mNumFrames;              // non-zero == Number of frames to capture.
+  uint32_t mAPIs;                   // Bitset of APIS to enable.
+  uint32_t mFlags;                  // Combination of FLAG_XX bits.
+  uint64_t mGvrHandle;              // Handle of GVR library.
+  char mLibInterceptorPath[MAX_PATH];  // Path of libinterceptor.so.
 };
 
-} // namespace gapii
+}  // namespace gapii
 
-#endif // GAPII_CONNECTION_HEADER_H
+#endif  // GAPII_CONNECTION_HEADER_H

--- a/gapii/cc/connection_stream.cpp
+++ b/gapii/cc/connection_stream.cpp
@@ -22,33 +22,31 @@
 namespace gapii {
 
 std::shared_ptr<ConnectionStream> ConnectionStream::listenSocket(
-        const char* hostname, const char* port) {
-    auto c = core::SocketConnection::createSocket(hostname, port);
-    GAPID_INFO("GAPII awaiting connection on socket %s:%s", hostname, port);
-    return std::shared_ptr<ConnectionStream>(new ConnectionStream(c->accept()));
+    const char* hostname, const char* port) {
+  auto c = core::SocketConnection::createSocket(hostname, port);
+  GAPID_INFO("GAPII awaiting connection on socket %s:%s", hostname, port);
+  return std::shared_ptr<ConnectionStream>(new ConnectionStream(c->accept()));
 }
 
 std::shared_ptr<ConnectionStream> ConnectionStream::listenPipe(
-        const char* pipename, bool abstract) {
-    auto c = core::SocketConnection::createPipe(pipename, abstract);
-    GAPID_INFO("GAPII awaiting connection on pipe %s%s",
-        pipename, (abstract ? " (abstract)" : ""));
-    return std::shared_ptr<ConnectionStream>(new ConnectionStream(c->accept()));
+    const char* pipename, bool abstract) {
+  auto c = core::SocketConnection::createPipe(pipename, abstract);
+  GAPID_INFO("GAPII awaiting connection on pipe %s%s", pipename,
+             (abstract ? " (abstract)" : ""));
+  return std::shared_ptr<ConnectionStream>(new ConnectionStream(c->accept()));
 }
 
 ConnectionStream::ConnectionStream(std::unique_ptr<core::Connection> connection)
     : mConnection(std::move(connection)) {}
 
 uint64_t ConnectionStream::read(void* data, uint64_t max_size) {
-    return mConnection->recv(data, max_size);
+  return mConnection->recv(data, max_size);
 }
 
 uint64_t ConnectionStream::write(const void* data, uint64_t size) {
-    return mConnection->send(data, size);
+  return mConnection->send(data, size);
 }
 
-void ConnectionStream::close() {
-    mConnection->close();
-}
+void ConnectionStream::close() { mConnection->close(); }
 
-} // namespace gapii
+}  // namespace gapii

--- a/gapii/cc/connection_stream.h
+++ b/gapii/cc/connection_stream.h
@@ -28,36 +28,39 @@ class Connection;
 
 }  // namespace core
 
-
 namespace gapii {
 
 // ConnectionStream is an implementation of the StreamReader and StreamWriter
 // interfaces that reads and writes to an incoming TCP connection.
 class ConnectionStream : public core::StreamWriter, public core::StreamReader {
-public:
-    // listenSocket blocks and waits for a TCP connection to be made on the specified host and
-    // port, returning a ConnectionStream once a connection is established.
-    static std::shared_ptr<ConnectionStream> listenSocket(const char* hostname, const char* port);
+ public:
+  // listenSocket blocks and waits for a TCP connection to be made on the
+  // specified host and port, returning a ConnectionStream once a connection is
+  // established.
+  static std::shared_ptr<ConnectionStream> listenSocket(const char* hostname,
+                                                        const char* port);
 
-    // listenPipe blocks and waits for a UNIX connection to be made on the specified pipe name,
-    // optionally abstract, returning a ConnectionStream once a connection is established.
-    static std::shared_ptr<ConnectionStream> listenPipe(const char* pipename, bool abstract);
+  // listenPipe blocks and waits for a UNIX connection to be made on the
+  // specified pipe name, optionally abstract, returning a ConnectionStream once
+  // a connection is established.
+  static std::shared_ptr<ConnectionStream> listenPipe(const char* pipename,
+                                                      bool abstract);
 
-    // core::StreamReader compliance
-    virtual uint64_t read(void* data, uint64_t max_size) override;
+  // core::StreamReader compliance
+  virtual uint64_t read(void* data, uint64_t max_size) override;
 
-    // core::StreamWriter compliance
-    virtual uint64_t write(const void* data, uint64_t size) override;
+  // core::StreamWriter compliance
+  virtual uint64_t write(const void* data, uint64_t size) override;
 
-    // Closes the connection stream
-    virtual void close();
+  // Closes the connection stream
+  virtual void close();
 
-private:
-    ConnectionStream(std::unique_ptr<core::Connection>);
+ private:
+  ConnectionStream(std::unique_ptr<core::Connection>);
 
-    std::unique_ptr<core::Connection> mConnection;
+  std::unique_ptr<core::Connection> mConnection;
 };
 
-} // namespace gapii
+}  // namespace gapii
 
 #endif  // GAPII_CONNECTION_STREAM_H

--- a/gapii/cc/gles_context.cpp
+++ b/gapii/cc/gles_context.cpp
@@ -17,291 +17,425 @@
 #include "gapii/cc/gles_spy.h"
 
 #include <iostream>
-#include <string>
 #include <sstream>
+#include <string>
 
-#define GET_SHADER_PRECISION_FORMAT(shader_type, precision_type, format)      \
-    do {                                                                      \
-        mImports.glGetShaderPrecisionFormat(shader_type, precision_type,      \
-            &(format).mMinRange, &(format).mPrecision);                       \
-        if (uint32_t err = mImports.glGetError()) {                           \
-            GAPID_WARNING("glGetShaderPrecisionFormat(" #shader_type ", "     \
-                                                        #precision_type ") "  \
-                          "gave error 0x%x", err);                            \
-        }                                                                     \
-    } while(false)
+#define GET_SHADER_PRECISION_FORMAT(shader_type, precision_type, format) \
+  do {                                                                   \
+    mImports.glGetShaderPrecisionFormat(shader_type, precision_type,     \
+                                        &(format).mMinRange,             \
+                                        &(format).mPrecision);           \
+    if (uint32_t err = mImports.glGetError()) {                          \
+      GAPID_WARNING("glGetShaderPrecisionFormat(" #shader_type           \
+                    ", " #precision_type                                 \
+                    ") "                                                 \
+                    "gave error 0x%x",                                   \
+                    err);                                                \
+    }                                                                    \
+  } while (false)
 
-#define GET(func, name, ...)                                                  \
-    do {                                                                      \
-        mImports.func(name, __VA_ARGS__);                                     \
-        if (uint32_t err = mImports.glGetError()) {                           \
-            GAPID_WARNING(#func "(" #name ") gave error 0x%x", err);          \
-        }                                                                     \
-    } while(false)
+#define GET(func, name, ...)                                   \
+  do {                                                         \
+    mImports.func(name, __VA_ARGS__);                          \
+    if (uint32_t err = mImports.glGetError()) {                \
+      GAPID_WARNING(#func "(" #name ") gave error 0x%x", err); \
+    }                                                          \
+  } while (false)
 
-#define GET_STRING(name, out)                                                 \
-    do {                                                                      \
-        auto str = mImports.glGetString(name);                                \
-        if (uint32_t err = mImports.glGetError()) {                           \
-            GAPID_WARNING("glGetString(" #name ") gave error 0x%x", err);     \
-        } else {                                                              \
-            *out = gapil::String(arena(), reinterpret_cast<const char*>(str));\
-        }                                                                     \
-    } while(false)
+#define GET_STRING(name, out)                                            \
+  do {                                                                   \
+    auto str = mImports.glGetString(name);                               \
+    if (uint32_t err = mImports.glGetError()) {                          \
+      GAPID_WARNING("glGetString(" #name ") gave error 0x%x", err);      \
+    } else {                                                             \
+      *out = gapil::String(arena(), reinterpret_cast<const char*>(str)); \
+    }                                                                    \
+  } while (false)
 
 namespace gapii {
 
 using namespace gapii::GLenum;
 
 void GlesSpy::getContextConstants(Constants& out) {
-    // Get essential constants which we always need regardless of version.
-    GET_STRING(GL_RENDERER, &out.mRenderer);
-    GET_STRING(GL_SHADING_LANGUAGE_VERSION, &out.mShadingLanguageVersion);
-    GET_STRING(GL_VENDOR, &out.mVendor);
-    GET_STRING(GL_VERSION, &out.mVersion);
-    GLint major_version = 0;
-    GLint minor_version = 0;
-    mImports.glGetError();  // Clear error state.
-    mImports.glGetIntegerv(GL_MAJOR_VERSION, &major_version);
-    mImports.glGetIntegerv(GL_MINOR_VERSION, &minor_version);
-    if (mImports.glGetError() != GL_NO_ERROR) {
-      // GL_MAJOR_VERSION/GL_MINOR_VERSION were introduced in GLES 3.0,
-      // so if the commands returned error we assume it is GLES 2.0.
-      major_version = 2;
-      minor_version = 0;
-      out.mMajorVersion = major_version;
-      out.mMinorVersion = minor_version;
-    }
-    if (major_version > 3) {
-        int32_t c;
-        GET(glGetIntegerv, GL_NUM_EXTENSIONS, &c);
-        for (int32_t i = 0; i < c; i++) {
-            auto ext = reinterpret_cast<const char*>(mImports.glGetStringi(GL_EXTENSIONS, i));
-            out.mExtensions[i] = gapil::String(arena(), ext);
-            if (uint32_t err = mImports.glGetError()) {
-                GAPID_WARNING("glGetStringi(GL_EXTENSIONS, %d) gave error 0x%x", i, err);
-            }
-        }
-    } else {
-        std::string extensions = reinterpret_cast<const char*>(mImports.glGetString(GL_EXTENSIONS));
-        if (uint32_t err = mImports.glGetError()) {
-            GAPID_WARNING("glGetString(GL_EXTENSIONS) gave error 0x%x", err);
-        }
-
-        std::istringstream iss(extensions);
-        std::string extension;
-        while (std::getline(iss, extension, ' ')) {
-            out.mExtensions[out.mExtensions.count()] = gapil::String(arena(), extension.c_str());
-        }
-    }
-    bool gles20 = true;
-    bool gles30 = (major_version > 3) || (major_version == 3 && minor_version >= 0);
-    bool gles31 = (major_version > 3) || (major_version == 3 && minor_version >= 1);
-    bool gles32 = (major_version > 3) || (major_version == 3 && minor_version >= 2);
-
-    // Constants defined in version 2.0.25 (November 2, 2010)
-    if (gles20) {
-      GET(glGetFloatv, GL_ALIASED_LINE_WIDTH_RANGE, out.mAliasedLineWidthRange);
-      GET(glGetFloatv, GL_ALIASED_POINT_SIZE_RANGE, out.mAliasedPointSizeRange);
-      GET(glGetIntegerv, GL_MAX_COMBINED_TEXTURE_IMAGE_UNITS, &out.mMaxCombinedTextureImageUnits);
-      GET(glGetIntegerv, GL_MAX_CUBE_MAP_TEXTURE_SIZE, &out.mMaxCubeMapTextureSize);
-      GET(glGetIntegerv, GL_MAX_FRAGMENT_UNIFORM_VECTORS, &out.mMaxFragmentUniformVectors);
-      GET(glGetIntegerv, GL_MAX_RENDERBUFFER_SIZE, &out.mMaxRenderbufferSize);
-      GET(glGetIntegerv, GL_MAX_TEXTURE_IMAGE_UNITS, &out.mMaxTextureImageUnits);
-      GET(glGetIntegerv, GL_MAX_TEXTURE_SIZE, &out.mMaxTextureSize);
-      GET(glGetIntegerv, GL_MAX_VARYING_VECTORS, &out.mMaxVaryingVectors);
-      GET(glGetIntegerv, GL_MAX_VERTEX_ATTRIBS, &out.mMaxVertexAttribs);
-      GET(glGetIntegerv, GL_MAX_VERTEX_TEXTURE_IMAGE_UNITS, &out.mMaxVertexTextureImageUnits);
-      GET(glGetIntegerv, GL_MAX_VERTEX_UNIFORM_VECTORS, &out.mMaxVertexUniformVectors);
-      GET(glGetIntegerv, GL_MAX_VIEWPORT_DIMS, out.mMaxViewportDims);
-      GET(glGetBooleanv, GL_SHADER_COMPILER, &out.mShaderCompiler);
-      GET(glGetIntegerv, GL_SUBPIXEL_BITS, &out.mSubpixelBits);
-      GET_SHADER_PRECISION_FORMAT(GL_VERTEX_SHADER, GL_LOW_FLOAT, out.mVertexShaderPrecisionFormat.mLowFloat);
-      GET_SHADER_PRECISION_FORMAT(GL_FRAGMENT_SHADER, GL_LOW_FLOAT, out.mFragmentShaderPrecisionFormat.mLowFloat);
-      GET_SHADER_PRECISION_FORMAT(GL_VERTEX_SHADER, GL_MEDIUM_FLOAT, out.mVertexShaderPrecisionFormat.mMediumFloat);
-      GET_SHADER_PRECISION_FORMAT(GL_FRAGMENT_SHADER, GL_MEDIUM_FLOAT, out.mFragmentShaderPrecisionFormat.mMediumFloat);
-      GET_SHADER_PRECISION_FORMAT(GL_VERTEX_SHADER, GL_HIGH_FLOAT, out.mVertexShaderPrecisionFormat.mHighFloat);
-      GET_SHADER_PRECISION_FORMAT(GL_FRAGMENT_SHADER, GL_HIGH_FLOAT, out.mFragmentShaderPrecisionFormat.mHighFloat);
-      GET_SHADER_PRECISION_FORMAT(GL_VERTEX_SHADER, GL_LOW_INT, out.mVertexShaderPrecisionFormat.mLowInt);
-      GET_SHADER_PRECISION_FORMAT(GL_FRAGMENT_SHADER, GL_LOW_INT, out.mFragmentShaderPrecisionFormat.mLowInt);
-      GET_SHADER_PRECISION_FORMAT(GL_VERTEX_SHADER, GL_MEDIUM_INT, out.mVertexShaderPrecisionFormat.mMediumInt);
-      GET_SHADER_PRECISION_FORMAT(GL_FRAGMENT_SHADER, GL_MEDIUM_INT, out.mFragmentShaderPrecisionFormat.mMediumInt);
-      GET_SHADER_PRECISION_FORMAT(GL_VERTEX_SHADER, GL_HIGH_INT, out.mVertexShaderPrecisionFormat.mHighInt);
-      GET_SHADER_PRECISION_FORMAT(GL_FRAGMENT_SHADER, GL_HIGH_INT, out.mFragmentShaderPrecisionFormat.mHighInt);
-
-      GLint count = 0;
-      std::vector<GLint> buf;
-      GET(glGetIntegerv, GL_NUM_COMPRESSED_TEXTURE_FORMATS, &count);
-      buf.resize(count);
-      GET(glGetIntegerv, GL_COMPRESSED_TEXTURE_FORMATS, &buf[0]);
-      for (GLint i = 0; i < count; i++) {
-          out.mCompressedTextureFormats[i] = buf[i];
-      }
-
-      count = 0;
-      GET(glGetIntegerv, GL_NUM_SHADER_BINARY_FORMATS, &count);
-      buf.resize(count);
-      GET(glGetIntegerv, GL_SHADER_BINARY_FORMATS, &buf[0]);
-      for (GLint i = 0; i < count; i++) {
-          out.mShaderBinaryFormats[i] = buf[i];
+  // Get essential constants which we always need regardless of version.
+  GET_STRING(GL_RENDERER, &out.mRenderer);
+  GET_STRING(GL_SHADING_LANGUAGE_VERSION, &out.mShadingLanguageVersion);
+  GET_STRING(GL_VENDOR, &out.mVendor);
+  GET_STRING(GL_VERSION, &out.mVersion);
+  GLint major_version = 0;
+  GLint minor_version = 0;
+  mImports.glGetError();  // Clear error state.
+  mImports.glGetIntegerv(GL_MAJOR_VERSION, &major_version);
+  mImports.glGetIntegerv(GL_MINOR_VERSION, &minor_version);
+  if (mImports.glGetError() != GL_NO_ERROR) {
+    // GL_MAJOR_VERSION/GL_MINOR_VERSION were introduced in GLES 3.0,
+    // so if the commands returned error we assume it is GLES 2.0.
+    major_version = 2;
+    minor_version = 0;
+    out.mMajorVersion = major_version;
+    out.mMinorVersion = minor_version;
+  }
+  if (major_version > 3) {
+    int32_t c;
+    GET(glGetIntegerv, GL_NUM_EXTENSIONS, &c);
+    for (int32_t i = 0; i < c; i++) {
+      auto ext = reinterpret_cast<const char*>(
+          mImports.glGetStringi(GL_EXTENSIONS, i));
+      out.mExtensions[i] = gapil::String(arena(), ext);
+      if (uint32_t err = mImports.glGetError()) {
+        GAPID_WARNING("glGetStringi(GL_EXTENSIONS, %d) gave error 0x%x", i,
+                      err);
       }
     }
-
-    // Constants defined in version 3.0.4 (August 27, 2014)
-    if (gles30) {
-      GET(glGetIntegerv, GL_MAJOR_VERSION, &out.mMajorVersion);
-      GET(glGetIntegerv, GL_MAX_3D_TEXTURE_SIZE, &out.mMax3dTextureSize);
-      GET(glGetIntegerv, GL_MAX_ARRAY_TEXTURE_LAYERS, &out.mMaxArrayTextureLayers);
-      GET(glGetIntegerv, GL_MAX_COLOR_ATTACHMENTS, &out.mMaxColorAttachments);
-      GET(glGetInteger64v, GL_MAX_COMBINED_FRAGMENT_UNIFORM_COMPONENTS, &out.mMaxCombinedFragmentUniformComponents);
-      GET(glGetIntegerv, GL_MAX_COMBINED_UNIFORM_BLOCKS, &out.mMaxCombinedUniformBlocks);
-      GET(glGetInteger64v, GL_MAX_COMBINED_VERTEX_UNIFORM_COMPONENTS, &out.mMaxCombinedVertexUniformComponents);
-      GET(glGetIntegerv, GL_MAX_DRAW_BUFFERS, &out.mMaxDrawBuffers);
-      GET(glGetIntegerv, GL_MAX_ELEMENTS_INDICES, &out.mMaxElementsIndices);
-      GET(glGetIntegerv, GL_MAX_ELEMENTS_VERTICES, &out.mMaxElementsVertices);
-      GET(glGetInteger64v, GL_MAX_ELEMENT_INDEX, &out.mMaxElementIndex);
-      GET(glGetIntegerv, GL_MAX_FRAGMENT_INPUT_COMPONENTS, &out.mMaxFragmentInputComponents);
-      GET(glGetIntegerv, GL_MAX_FRAGMENT_UNIFORM_BLOCKS, &out.mMaxFragmentUniformBlocks);
-      GET(glGetIntegerv, GL_MAX_FRAGMENT_UNIFORM_COMPONENTS, &out.mMaxFragmentUniformComponents);
-      GET(glGetIntegerv, GL_MAX_PROGRAM_TEXEL_OFFSET, &out.mMaxProgramTexelOffset);
-      GET(glGetInteger64v, GL_MAX_SERVER_WAIT_TIMEOUT, &out.mMaxServerWaitTimeout);
-      GET(glGetFloatv, GL_MAX_TEXTURE_LOD_BIAS, &out.mMaxTextureLodBias);
-      GET(glGetIntegerv, GL_MAX_TRANSFORM_FEEDBACK_INTERLEAVED_COMPONENTS, &out.mMaxTransformFeedbackInterleavedComponents);
-      GET(glGetIntegerv, GL_MAX_TRANSFORM_FEEDBACK_SEPARATE_ATTRIBS, &out.mMaxTransformFeedbackSeparateAttribs);
-      GET(glGetIntegerv, GL_MAX_TRANSFORM_FEEDBACK_SEPARATE_COMPONENTS, &out.mMaxTransformFeedbackSeparateComponents);
-      GET(glGetInteger64v, GL_MAX_UNIFORM_BLOCK_SIZE, &out.mMaxUniformBlockSize);
-      GET(glGetIntegerv, GL_MAX_UNIFORM_BUFFER_BINDINGS, &out.mMaxUniformBufferBindings);
-      GET(glGetIntegerv, GL_MAX_VARYING_COMPONENTS, &out.mMaxVaryingComponents);
-      GET(glGetIntegerv, GL_MAX_VERTEX_OUTPUT_COMPONENTS, &out.mMaxVertexOutputComponents);
-      GET(glGetIntegerv, GL_MAX_VERTEX_UNIFORM_BLOCKS, &out.mMaxVertexUniformBlocks);
-      GET(glGetIntegerv, GL_MAX_VERTEX_UNIFORM_COMPONENTS, &out.mMaxVertexUniformComponents);
-      GET(glGetIntegerv, GL_MINOR_VERSION, &out.mMinorVersion);
-      GET(glGetIntegerv, GL_MIN_PROGRAM_TEXEL_OFFSET, &out.mMinProgramTexelOffset);
-      GET(glGetIntegerv, GL_UNIFORM_BUFFER_OFFSET_ALIGNMENT, &out.mUniformBufferOffsetAlignment);
-
-      GLint count = 0;
-      std::vector<GLint> buf;
-      GET(glGetIntegerv, GL_NUM_PROGRAM_BINARY_FORMATS, &count);
-      buf.resize(count);
-      GET(glGetIntegerv, GL_PROGRAM_BINARY_FORMATS, &buf[0]);
-      for (GLint i = 0; i < count; i++) {
-          out.mProgramBinaryFormats[i] = buf[i];
-      }
+  } else {
+    std::string extensions =
+        reinterpret_cast<const char*>(mImports.glGetString(GL_EXTENSIONS));
+    if (uint32_t err = mImports.glGetError()) {
+      GAPID_WARNING("glGetString(GL_EXTENSIONS) gave error 0x%x", err);
     }
 
-    // Constants defined in version 3.1 (April 29, 2015)
-    if (gles31) {
-      GET(glGetIntegerv, GL_MAX_ATOMIC_COUNTER_BUFFER_BINDINGS, &out.mMaxAtomicCounterBufferBindings);
-      GET(glGetIntegerv, GL_MAX_ATOMIC_COUNTER_BUFFER_SIZE, &out.mMaxAtomicCounterBufferSize);
-      GET(glGetIntegerv, GL_MAX_COLOR_TEXTURE_SAMPLES, &out.mMaxColorTextureSamples);
-      GET(glGetIntegerv, GL_MAX_COMBINED_ATOMIC_COUNTERS, &out.mMaxCombinedAtomicCounters);
-      GET(glGetIntegerv, GL_MAX_COMBINED_ATOMIC_COUNTER_BUFFERS, &out.mMaxCombinedAtomicCounterBuffers);
-      GET(glGetIntegerv, GL_MAX_COMBINED_COMPUTE_UNIFORM_COMPONENTS, &out.mMaxCombinedComputeUniformComponents);
-      GET(glGetIntegerv, GL_MAX_COMBINED_IMAGE_UNIFORMS, &out.mMaxCombinedImageUniforms);
-      GET(glGetIntegerv, GL_MAX_COMBINED_SHADER_OUTPUT_RESOURCES, &out.mMaxCombinedShaderOutputResources);
-      GET(glGetIntegerv, GL_MAX_COMBINED_SHADER_STORAGE_BLOCKS, &out.mMaxCombinedShaderStorageBlocks);
-      GET(glGetIntegerv, GL_MAX_COMPUTE_ATOMIC_COUNTERS, &out.mMaxComputeAtomicCounters);
-      GET(glGetIntegerv, GL_MAX_COMPUTE_ATOMIC_COUNTER_BUFFERS, &out.mMaxComputeAtomicCounterBuffers);
-      GET(glGetIntegerv, GL_MAX_COMPUTE_IMAGE_UNIFORMS, &out.mMaxComputeImageUniforms);
-      GET(glGetIntegerv, GL_MAX_COMPUTE_SHADER_STORAGE_BLOCKS, &out.mMaxComputeShaderStorageBlocks);
-      GET(glGetIntegerv, GL_MAX_COMPUTE_SHARED_MEMORY_SIZE, &out.mMaxComputeSharedMemorySize);
-      GET(glGetIntegerv, GL_MAX_COMPUTE_TEXTURE_IMAGE_UNITS, &out.mMaxComputeTextureImageUnits);
-      GET(glGetIntegerv, GL_MAX_COMPUTE_UNIFORM_BLOCKS, &out.mMaxComputeUniformBlocks);
-      GET(glGetIntegerv, GL_MAX_COMPUTE_UNIFORM_COMPONENTS, &out.mMaxComputeUniformComponents);
-      GET(glGetIntegeri_v, GL_MAX_COMPUTE_WORK_GROUP_COUNT, 0, &out.mMaxComputeWorkGroupCount[0]);
-      GET(glGetIntegeri_v, GL_MAX_COMPUTE_WORK_GROUP_COUNT, 1, &out.mMaxComputeWorkGroupCount[1]);
-      GET(glGetIntegeri_v, GL_MAX_COMPUTE_WORK_GROUP_COUNT, 2, &out.mMaxComputeWorkGroupCount[2]);
-      GET(glGetIntegerv, GL_MAX_COMPUTE_WORK_GROUP_INVOCATIONS, &out.mMaxComputeWorkGroupInvocations);
-      GET(glGetIntegeri_v, GL_MAX_COMPUTE_WORK_GROUP_SIZE, 0, &out.mMaxComputeWorkGroupSize[0]);
-      GET(glGetIntegeri_v, GL_MAX_COMPUTE_WORK_GROUP_SIZE, 1, &out.mMaxComputeWorkGroupSize[1]);
-      GET(glGetIntegeri_v, GL_MAX_COMPUTE_WORK_GROUP_SIZE, 2, &out.mMaxComputeWorkGroupSize[2]);
-      GET(glGetIntegerv, GL_MAX_DEPTH_TEXTURE_SAMPLES, &out.mMaxDepthTextureSamples);
-      GET(glGetIntegerv, GL_MAX_FRAGMENT_ATOMIC_COUNTERS, &out.mMaxFragmentAtomicCounters);
-      GET(glGetIntegerv, GL_MAX_FRAGMENT_ATOMIC_COUNTER_BUFFERS, &out.mMaxFragmentAtomicCounterBuffers);
-      GET(glGetIntegerv, GL_MAX_FRAGMENT_IMAGE_UNIFORMS, &out.mMaxFragmentImageUniforms);
-      GET(glGetIntegerv, GL_MAX_FRAGMENT_SHADER_STORAGE_BLOCKS, &out.mMaxFragmentShaderStorageBlocks);
-      GET(glGetIntegerv, GL_MAX_FRAMEBUFFER_HEIGHT, &out.mMaxFramebufferHeight);
-      GET(glGetIntegerv, GL_MAX_FRAMEBUFFER_SAMPLES, &out.mMaxFramebufferSamples);
-      GET(glGetIntegerv, GL_MAX_FRAMEBUFFER_WIDTH, &out.mMaxFramebufferWidth);
-      GET(glGetIntegerv, GL_MAX_IMAGE_UNITS, &out.mMaxImageUnits);
-      GET(glGetIntegerv, GL_MAX_INTEGER_SAMPLES, &out.mMaxIntegerSamples);
-      GET(glGetIntegerv, GL_MAX_PROGRAM_TEXTURE_GATHER_OFFSET, &out.mMaxProgramTextureGatherOffset);
-      GET(glGetIntegerv, GL_MAX_SAMPLE_MASK_WORDS, &out.mMaxSampleMaskWords);
-      GET(glGetInteger64v, GL_MAX_SHADER_STORAGE_BLOCK_SIZE, &out.mMaxShaderStorageBlockSize);
-      GET(glGetIntegerv, GL_MAX_SHADER_STORAGE_BUFFER_BINDINGS, &out.mMaxShaderStorageBufferBindings);
-      GET(glGetIntegerv, GL_MAX_UNIFORM_LOCATIONS, &out.mMaxUniformLocations);
-      GET(glGetIntegerv, GL_MAX_VERTEX_ATOMIC_COUNTERS, &out.mMaxVertexAtomicCounters);
-      GET(glGetIntegerv, GL_MAX_VERTEX_ATOMIC_COUNTER_BUFFERS, &out.mMaxVertexAtomicCounterBuffers);
-      GET(glGetIntegerv, GL_MAX_VERTEX_ATTRIB_BINDINGS, &out.mMaxVertexAttribBindings);
-      GET(glGetIntegerv, GL_MAX_VERTEX_ATTRIB_RELATIVE_OFFSET, &out.mMaxVertexAttribRelativeOffset);
-      GET(glGetIntegerv, GL_MAX_VERTEX_ATTRIB_STRIDE, &out.mMaxVertexAttribStride);
-      GET(glGetIntegerv, GL_MAX_VERTEX_IMAGE_UNIFORMS, &out.mMaxVertexImageUniforms);
-      GET(glGetIntegerv, GL_MAX_VERTEX_SHADER_STORAGE_BLOCKS, &out.mMaxVertexShaderStorageBlocks);
-      GET(glGetIntegerv, GL_MIN_PROGRAM_TEXTURE_GATHER_OFFSET, &out.mMinProgramTextureGatherOffset);
-      GET(glGetIntegerv, GL_SHADER_STORAGE_BUFFER_OFFSET_ALIGNMENT, &out.mShaderStorageBufferOffsetAlignment);
+    std::istringstream iss(extensions);
+    std::string extension;
+    while (std::getline(iss, extension, ' ')) {
+      out.mExtensions[out.mExtensions.count()] =
+          gapil::String(arena(), extension.c_str());
+    }
+  }
+  bool gles20 = true;
+  bool gles30 =
+      (major_version > 3) || (major_version == 3 && minor_version >= 0);
+  bool gles31 =
+      (major_version > 3) || (major_version == 3 && minor_version >= 1);
+  bool gles32 =
+      (major_version > 3) || (major_version == 3 && minor_version >= 2);
+
+  // Constants defined in version 2.0.25 (November 2, 2010)
+  if (gles20) {
+    GET(glGetFloatv, GL_ALIASED_LINE_WIDTH_RANGE, out.mAliasedLineWidthRange);
+    GET(glGetFloatv, GL_ALIASED_POINT_SIZE_RANGE, out.mAliasedPointSizeRange);
+    GET(glGetIntegerv, GL_MAX_COMBINED_TEXTURE_IMAGE_UNITS,
+        &out.mMaxCombinedTextureImageUnits);
+    GET(glGetIntegerv, GL_MAX_CUBE_MAP_TEXTURE_SIZE,
+        &out.mMaxCubeMapTextureSize);
+    GET(glGetIntegerv, GL_MAX_FRAGMENT_UNIFORM_VECTORS,
+        &out.mMaxFragmentUniformVectors);
+    GET(glGetIntegerv, GL_MAX_RENDERBUFFER_SIZE, &out.mMaxRenderbufferSize);
+    GET(glGetIntegerv, GL_MAX_TEXTURE_IMAGE_UNITS, &out.mMaxTextureImageUnits);
+    GET(glGetIntegerv, GL_MAX_TEXTURE_SIZE, &out.mMaxTextureSize);
+    GET(glGetIntegerv, GL_MAX_VARYING_VECTORS, &out.mMaxVaryingVectors);
+    GET(glGetIntegerv, GL_MAX_VERTEX_ATTRIBS, &out.mMaxVertexAttribs);
+    GET(glGetIntegerv, GL_MAX_VERTEX_TEXTURE_IMAGE_UNITS,
+        &out.mMaxVertexTextureImageUnits);
+    GET(glGetIntegerv, GL_MAX_VERTEX_UNIFORM_VECTORS,
+        &out.mMaxVertexUniformVectors);
+    GET(glGetIntegerv, GL_MAX_VIEWPORT_DIMS, out.mMaxViewportDims);
+    GET(glGetBooleanv, GL_SHADER_COMPILER, &out.mShaderCompiler);
+    GET(glGetIntegerv, GL_SUBPIXEL_BITS, &out.mSubpixelBits);
+    GET_SHADER_PRECISION_FORMAT(GL_VERTEX_SHADER, GL_LOW_FLOAT,
+                                out.mVertexShaderPrecisionFormat.mLowFloat);
+    GET_SHADER_PRECISION_FORMAT(GL_FRAGMENT_SHADER, GL_LOW_FLOAT,
+                                out.mFragmentShaderPrecisionFormat.mLowFloat);
+    GET_SHADER_PRECISION_FORMAT(GL_VERTEX_SHADER, GL_MEDIUM_FLOAT,
+                                out.mVertexShaderPrecisionFormat.mMediumFloat);
+    GET_SHADER_PRECISION_FORMAT(
+        GL_FRAGMENT_SHADER, GL_MEDIUM_FLOAT,
+        out.mFragmentShaderPrecisionFormat.mMediumFloat);
+    GET_SHADER_PRECISION_FORMAT(GL_VERTEX_SHADER, GL_HIGH_FLOAT,
+                                out.mVertexShaderPrecisionFormat.mHighFloat);
+    GET_SHADER_PRECISION_FORMAT(GL_FRAGMENT_SHADER, GL_HIGH_FLOAT,
+                                out.mFragmentShaderPrecisionFormat.mHighFloat);
+    GET_SHADER_PRECISION_FORMAT(GL_VERTEX_SHADER, GL_LOW_INT,
+                                out.mVertexShaderPrecisionFormat.mLowInt);
+    GET_SHADER_PRECISION_FORMAT(GL_FRAGMENT_SHADER, GL_LOW_INT,
+                                out.mFragmentShaderPrecisionFormat.mLowInt);
+    GET_SHADER_PRECISION_FORMAT(GL_VERTEX_SHADER, GL_MEDIUM_INT,
+                                out.mVertexShaderPrecisionFormat.mMediumInt);
+    GET_SHADER_PRECISION_FORMAT(GL_FRAGMENT_SHADER, GL_MEDIUM_INT,
+                                out.mFragmentShaderPrecisionFormat.mMediumInt);
+    GET_SHADER_PRECISION_FORMAT(GL_VERTEX_SHADER, GL_HIGH_INT,
+                                out.mVertexShaderPrecisionFormat.mHighInt);
+    GET_SHADER_PRECISION_FORMAT(GL_FRAGMENT_SHADER, GL_HIGH_INT,
+                                out.mFragmentShaderPrecisionFormat.mHighInt);
+
+    GLint count = 0;
+    std::vector<GLint> buf;
+    GET(glGetIntegerv, GL_NUM_COMPRESSED_TEXTURE_FORMATS, &count);
+    buf.resize(count);
+    GET(glGetIntegerv, GL_COMPRESSED_TEXTURE_FORMATS, &buf[0]);
+    for (GLint i = 0; i < count; i++) {
+      out.mCompressedTextureFormats[i] = buf[i];
     }
 
-    // Constants defined in version 3.2 (June 15, 2016)
-    if (gles32) {
-      GET(glGetIntegerv, GL_CONTEXT_FLAGS, &out.mContextFlags);
-      GET(glGetIntegerv, GL_FRAGMENT_INTERPOLATION_OFFSET_BITS, &out.mFragmentInterpolationOffsetBits);
-      GET(glGetIntegerv, GL_LAYER_PROVOKING_VERTEX, reinterpret_cast<GLint*>(&out.mLayerProvokingVertex));
-      GET(glGetIntegerv, GL_MAX_COMBINED_GEOMETRY_UNIFORM_COMPONENTS, &out.mMaxCombinedGeometryUniformComponents);
-      GET(glGetIntegerv, GL_MAX_COMBINED_TESS_CONTROL_UNIFORM_COMPONENTS, &out.mMaxCombinedTessControlUniformComponents);
-      GET(glGetIntegerv, GL_MAX_COMBINED_TESS_EVALUATION_UNIFORM_COMPONENTS, &out.mMaxCombinedTessEvaluationUniformComponents);
-      GET(glGetIntegerv, GL_MAX_DEBUG_GROUP_STACK_DEPTH, &out.mMaxDebugGroupStackDepth);
-      GET(glGetIntegerv, GL_MAX_DEBUG_LOGGED_MESSAGES, &out.mMaxDebugLoggedMessages);
-      GET(glGetIntegerv, GL_MAX_DEBUG_MESSAGE_LENGTH, &out.mMaxDebugMessageLength);
-      GET(glGetFloatv, GL_MAX_FRAGMENT_INTERPOLATION_OFFSET, &out.mMaxFragmentInterpolationOffset);
-      GET(glGetIntegerv, GL_MAX_FRAMEBUFFER_LAYERS, &out.mMaxFramebufferLayers);
-      GET(glGetIntegerv, GL_MAX_GEOMETRY_ATOMIC_COUNTERS, &out.mMaxGeometryAtomicCounters);
-      GET(glGetIntegerv, GL_MAX_GEOMETRY_ATOMIC_COUNTER_BUFFERS, &out.mMaxGeometryAtomicCounterBuffers);
-      GET(glGetIntegerv, GL_MAX_GEOMETRY_IMAGE_UNIFORMS, &out.mMaxGeometryImageUniforms);
-      GET(glGetIntegerv, GL_MAX_GEOMETRY_INPUT_COMPONENTS, &out.mMaxGeometryInputComponents);
-      GET(glGetIntegerv, GL_MAX_GEOMETRY_OUTPUT_COMPONENTS, &out.mMaxGeometryOutputComponents);
-      GET(glGetIntegerv, GL_MAX_GEOMETRY_OUTPUT_VERTICES, &out.mMaxGeometryOutputVertices);
-      GET(glGetIntegerv, GL_MAX_GEOMETRY_SHADER_INVOCATIONS, &out.mMaxGeometryShaderInvocations);
-      GET(glGetIntegerv, GL_MAX_GEOMETRY_SHADER_STORAGE_BLOCKS, &out.mMaxGeometryShaderStorageBlocks);
-      GET(glGetIntegerv, GL_MAX_GEOMETRY_TEXTURE_IMAGE_UNITS, &out.mMaxGeometryTextureImageUnits);
-      GET(glGetIntegerv, GL_MAX_GEOMETRY_TOTAL_OUTPUT_COMPONENTS, &out.mMaxGeometryTotalOutputComponents);
-      GET(glGetIntegerv, GL_MAX_GEOMETRY_UNIFORM_BLOCKS, &out.mMaxGeometryUniformBlocks);
-      GET(glGetIntegerv, GL_MAX_GEOMETRY_UNIFORM_COMPONENTS, &out.mMaxGeometryUniformComponents);
-      GET(glGetIntegerv, GL_MAX_LABEL_LENGTH, &out.mMaxLabelLength);
-      GET(glGetIntegerv, GL_MAX_PATCH_VERTICES, &out.mMaxPatchVertices);
-      GET(glGetIntegerv, GL_MAX_TESS_CONTROL_ATOMIC_COUNTERS, &out.mMaxTessControlAtomicCounters);
-      GET(glGetIntegerv, GL_MAX_TESS_CONTROL_ATOMIC_COUNTER_BUFFERS, &out.mMaxTessControlAtomicCounterBuffers);
-      GET(glGetIntegerv, GL_MAX_TESS_CONTROL_IMAGE_UNIFORMS, &out.mMaxTessControlImageUniforms);
-      GET(glGetIntegerv, GL_MAX_TESS_CONTROL_INPUT_COMPONENTS, &out.mMaxTessControlInputComponents);
-      GET(glGetIntegerv, GL_MAX_TESS_CONTROL_OUTPUT_COMPONENTS, &out.mMaxTessControlOutputComponents);
-      GET(glGetIntegerv, GL_MAX_TESS_CONTROL_SHADER_STORAGE_BLOCKS, &out.mMaxTessControlShaderStorageBlocks);
-      GET(glGetIntegerv, GL_MAX_TESS_CONTROL_TEXTURE_IMAGE_UNITS, &out.mMaxTessControlTextureImageUnits);
-      GET(glGetIntegerv, GL_MAX_TESS_CONTROL_TOTAL_OUTPUT_COMPONENTS, &out.mMaxTessControlTotalOutputComponents);
-      GET(glGetIntegerv, GL_MAX_TESS_CONTROL_UNIFORM_BLOCKS, &out.mMaxTessControlUniformBlocks);
-      GET(glGetIntegerv, GL_MAX_TESS_CONTROL_UNIFORM_COMPONENTS, &out.mMaxTessControlUniformComponents);
-      GET(glGetIntegerv, GL_MAX_TESS_EVALUATION_ATOMIC_COUNTERS, &out.mMaxTessEvaluationAtomicCounters);
-      GET(glGetIntegerv, GL_MAX_TESS_EVALUATION_ATOMIC_COUNTER_BUFFERS, &out.mMaxTessEvaluationAtomicCounterBuffers);
-      GET(glGetIntegerv, GL_MAX_TESS_EVALUATION_IMAGE_UNIFORMS, &out.mMaxTessEvaluationImageUniforms);
-      GET(glGetIntegerv, GL_MAX_TESS_EVALUATION_INPUT_COMPONENTS, &out.mMaxTessEvaluationInputComponents);
-      GET(glGetIntegerv, GL_MAX_TESS_EVALUATION_OUTPUT_COMPONENTS, &out.mMaxTessEvaluationOutputComponents);
-      GET(glGetIntegerv, GL_MAX_TESS_EVALUATION_SHADER_STORAGE_BLOCKS, &out.mMaxTessEvaluationShaderStorageBlocks);
-      GET(glGetIntegerv, GL_MAX_TESS_EVALUATION_TEXTURE_IMAGE_UNITS, &out.mMaxTessEvaluationTextureImageUnits);
-      GET(glGetIntegerv, GL_MAX_TESS_EVALUATION_UNIFORM_BLOCKS, &out.mMaxTessEvaluationUniformBlocks);
-      GET(glGetIntegerv, GL_MAX_TESS_EVALUATION_UNIFORM_COMPONENTS, &out.mMaxTessEvaluationUniformComponents);
-      GET(glGetIntegerv, GL_MAX_TESS_GEN_LEVEL, &out.mMaxTessGenLevel);
-      GET(glGetIntegerv, GL_MAX_TESS_PATCH_COMPONENTS, &out.mMaxTessPatchComponents);
-      GET(glGetIntegerv, GL_MAX_TEXTURE_BUFFER_SIZE, &out.mMaxTextureBufferSize);
-      GET(glGetFloatv, GL_MIN_FRAGMENT_INTERPOLATION_OFFSET, &out.mMinFragmentInterpolationOffset);
-      GET(glGetFloatv, GL_MULTISAMPLE_LINE_WIDTH_GRANULARITY, &out.mMultisampleLineWidthGranularity);
-      GET(glGetFloatv, GL_MULTISAMPLE_LINE_WIDTH_RANGE, out.mMultisampleLineWidthRange);
-      GET(glGetBooleanv, GL_PRIMITIVE_RESTART_FOR_PATCHES_SUPPORTED, &out.mPrimitiveRestartForPatchesSupported);
-      GET(glGetIntegerv, GL_TEXTURE_BUFFER_OFFSET_ALIGNMENT, &out.mTextureBufferOffsetAlignment);
-      GET(glGetIntegerv, GL_RESET_NOTIFICATION_STRATEGY, &out.mResetNotificationStrategy);
+    count = 0;
+    GET(glGetIntegerv, GL_NUM_SHADER_BINARY_FORMATS, &count);
+    buf.resize(count);
+    GET(glGetIntegerv, GL_SHADER_BINARY_FORMATS, &buf[0]);
+    for (GLint i = 0; i < count; i++) {
+      out.mShaderBinaryFormats[i] = buf[i];
     }
+  }
 
-    // Constants defined in extensions
-    GET(glGetFloatv, GL_MAX_TEXTURE_MAX_ANISOTROPY_EXT, &out.mMaxTextureMaxAnisotropyExt);
-    GET(glGetIntegerv, GL_MAX_VIEWS_OVR, &out.mMaxViewsExt);
+  // Constants defined in version 3.0.4 (August 27, 2014)
+  if (gles30) {
+    GET(glGetIntegerv, GL_MAJOR_VERSION, &out.mMajorVersion);
+    GET(glGetIntegerv, GL_MAX_3D_TEXTURE_SIZE, &out.mMax3dTextureSize);
+    GET(glGetIntegerv, GL_MAX_ARRAY_TEXTURE_LAYERS,
+        &out.mMaxArrayTextureLayers);
+    GET(glGetIntegerv, GL_MAX_COLOR_ATTACHMENTS, &out.mMaxColorAttachments);
+    GET(glGetInteger64v, GL_MAX_COMBINED_FRAGMENT_UNIFORM_COMPONENTS,
+        &out.mMaxCombinedFragmentUniformComponents);
+    GET(glGetIntegerv, GL_MAX_COMBINED_UNIFORM_BLOCKS,
+        &out.mMaxCombinedUniformBlocks);
+    GET(glGetInteger64v, GL_MAX_COMBINED_VERTEX_UNIFORM_COMPONENTS,
+        &out.mMaxCombinedVertexUniformComponents);
+    GET(glGetIntegerv, GL_MAX_DRAW_BUFFERS, &out.mMaxDrawBuffers);
+    GET(glGetIntegerv, GL_MAX_ELEMENTS_INDICES, &out.mMaxElementsIndices);
+    GET(glGetIntegerv, GL_MAX_ELEMENTS_VERTICES, &out.mMaxElementsVertices);
+    GET(glGetInteger64v, GL_MAX_ELEMENT_INDEX, &out.mMaxElementIndex);
+    GET(glGetIntegerv, GL_MAX_FRAGMENT_INPUT_COMPONENTS,
+        &out.mMaxFragmentInputComponents);
+    GET(glGetIntegerv, GL_MAX_FRAGMENT_UNIFORM_BLOCKS,
+        &out.mMaxFragmentUniformBlocks);
+    GET(glGetIntegerv, GL_MAX_FRAGMENT_UNIFORM_COMPONENTS,
+        &out.mMaxFragmentUniformComponents);
+    GET(glGetIntegerv, GL_MAX_PROGRAM_TEXEL_OFFSET,
+        &out.mMaxProgramTexelOffset);
+    GET(glGetInteger64v, GL_MAX_SERVER_WAIT_TIMEOUT,
+        &out.mMaxServerWaitTimeout);
+    GET(glGetFloatv, GL_MAX_TEXTURE_LOD_BIAS, &out.mMaxTextureLodBias);
+    GET(glGetIntegerv, GL_MAX_TRANSFORM_FEEDBACK_INTERLEAVED_COMPONENTS,
+        &out.mMaxTransformFeedbackInterleavedComponents);
+    GET(glGetIntegerv, GL_MAX_TRANSFORM_FEEDBACK_SEPARATE_ATTRIBS,
+        &out.mMaxTransformFeedbackSeparateAttribs);
+    GET(glGetIntegerv, GL_MAX_TRANSFORM_FEEDBACK_SEPARATE_COMPONENTS,
+        &out.mMaxTransformFeedbackSeparateComponents);
+    GET(glGetInteger64v, GL_MAX_UNIFORM_BLOCK_SIZE, &out.mMaxUniformBlockSize);
+    GET(glGetIntegerv, GL_MAX_UNIFORM_BUFFER_BINDINGS,
+        &out.mMaxUniformBufferBindings);
+    GET(glGetIntegerv, GL_MAX_VARYING_COMPONENTS, &out.mMaxVaryingComponents);
+    GET(glGetIntegerv, GL_MAX_VERTEX_OUTPUT_COMPONENTS,
+        &out.mMaxVertexOutputComponents);
+    GET(glGetIntegerv, GL_MAX_VERTEX_UNIFORM_BLOCKS,
+        &out.mMaxVertexUniformBlocks);
+    GET(glGetIntegerv, GL_MAX_VERTEX_UNIFORM_COMPONENTS,
+        &out.mMaxVertexUniformComponents);
+    GET(glGetIntegerv, GL_MINOR_VERSION, &out.mMinorVersion);
+    GET(glGetIntegerv, GL_MIN_PROGRAM_TEXEL_OFFSET,
+        &out.mMinProgramTexelOffset);
+    GET(glGetIntegerv, GL_UNIFORM_BUFFER_OFFSET_ALIGNMENT,
+        &out.mUniformBufferOffsetAlignment);
+
+    GLint count = 0;
+    std::vector<GLint> buf;
+    GET(glGetIntegerv, GL_NUM_PROGRAM_BINARY_FORMATS, &count);
+    buf.resize(count);
+    GET(glGetIntegerv, GL_PROGRAM_BINARY_FORMATS, &buf[0]);
+    for (GLint i = 0; i < count; i++) {
+      out.mProgramBinaryFormats[i] = buf[i];
+    }
+  }
+
+  // Constants defined in version 3.1 (April 29, 2015)
+  if (gles31) {
+    GET(glGetIntegerv, GL_MAX_ATOMIC_COUNTER_BUFFER_BINDINGS,
+        &out.mMaxAtomicCounterBufferBindings);
+    GET(glGetIntegerv, GL_MAX_ATOMIC_COUNTER_BUFFER_SIZE,
+        &out.mMaxAtomicCounterBufferSize);
+    GET(glGetIntegerv, GL_MAX_COLOR_TEXTURE_SAMPLES,
+        &out.mMaxColorTextureSamples);
+    GET(glGetIntegerv, GL_MAX_COMBINED_ATOMIC_COUNTERS,
+        &out.mMaxCombinedAtomicCounters);
+    GET(glGetIntegerv, GL_MAX_COMBINED_ATOMIC_COUNTER_BUFFERS,
+        &out.mMaxCombinedAtomicCounterBuffers);
+    GET(glGetIntegerv, GL_MAX_COMBINED_COMPUTE_UNIFORM_COMPONENTS,
+        &out.mMaxCombinedComputeUniformComponents);
+    GET(glGetIntegerv, GL_MAX_COMBINED_IMAGE_UNIFORMS,
+        &out.mMaxCombinedImageUniforms);
+    GET(glGetIntegerv, GL_MAX_COMBINED_SHADER_OUTPUT_RESOURCES,
+        &out.mMaxCombinedShaderOutputResources);
+    GET(glGetIntegerv, GL_MAX_COMBINED_SHADER_STORAGE_BLOCKS,
+        &out.mMaxCombinedShaderStorageBlocks);
+    GET(glGetIntegerv, GL_MAX_COMPUTE_ATOMIC_COUNTERS,
+        &out.mMaxComputeAtomicCounters);
+    GET(glGetIntegerv, GL_MAX_COMPUTE_ATOMIC_COUNTER_BUFFERS,
+        &out.mMaxComputeAtomicCounterBuffers);
+    GET(glGetIntegerv, GL_MAX_COMPUTE_IMAGE_UNIFORMS,
+        &out.mMaxComputeImageUniforms);
+    GET(glGetIntegerv, GL_MAX_COMPUTE_SHADER_STORAGE_BLOCKS,
+        &out.mMaxComputeShaderStorageBlocks);
+    GET(glGetIntegerv, GL_MAX_COMPUTE_SHARED_MEMORY_SIZE,
+        &out.mMaxComputeSharedMemorySize);
+    GET(glGetIntegerv, GL_MAX_COMPUTE_TEXTURE_IMAGE_UNITS,
+        &out.mMaxComputeTextureImageUnits);
+    GET(glGetIntegerv, GL_MAX_COMPUTE_UNIFORM_BLOCKS,
+        &out.mMaxComputeUniformBlocks);
+    GET(glGetIntegerv, GL_MAX_COMPUTE_UNIFORM_COMPONENTS,
+        &out.mMaxComputeUniformComponents);
+    GET(glGetIntegeri_v, GL_MAX_COMPUTE_WORK_GROUP_COUNT, 0,
+        &out.mMaxComputeWorkGroupCount[0]);
+    GET(glGetIntegeri_v, GL_MAX_COMPUTE_WORK_GROUP_COUNT, 1,
+        &out.mMaxComputeWorkGroupCount[1]);
+    GET(glGetIntegeri_v, GL_MAX_COMPUTE_WORK_GROUP_COUNT, 2,
+        &out.mMaxComputeWorkGroupCount[2]);
+    GET(glGetIntegerv, GL_MAX_COMPUTE_WORK_GROUP_INVOCATIONS,
+        &out.mMaxComputeWorkGroupInvocations);
+    GET(glGetIntegeri_v, GL_MAX_COMPUTE_WORK_GROUP_SIZE, 0,
+        &out.mMaxComputeWorkGroupSize[0]);
+    GET(glGetIntegeri_v, GL_MAX_COMPUTE_WORK_GROUP_SIZE, 1,
+        &out.mMaxComputeWorkGroupSize[1]);
+    GET(glGetIntegeri_v, GL_MAX_COMPUTE_WORK_GROUP_SIZE, 2,
+        &out.mMaxComputeWorkGroupSize[2]);
+    GET(glGetIntegerv, GL_MAX_DEPTH_TEXTURE_SAMPLES,
+        &out.mMaxDepthTextureSamples);
+    GET(glGetIntegerv, GL_MAX_FRAGMENT_ATOMIC_COUNTERS,
+        &out.mMaxFragmentAtomicCounters);
+    GET(glGetIntegerv, GL_MAX_FRAGMENT_ATOMIC_COUNTER_BUFFERS,
+        &out.mMaxFragmentAtomicCounterBuffers);
+    GET(glGetIntegerv, GL_MAX_FRAGMENT_IMAGE_UNIFORMS,
+        &out.mMaxFragmentImageUniforms);
+    GET(glGetIntegerv, GL_MAX_FRAGMENT_SHADER_STORAGE_BLOCKS,
+        &out.mMaxFragmentShaderStorageBlocks);
+    GET(glGetIntegerv, GL_MAX_FRAMEBUFFER_HEIGHT, &out.mMaxFramebufferHeight);
+    GET(glGetIntegerv, GL_MAX_FRAMEBUFFER_SAMPLES, &out.mMaxFramebufferSamples);
+    GET(glGetIntegerv, GL_MAX_FRAMEBUFFER_WIDTH, &out.mMaxFramebufferWidth);
+    GET(glGetIntegerv, GL_MAX_IMAGE_UNITS, &out.mMaxImageUnits);
+    GET(glGetIntegerv, GL_MAX_INTEGER_SAMPLES, &out.mMaxIntegerSamples);
+    GET(glGetIntegerv, GL_MAX_PROGRAM_TEXTURE_GATHER_OFFSET,
+        &out.mMaxProgramTextureGatherOffset);
+    GET(glGetIntegerv, GL_MAX_SAMPLE_MASK_WORDS, &out.mMaxSampleMaskWords);
+    GET(glGetInteger64v, GL_MAX_SHADER_STORAGE_BLOCK_SIZE,
+        &out.mMaxShaderStorageBlockSize);
+    GET(glGetIntegerv, GL_MAX_SHADER_STORAGE_BUFFER_BINDINGS,
+        &out.mMaxShaderStorageBufferBindings);
+    GET(glGetIntegerv, GL_MAX_UNIFORM_LOCATIONS, &out.mMaxUniformLocations);
+    GET(glGetIntegerv, GL_MAX_VERTEX_ATOMIC_COUNTERS,
+        &out.mMaxVertexAtomicCounters);
+    GET(glGetIntegerv, GL_MAX_VERTEX_ATOMIC_COUNTER_BUFFERS,
+        &out.mMaxVertexAtomicCounterBuffers);
+    GET(glGetIntegerv, GL_MAX_VERTEX_ATTRIB_BINDINGS,
+        &out.mMaxVertexAttribBindings);
+    GET(glGetIntegerv, GL_MAX_VERTEX_ATTRIB_RELATIVE_OFFSET,
+        &out.mMaxVertexAttribRelativeOffset);
+    GET(glGetIntegerv, GL_MAX_VERTEX_ATTRIB_STRIDE,
+        &out.mMaxVertexAttribStride);
+    GET(glGetIntegerv, GL_MAX_VERTEX_IMAGE_UNIFORMS,
+        &out.mMaxVertexImageUniforms);
+    GET(glGetIntegerv, GL_MAX_VERTEX_SHADER_STORAGE_BLOCKS,
+        &out.mMaxVertexShaderStorageBlocks);
+    GET(glGetIntegerv, GL_MIN_PROGRAM_TEXTURE_GATHER_OFFSET,
+        &out.mMinProgramTextureGatherOffset);
+    GET(glGetIntegerv, GL_SHADER_STORAGE_BUFFER_OFFSET_ALIGNMENT,
+        &out.mShaderStorageBufferOffsetAlignment);
+  }
+
+  // Constants defined in version 3.2 (June 15, 2016)
+  if (gles32) {
+    GET(glGetIntegerv, GL_CONTEXT_FLAGS, &out.mContextFlags);
+    GET(glGetIntegerv, GL_FRAGMENT_INTERPOLATION_OFFSET_BITS,
+        &out.mFragmentInterpolationOffsetBits);
+    GET(glGetIntegerv, GL_LAYER_PROVOKING_VERTEX,
+        reinterpret_cast<GLint*>(&out.mLayerProvokingVertex));
+    GET(glGetIntegerv, GL_MAX_COMBINED_GEOMETRY_UNIFORM_COMPONENTS,
+        &out.mMaxCombinedGeometryUniformComponents);
+    GET(glGetIntegerv, GL_MAX_COMBINED_TESS_CONTROL_UNIFORM_COMPONENTS,
+        &out.mMaxCombinedTessControlUniformComponents);
+    GET(glGetIntegerv, GL_MAX_COMBINED_TESS_EVALUATION_UNIFORM_COMPONENTS,
+        &out.mMaxCombinedTessEvaluationUniformComponents);
+    GET(glGetIntegerv, GL_MAX_DEBUG_GROUP_STACK_DEPTH,
+        &out.mMaxDebugGroupStackDepth);
+    GET(glGetIntegerv, GL_MAX_DEBUG_LOGGED_MESSAGES,
+        &out.mMaxDebugLoggedMessages);
+    GET(glGetIntegerv, GL_MAX_DEBUG_MESSAGE_LENGTH,
+        &out.mMaxDebugMessageLength);
+    GET(glGetFloatv, GL_MAX_FRAGMENT_INTERPOLATION_OFFSET,
+        &out.mMaxFragmentInterpolationOffset);
+    GET(glGetIntegerv, GL_MAX_FRAMEBUFFER_LAYERS, &out.mMaxFramebufferLayers);
+    GET(glGetIntegerv, GL_MAX_GEOMETRY_ATOMIC_COUNTERS,
+        &out.mMaxGeometryAtomicCounters);
+    GET(glGetIntegerv, GL_MAX_GEOMETRY_ATOMIC_COUNTER_BUFFERS,
+        &out.mMaxGeometryAtomicCounterBuffers);
+    GET(glGetIntegerv, GL_MAX_GEOMETRY_IMAGE_UNIFORMS,
+        &out.mMaxGeometryImageUniforms);
+    GET(glGetIntegerv, GL_MAX_GEOMETRY_INPUT_COMPONENTS,
+        &out.mMaxGeometryInputComponents);
+    GET(glGetIntegerv, GL_MAX_GEOMETRY_OUTPUT_COMPONENTS,
+        &out.mMaxGeometryOutputComponents);
+    GET(glGetIntegerv, GL_MAX_GEOMETRY_OUTPUT_VERTICES,
+        &out.mMaxGeometryOutputVertices);
+    GET(glGetIntegerv, GL_MAX_GEOMETRY_SHADER_INVOCATIONS,
+        &out.mMaxGeometryShaderInvocations);
+    GET(glGetIntegerv, GL_MAX_GEOMETRY_SHADER_STORAGE_BLOCKS,
+        &out.mMaxGeometryShaderStorageBlocks);
+    GET(glGetIntegerv, GL_MAX_GEOMETRY_TEXTURE_IMAGE_UNITS,
+        &out.mMaxGeometryTextureImageUnits);
+    GET(glGetIntegerv, GL_MAX_GEOMETRY_TOTAL_OUTPUT_COMPONENTS,
+        &out.mMaxGeometryTotalOutputComponents);
+    GET(glGetIntegerv, GL_MAX_GEOMETRY_UNIFORM_BLOCKS,
+        &out.mMaxGeometryUniformBlocks);
+    GET(glGetIntegerv, GL_MAX_GEOMETRY_UNIFORM_COMPONENTS,
+        &out.mMaxGeometryUniformComponents);
+    GET(glGetIntegerv, GL_MAX_LABEL_LENGTH, &out.mMaxLabelLength);
+    GET(glGetIntegerv, GL_MAX_PATCH_VERTICES, &out.mMaxPatchVertices);
+    GET(glGetIntegerv, GL_MAX_TESS_CONTROL_ATOMIC_COUNTERS,
+        &out.mMaxTessControlAtomicCounters);
+    GET(glGetIntegerv, GL_MAX_TESS_CONTROL_ATOMIC_COUNTER_BUFFERS,
+        &out.mMaxTessControlAtomicCounterBuffers);
+    GET(glGetIntegerv, GL_MAX_TESS_CONTROL_IMAGE_UNIFORMS,
+        &out.mMaxTessControlImageUniforms);
+    GET(glGetIntegerv, GL_MAX_TESS_CONTROL_INPUT_COMPONENTS,
+        &out.mMaxTessControlInputComponents);
+    GET(glGetIntegerv, GL_MAX_TESS_CONTROL_OUTPUT_COMPONENTS,
+        &out.mMaxTessControlOutputComponents);
+    GET(glGetIntegerv, GL_MAX_TESS_CONTROL_SHADER_STORAGE_BLOCKS,
+        &out.mMaxTessControlShaderStorageBlocks);
+    GET(glGetIntegerv, GL_MAX_TESS_CONTROL_TEXTURE_IMAGE_UNITS,
+        &out.mMaxTessControlTextureImageUnits);
+    GET(glGetIntegerv, GL_MAX_TESS_CONTROL_TOTAL_OUTPUT_COMPONENTS,
+        &out.mMaxTessControlTotalOutputComponents);
+    GET(glGetIntegerv, GL_MAX_TESS_CONTROL_UNIFORM_BLOCKS,
+        &out.mMaxTessControlUniformBlocks);
+    GET(glGetIntegerv, GL_MAX_TESS_CONTROL_UNIFORM_COMPONENTS,
+        &out.mMaxTessControlUniformComponents);
+    GET(glGetIntegerv, GL_MAX_TESS_EVALUATION_ATOMIC_COUNTERS,
+        &out.mMaxTessEvaluationAtomicCounters);
+    GET(glGetIntegerv, GL_MAX_TESS_EVALUATION_ATOMIC_COUNTER_BUFFERS,
+        &out.mMaxTessEvaluationAtomicCounterBuffers);
+    GET(glGetIntegerv, GL_MAX_TESS_EVALUATION_IMAGE_UNIFORMS,
+        &out.mMaxTessEvaluationImageUniforms);
+    GET(glGetIntegerv, GL_MAX_TESS_EVALUATION_INPUT_COMPONENTS,
+        &out.mMaxTessEvaluationInputComponents);
+    GET(glGetIntegerv, GL_MAX_TESS_EVALUATION_OUTPUT_COMPONENTS,
+        &out.mMaxTessEvaluationOutputComponents);
+    GET(glGetIntegerv, GL_MAX_TESS_EVALUATION_SHADER_STORAGE_BLOCKS,
+        &out.mMaxTessEvaluationShaderStorageBlocks);
+    GET(glGetIntegerv, GL_MAX_TESS_EVALUATION_TEXTURE_IMAGE_UNITS,
+        &out.mMaxTessEvaluationTextureImageUnits);
+    GET(glGetIntegerv, GL_MAX_TESS_EVALUATION_UNIFORM_BLOCKS,
+        &out.mMaxTessEvaluationUniformBlocks);
+    GET(glGetIntegerv, GL_MAX_TESS_EVALUATION_UNIFORM_COMPONENTS,
+        &out.mMaxTessEvaluationUniformComponents);
+    GET(glGetIntegerv, GL_MAX_TESS_GEN_LEVEL, &out.mMaxTessGenLevel);
+    GET(glGetIntegerv, GL_MAX_TESS_PATCH_COMPONENTS,
+        &out.mMaxTessPatchComponents);
+    GET(glGetIntegerv, GL_MAX_TEXTURE_BUFFER_SIZE, &out.mMaxTextureBufferSize);
+    GET(glGetFloatv, GL_MIN_FRAGMENT_INTERPOLATION_OFFSET,
+        &out.mMinFragmentInterpolationOffset);
+    GET(glGetFloatv, GL_MULTISAMPLE_LINE_WIDTH_GRANULARITY,
+        &out.mMultisampleLineWidthGranularity);
+    GET(glGetFloatv, GL_MULTISAMPLE_LINE_WIDTH_RANGE,
+        out.mMultisampleLineWidthRange);
+    GET(glGetBooleanv, GL_PRIMITIVE_RESTART_FOR_PATCHES_SUPPORTED,
+        &out.mPrimitiveRestartForPatchesSupported);
+    GET(glGetIntegerv, GL_TEXTURE_BUFFER_OFFSET_ALIGNMENT,
+        &out.mTextureBufferOffsetAlignment);
+    GET(glGetIntegerv, GL_RESET_NOTIFICATION_STRATEGY,
+        &out.mResetNotificationStrategy);
+  }
+
+  // Constants defined in extensions
+  GET(glGetFloatv, GL_MAX_TEXTURE_MAX_ANISOTROPY_EXT,
+      &out.mMaxTextureMaxAnisotropyExt);
+  GET(glGetIntegerv, GL_MAX_VIEWS_OVR, &out.mMaxViewsExt);
 }
 
-
-} // namespace gapii
+}  // namespace gapii

--- a/gapii/cc/gles_exports.h
+++ b/gapii/cc/gles_exports.h
@@ -25,6 +25,6 @@ struct Symbol {
 };
 
 extern Symbol kGLESExports[];
-}
+}  // namespace gapii
 
 #endif

--- a/gapii/cc/gles_spy_externs.cpp
+++ b/gapii/cc/gles_spy_externs.cpp
@@ -14,13 +14,19 @@
  * limitations under the License.
  */
 
-#include "gapii/cc/gles_spy.h"
 #include "gapii/cc/call_observer.h"
+#include "gapii/cc/gles_spy.h"
 
 namespace gapii {
 
-template<typename T> T inline min(T a, T b) { return (a < b) ? a : b; }
-template<typename T> T inline max(T a, T b) { return (a > b) ? a : b; }
+template <typename T>
+T inline min(T a, T b) {
+  return (a < b) ? a : b;
+}
+template <typename T>
+T inline max(T a, T b) {
+  return (a > b) ? a : b;
+}
 
 // Externs not implemented in GAPII.
 void GlesSpy::mapMemory(CallObserver*, gapil::Slice<uint8_t>) {}
@@ -28,82 +34,84 @@ void GlesSpy::unmapMemory(CallObserver*, gapil::Slice<uint8_t>) {}
 MsgID GlesSpy::newMsg(CallObserver*, uint32_t, const char*) { return 0; }
 void GlesSpy::addTag(CallObserver*, uint32_t, const char*) {}
 
-u32Limits GlesSpy::IndexLimits(CallObserver*, gapil::Slice<uint8_t> indices, int32_t sizeof_index) {
-    uint32_t low = ~(uint32_t)0;
-    uint32_t high = 0;
-    switch (sizeof_index) {
-        case 1: {
-            for (auto i : indices.as<uint8_t>()) {
-                low = min<uint32_t>(low, i);
-                high = max<uint32_t>(high, i);
-            }
-            break;
-        }
-        case 2: {
-            for (auto i : indices.as<uint16_t>()) {
-                low = min<uint32_t>(low, i);
-                high = max<uint32_t>(high, i);
-            }
-            break;
-        }
-        case 4: {
-            for (auto i : indices.as<uint32_t>()) {
-                low = min<uint32_t>(low, i);
-                high = max<uint32_t>(high, i);
-            }
-            break;
-        }
-        default: {
-            GAPID_FATAL("Invalid index size");
-        }
+u32Limits GlesSpy::IndexLimits(CallObserver*, gapil::Slice<uint8_t> indices,
+                               int32_t sizeof_index) {
+  uint32_t low = ~(uint32_t)0;
+  uint32_t high = 0;
+  switch (sizeof_index) {
+    case 1: {
+      for (auto i : indices.as<uint8_t>()) {
+        low = min<uint32_t>(low, i);
+        high = max<uint32_t>(high, i);
+      }
+      break;
     }
-    if (low <= high) {
-        return u32Limits(low, high+1-low);
-    } else {
-        return u32Limits(0, 0);
+    case 2: {
+      for (auto i : indices.as<uint16_t>()) {
+        low = min<uint32_t>(low, i);
+        high = max<uint32_t>(high, i);
+      }
+      break;
     }
+    case 4: {
+      for (auto i : indices.as<uint32_t>()) {
+        low = min<uint32_t>(low, i);
+        high = max<uint32_t>(high, i);
+      }
+      break;
+    }
+    default: { GAPID_FATAL("Invalid index size"); }
+  }
+  if (low <= high) {
+    return u32Limits(low, high + 1 - low);
+  } else {
+    return u32Limits(0, 0);
+  }
 }
 
 void GlesSpy::onGlError(CallObserver* observer, GLenum_Error err) {
-    const char* current_cmd_name = observer->getCurrentCommandName();
-    switch (err) {
-        case GLenum::GL_INVALID_ENUM:
-            GAPID_WARNING("Error calling %s: GL_INVALID_ENUM", current_cmd_name);
-            break;
-        case GLenum::GL_INVALID_VALUE:
-            GAPID_WARNING("Error calling %s: GL_INVALID_VALUE", current_cmd_name);
-            break;
-        case GLenum::GL_INVALID_OPERATION:
-            GAPID_WARNING("Error calling %s: GL_INVALID_OPERATION", current_cmd_name);
-            break;
-        case GLenum::GL_STACK_OVERFLOW:
-            GAPID_WARNING("Error calling %s: GL_STACK_OVERFLOW", current_cmd_name);
-            break;
-        case GLenum::GL_STACK_UNDERFLOW:
-            GAPID_WARNING("Error calling %s: GL_STACK_UNDERFLOW", current_cmd_name);
-            break;
-        case GLenum::GL_OUT_OF_MEMORY:
-            GAPID_WARNING("Error calling %s: GL_OUT_OF_MEMORY", current_cmd_name);
-            break;
-        case GLenum::GL_INVALID_FRAMEBUFFER_OPERATION:
-            GAPID_WARNING("Error calling %s: GL_INVALID_FRAMEBUFFER_OPERATION", current_cmd_name);
-            break;
-        case GLenum::GL_CONTEXT_LOST:
-            GAPID_WARNING("Error calling %s: GL_CONTEXT_LOST", current_cmd_name);
-            break;
-        default:
-            GAPID_WARNING("Error calling %s: %d", current_cmd_name, err);
-            break;
-    }
+  const char* current_cmd_name = observer->getCurrentCommandName();
+  switch (err) {
+    case GLenum::GL_INVALID_ENUM:
+      GAPID_WARNING("Error calling %s: GL_INVALID_ENUM", current_cmd_name);
+      break;
+    case GLenum::GL_INVALID_VALUE:
+      GAPID_WARNING("Error calling %s: GL_INVALID_VALUE", current_cmd_name);
+      break;
+    case GLenum::GL_INVALID_OPERATION:
+      GAPID_WARNING("Error calling %s: GL_INVALID_OPERATION", current_cmd_name);
+      break;
+    case GLenum::GL_STACK_OVERFLOW:
+      GAPID_WARNING("Error calling %s: GL_STACK_OVERFLOW", current_cmd_name);
+      break;
+    case GLenum::GL_STACK_UNDERFLOW:
+      GAPID_WARNING("Error calling %s: GL_STACK_UNDERFLOW", current_cmd_name);
+      break;
+    case GLenum::GL_OUT_OF_MEMORY:
+      GAPID_WARNING("Error calling %s: GL_OUT_OF_MEMORY", current_cmd_name);
+      break;
+    case GLenum::GL_INVALID_FRAMEBUFFER_OPERATION:
+      GAPID_WARNING("Error calling %s: GL_INVALID_FRAMEBUFFER_OPERATION",
+                    current_cmd_name);
+      break;
+    case GLenum::GL_CONTEXT_LOST:
+      GAPID_WARNING("Error calling %s: GL_CONTEXT_LOST", current_cmd_name);
+      break;
+    default:
+      GAPID_WARNING("Error calling %s: %d", current_cmd_name, err);
+      break;
+  }
 
-    // Set error only if has not been previously set
-    if (observer->getError() == GLenum::GL_NO_ERROR) {
-        observer->setError(err);
-    }
+  // Set error only if has not been previously set
+  if (observer->getError() == GLenum::GL_NO_ERROR) {
+    observer->setError(err);
+  }
 }
 
-gapil::Slice<uint8_t> GlesSpy::ReadGPUTextureData(CallObserver* observer, gapil::Ref<Texture> texture, GLint level, GLint layer) {
-    return gapil::Slice<uint8_t>(); // Not currently required for gapii.
+gapil::Slice<uint8_t> GlesSpy::ReadGPUTextureData(CallObserver* observer,
+                                                  gapil::Ref<Texture> texture,
+                                                  GLint level, GLint layer) {
+  return gapil::Slice<uint8_t>();  // Not currently required for gapii.
 }
 
-}
+}  // namespace gapii

--- a/gapii/cc/gvr_abi_types.h
+++ b/gapii/cc/gvr_abi_types.h
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-
 #ifndef GAPII_GVR_ABI_TYPES_H
 #define GAPII_GVR_ABI_TYPES_H
 
@@ -26,11 +25,11 @@ struct gvr_mat4_abi : core::CStaticArray<float, 16> {};
 
 gvr_mat4f::gvr_mat4f(gvr_mat4_abi const& abi) : mm(abi) {}
 gvr_mat4f::operator gvr_mat4_abi() const {
-    gvr_mat4_abi out;
-    memcpy(&out, &this->mm, sizeof(out));
-    return out;
+  gvr_mat4_abi out;
+  memcpy(&out, &this->mm, sizeof(out));
+  return out;
 }
 
-} // namespace gapii
+}  // namespace gapii
 
-#endif // GAPII_GVR_ABI_TYPES_H
+#endif  // GAPII_GVR_ABI_TYPES_H

--- a/gapii/cc/gvr_extras.cpp
+++ b/gapii/cc/gvr_extras.cpp
@@ -18,55 +18,58 @@
 
 namespace gapii {
 
-bool GvrSpy::observeFramebuffer(CallObserver* observer, uint32_t* w, uint32_t* h, std::vector<uint8_t>* data) {
-    auto spy = static_cast<Spy*>(this);
-    auto gles_state = static_cast<GlesSpy*>(spy)->mState;
+bool GvrSpy::observeFramebuffer(CallObserver* observer, uint32_t* w,
+                                uint32_t* h, std::vector<uint8_t>* data) {
+  auto spy = static_cast<Spy*>(this);
+  auto gles_state = static_cast<GlesSpy*>(spy)->mState;
 
-    auto contextIt = gles_state.Contexts.find(observer->getCurrentThread());
-    if (contextIt == gles_state.Contexts.end() || contextIt->second == nullptr) {
-        GAPID_WARNING("No GLES context bound to thread");
-        return false;
-    }
-    auto context = contextIt->second;
+  auto contextIt = gles_state.Contexts.find(observer->getCurrentThread());
+  if (contextIt == gles_state.Contexts.end() || contextIt->second == nullptr) {
+    GAPID_WARNING("No GLES context bound to thread");
+    return false;
+  }
+  auto context = contextIt->second;
 
-    constexpr int frameIndex = 0; // TODO: other indices.
-    auto framebufferId = mImports.gvr_frame_get_framebuffer_object(mLastSubmittedFrame, frameIndex);
+  constexpr int frameIndex = 0;  // TODO: other indices.
+  auto framebufferId = mImports.gvr_frame_get_framebuffer_object(
+      mLastSubmittedFrame, frameIndex);
 
-    GAPID_INFO("frame=%p, framebufferId=%d", mLastSubmittedFrame, framebufferId);
+  GAPID_INFO("frame=%p, framebufferId=%d", mLastSubmittedFrame, framebufferId);
 
-    auto framebufferIt = context->mObjects.mFramebuffers.find(framebufferId);
-    if (framebufferIt == context->mObjects.mFramebuffers.end()) {
-        GAPID_WARNING("Framebuffer %d not found", framebufferId);
-        return false;
-    }
-    auto framebuffer = framebufferIt->second;
+  auto framebufferIt = context->mObjects.mFramebuffers.find(framebufferId);
+  if (framebufferIt == context->mObjects.mFramebuffers.end()) {
+    GAPID_WARNING("Framebuffer %d not found", framebufferId);
+    return false;
+  }
+  auto framebuffer = framebufferIt->second;
 
-    if (!spy->GlesSpy::getFramebufferAttachmentSize(observer, framebuffer.get(), w, h)) {
-        GAPID_WARNING("Could not get the framebuffer size");
-        return false;
-    }
+  if (!spy->GlesSpy::getFramebufferAttachmentSize(observer, framebuffer.get(),
+                                                  w, h)) {
+    GAPID_WARNING("Could not get the framebuffer size");
+    return false;
+  }
 
-    auto gles = spy->GlesSpy::imports();
+  auto gles = spy->GlesSpy::imports();
 
-    // Get current framebuffer state.
-    GLint prevFramebufferId = 0;
-    GLint prevReadBuffer = 0;
-    gles.glGetIntegerv(GLenum::GL_READ_FRAMEBUFFER_BINDING, &prevFramebufferId);
-    gles.glGetIntegerv(GLenum::GL_READ_BUFFER, &prevReadBuffer);
+  // Get current framebuffer state.
+  GLint prevFramebufferId = 0;
+  GLint prevReadBuffer = 0;
+  gles.glGetIntegerv(GLenum::GL_READ_FRAMEBUFFER_BINDING, &prevFramebufferId);
+  gles.glGetIntegerv(GLenum::GL_READ_BUFFER, &prevReadBuffer);
 
-    // Bind submitted framebuffer for reading.
-    gles.glBindFramebuffer(GLenum::GL_READ_FRAMEBUFFER, framebufferId);
-    gles.glReadBuffer(GLenum::GL_COLOR_ATTACHMENT0);
+  // Bind submitted framebuffer for reading.
+  gles.glBindFramebuffer(GLenum::GL_READ_FRAMEBUFFER, framebufferId);
+  gles.glReadBuffer(GLenum::GL_COLOR_ATTACHMENT0);
 
-    // Do the read.
-    data->resize((*w) * (*h) * 4);
-    gles.glReadPixels(0, 0, int32_t(*w), int32_t(*h),
-            GLenum::GL_RGBA, GLenum::GL_UNSIGNED_BYTE, data->data());
+  // Do the read.
+  data->resize((*w) * (*h) * 4);
+  gles.glReadPixels(0, 0, int32_t(*w), int32_t(*h), GLenum::GL_RGBA,
+                    GLenum::GL_UNSIGNED_BYTE, data->data());
 
-    // Restore previous state.
-    gles.glBindFramebuffer(GLenum::GL_READ_FRAMEBUFFER, prevFramebufferId);
-    gles.glReadBuffer(prevReadBuffer);
-    return true;
+  // Restore previous state.
+  gles.glBindFramebuffer(GLenum::GL_READ_FRAMEBUFFER, prevFramebufferId);
+  gles.glReadBuffer(prevReadBuffer);
+  return true;
 }
 
 }  // namespace gapii

--- a/gapii/cc/pack_encoder.cpp
+++ b/gapii/cc/pack_encoder.cpp
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-
 #include "pack_encoder.h"
 #include "chunk_writer.h"
 
@@ -26,312 +25,320 @@
 
 #include <mutex>
 
-using ::google::protobuf::Message;
 using ::google::protobuf::Descriptor;
 using ::google::protobuf::DescriptorProto;
+using ::google::protobuf::Message;
 using ::google::protobuf::io::CodedOutputStream;
 
 namespace {
 
-const uint64_t NO_ID               = 0xffffffffffffffff;
+const uint64_t NO_ID = 0xffffffffffffffff;
 
-constexpr int TYPE_ID_CACHE_COUNT  = 4;
+constexpr int TYPE_ID_CACHE_COUNT = 4;
 
 const char header[] = "ProtoPack\r\n2.0\n";
 
 // PackEncoderImpl implements the PackEncoder interface.
 class PackEncoderImpl : public gapii::PackEncoder {
-public:
-    PackEncoderImpl(const std::shared_ptr<core::StringWriter>& writer);
-    ~PackEncoderImpl();
+ public:
+  PackEncoderImpl(const std::shared_ptr<core::StringWriter>& writer);
+  ~PackEncoderImpl();
 
-    virtual TypeIDAndIsNew type(const char* name, size_t size, const void* data) override;
-    virtual void object(const Message* msg) override;
-    virtual void object(TypeID type, size_t size, const void* data) override;
-    virtual SPtr group(const Message* msg) override;
-    virtual PackEncoder* group(TypeID type, size_t size, const void* data) override;
-    virtual void flush() override;
+  virtual TypeIDAndIsNew type(const char* name, size_t size,
+                              const void* data) override;
+  virtual void object(const Message* msg) override;
+  virtual void object(TypeID type, size_t size, const void* data) override;
+  virtual SPtr group(const Message* msg) override;
+  virtual PackEncoder* group(TypeID type, size_t size,
+                             const void* data) override;
+  virtual void flush() override;
 
-private:
-    struct TypeIDCache {
-        std::mutex mutex;
-        std::unordered_map<const void*, TypeID> type_ids;
-    };
+ private:
+  struct TypeIDCache {
+    std::mutex mutex;
+    std::unordered_map<const void*, TypeID> type_ids;
+  };
 
-    struct Shared {
-        Shared(const std::shared_ptr<core::StringWriter>& writer);
+  struct Shared {
+    Shared(const std::shared_ptr<core::StringWriter>& writer);
 
-        std::recursive_mutex mutex;
-        std::shared_ptr<core::StringWriter> writer;
-        std::unordered_map<const void*, TypeID> type_ids;
-        TypeIDCache type_id_caches[TYPE_ID_CACHE_COUNT];
-        uint64_t mCurrentChunkId;
-    };
+    std::recursive_mutex mutex;
+    std::shared_ptr<core::StringWriter> writer;
+    std::unordered_map<const void*, TypeID> type_ids;
+    TypeIDCache type_id_caches[TYPE_ID_CACHE_COUNT];
+    uint64_t mCurrentChunkId;
+  };
 
-    PackEncoderImpl(const std::shared_ptr<Shared>& shared, uint64_t parentChunkId);
+  PackEncoderImpl(const std::shared_ptr<Shared>& shared,
+                  uint64_t parentChunkId);
 
-    void writeParentID(std::string& buffer);
-    TypeIDAndIsNew writeTypeIfNew(const Descriptor* desc);
-    TypeIDAndIsNew writeTypeIfNew(const char* name, size_t size, const void* data);
-    TypeIDAndIsNew writeTypeIfNewBlocking(const Descriptor* desc);
-    TypeIDAndIsNew writeTypeIfNewBlocking(const char* name, size_t size, const void* data);
-    void writeString(std::string& buffer, const std::string& str);
-    void writeZigzag(std::string& buffer, int64_t value);
-    void writeVarint(std::string& buffer, uint64_t value);
-    uint64_t flushChunk(std::string& buffer, bool isTypeDefChunk);
+  void writeParentID(std::string& buffer);
+  TypeIDAndIsNew writeTypeIfNew(const Descriptor* desc);
+  TypeIDAndIsNew writeTypeIfNew(const char* name, size_t size,
+                                const void* data);
+  TypeIDAndIsNew writeTypeIfNewBlocking(const Descriptor* desc);
+  TypeIDAndIsNew writeTypeIfNewBlocking(const char* name, size_t size,
+                                        const void* data);
+  void writeString(std::string& buffer, const std::string& str);
+  void writeZigzag(std::string& buffer, int64_t value);
+  void writeVarint(std::string& buffer, uint64_t value);
+  uint64_t flushChunk(std::string& buffer, bool isTypeDefChunk);
 
-    std::shared_ptr<Shared> mShared;
-    uint64_t mParentChunkId;
+  std::shared_ptr<Shared> mShared;
+  uint64_t mParentChunkId;
 };
 
-PackEncoderImpl::Shared::Shared(const std::shared_ptr<core::StringWriter>& writer)
-        : writer(writer)
-        , type_ids{{nullptr, 0}}
-        , mCurrentChunkId(0) {}
+PackEncoderImpl::Shared::Shared(
+    const std::shared_ptr<core::StringWriter>& writer)
+    : writer(writer), type_ids{{nullptr, 0}}, mCurrentChunkId(0) {}
 
-PackEncoderImpl::PackEncoderImpl(const std::shared_ptr<core::StringWriter>& writer)
-        : mShared(new Shared(writer))
-        , mParentChunkId(NO_ID) {}
+PackEncoderImpl::PackEncoderImpl(
+    const std::shared_ptr<core::StringWriter>& writer)
+    : mShared(new Shared(writer)), mParentChunkId(NO_ID) {}
 
-PackEncoderImpl::PackEncoderImpl(const std::shared_ptr<Shared>& shared, uint64_t parentChunkId)
-        : mShared(shared)
-        , mParentChunkId(parentChunkId) {
-}
+PackEncoderImpl::PackEncoderImpl(const std::shared_ptr<Shared>& shared,
+                                 uint64_t parentChunkId)
+    : mShared(shared), mParentChunkId(parentChunkId) {}
 
 PackEncoderImpl::~PackEncoderImpl() {
-    if (mParentChunkId != NO_ID) {
-        std::string buffer;
-        std::lock_guard<std::recursive_mutex> lock(mShared->mutex);
-        writeParentID(buffer);
-        flushChunk(buffer, false);
-    }
+  if (mParentChunkId != NO_ID) {
+    std::string buffer;
+    std::lock_guard<std::recursive_mutex> lock(mShared->mutex);
+    writeParentID(buffer);
+    flushChunk(buffer, false);
+  }
 }
 
-void PackEncoderImpl::flush() {
-    mShared->writer->flush();
-}
+void PackEncoderImpl::flush() { mShared->writer->flush(); }
 
-gapii::PackEncoder::TypeIDAndIsNew
-PackEncoderImpl::type(const char* name, size_t size, const void* data) {
-    return writeTypeIfNew(name, size, data);
+gapii::PackEncoder::TypeIDAndIsNew PackEncoderImpl::type(const char* name,
+                                                         size_t size,
+                                                         const void* data) {
+  return writeTypeIfNew(name, size, data);
 }
 
 void PackEncoderImpl::object(const Message* msg) {
-    std::string buffer;
-    auto type_id = writeTypeIfNew(msg->GetDescriptor()).first;
+  std::string buffer;
+  auto type_id = writeTypeIfNew(msg->GetDescriptor()).first;
 
-    std::lock_guard<std::recursive_mutex> lock(mShared->mutex);
-    writeParentID(buffer);
-    writeZigzag(buffer, type_id);
-    msg->AppendToString(&buffer);
-    flushChunk(buffer, false);
+  std::lock_guard<std::recursive_mutex> lock(mShared->mutex);
+  writeParentID(buffer);
+  writeZigzag(buffer, type_id);
+  msg->AppendToString(&buffer);
+  flushChunk(buffer, false);
 }
 
 void PackEncoderImpl::object(TypeID type_id, size_t size, const void* data) {
-    std::string buffer;
-    std::lock_guard<std::recursive_mutex> lock(mShared->mutex);
-    writeParentID(buffer);
-    writeZigzag(buffer, type_id);
-    buffer.append(reinterpret_cast<const char*>(data), size);
-    flushChunk(buffer, false);
+  std::string buffer;
+  std::lock_guard<std::recursive_mutex> lock(mShared->mutex);
+  writeParentID(buffer);
+  writeZigzag(buffer, type_id);
+  buffer.append(reinterpret_cast<const char*>(data), size);
+  flushChunk(buffer, false);
 }
 
 gapii::PackEncoder::SPtr PackEncoderImpl::group(const Message* msg) {
-    std::string buffer;
-    auto type_id = writeTypeIfNew(msg->GetDescriptor()).first;
+  std::string buffer;
+  auto type_id = writeTypeIfNew(msg->GetDescriptor()).first;
 
-    std::lock_guard<std::recursive_mutex> lock(mShared->mutex);
-    writeParentID(buffer);
-    writeZigzag(buffer, -(int64_t)type_id);
-    msg->AppendToString(&buffer);
-    auto chunkID = flushChunk(buffer, false);
+  std::lock_guard<std::recursive_mutex> lock(mShared->mutex);
+  writeParentID(buffer);
+  writeZigzag(buffer, -(int64_t)type_id);
+  msg->AppendToString(&buffer);
+  auto chunkID = flushChunk(buffer, false);
 
-    return PackEncoder::SPtr(new PackEncoderImpl(mShared, chunkID));
+  return PackEncoder::SPtr(new PackEncoderImpl(mShared, chunkID));
 }
 
-gapii::PackEncoder* PackEncoderImpl::group(TypeID type_id, size_t size, const void* data) {
-    std::string buffer;
-    std::lock_guard<std::recursive_mutex> lock(mShared->mutex);
-    writeParentID(buffer);
-    writeZigzag(buffer, -(int64_t)type_id);
-    buffer.append(reinterpret_cast<const char*>(data), size);
-    auto chunkID = flushChunk(buffer, false);
+gapii::PackEncoder* PackEncoderImpl::group(TypeID type_id, size_t size,
+                                           const void* data) {
+  std::string buffer;
+  std::lock_guard<std::recursive_mutex> lock(mShared->mutex);
+  writeParentID(buffer);
+  writeZigzag(buffer, -(int64_t)type_id);
+  buffer.append(reinterpret_cast<const char*>(data), size);
+  auto chunkID = flushChunk(buffer, false);
 
-    return new PackEncoderImpl(mShared, chunkID);
+  return new PackEncoderImpl(mShared, chunkID);
 }
 
 void PackEncoderImpl::writeParentID(std::string& buffer) {
-    if (mParentChunkId == NO_ID) {
-        writeZigzag(buffer, 0);
-    } else {
-        writeZigzag(buffer, mParentChunkId - mShared->mCurrentChunkId);
-    }
+  if (mParentChunkId == NO_ID) {
+    writeZigzag(buffer, 0);
+  } else {
+    writeZigzag(buffer, mParentChunkId - mShared->mCurrentChunkId);
+  }
 }
 
 // TODO: Refactor the body of this out into something that can be shared with
 //       the two overloads.
-gapii::PackEncoder::TypeIDAndIsNew
-PackEncoderImpl::writeTypeIfNew(const Descriptor* desc) {
-    TypeIDCache* type_id_cache = nullptr;
-    std::unique_lock<std::mutex> cache_lock;
+gapii::PackEncoder::TypeIDAndIsNew PackEncoderImpl::writeTypeIfNew(
+    const Descriptor* desc) {
+  TypeIDCache* type_id_cache = nullptr;
+  std::unique_lock<std::mutex> cache_lock;
 
-    for(int index = 0; !type_id_cache && index < TYPE_ID_CACHE_COUNT; ++index) {
-        if (mShared->type_id_caches[index].mutex.try_lock()) {
-            type_id_cache = &mShared->type_id_caches[index];
-            cache_lock = std::unique_lock<std::mutex>(type_id_cache->mutex, std::adopt_lock);
-        }
+  for (int index = 0; !type_id_cache && index < TYPE_ID_CACHE_COUNT; ++index) {
+    if (mShared->type_id_caches[index].mutex.try_lock()) {
+      type_id_cache = &mShared->type_id_caches[index];
+      cache_lock =
+          std::unique_lock<std::mutex>(type_id_cache->mutex, std::adopt_lock);
     }
+  }
 
-    if (!type_id_cache) {
-        return writeTypeIfNewBlocking(desc);
-    }
+  if (!type_id_cache) {
+    return writeTypeIfNewBlocking(desc);
+  }
 
-    TypeIDAndIsNew res;
+  TypeIDAndIsNew res;
 
-    auto iter_id = type_id_cache->type_ids.find(desc);
-    if (iter_id == end(type_id_cache->type_ids)) {
-        res = writeTypeIfNewBlocking(desc);
-        type_id_cache->type_ids.insert(std::make_pair(desc, res.first));
-    } else {
-        res = std::make_pair(iter_id->second, false);
-    }
+  auto iter_id = type_id_cache->type_ids.find(desc);
+  if (iter_id == end(type_id_cache->type_ids)) {
+    res = writeTypeIfNewBlocking(desc);
+    type_id_cache->type_ids.insert(std::make_pair(desc, res.first));
+  } else {
+    res = std::make_pair(iter_id->second, false);
+  }
 
-    return res;
+  return res;
 }
 
-gapii::PackEncoder::TypeIDAndIsNew
-PackEncoderImpl::writeTypeIfNew(const char* name, size_t size, const void* data) {
-    TypeIDCache* type_id_cache = nullptr;
-    std::unique_lock<std::mutex> cache_lock;
+gapii::PackEncoder::TypeIDAndIsNew PackEncoderImpl::writeTypeIfNew(
+    const char* name, size_t size, const void* data) {
+  TypeIDCache* type_id_cache = nullptr;
+  std::unique_lock<std::mutex> cache_lock;
 
-    for(int index = 0; !type_id_cache && index < TYPE_ID_CACHE_COUNT; ++index) {
-        if (mShared->type_id_caches[index].mutex.try_lock()) {
-            type_id_cache = &mShared->type_id_caches[index];
-            cache_lock = std::unique_lock<std::mutex>(type_id_cache->mutex, std::adopt_lock);
-        }
+  for (int index = 0; !type_id_cache && index < TYPE_ID_CACHE_COUNT; ++index) {
+    if (mShared->type_id_caches[index].mutex.try_lock()) {
+      type_id_cache = &mShared->type_id_caches[index];
+      cache_lock =
+          std::unique_lock<std::mutex>(type_id_cache->mutex, std::adopt_lock);
     }
+  }
 
-    if (!type_id_cache) {
-        return writeTypeIfNewBlocking(name, size, data);
-    }
+  if (!type_id_cache) {
+    return writeTypeIfNewBlocking(name, size, data);
+  }
 
-    TypeIDAndIsNew res;
+  TypeIDAndIsNew res;
 
-    auto iter_id = type_id_cache->type_ids.find(data);
-    if (iter_id == end(type_id_cache->type_ids)) {
-        res = writeTypeIfNewBlocking(name, size, data);
-        type_id_cache->type_ids.insert(std::make_pair(data, res.first));
-    } else {
-        res = std::make_pair(iter_id->second, false);
-    }
+  auto iter_id = type_id_cache->type_ids.find(data);
+  if (iter_id == end(type_id_cache->type_ids)) {
+    res = writeTypeIfNewBlocking(name, size, data);
+    type_id_cache->type_ids.insert(std::make_pair(data, res.first));
+  } else {
+    res = std::make_pair(iter_id->second, false);
+  }
 
-    return res;
+  return res;
 }
 
-gapii::PackEncoder::TypeIDAndIsNew
-PackEncoderImpl::writeTypeIfNewBlocking(const char* name, size_t size, const void* data) {
-    std::lock_guard<std::recursive_mutex> lock(mShared->mutex);
-    auto insert = mShared->type_ids.insert(std::make_pair(data, mShared->type_ids.size()));
-    auto type_id = insert.first->second;
-    if (!insert.second) {
-        return std::make_pair(type_id, false);
-    }
+gapii::PackEncoder::TypeIDAndIsNew PackEncoderImpl::writeTypeIfNewBlocking(
+    const char* name, size_t size, const void* data) {
+  std::lock_guard<std::recursive_mutex> lock(mShared->mutex);
+  auto insert =
+      mShared->type_ids.insert(std::make_pair(data, mShared->type_ids.size()));
+  auto type_id = insert.first->second;
+  if (!insert.second) {
+    return std::make_pair(type_id, false);
+  }
 
-    std::string buffer;
-    writeString(buffer, name);
-    buffer.append(reinterpret_cast<const char*>(data), size);
-    flushChunk(buffer, true);
-    return std::make_pair(type_id, true);
+  std::string buffer;
+  writeString(buffer, name);
+  buffer.append(reinterpret_cast<const char*>(data), size);
+  flushChunk(buffer, true);
+  return std::make_pair(type_id, true);
 }
 
-gapii::PackEncoder::TypeIDAndIsNew
-PackEncoderImpl::writeTypeIfNewBlocking(const Descriptor* desc) {
-    std::lock_guard<std::recursive_mutex> lock(mShared->mutex);
-    auto insert = mShared->type_ids.insert(std::make_pair(desc, mShared->type_ids.size()));
-    auto type_id = insert.first->second;
-    if (!insert.second) {
-        return std::make_pair(type_id, false);
-    }
+gapii::PackEncoder::TypeIDAndIsNew PackEncoderImpl::writeTypeIfNewBlocking(
+    const Descriptor* desc) {
+  std::lock_guard<std::recursive_mutex> lock(mShared->mutex);
+  auto insert =
+      mShared->type_ids.insert(std::make_pair(desc, mShared->type_ids.size()));
+  auto type_id = insert.first->second;
+  if (!insert.second) {
+    return std::make_pair(type_id, false);
+  }
 
-    std::string buffer;
-    DescriptorProto descMsg;
-    desc->CopyTo(&descMsg);
-    writeString(buffer, desc->full_name());
-    descMsg.AppendToString(&buffer);
-    flushChunk(buffer, true);
+  std::string buffer;
+  DescriptorProto descMsg;
+  desc->CopyTo(&descMsg);
+  writeString(buffer, desc->full_name());
+  descMsg.AppendToString(&buffer);
+  flushChunk(buffer, true);
 
-    for (int i = 0; i < desc->field_count(); i++) {
-        if (auto fieldDesc = desc->field(i)->message_type()) {
-            writeTypeIfNewBlocking(fieldDesc);
-        }
+  for (int i = 0; i < desc->field_count(); i++) {
+    if (auto fieldDesc = desc->field(i)->message_type()) {
+      writeTypeIfNewBlocking(fieldDesc);
     }
-    for (int i = 0; i < desc->nested_type_count(); i++) {
-        writeTypeIfNewBlocking(desc->nested_type(i));
-    }
+  }
+  for (int i = 0; i < desc->nested_type_count(); i++) {
+    writeTypeIfNewBlocking(desc->nested_type(i));
+  }
 
-    return std::make_pair(type_id, true);
+  return std::make_pair(type_id, true);
 }
 
 void PackEncoderImpl::writeString(std::string& buffer, const std::string& str) {
-    writeVarint(buffer, str.length());
-    buffer.append(str);
+  writeVarint(buffer, str.length());
+  buffer.append(str);
 }
 
 void PackEncoderImpl::writeZigzag(std::string& buffer, int64_t n) {
-    writeVarint(buffer, uint64_t((n << 1) ^ (n >> 63)));
+  writeVarint(buffer, uint64_t((n << 1) ^ (n >> 63)));
 }
 
 void PackEncoderImpl::writeVarint(std::string& buffer, uint64_t value) {
-    uint8_t buf[16];
-    auto count = CodedOutputStream::WriteVarint64ToArray(value, &buf[0]) - &buf[0];
-    buffer.append(reinterpret_cast<char*>(&buf[0]), count);
+  uint8_t buf[16];
+  auto count =
+      CodedOutputStream::WriteVarint64ToArray(value, &buf[0]) - &buf[0];
+  buffer.append(reinterpret_cast<char*>(&buf[0]), count);
 }
 
 uint64_t PackEncoderImpl::flushChunk(std::string& buffer, bool isTypeDefChunk) {
-    int64_t size = buffer.size();
-    std::string sizeBuffer;
-    writeZigzag(sizeBuffer, isTypeDefChunk ? -size : size);
-    mShared->writer->write(sizeBuffer);
-    mShared->writer->write(buffer);
-    buffer.clear();
-    return mShared->mCurrentChunkId++;
+  int64_t size = buffer.size();
+  std::string sizeBuffer;
+  writeZigzag(sizeBuffer, isTypeDefChunk ? -size : size);
+  mShared->writer->write(sizeBuffer);
+  mShared->writer->write(buffer);
+  buffer.clear();
+  return mShared->mCurrentChunkId++;
 }
 
 // PackEncoderNoop is a no-op implementation of the PackEncoder interface.
 class PackEncoderNoop : public gapii::PackEncoder {
-public:
-    static SPtr instance;
+ public:
+  static SPtr instance;
 
-    virtual TypeIDAndIsNew type(const char* name, size_t size, const void* data) override {
-        return std::make_pair(0, false);
-    }
-    virtual void object(const Message* msg) override {}
-    virtual void object(TypeID type, size_t size, const void* data) override {}
-    virtual SPtr group(const Message* msg) override {
-        return instance;
-    }
-    virtual PackEncoder* group(TypeID type, size_t size, const void* data) override {
-        return new PackEncoderNoop();
-    }
-    virtual void flush() override {}
+  virtual TypeIDAndIsNew type(const char* name, size_t size,
+                              const void* data) override {
+    return std::make_pair(0, false);
+  }
+  virtual void object(const Message* msg) override {}
+  virtual void object(TypeID type, size_t size, const void* data) override {}
+  virtual SPtr group(const Message* msg) override { return instance; }
+  virtual PackEncoder* group(TypeID type, size_t size,
+                             const void* data) override {
+    return new PackEncoderNoop();
+  }
+  virtual void flush() override {}
 };
 
-gapii::PackEncoder::SPtr PackEncoderNoop::instance = gapii::PackEncoder::SPtr(new PackEncoderNoop);
+gapii::PackEncoder::SPtr PackEncoderNoop::instance =
+    gapii::PackEncoder::SPtr(new PackEncoderNoop);
 
-} // anonymous namespace
+}  // anonymous namespace
 
 namespace gapii {
 
 // create returns a PackEncoder::SPtr that writes to output.
-PackEncoder::SPtr PackEncoder::create(std::shared_ptr<core::StreamWriter> stream, bool no_buffer) {
-    stream->write(header, sizeof(header));
-    auto writer = ChunkWriter::create(stream, no_buffer);
-    return PackEncoder::SPtr(new PackEncoderImpl(writer));
+PackEncoder::SPtr PackEncoder::create(
+    std::shared_ptr<core::StreamWriter> stream, bool no_buffer) {
+  stream->write(header, sizeof(header));
+  auto writer = ChunkWriter::create(stream, no_buffer);
+  return PackEncoder::SPtr(new PackEncoderImpl(writer));
 }
 
 // noop returns a PackEncoder::SPtr that does nothing.
-PackEncoder::SPtr PackEncoder::noop() {
-    return PackEncoderNoop::instance;
-}
+PackEncoder::SPtr PackEncoder::noop() { return PackEncoderNoop::instance; }
 
-} // namespace gapii
+}  // namespace gapii

--- a/gapii/cc/pack_encoder.h
+++ b/gapii/cc/pack_encoder.h
@@ -26,60 +26,62 @@
 
 namespace google {
 namespace protobuf {
-    class Descriptor;
-    class Message;
-} // namespace protobuf
-} // namespace google
+class Descriptor;
+class Message;
+}  // namespace protobuf
+}  // namespace google
 
 namespace core {
-    class StreamWriter;
-} // namespace core
+class StreamWriter;
+}  // namespace core
 
 namespace gapii {
 
 // PackEncoder provides methods for encoding protobuf messages to the provided
 // StreamWriter using the pack-stream format.
 class PackEncoder {
-public:
-    typedef std::shared_ptr<PackEncoder> SPtr;
+ public:
+  typedef std::shared_ptr<PackEncoder> SPtr;
 
-    typedef uint32_t TypeID;
-    typedef std::pair<TypeID, bool> TypeIDAndIsNew;
+  typedef uint32_t TypeID;
+  typedef std::pair<TypeID, bool> TypeIDAndIsNew;
 
-    virtual ~PackEncoder() = default;
+  virtual ~PackEncoder() = default;
 
-    // type encodes the given type descriptor if it hasn't been already,
-    // returning the type identifier and a boolean indicating whether the type
-    // was encoded this call.
-    // type assumes the data pointer is stable between calls of the same type.
-    virtual TypeIDAndIsNew type(const char* name, size_t size, const void* data) = 0;
+  // type encodes the given type descriptor if it hasn't been already,
+  // returning the type identifier and a boolean indicating whether the type
+  // was encoded this call.
+  // type assumes the data pointer is stable between calls of the same type.
+  virtual TypeIDAndIsNew type(const char* name, size_t size,
+                              const void* data) = 0;
 
-    // object encodes the leaf protobuf message.
-    virtual void object(const ::google::protobuf::Message* msg) = 0;
+  // object encodes the leaf protobuf message.
+  virtual void object(const ::google::protobuf::Message* msg) = 0;
 
-    // object encodes the leaf object from an already encoded protobuf message.
-    virtual void object(TypeID type, size_t size, const void* data) = 0;
+  // object encodes the leaf object from an already encoded protobuf message.
+  virtual void object(TypeID type, size_t size, const void* data) = 0;
 
-    // group encodes the protobuf message as a group that can contain other
-    // objects and groups.
-    virtual SPtr group(const ::google::protobuf::Message* msg) = 0;
+  // group encodes the protobuf message as a group that can contain other
+  // objects and groups.
+  virtual SPtr group(const ::google::protobuf::Message* msg) = 0;
 
-    // object encodes the group object from an already encoded protobuf message.
-    // The returned PackEncoder can be used to encode objects into this group,
-    // and must be deleted by the caller.
-    virtual PackEncoder* group(TypeID type, size_t size, const void* data) = 0;
+  // object encodes the group object from an already encoded protobuf message.
+  // The returned PackEncoder can be used to encode objects into this group,
+  // and must be deleted by the caller.
+  virtual PackEncoder* group(TypeID type, size_t size, const void* data) = 0;
 
-    // flush flushes out all of the pending in the encoder
-    virtual void flush() = 0;
+  // flush flushes out all of the pending in the encoder
+  virtual void flush() = 0;
 
-    // create returns a PackEncoder::SPtr that writes to output.
-    // If no_buffer is true, thn the output will be flushed after every write.
-    static SPtr create(std::shared_ptr<core::StreamWriter> output, bool no_buffer);
+  // create returns a PackEncoder::SPtr that writes to output.
+  // If no_buffer is true, thn the output will be flushed after every write.
+  static SPtr create(std::shared_ptr<core::StreamWriter> output,
+                     bool no_buffer);
 
-    // noop returns a PackEncoder::SPtr that does nothing.
-    static SPtr noop();
+  // noop returns a PackEncoder::SPtr that does nothing.
+  static SPtr noop();
 };
 
-} // namespace gapii
+}  // namespace gapii
 
-#endif // GAPII_PACK_ENCODER_H
+#endif  // GAPII_PACK_ENCODER_H

--- a/gapii/cc/runtime.cpp
+++ b/gapii/cc/runtime.cpp
@@ -16,8 +16,8 @@
 
 #include "core/memory/arena/cc/arena.h"
 
-#include "gapil/runtime/cc/runtime.h"
 #include "gapil/runtime/cc/encoder.h"
+#include "gapil/runtime/cc/runtime.h"
 
 #include "gapii/cc/call_observer.h"
 #include "gapii/cc/pack_encoder.h"
@@ -30,41 +30,44 @@
 
 extern "C" {
 
-int64_t gapil_encode_type(context* ctx, uint8_t* name, uint32_t desc_size, void* desc) {
-    DEBUG_PRINT("gapil_encode_type(%p, %s, %d, %p)", ctx, name, desc_size, desc);
-    auto cb = static_cast<gapii::CallObserver*>(ctx);
-    auto e = cb->encoder();
-    auto res = e->type(reinterpret_cast<const char*>(name), desc_size, desc);
-    auto id = static_cast<int64_t>(res.first);
-    auto isnew = res.second;
-    return isnew ? id : -id;
+int64_t gapil_encode_type(context* ctx, uint8_t* name, uint32_t desc_size,
+                          void* desc) {
+  DEBUG_PRINT("gapil_encode_type(%p, %s, %d, %p)", ctx, name, desc_size, desc);
+  auto cb = static_cast<gapii::CallObserver*>(ctx);
+  auto e = cb->encoder();
+  auto res = e->type(reinterpret_cast<const char*>(name), desc_size, desc);
+  auto id = static_cast<int64_t>(res.first);
+  auto isnew = res.second;
+  return isnew ? id : -id;
 }
 
-void* gapil_encode_object(context* ctx, uint8_t is_group, uint32_t type, uint32_t data_size, void* data) {
-    DEBUG_PRINT("gapil_encode_object(%p, %s, %d, %d, %p)", ctx, is_group ? "true" : "false", type, data_size, data);
-    auto cb = static_cast<gapii::CallObserver*>(ctx);
-    auto e = cb->encoder();
-    if (is_group) {
-        return e->group(type, data_size, data);
-    }
-    e->object(type, data_size, data);
-    return nullptr;
+void* gapil_encode_object(context* ctx, uint8_t is_group, uint32_t type,
+                          uint32_t data_size, void* data) {
+  DEBUG_PRINT("gapil_encode_object(%p, %s, %d, %d, %p)", ctx,
+              is_group ? "true" : "false", type, data_size, data);
+  auto cb = static_cast<gapii::CallObserver*>(ctx);
+  auto e = cb->encoder();
+  if (is_group) {
+    return e->group(type, data_size, data);
+  }
+  e->object(type, data_size, data);
+  return nullptr;
 }
 
 void gapil_slice_encoded(context* ctx, slice_t* slice) {
-    DEBUG_PRINT("gapil_on_encode_slice(%p, %p)", ctx, slice);
-    auto cb = static_cast<gapii::CallObserver*>(ctx);
-    cb->slice_encoded(slice);
+  DEBUG_PRINT("gapil_on_encode_slice(%p, %p)", ctx, slice);
+  auto cb = static_cast<gapii::CallObserver*>(ctx);
+  cb->slice_encoded(slice);
 }
 
 int64_t gapil_encode_backref(context* ctx, void* object) {
-    auto cb = static_cast<gapii::CallObserver*>(ctx);
-    auto res = cb->reference_id(object);
-    auto id = static_cast<int64_t>(res.first);
-    auto isnew = res.second;
-    DEBUG_PRINT("gapil_encode_backref(%p, %p) -> new: %s id: %d",
-            ctx, object, isnew ? "true" : "false", int(id));
-    return isnew ? id : -id;
+  auto cb = static_cast<gapii::CallObserver*>(ctx);
+  auto res = cb->reference_id(object);
+  auto id = static_cast<int64_t>(res.first);
+  auto isnew = res.second;
+  DEBUG_PRINT("gapil_encode_backref(%p, %p) -> new: %s id: %d", ctx, object,
+              isnew ? "true" : "false", int(id));
+  return isnew ? id : -id;
 }
 
-} // extern "C"
+}  // extern "C"

--- a/gapii/cc/spy.cpp
+++ b/gapii/cc/spy.cpp
@@ -30,38 +30,37 @@
 #include "core/cc/target.h"
 #include "core/os/device/deviceinfo/cc/query.h"
 
-#include "gapis/capture/capture.pb.h"
 #include "gapis/api/gles/gles_pb/extras.pb.h"
+#include "gapis/capture/capture.pb.h"
 #include "gapis/memory/memory_pb/memory.pb.h"
 
 #include <cstdlib>
-#include <vector>
 #include <memory>
+#include <vector>
 
 #if TARGET_OS == GAPID_OS_WINDOWS
 #include "windows/wgl.h"
-#endif //  TARGET_OS == GAPID_OS_WINDOWS
+#endif  //  TARGET_OS == GAPID_OS_WINDOWS
 
 #if TARGET_OS == GAPID_OS_ANDROID
-#include "gapii/cc/android/installer.h"
 #include "gapii/cc/android/gvr_install.h"
+#include "gapii/cc/android/installer.h"
 
-#include <sys/prctl.h>
 #include <jni.h>
+#include <sys/prctl.h>
 
 static std::unique_ptr<gapii::Installer> gInstaller;
 static JavaVM* gJavaVM = nullptr;
 
-extern "C"
-jint JNI_OnLoad(JavaVM *vm, void *reserved) {
-    GAPID_INFO("JNI_OnLoad() was called. vm = %p", vm);
-    gJavaVM = vm;
-    gapii::Spy::get(); // Construct the spy.
-    return JNI_VERSION_1_6;
+extern "C" jint JNI_OnLoad(JavaVM* vm, void* reserved) {
+  GAPID_INFO("JNI_OnLoad() was called. vm = %p", vm);
+  gJavaVM = vm;
+  gapii::Spy::get();  // Construct the spy.
+  return JNI_VERSION_1_6;
 }
 
 void* queryPlatformData() { return gJavaVM; }
-#else  // TARGET_OS == GAPID_OS_ANDROID
+#else   // TARGET_OS == GAPID_OS_ANDROID
 void* queryPlatformData() { return nullptr; }
 #endif  // TARGET_OS == GAPID_OS_ANDROID
 
@@ -71,569 +70,604 @@ namespace {
 
 typedef uint32_t EGLint;
 
-const EGLint EGL_TRUE                      = 0x0001;
-const EGLint EGL_ALPHA_SIZE                = 0x3021;
-const EGLint EGL_BLUE_SIZE                 = 0x3022;
-const EGLint EGL_GREEN_SIZE                = 0x3023;
-const EGLint EGL_RED_SIZE                  = 0x3024;
-const EGLint EGL_DEPTH_SIZE                = 0x3025;
-const EGLint EGL_STENCIL_SIZE              = 0x3026;
-const EGLint EGL_CONFIG_ID                 = 0x3028;
-const EGLint EGL_NONE                      = 0x3038;
-const EGLint EGL_HEIGHT                    = 0x3056;
-const EGLint EGL_WIDTH                     = 0x3057;
-const EGLint EGL_SWAP_BEHAVIOR             = 0x3093;
-const EGLint EGL_BUFFER_PRESERVED          = 0x3094;
+const EGLint EGL_TRUE = 0x0001;
+const EGLint EGL_ALPHA_SIZE = 0x3021;
+const EGLint EGL_BLUE_SIZE = 0x3022;
+const EGLint EGL_GREEN_SIZE = 0x3023;
+const EGLint EGL_RED_SIZE = 0x3024;
+const EGLint EGL_DEPTH_SIZE = 0x3025;
+const EGLint EGL_STENCIL_SIZE = 0x3026;
+const EGLint EGL_CONFIG_ID = 0x3028;
+const EGLint EGL_NONE = 0x3038;
+const EGLint EGL_HEIGHT = 0x3056;
+const EGLint EGL_WIDTH = 0x3057;
+const EGLint EGL_SWAP_BEHAVIOR = 0x3093;
+const EGLint EGL_BUFFER_PRESERVED = 0x3094;
 
-const EGLint EGL_CONTEXT_MAJOR_VERSION_KHR       = 0x3098;
-const EGLint EGL_CONTEXT_MINOR_VERSION_KHR       = 0x30FB;
-const EGLint EGL_CONTEXT_FLAGS_KHR               = 0x30FC;
-const EGLint EGL_CONTEXT_OPENGL_DEBUG_BIT_KHR    = 0x0001;
+const EGLint EGL_CONTEXT_MAJOR_VERSION_KHR = 0x3098;
+const EGLint EGL_CONTEXT_MINOR_VERSION_KHR = 0x30FB;
+const EGLint EGL_CONTEXT_FLAGS_KHR = 0x30FC;
+const EGLint EGL_CONTEXT_OPENGL_DEBUG_BIT_KHR = 0x0001;
 const EGLint EGL_CONTEXT_OPENGL_PROFILE_MASK_KHR = 0x30FD;
 
 const uint32_t kMaxFramebufferObservationWidth = 1920 / 2;
 const uint32_t kMaxFramebufferObservationHeight = 1280 / 2;
 
-const uint32_t kStartMidExecutionCapture =  0xdeadbeef;
+const uint32_t kStartMidExecutionCapture = 0xdeadbeef;
 
-const int32_t  kSuspendIndefinitely = -1;
+const int32_t kSuspendIndefinitely = -1;
 
 std::recursive_mutex gMutex;  // Guards gSpy.
 std::unique_ptr<gapii::Spy> gSpy;
 thread_local gapii::CallObserver* gContext = nullptr;
 
-} // anonymous namespace
+}  // anonymous namespace
 
 namespace gapii {
 
 Spy* Spy::get() {
-    std::lock_guard<std::recursive_mutex> lock(gMutex);
-    if (!gSpy) {
-        GAPID_INFO("Constructing spy...");
-        gSpy.reset(new Spy());
-        GAPID_INFO("Registering spy symbols...");
-        for (int i = 0; kGLESExports[i].mName != NULL; ++i) {
-            gSpy->RegisterSymbol(kGLESExports[i].mName, kGLESExports[i].mFunc);
-        }
+  std::lock_guard<std::recursive_mutex> lock(gMutex);
+  if (!gSpy) {
+    GAPID_INFO("Constructing spy...");
+    gSpy.reset(new Spy());
+    GAPID_INFO("Registering spy symbols...");
+    for (int i = 0; kGLESExports[i].mName != NULL; ++i) {
+      gSpy->RegisterSymbol(kGLESExports[i].mName, kGLESExports[i].mFunc);
     }
-    return gSpy.get();
+  }
+  return gSpy.get();
 }
 
 Spy::Spy()
-  : mNumFrames(0)
-  , mSuspendCaptureFrames(0)
-  , mCaptureFrames(0)
-  , mNumDraws(0)
-  , mNumDrawsPerFrame(0)
-  , mObserveFrameFrequency(0)
-  , mObserveDrawFrequency(0)
-  , mDisablePrecompiledShaders(false)
-  , mRecordGLErrorState(false)
-  , mNestedFrameStart(0)
-  , mNestedFrameEnd(0) {
+    : mNumFrames(0),
+      mSuspendCaptureFrames(0),
+      mCaptureFrames(0),
+      mNumDraws(0),
+      mNumDrawsPerFrame(0),
+      mObserveFrameFrequency(0),
+      mObserveDrawFrequency(0),
+      mDisablePrecompiledShaders(false),
+      mRecordGLErrorState(false),
+      mNestedFrameStart(0),
+      mNestedFrameEnd(0) {
+#if TARGET_OS == GAPID_OS_ANDROID
+  // Use a "localabstract" pipe on Android to prevent depending on the traced
+  // application having the INTERNET permission set, required for opening and
+  // listening on a TCP socket.
+  mConnection = ConnectionStream::listenPipe("gapii", true);
+#else   // TARGET_OS
+  mConnection = ConnectionStream::listenSocket("127.0.0.1", "9286");
+#endif  // TARGET_OS
 
+  if (!mConnection->write("gapii", 5)) {  // handshake magic
+    GAPID_FATAL("Couldn't send handshake magic");
+  }
+
+  GAPID_INFO("Connection made");
+
+  ConnectionHeader header;
+  if (!header.read(mConnection.get())) {
+    GAPID_FATAL("Failed to read connection header");
+  }
+
+  GAPID_INFO("Connection header read");
+
+  mObserveFrameFrequency = header.mObserveFrameFrequency;
+  mObserveDrawFrequency = header.mObserveDrawFrequency;
+  mDisablePrecompiledShaders =
+      (header.mFlags & ConnectionHeader::FLAG_DISABLE_PRECOMPILED_SHADERS) != 0;
+  mRecordGLErrorState =
+      (header.mFlags & ConnectionHeader::FLAG_RECORD_ERROR_STATE) != 0;
+  // This will be over-written if we also set the header flags
+  mSuspendCaptureFrames = header.mStartFrame;
+  mCaptureFrames = header.mNumFrames;
+  mSuspendCaptureFrames.store(
+      (header.mFlags & ConnectionHeader::FLAG_DEFER_START)
+          ? kSuspendIndefinitely
+          : mSuspendCaptureFrames.load());
+
+  set_valid_apis(header.mAPIs);
+  GAPID_ERROR("APIS %08x", header.mAPIs);
+  GAPID_INFO("GAPII connection established. Settings:");
+  GAPID_INFO("Observe framebuffer every %d frames", mObserveFrameFrequency);
+  GAPID_INFO("Observe framebuffer every %d draws", mObserveDrawFrequency);
+  GAPID_INFO("Disable precompiled shaders: %s",
+             mDisablePrecompiledShaders ? "true" : "false");
+
+  mEncoder = gapii::PackEncoder::create(
+      mConnection, header.mFlags & ConnectionHeader::FLAG_NO_BUFFER);
+
+  // writeHeader needs to come before the installer is created as the
+  // deviceinfo queries want to call into EGL / GL commands which will be
+  // patched.
+  query::Option query_opt;
+  SpyBase::set_device_instance(
+      query::getDeviceInstance(query_opt, queryPlatformData()));
+  SpyBase::set_current_abi(query::currentABI());
+  if (!SpyBase::writeHeader()) {
+    GAPID_ERROR("Failed at writing trace header.");
+  }
 
 #if TARGET_OS == GAPID_OS_ANDROID
-    // Use a "localabstract" pipe on Android to prevent depending on the traced application
-    // having the INTERNET permission set, required for opening and listening on a TCP socket.
-    mConnection = ConnectionStream::listenPipe("gapii", true);
-#else // TARGET_OS
-    mConnection = ConnectionStream::listenSocket("127.0.0.1", "9286");
-#endif // TARGET_OS
+  if (strlen(header.mLibInterceptorPath) > 0) {
+    gInstaller =
+        std::unique_ptr<Installer>(new Installer(header.mLibInterceptorPath));
+  }
+  if (header.mGvrHandle != 0) {
+    auto gvr_lib = reinterpret_cast<void*>(header.mGvrHandle);
+    install_gvr(gInstaller.get(), gvr_lib, &this->GvrSpy::mImports);
+  }
+#endif  // TARGET_OS == GAPID_OS_ANDROID
 
-    if (!mConnection->write("gapii", 5)) { // handshake magic
-        GAPID_FATAL("Couldn't send handshake magic");
-    }
+  auto context = enter("init", 0);
+  GlesSpy::init();
+  VulkanSpy::init();
+  SpyBase::init(context);
+  exit();
 
-    GAPID_INFO("Connection made");
-
-    ConnectionHeader header;
-    if (!header.read(mConnection.get())) {
-        GAPID_FATAL("Failed to read connection header");
-    }
-
-    GAPID_INFO("Connection header read");
-
-    mObserveFrameFrequency = header.mObserveFrameFrequency;
-    mObserveDrawFrequency = header.mObserveDrawFrequency;
-    mDisablePrecompiledShaders =
-            (header.mFlags & ConnectionHeader::FLAG_DISABLE_PRECOMPILED_SHADERS) != 0;
-    mRecordGLErrorState =
-            (header.mFlags & ConnectionHeader::FLAG_RECORD_ERROR_STATE) != 0;
-    // This will be over-written if we also set the header flags
-    mSuspendCaptureFrames = header.mStartFrame;
-    mCaptureFrames = header.mNumFrames;
-    mSuspendCaptureFrames.store((header.mFlags & ConnectionHeader::FLAG_DEFER_START)?
-        kSuspendIndefinitely: mSuspendCaptureFrames.load());
-
-    set_valid_apis(header.mAPIs);
-    GAPID_ERROR("APIS %08x", header.mAPIs);
-    GAPID_INFO("GAPII connection established. Settings:");
-    GAPID_INFO("Observe framebuffer every %d frames", mObserveFrameFrequency);
-    GAPID_INFO("Observe framebuffer every %d draws", mObserveDrawFrequency);
-    GAPID_INFO("Disable precompiled shaders: %s", mDisablePrecompiledShaders ? "true" : "false");
-
-    mEncoder = gapii::PackEncoder::create(mConnection, header.mFlags & ConnectionHeader::FLAG_NO_BUFFER);
-
-    // writeHeader needs to come before the installer is created as the
-    // deviceinfo queries want to call into EGL / GL commands which will be
-    // patched.
-    query::Option query_opt;
-    SpyBase::set_device_instance(
-        query::getDeviceInstance(query_opt, queryPlatformData()));
-    SpyBase::set_current_abi(query::currentABI());
-    if (!SpyBase::writeHeader()) {
-      GAPID_ERROR("Failed at writing trace header.");
-    }
-
-#if TARGET_OS == GAPID_OS_ANDROID
-    if (strlen(header.mLibInterceptorPath) > 0) {
-        gInstaller = std::unique_ptr<Installer>(new Installer(header.mLibInterceptorPath));
-    }
-    if (header.mGvrHandle != 0) {
-        auto gvr_lib = reinterpret_cast<void*>(header.mGvrHandle);
-        install_gvr(gInstaller.get(), gvr_lib, &this->GvrSpy::mImports);
-    }
-#endif // TARGET_OS == GAPID_OS_ANDROID
-
-    auto context = enter("init", 0);
-    GlesSpy::init();
-    VulkanSpy::init();
-    SpyBase::init(context);
-    exit();
-
-    if (mSuspendCaptureFrames.load() == kSuspendIndefinitely) {
-        mDeferStartJob = std::unique_ptr<core::AsyncJob>(
-        new core::AsyncJob([this]() {
-            uint32_t buffer;
-            if (4 == mConnection->read(&buffer, 4)) {
-                if (buffer == kStartMidExecutionCapture) {
-                    mSuspendCaptureFrames.store(1);
-                }
+  if (mSuspendCaptureFrames.load() == kSuspendIndefinitely) {
+    mDeferStartJob =
+        std::unique_ptr<core::AsyncJob>(new core::AsyncJob([this]() {
+          uint32_t buffer;
+          if (4 == mConnection->read(&buffer, 4)) {
+            if (buffer == kStartMidExecutionCapture) {
+              mSuspendCaptureFrames.store(1);
             }
+          }
         }));
-    }
-    set_suspended(mSuspendCaptureFrames.load() != 0);
-    set_observing(mObserveFrameFrequency != 0 || mObserveDrawFrequency != 0);
+  }
+  set_suspended(mSuspendCaptureFrames.load() != 0);
+  set_observing(mObserveFrameFrequency != 0 || mObserveDrawFrequency != 0);
 }
 
-void Spy::resolveImports() {
-    GlesSpy::mImports.resolve();
-}
+void Spy::resolveImports() { GlesSpy::mImports.resolve(); }
 
 CallObserver* Spy::enter(const char* name, uint32_t api) {
-    auto ctx = new CallObserver(this, gContext, api);
-    lock(ctx);
-    ctx->setCurrentCommandName(name);
-    gContext = ctx;
-    return ctx;
+  auto ctx = new CallObserver(this, gContext, api);
+  lock(ctx);
+  ctx->setCurrentCommandName(name);
+  gContext = ctx;
+  return ctx;
 }
 
 void Spy::exit() {
-    auto context = gContext;
-    gContext = context->getParent();
-    delete context;
-    unlock();
+  auto context = gContext;
+  gContext = context->getParent();
+  delete context;
+  unlock();
 }
 
-EGLBoolean Spy::eglInitialize(CallObserver* observer, EGLDisplay dpy, EGLint* major, EGLint* minor) {
-    EGLBoolean res = GlesSpy::eglInitialize(observer, dpy, major, minor);
-    if (res != 0) {
-        resolveImports(); // Imports may have changed. Re-resolve.
-    }
-    return res;
+EGLBoolean Spy::eglInitialize(CallObserver* observer, EGLDisplay dpy,
+                              EGLint* major, EGLint* minor) {
+  EGLBoolean res = GlesSpy::eglInitialize(observer, dpy, major, minor);
+  if (res != 0) {
+    resolveImports();  // Imports may have changed. Re-resolve.
+  }
+  return res;
 }
 
-EGLContext Spy::eglCreateContext(CallObserver* observer, EGLDisplay display, EGLConfig config,
-                                 EGLContext share_context, EGLint* attrib_list) {
-    // Read attrib list
-    std::map<EGLint, EGLint> attribs;
-    while(attrib_list != nullptr && *attrib_list != EGL_NONE) {
-        EGLint key = *(attrib_list++);
-        EGLint val = *(attrib_list++);
-        attribs[key] = val;
-    }
+EGLContext Spy::eglCreateContext(CallObserver* observer, EGLDisplay display,
+                                 EGLConfig config, EGLContext share_context,
+                                 EGLint* attrib_list) {
+  // Read attrib list
+  std::map<EGLint, EGLint> attribs;
+  while (attrib_list != nullptr && *attrib_list != EGL_NONE) {
+    EGLint key = *(attrib_list++);
+    EGLint val = *(attrib_list++);
+    attribs[key] = val;
+  }
 
-    // Modify attrib list
-    if (mRecordGLErrorState) {
-        attribs[EGL_CONTEXT_FLAGS_KHR] |= EGL_CONTEXT_OPENGL_DEBUG_BIT_KHR;
-    }
+  // Modify attrib list
+  if (mRecordGLErrorState) {
+    attribs[EGL_CONTEXT_FLAGS_KHR] |= EGL_CONTEXT_OPENGL_DEBUG_BIT_KHR;
+  }
 
-    // Write attrib list
-    std::vector<EGLint> attrib_vector;
-    for(auto it: attribs) {
-        attrib_vector.push_back(it.first);
-        attrib_vector.push_back(it.second);
-    }
-    attrib_vector.push_back(EGL_NONE);
-    attrib_vector.push_back(EGL_NONE);
+  // Write attrib list
+  std::vector<EGLint> attrib_vector;
+  for (auto it : attribs) {
+    attrib_vector.push_back(it.first);
+    attrib_vector.push_back(it.second);
+  }
+  attrib_vector.push_back(EGL_NONE);
+  attrib_vector.push_back(EGL_NONE);
 
-    auto res = GlesSpy::eglCreateContext(observer, display, config, share_context, attrib_vector.data());
+  auto res = GlesSpy::eglCreateContext(observer, display, config, share_context,
+                                       attrib_vector.data());
 
-    // NB: The getters modify the std::map, so this log must be last.
-    GAPID_INFO("eglCreateContext requested: GL %i.%i, profile 0x%x, flags 0x%x -> %p",
-               attribs[EGL_CONTEXT_MAJOR_VERSION_KHR], attribs[EGL_CONTEXT_MINOR_VERSION_KHR],
-               attribs[EGL_CONTEXT_OPENGL_PROFILE_MASK_KHR], attribs[EGL_CONTEXT_FLAGS_KHR],
-               res);
-    return res;
+  // NB: The getters modify the std::map, so this log must be last.
+  GAPID_INFO(
+      "eglCreateContext requested: GL %i.%i, profile 0x%x, flags 0x%x -> %p",
+      attribs[EGL_CONTEXT_MAJOR_VERSION_KHR],
+      attribs[EGL_CONTEXT_MINOR_VERSION_KHR],
+      attribs[EGL_CONTEXT_OPENGL_PROFILE_MASK_KHR],
+      attribs[EGL_CONTEXT_FLAGS_KHR], res);
+  return res;
 }
 
-static void STDCALL DebugCallback(uint32_t source, uint32_t type, uint32_t id, uint32_t severity,
-                                  uint32_t length, const char* message, void* user_param) {
-    if (type == GL_DEBUG_TYPE_PUSH_GROUP || type == GL_DEBUG_TYPE_POP_GROUP) {
-        return; // Ignore
-    } else if (type == GL_DEBUG_TYPE_ERROR || severity == GL_DEBUG_SEVERITY_HIGH) {
-        GAPID_ERROR("KHR_debug: %s", message);
-    } else {
-        GAPID_INFO("KHR_debug: %s", message);
-    }
-    // TODO: We should store the message in the trace.
+static void STDCALL DebugCallback(uint32_t source, uint32_t type, uint32_t id,
+                                  uint32_t severity, uint32_t length,
+                                  const char* message, void* user_param) {
+  if (type == GL_DEBUG_TYPE_PUSH_GROUP || type == GL_DEBUG_TYPE_POP_GROUP) {
+    return;  // Ignore
+  } else if (type == GL_DEBUG_TYPE_ERROR ||
+             severity == GL_DEBUG_SEVERITY_HIGH) {
+    GAPID_ERROR("KHR_debug: %s", message);
+  } else {
+    GAPID_INFO("KHR_debug: %s", message);
+  }
+  // TODO: We should store the message in the trace.
 }
 
-EGLBoolean Spy::eglMakeCurrent(CallObserver* observer, EGLDisplay display, EGLSurface draw, EGLSurface read, EGLContext context) {
-    EGLBoolean res = GlesSpy::eglMakeCurrent(observer, display, draw, read, context);
-    auto& ext = GlesSpy::mState.Extension;
-    if (mRecordGLErrorState && ext != nullptr && ext->mGL_KHR_debug) {
-        void* old_callback = nullptr;
-        void* new_callback = reinterpret_cast<void*>(&DebugCallback);
-        GlesSpy::mImports.glGetPointerv(GL_DEBUG_CALLBACK_FUNCTION, &old_callback);
-        if (old_callback != new_callback) {
-            GlesSpy::mImports.glDebugMessageCallback(new_callback, this);
-            GlesSpy::mImports.glEnable(GL_DEBUG_OUTPUT);
-            GlesSpy::mImports.glEnable(GL_DEBUG_OUTPUT_SYNCHRONOUS);
-            GAPID_INFO("KHR_debug extension enabled");
-        }
+EGLBoolean Spy::eglMakeCurrent(CallObserver* observer, EGLDisplay display,
+                               EGLSurface draw, EGLSurface read,
+                               EGLContext context) {
+  EGLBoolean res =
+      GlesSpy::eglMakeCurrent(observer, display, draw, read, context);
+  auto& ext = GlesSpy::mState.Extension;
+  if (mRecordGLErrorState && ext != nullptr && ext->mGL_KHR_debug) {
+    void* old_callback = nullptr;
+    void* new_callback = reinterpret_cast<void*>(&DebugCallback);
+    GlesSpy::mImports.glGetPointerv(GL_DEBUG_CALLBACK_FUNCTION, &old_callback);
+    if (old_callback != new_callback) {
+      GlesSpy::mImports.glDebugMessageCallback(new_callback, this);
+      GlesSpy::mImports.glEnable(GL_DEBUG_OUTPUT);
+      GlesSpy::mImports.glEnable(GL_DEBUG_OUTPUT_SYNCHRONOUS);
+      GAPID_INFO("KHR_debug extension enabled");
     }
-    return res;
+  }
+  return res;
 }
 
-gapil::Ref<StaticContextState> GlesSpy::GetEGLStaticContextState(CallObserver* observer, EGLDisplay display, EGLContext context) {
-    Constants constants(arena());
-    getContextConstants(constants);
+gapil::Ref<StaticContextState> GlesSpy::GetEGLStaticContextState(
+    CallObserver* observer, EGLDisplay display, EGLContext context) {
+  Constants constants(arena());
+  getContextConstants(constants);
 
-    gapil::String threadName;
+  gapil::String threadName;
 #if TARGET_OS == GAPID_OS_ANDROID
-    char buffer[256] = { 0 };
-    prctl(PR_GET_NAME, (unsigned long)buffer, 0, 0, 0);
-    threadName = gapil::String(arena(), buffer);
+  char buffer[256] = {0};
+  prctl(PR_GET_NAME, (unsigned long)buffer, 0, 0, 0);
+  threadName = gapil::String(arena(), buffer);
 #endif
 
-    auto out = gapil::Ref<StaticContextState>::create(arena(), constants, threadName);
+  auto out =
+      gapil::Ref<StaticContextState>::create(arena(), constants, threadName);
 
-    observer->encode(*out.get());
+  observer->encode(*out.get());
 
-    return out;
+  return out;
 }
 
-#define EGL_QUERY_SURFACE(name, draw, var) \
-if (GlesSpy::mImports.eglQuerySurface(display, draw, name, var) != EGL_TRUE) { \
-    GAPID_WARNING("eglQuerySurface(0x%p, 0x%p, " #name ", " #var ") failed", display, draw); \
-}
-#define EGL_GET_CONFIG_ATTRIB(name, var) \
-if (GlesSpy::mImports.eglGetConfigAttrib(display, config, name, var) != EGL_TRUE) { \
-    GAPID_WARNING("eglGetConfigAttrib(0x%p, 0x%p, " #name ", " #var ") failed", display, config); \
-}
+#define EGL_QUERY_SURFACE(name, draw, var)                                   \
+  if (GlesSpy::mImports.eglQuerySurface(display, draw, name, var) !=         \
+      EGL_TRUE) {                                                            \
+    GAPID_WARNING("eglQuerySurface(0x%p, 0x%p, " #name ", " #var ") failed", \
+                  display, draw);                                            \
+  }
+#define EGL_GET_CONFIG_ATTRIB(name, var)                                  \
+  if (GlesSpy::mImports.eglGetConfigAttrib(display, config, name, var) != \
+      EGL_TRUE) {                                                         \
+    GAPID_WARNING("eglGetConfigAttrib(0x%p, 0x%p, " #name ", " #var       \
+                  ") failed",                                             \
+                  display, config);                                       \
+  }
 
-gapil::Ref<DynamicContextState> GlesSpy::GetEGLDynamicContextState(CallObserver* observer, EGLDisplay display, EGLSurface draw, EGLContext context) {
-    EGLint width = 0;
-    EGLint height = 0;
-    EGLint swapBehavior = 0;
-    if (draw != nullptr) {
-        EGL_QUERY_SURFACE(EGL_WIDTH, draw, &width);
-        EGL_QUERY_SURFACE(EGL_HEIGHT, draw, &height);
-        EGL_QUERY_SURFACE(EGL_SWAP_BEHAVIOR, draw, &swapBehavior);
-    }
+gapil::Ref<DynamicContextState> GlesSpy::GetEGLDynamicContextState(
+    CallObserver* observer, EGLDisplay display, EGLSurface draw,
+    EGLContext context) {
+  EGLint width = 0;
+  EGLint height = 0;
+  EGLint swapBehavior = 0;
+  if (draw != nullptr) {
+    EGL_QUERY_SURFACE(EGL_WIDTH, draw, &width);
+    EGL_QUERY_SURFACE(EGL_HEIGHT, draw, &height);
+    EGL_QUERY_SURFACE(EGL_SWAP_BEHAVIOR, draw, &swapBehavior);
+  }
 
-    // Get the backbuffer formats.
-    uint32_t backbufferColorFmt = GL_RGBA8;
-    uint32_t backbufferDepthFmt = GL_DEPTH24_STENCIL8;
-    uint32_t backbufferStencilFmt = GL_DEPTH24_STENCIL8;
+  // Get the backbuffer formats.
+  uint32_t backbufferColorFmt = GL_RGBA8;
+  uint32_t backbufferDepthFmt = GL_DEPTH24_STENCIL8;
+  uint32_t backbufferStencilFmt = GL_DEPTH24_STENCIL8;
 
-    EGLint configId = 0;
-    EGLint r = 0, g = 0, b = 0, a = 0, d = 0, s = 0;
-    if (GlesSpy::mImports.eglQueryContext(display, context, EGL_CONFIG_ID, &configId) == EGL_TRUE) {
-        if (configId != 0) { // EGL_NO_CONFIG_KHR. See EGL_KHR_no_config_context
-            EGLint attribs[] = { EGL_CONFIG_ID, configId, EGL_NONE };
-            EGLConfig config;
-            EGLint count = 0;
-            if (GlesSpy::mImports.eglChooseConfig(display, attribs, &config, 1, &count) == EGL_TRUE) {
-                EGL_GET_CONFIG_ATTRIB(EGL_RED_SIZE, &r);
-                EGL_GET_CONFIG_ATTRIB(EGL_GREEN_SIZE, &g);
-                EGL_GET_CONFIG_ATTRIB(EGL_BLUE_SIZE, &b);
-                EGL_GET_CONFIG_ATTRIB(EGL_ALPHA_SIZE, &a);
-                EGL_GET_CONFIG_ATTRIB(EGL_DEPTH_SIZE, &d);
-                EGL_GET_CONFIG_ATTRIB(EGL_STENCIL_SIZE, &s);
-                GAPID_INFO("Framebuffer config: R%d G%d B%d A%d D%d S%d", r, g, b, a, d, s);
+  EGLint configId = 0;
+  EGLint r = 0, g = 0, b = 0, a = 0, d = 0, s = 0;
+  if (GlesSpy::mImports.eglQueryContext(display, context, EGL_CONFIG_ID,
+                                        &configId) == EGL_TRUE) {
+    if (configId != 0) {  // EGL_NO_CONFIG_KHR. See EGL_KHR_no_config_context
+      EGLint attribs[] = {EGL_CONFIG_ID, configId, EGL_NONE};
+      EGLConfig config;
+      EGLint count = 0;
+      if (GlesSpy::mImports.eglChooseConfig(display, attribs, &config, 1,
+                                            &count) == EGL_TRUE) {
+        EGL_GET_CONFIG_ATTRIB(EGL_RED_SIZE, &r);
+        EGL_GET_CONFIG_ATTRIB(EGL_GREEN_SIZE, &g);
+        EGL_GET_CONFIG_ATTRIB(EGL_BLUE_SIZE, &b);
+        EGL_GET_CONFIG_ATTRIB(EGL_ALPHA_SIZE, &a);
+        EGL_GET_CONFIG_ATTRIB(EGL_DEPTH_SIZE, &d);
+        EGL_GET_CONFIG_ATTRIB(EGL_STENCIL_SIZE, &s);
+        GAPID_INFO("Framebuffer config: R%d G%d B%d A%d D%d S%d", r, g, b, a, d,
+                   s);
 
-                // Get the formats from the bit depths.
-                if (!core::gl::getColorFormat(r, g, b, a, backbufferColorFmt)) {
-                    GAPID_WARNING("getColorFormat(%d, %d, %d, %d) failed", r, g, b, a);
-                }
-                if (!core::gl::getDepthStencilFormat(d, s, backbufferDepthFmt, backbufferStencilFmt)) {
-                    GAPID_WARNING("getDepthStencilFormat(%d, %d) failed", d, s);
-                }
-            } else {
-                GAPID_WARNING("eglChooseConfig() failed for config ID %d. Assuming defaults.", configId);
-            }
-        } // TODO: Try getting dynamic context state for EGL_NO_CONFIG_KHR?
-    } else {
-        GAPID_WARNING("eglQueryContext(0x%p, 0x%p, EGL_CONFIG_ID, &configId) failed. "
-                "Assuming defaults.", display, context);
-    }
+        // Get the formats from the bit depths.
+        if (!core::gl::getColorFormat(r, g, b, a, backbufferColorFmt)) {
+          GAPID_WARNING("getColorFormat(%d, %d, %d, %d) failed", r, g, b, a);
+        }
+        if (!core::gl::getDepthStencilFormat(d, s, backbufferDepthFmt,
+                                             backbufferStencilFmt)) {
+          GAPID_WARNING("getDepthStencilFormat(%d, %d) failed", d, s);
+        }
+      } else {
+        GAPID_WARNING(
+            "eglChooseConfig() failed for config ID %d. Assuming defaults.",
+            configId);
+      }
+    }  // TODO: Try getting dynamic context state for EGL_NO_CONFIG_KHR?
+  } else {
+    GAPID_WARNING(
+        "eglQueryContext(0x%p, 0x%p, EGL_CONFIG_ID, &configId) failed. "
+        "Assuming defaults.",
+        display, context);
+  }
 
-    bool resetViewportScissor = true;
-    bool preserveBuffersOnSwap = swapBehavior == EGL_BUFFER_PRESERVED;
+  bool resetViewportScissor = true;
+  bool preserveBuffersOnSwap = swapBehavior == EGL_BUFFER_PRESERVED;
 
-    auto out = gapil::Ref<DynamicContextState>::create(arena(),
-        width, height,
-        backbufferColorFmt, backbufferDepthFmt, backbufferStencilFmt,
-        resetViewportScissor,
-        preserveBuffersOnSwap,
-        r, g, b, a, d, s
-    );
+  auto out = gapil::Ref<DynamicContextState>::create(
+      arena(), width, height, backbufferColorFmt, backbufferDepthFmt,
+      backbufferStencilFmt, resetViewportScissor, preserveBuffersOnSwap, r, g,
+      b, a, d, s);
 
-    // Store the DynamicContextState as an extra.
-    observer->encode(*out.get());
+  // Store the DynamicContextState as an extra.
+  observer->encode(*out.get());
 
-    return out;
+  return out;
 }
 
 #undef EGL_QUERY_SURFACE
 #undef EGL_GET_CONFIG_ATTRIB
 
-void Spy::gvr_frame_submit(CallObserver* observer, gvr_frame** frame, const gvr_buffer_viewport_list* list, gvr_mat4_abi head_space_from_start_space) {
-    GvrSpy::mLastSubmittedFrame = (frame != nullptr) ? (*frame) : nullptr;
-    GvrSpy::gvr_frame_submit(observer, frame, list, head_space_from_start_space);
+void Spy::gvr_frame_submit(CallObserver* observer, gvr_frame** frame,
+                           const gvr_buffer_viewport_list* list,
+                           gvr_mat4_abi head_space_from_start_space) {
+  GvrSpy::mLastSubmittedFrame = (frame != nullptr) ? (*frame) : nullptr;
+  GvrSpy::gvr_frame_submit(observer, frame, list, head_space_from_start_space);
 }
 
 void Spy::onPostDrawCall(CallObserver* observer, uint8_t api) {
-    if (is_suspended()) {
-         return;
-    }
-    if (mObserveDrawFrequency != 0 && (mNumDraws % mObserveDrawFrequency == 0)) {
-        GAPID_DEBUG("Observe framebuffer after draw call %d", mNumDraws);
-        observeFramebuffer(observer, api);
-    }
-    mNumDraws++;
-    mNumDrawsPerFrame++;
+  if (is_suspended()) {
+    return;
+  }
+  if (mObserveDrawFrequency != 0 && (mNumDraws % mObserveDrawFrequency == 0)) {
+    GAPID_DEBUG("Observe framebuffer after draw call %d", mNumDraws);
+    observeFramebuffer(observer, api);
+  }
+  mNumDraws++;
+  mNumDrawsPerFrame++;
 }
 
 void Spy::onPreStartOfFrame(CallObserver* observer, uint8_t api) {
-    GAPID_ASSERT(mNestedFrameEnd < 2048);
-    if (++mNestedFrameStart > 1) {
-        return;
-    }
-    if (is_suspended()) {
-        return;
-    }
-    if (mObserveFrameFrequency != 0 && (mNumFrames % mObserveFrameFrequency == 0)) {
-        GAPID_DEBUG("Observe framebuffer after frame %d", mNumFrames);
-        observeFramebuffer(observer, api);
-    }
-    GAPID_DEBUG("NumFrames:%d NumDraws:%d NumDrawsPerFrame:%d",
-               mNumFrames, mNumDraws, mNumDrawsPerFrame);
-    mNumFrames++;
-    mNumDrawsPerFrame = 0;
+  GAPID_ASSERT(mNestedFrameEnd < 2048);
+  if (++mNestedFrameStart > 1) {
+    return;
+  }
+  if (is_suspended()) {
+    return;
+  }
+  if (mObserveFrameFrequency != 0 &&
+      (mNumFrames % mObserveFrameFrequency == 0)) {
+    GAPID_DEBUG("Observe framebuffer after frame %d", mNumFrames);
+    observeFramebuffer(observer, api);
+  }
+  GAPID_DEBUG("NumFrames:%d NumDraws:%d NumDrawsPerFrame:%d", mNumFrames,
+              mNumDraws, mNumDrawsPerFrame);
+  mNumFrames++;
+  mNumDrawsPerFrame = 0;
 }
 
 void Spy::saveInitialState() {
-    GAPID_INFO("Saving initial state");
+  GAPID_INFO("Saving initial state");
 
-    saveInitialStateForApi<GlesSpy>("gles-initial-state");
-    saveInitialStateForApi<VulkanSpy>("vulkan-initial-state");
+  saveInitialStateForApi<GlesSpy>("gles-initial-state");
+  saveInitialStateForApi<VulkanSpy>("vulkan-initial-state");
 }
 
-template<typename T>
+template <typename T>
 void Spy::saveInitialStateForApi(const char* name) {
-    if (should_trace(T::kApiIndex)) {
-        auto observer = enter(name, T::kApiIndex);
-        StateSerializer serializer(this, T::kApiIndex, observer);
+  if (should_trace(T::kApiIndex)) {
+    auto observer = enter(name, T::kApiIndex);
+    StateSerializer serializer(this, T::kApiIndex, observer);
 
-        serializer.encodeState(T::mState, [this](StateSerializer* s) { T::serializeGPUBuffers(s); });
-        exit();
-    }
+    serializer.encodeState(
+        T::mState, [this](StateSerializer* s) { T::serializeGPUBuffers(s); });
+    exit();
+  }
 }
 
 void Spy::onPostFrameBoundary(bool isStartOfFrame) {
-    if (!is_suspended() && mCaptureFrames >= 1) {
-        mCaptureFrames -= 1;
-        if (mCaptureFrames == 0) {
-            mEncoder->flush();
-            mConnection->close();
-            set_suspended(true);
-        }
+  if (!is_suspended() && mCaptureFrames >= 1) {
+    mCaptureFrames -= 1;
+    if (mCaptureFrames == 0) {
+      mEncoder->flush();
+      mConnection->close();
+      set_suspended(true);
     }
-    if (mSuspendCaptureFrames.load() > 0) {
-        if (is_suspended() && mSuspendCaptureFrames.fetch_sub(1) == 1) {
-            exit();
-            set_suspended(false);
-            saveInitialState();
-            enter("RecreateState", 2);
-        }
+  }
+  if (mSuspendCaptureFrames.load() > 0) {
+    if (is_suspended() && mSuspendCaptureFrames.fetch_sub(1) == 1) {
+      exit();
+      set_suspended(false);
+      saveInitialState();
+      enter("RecreateState", 2);
     }
+  }
 }
 
 void Spy::onPostStartOfFrame() {
-    GAPID_ASSERT(mNestedFrameStart > 0);
-    if (--mNestedFrameStart == 0) {
-        onPostFrameBoundary(true);
-    }
+  GAPID_ASSERT(mNestedFrameStart > 0);
+  if (--mNestedFrameStart == 0) {
+    onPostFrameBoundary(true);
+  }
 }
 
 void Spy::onPreEndOfFrame(CallObserver* observer, uint8_t api) {
-    GAPID_ASSERT(mNestedFrameEnd < 2048);
-    if (++mNestedFrameEnd > 1) {
-        return;
-    }
-    if (is_suspended()) {
-        return;
-    }
-    if (mObserveFrameFrequency != 0 && (mNumFrames % mObserveFrameFrequency == 0)) {
-        GAPID_DEBUG("Observe framebuffer after frame %d", mNumFrames);
-        observeFramebuffer(observer, api);
-    }
-    GAPID_DEBUG("NumFrames:%d NumDraws:%d NumDrawsPerFrame:%d",
-               mNumFrames, mNumDraws, mNumDrawsPerFrame);
-    mNumFrames++;
-    mNumDrawsPerFrame = 0;
+  GAPID_ASSERT(mNestedFrameEnd < 2048);
+  if (++mNestedFrameEnd > 1) {
+    return;
+  }
+  if (is_suspended()) {
+    return;
+  }
+  if (mObserveFrameFrequency != 0 &&
+      (mNumFrames % mObserveFrameFrequency == 0)) {
+    GAPID_DEBUG("Observe framebuffer after frame %d", mNumFrames);
+    observeFramebuffer(observer, api);
+  }
+  GAPID_DEBUG("NumFrames:%d NumDraws:%d NumDrawsPerFrame:%d", mNumFrames,
+              mNumDraws, mNumDrawsPerFrame);
+  mNumFrames++;
+  mNumDrawsPerFrame = 0;
 }
 
 void Spy::onPostEndOfFrame() {
-    GAPID_ASSERT(mNestedFrameEnd > 0);
-    if (--mNestedFrameEnd == 0) {
-        onPostFrameBoundary(false);
-    }
+  GAPID_ASSERT(mNestedFrameEnd > 0);
+  if (--mNestedFrameEnd == 0) {
+    onPostFrameBoundary(false);
+  }
 }
 
-static bool downsamplePixels(const std::vector<uint8_t>& srcData, uint32_t srcW, uint32_t srcH,
-                             std::vector<uint8_t>* outData, uint32_t* outW, uint32_t* outH,
-                             uint32_t maxW, uint32_t maxH) {
-    // Calculate the minimal scaling factor as integer fraction.
-    uint32_t mul = 1;
-    uint32_t div = 1;
-    if (mul*srcW > maxW*div) { // if mul/div > maxW/srcW
-        mul = maxW;
-        div = srcW;
-    }
-    if (mul*srcH > maxH*div) { // if mul/div > maxH/srcH
-        mul = maxH;
-        div = srcH;
-    }
+static bool downsamplePixels(const std::vector<uint8_t>& srcData, uint32_t srcW,
+                             uint32_t srcH, std::vector<uint8_t>* outData,
+                             uint32_t* outW, uint32_t* outH, uint32_t maxW,
+                             uint32_t maxH) {
+  // Calculate the minimal scaling factor as integer fraction.
+  uint32_t mul = 1;
+  uint32_t div = 1;
+  if (mul * srcW > maxW * div) {  // if mul/div > maxW/srcW
+    mul = maxW;
+    div = srcW;
+  }
+  if (mul * srcH > maxH * div) {  // if mul/div > maxH/srcH
+    mul = maxH;
+    div = srcH;
+  }
 
-    // Calculate the final dimensions (round up) and allocate new buffer.
-    uint32_t dstW = (srcW*mul + div - 1) / div;
-    uint32_t dstH = (srcH*mul + div - 1) / div;
-    outData->reserve(dstW*dstH*4);
+  // Calculate the final dimensions (round up) and allocate new buffer.
+  uint32_t dstW = (srcW * mul + div - 1) / div;
+  uint32_t dstH = (srcH * mul + div - 1) / div;
+  outData->reserve(dstW * dstH * 4);
 
-    // Downsample the image by averaging the colours of neighbouring pixels.
-    for (uint32_t srcY = 0, y = 0, dstY = 0; dstY < dstH; srcY = y, dstY++) {
-        for (uint32_t srcX = 0, x = 0, dstX = 0; dstX < dstW; srcX = x, dstX++) {
-            uint32_t r = 0, g = 0, b = 0, a = 0, n = 0;
-            // We need to loop over srcX/srcY ranges several times, so we keep them in x/y,
-            // and we update srcX/srcY to the last x/y only once we are done with the pixel.
-            for (y = srcY; y*dstH < (dstY+1)*srcH; y++) { // while y*yScale < dstY+1
-                const uint8_t* src = &srcData[(srcX + y*srcW) * 4];
-                for (x = srcX; x*dstW < (dstX+1)*srcW; x++) { // while x*xScale < dstX+1
-                    r += *(src++);
-                    g += *(src++);
-                    b += *(src++);
-                    a += *(src++);
-                    n += 1;
-                }
-            }
-            outData->push_back(r/n);
-            outData->push_back(g/n);
-            outData->push_back(b/n);
-            outData->push_back(a/n);
+  // Downsample the image by averaging the colours of neighbouring pixels.
+  for (uint32_t srcY = 0, y = 0, dstY = 0; dstY < dstH; srcY = y, dstY++) {
+    for (uint32_t srcX = 0, x = 0, dstX = 0; dstX < dstW; srcX = x, dstX++) {
+      uint32_t r = 0, g = 0, b = 0, a = 0, n = 0;
+      // We need to loop over srcX/srcY ranges several times, so we keep them in
+      // x/y, and we update srcX/srcY to the last x/y only once we are done with
+      // the pixel.
+      for (y = srcY; y * dstH < (dstY + 1) * srcH;
+           y++) {  // while y*yScale < dstY+1
+        const uint8_t* src = &srcData[(srcX + y * srcW) * 4];
+        for (x = srcX; x * dstW < (dstX + 1) * srcW;
+             x++) {  // while x*xScale < dstX+1
+          r += *(src++);
+          g += *(src++);
+          b += *(src++);
+          a += *(src++);
+          n += 1;
         }
+      }
+      outData->push_back(r / n);
+      outData->push_back(g / n);
+      outData->push_back(b / n);
+      outData->push_back(a / n);
     }
+  }
 
-    *outW = dstW;
-    *outH = dstH;
-    return true;
+  *outW = dstW;
+  *outH = dstH;
+  return true;
 }
 
 // observeFramebuffer captures the currently bound framebuffer, and writes
 // it to a FramebufferObservation extra.
 void Spy::observeFramebuffer(CallObserver* observer, uint8_t api) {
-    uint32_t w = 0;
-    uint32_t h = 0;
-    std::vector<uint8_t> data;
-    switch(api) {
-        case GlesSpy::kApiIndex:
-            if (!GlesSpy::observeFramebuffer(observer, &w, &h, &data)) {
-                return;
-            }
-            break;
-        case VulkanSpy::kApiIndex:
-            if (!VulkanSpy::observeFramebuffer(observer, &w, &h, &data)) {
-                return;
-            }
-            break;
-        case GvrSpy::kApiIndex:
-            if (!GvrSpy::observeFramebuffer(observer, &w, &h, &data)) {
-                return;
-            }
-            break;
-    }
+  uint32_t w = 0;
+  uint32_t h = 0;
+  std::vector<uint8_t> data;
+  switch (api) {
+    case GlesSpy::kApiIndex:
+      if (!GlesSpy::observeFramebuffer(observer, &w, &h, &data)) {
+        return;
+      }
+      break;
+    case VulkanSpy::kApiIndex:
+      if (!VulkanSpy::observeFramebuffer(observer, &w, &h, &data)) {
+        return;
+      }
+      break;
+    case GvrSpy::kApiIndex:
+      if (!GvrSpy::observeFramebuffer(observer, &w, &h, &data)) {
+        return;
+      }
+      break;
+  }
 
-    uint32_t downsampledW, downsampledH;
-    std::vector<uint8_t> downsampledData;
-    if (downsamplePixels(data, w, h,
-                         &downsampledData, &downsampledW, &downsampledH,
-                         kMaxFramebufferObservationWidth, kMaxFramebufferObservationHeight)) {
-        auto observation = new capture::FramebufferObservation();
-        observation->set_original_width(w);
-        observation->set_original_height(h);
-        observation->set_data_width(downsampledW);
-        observation->set_data_height(downsampledH);
-        observation->set_data(downsampledData.data(), downsampledData.size());
-        observer->encodeAndDelete(observation);
-    }
+  uint32_t downsampledW, downsampledH;
+  std::vector<uint8_t> downsampledData;
+  if (downsamplePixels(data, w, h, &downsampledData, &downsampledW,
+                       &downsampledH, kMaxFramebufferObservationWidth,
+                       kMaxFramebufferObservationHeight)) {
+    auto observation = new capture::FramebufferObservation();
+    observation->set_original_width(w);
+    observation->set_original_height(h);
+    observation->set_data_width(downsampledW);
+    observation->set_data_height(downsampledH);
+    observation->set_data(downsampledData.data(), downsampledData.size());
+    observer->encodeAndDelete(observation);
+  }
 }
 
 void Spy::onPostFence(CallObserver* observer) {
-    if (mRecordGLErrorState) {
-        auto traceErr = GlesSpy::mImports.glGetError();
+  if (mRecordGLErrorState) {
+    auto traceErr = GlesSpy::mImports.glGetError();
 
-        // glGetError() cleared the error in the driver.
-        // Fake it the next time the user calls glGetError().
-        if (traceErr != 0) {
-            setFakeGlError(observer, traceErr);
-        }
-
-        auto es = new gles_pb::ErrorState();
-        es->set_tracedriversglerror(traceErr);
-        es->set_interceptorsglerror(observer->getError());
-        observer->encodeAndDelete(es);
+    // glGetError() cleared the error in the driver.
+    // Fake it the next time the user calls glGetError().
+    if (traceErr != 0) {
+      setFakeGlError(observer, traceErr);
     }
+
+    auto es = new gles_pb::ErrorState();
+    es->set_tracedriversglerror(traceErr);
+    es->set_interceptorsglerror(observer->getError());
+    observer->encodeAndDelete(es);
+  }
 }
 
 void Spy::setFakeGlError(CallObserver* observer, GLenum_Error error) {
-    auto ctx = this->GlesSpy::mState.Contexts[observer->getCurrentThread()];
-    if (ctx) {
-        GLenum_Error& fakeGlError = this->mFakeGlError[ctx->mIdentifier];
-        if (fakeGlError == 0) {
-            fakeGlError = error;
-        }
+  auto ctx = this->GlesSpy::mState.Contexts[observer->getCurrentThread()];
+  if (ctx) {
+    GLenum_Error& fakeGlError = this->mFakeGlError[ctx->mIdentifier];
+    if (fakeGlError == 0) {
+      fakeGlError = error;
     }
+  }
 }
 
 uint32_t Spy::glGetError(CallObserver* observer) {
-    auto ctx = this->GlesSpy::mState.Contexts[observer->getCurrentThread()];
-    if (ctx) {
-        GLenum_Error& fakeGlError = this->mFakeGlError[ctx->mIdentifier];
-        if (fakeGlError != 0) {
-            observer->encode(cmd::glGetError{observer->getCurrentThread()});
-            GLenum_Error err = fakeGlError;
-            fakeGlError = 0;
-            return err;
-        }
+  auto ctx = this->GlesSpy::mState.Contexts[observer->getCurrentThread()];
+  if (ctx) {
+    GLenum_Error& fakeGlError = this->mFakeGlError[ctx->mIdentifier];
+    if (fakeGlError != 0) {
+      observer->encode(cmd::glGetError{observer->getCurrentThread()});
+      GLenum_Error err = fakeGlError;
+      fakeGlError = 0;
+      return err;
     }
-    return GlesSpy::glGetError(observer);
+  }
+  return GlesSpy::glGetError(observer);
 }
 
-#if 0 // NON-EGL CONTEXTS ARE CURRENTLY NOT SUPPORTED
+#if 0  // NON-EGL CONTEXTS ARE CURRENTLY NOT SUPPORTED
 gapil::Ref<ContextState> Spy::getWGLContextState(CallObserver*, HDC hdc, HGLRC hglrc) {
     if (hglrc == nullptr) {
         return nullptr;
@@ -646,9 +680,9 @@ gapil::Ref<ContextState> Spy::getWGLContextState(CallObserver*, HDC hdc, HGLRC h
             info.colorFormat, info.depthFormat, info.stencilFormat,
             /* resetViewportScissor */ true,
             /* preserveBuffersOnSwap */ false);
-#else // TARGET_OS
+#else   // TARGET_OS
     return nullptr;
-#endif // TARGET_OS
+#endif  // TARGET_OS
 }
 
 gapil::Ref<ContextState> Spy::getCGLContextState(CallObserver* observer, CGLContextObj ctx) {
@@ -691,6 +725,6 @@ gapil::Ref<ContextState> Spy::getGLXContextState(CallObserver* observer, void* d
             /* resetViewportScissor */ true,
             /* preserveBuffersOnSwap */ false);
 }
-#endif // #if 0
+#endif  // #if 0
 
-} // namespace gapii
+}  // namespace gapii

--- a/gapii/cc/spy.h
+++ b/gapii/cc/spy.h
@@ -48,7 +48,9 @@ class Spy : public GlesSpy, public GvrSpy, public VulkanSpy {
   EGLContext eglCreateContext(CallObserver* observer, EGLDisplay display,
                               EGLConfig config, EGLContext share_context,
                               EGLint* attrib_list);
-  EGLBoolean eglMakeCurrent(CallObserver* observer, EGLDisplay display, EGLSurface draw, EGLSurface read, EGLContext context);
+  EGLBoolean eglMakeCurrent(CallObserver* observer, EGLDisplay display,
+                            EGLSurface draw, EGLSurface read,
+                            EGLContext context);
 
   // Intercepted GLES methods to optionally fake no support for precompiled
   // shaders.
@@ -58,16 +60,18 @@ class Spy : public GlesSpy, public GvrSpy, public VulkanSpy {
   void glProgramBinaryOES(CallObserver* observer, uint32_t program,
                           uint32_t binary_format, const void* binary,
                           int32_t binary_size);
-  void glShaderBinary(CallObserver* observer,
-                      int32_t count, const uint32_t* shaders,
-                      uint32_t binary_format, const void* binary,
-                      int32_t binary_size);
+  void glShaderBinary(CallObserver* observer, int32_t count,
+                      const uint32_t* shaders, uint32_t binary_format,
+                      const void* binary, int32_t binary_size);
   void glGetInteger64v(CallObserver* observer, uint32_t param, int64_t* values);
   void glGetIntegerv(CallObserver* observer, uint32_t param, int32_t* values);
   const GLubyte* glGetString(CallObserver* observer, uint32_t name);
-  const GLubyte* glGetStringi(CallObserver* observer, uint32_t name, GLuint index);
+  const GLubyte* glGetStringi(CallObserver* observer, uint32_t name,
+                              GLuint index);
 
-  void gvr_frame_submit(CallObserver* observer, gvr_frame** frame, const gvr_buffer_viewport_list* list, gvr_mat4_abi head_space_from_start_space);
+  void gvr_frame_submit(CallObserver* observer, gvr_frame** frame,
+                        const gvr_buffer_viewport_list* list,
+                        gvr_mat4_abi head_space_from_start_space);
 
   void onPostDrawCall(CallObserver* observer, uint8_t api) override;
   void onPreStartOfFrame(CallObserver* observer, uint8_t api) override;
@@ -98,12 +102,13 @@ class Spy : public GlesSpy, public GvrSpy, public VulkanSpy {
   // getFramebufferAttachmentSize attempts to retrieve the currently bound
   // framebuffer's color buffer dimensions, returning true on success or
   // false if the dimensions could not be retrieved.
-  bool getFramebufferAttachmentSize(CallObserver* observer, uint32_t& width, uint32_t& height);
+  bool getFramebufferAttachmentSize(CallObserver* observer, uint32_t& width,
+                                    uint32_t& height);
 
   // saveInitialState serializes the current global state.
   void saveInitialState();
 
-  template<typename T>
+  template <typename T>
   void saveInitialStateForApi(const char* name);
 
   // onPostFrameBoundary is called from onPost{Start,End}OfFrame().

--- a/gapii/cc/spy_base.cpp
+++ b/gapii/cc/spy_base.cpp
@@ -21,80 +21,76 @@
 #define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 
-// CurrentCaptureVersion is incremented on breaking changes to the capture format.
-// NB: Also update equally named field in capture.go
+// CurrentCaptureVersion is incremented on breaking changes to the capture
+// format. NB: Also update equally named field in capture.go
 static const int CurrentCaptureVersion = 3;
 
 using core::Interval;
 
 namespace gapii {
 
-SpyBase::SpyBase() :
+SpyBase::SpyBase()
+    :
 #if COHERENT_TRACKING_ENABLED
-    mMemoryTracker(),
-#endif // TARGET_OS
-    mNullEncoder(PackEncoder::noop()),
-    mDeviceInstance(nullptr),
-    mCurrentABI(nullptr),
-    mResources{{core::Id{{0}}, 0}},
-    mObserveApplicationPool(true),
-    mWatchedApis(0xFFFFFFFF)
-{
+      mMemoryTracker(),
+#endif  // TARGET_OS
+      mNullEncoder(PackEncoder::noop()),
+      mDeviceInstance(nullptr),
+      mCurrentABI(nullptr),
+      mResources{{core::Id{{0}}, 0}},
+      mObserveApplicationPool(true),
+      mWatchedApis(0xFFFFFFFF) {
 }
 
 void SpyBase::init(CallObserver* observer) {
-    mObserveApplicationPool = true;
-    mIsSuspended = false;
+  mObserveApplicationPool = true;
+  mIsSuspended = false;
 }
 
-void SpyBase::lock(CallObserver* observer) {
-    mMutex.lock();
-}
+void SpyBase::lock(CallObserver* observer) { mMutex.lock(); }
 
-void SpyBase::unlock() {
-    mMutex.unlock();
-}
+void SpyBase::unlock() { mMutex.unlock(); }
 
 void SpyBase::abort() {
-    GAPID_DEBUG("Command aborted");
-    throw AbortException();
+  GAPID_DEBUG("Command aborted");
+  throw AbortException();
 }
 
 int64_t SpyBase::sendResource(uint8_t api, const void* data, size_t size) {
-    GAPID_ASSERT(should_trace(api));
-    auto hash = core::Id::Hash(data, size);
+  GAPID_ASSERT(should_trace(api));
+  auto hash = core::Id::Hash(data, size);
 
-    // Fast-path if resource with the same hash was already send.
-    {
-        std::lock_guard<std::mutex> lock(mResourcesMutex);
-        auto it = mResources.find(hash);
-        if (it != mResources.end()) {
-            return it->second;
-        }
-    }
-
-    // Slow-path if we need to encode and send the resource.
-    capture::Resource resource;
-    resource.set_data(data, size);
+  // Fast-path if resource with the same hash was already send.
+  {
     std::lock_guard<std::mutex> lock(mResourcesMutex);
-    auto res = mResources.emplace(hash, mResources.size());
-    int64_t index = res.first->second;
-    if (res.second) { // Inserted/new.
-        // Keep the resource mutex during send to ensure other thread
-        // can not read the index and reference it before we send it.
-        resource.set_index(index);
-        getEncoder(api)->object(&resource);
+    auto it = mResources.find(hash);
+    if (it != mResources.end()) {
+      return it->second;
     }
+  }
 
-    return index;
+  // Slow-path if we need to encode and send the resource.
+  capture::Resource resource;
+  resource.set_data(data, size);
+  std::lock_guard<std::mutex> lock(mResourcesMutex);
+  auto res = mResources.emplace(hash, mResources.size());
+  int64_t index = res.first->second;
+  if (res.second) {  // Inserted/new.
+    // Keep the resource mutex during send to ensure other thread
+    // can not read the index and reference it before we send it.
+    resource.set_index(index);
+    getEncoder(api)->object(&resource);
+  }
+
+  return index;
 }
 
 bool SpyBase::writeHeader() {
   capture::Header file_header;
   file_header.set_version(CurrentCaptureVersion);
   if (mDeviceInstance != nullptr) {
-      device::Instance* t = new device::Instance(*device_instance());
-      file_header.set_allocated_device(t);
+    device::Instance* t = new device::Instance(*device_instance());
+    file_header.set_allocated_device(t);
   }
   if (mCurrentABI != nullptr) {
     device::ABI* t = new device::ABI(*current_abi());

--- a/gapii/cc/spy_base.h
+++ b/gapii/cc/spy_base.h
@@ -34,7 +34,7 @@
 
 #if (TARGET_OS == GAPID_OS_LINUX) || (TARGET_OS == GAPID_OS_ANDROID)
 #include "core/memory_tracker/cc/memory_tracker.h"
-#endif // TARGET_OS
+#endif  // TARGET_OS
 
 #include "gapil/runtime/cc/slice.h"
 
@@ -53,218 +53,227 @@ const uint8_t kAllAPIs = 0xFF;
 class PackEncoder;
 
 class SpyBase {
-public:
-    SpyBase();
+ public:
+  SpyBase();
 
-    void init(CallObserver* observer);
+  void init(CallObserver* observer);
 
-    // Set whether to observe the application pool. If true, the default,
-    // then reads and writes to the application pools are observed, but
-    // writes do not change the memory contents. If false, then
-    // no-observations are made and writes change the application memory.
-    inline void setObserveApplicationPool(bool observeApplicationPool);
+  // Set whether to observe the application pool. If true, the default,
+  // then reads and writes to the application pools are observed, but
+  // writes do not change the memory contents. If false, then
+  // no-observations are made and writes change the application memory.
+  inline void setObserveApplicationPool(bool observeApplicationPool);
 
-    // Encode and write data blob if we have not already sent it.
-    // Returns the index of the resource which can be used to reference it.
-    int64_t sendResource(uint8_t api, const void* data, size_t size);
+  // Encode and write data blob if we have not already sent it.
+  // Returns the index of the resource which can be used to reference it.
+  int64_t sendResource(uint8_t api, const void* data, size_t size);
 
-    // writeHeader encodes a header with current tracing device and
-    // ABI info then return true, if the encoder is ready. Otherwise returns false.
-    bool writeHeader();
+  // writeHeader encodes a header with current tracing device and
+  // ABI info then return true, if the encoder is ready. Otherwise returns
+  // false.
+  bool writeHeader();
 
-    // returns the spy's memory arena.
-    inline core::Arena* arena() { return &mArena; }
+  // returns the spy's memory arena.
+  inline core::Arena* arena() { return &mArena; }
 
-    // returns a handle to the identifier of the next pool to be allocated.
-    inline uint32_t& next_pool_id() { return mNextPoolId; }
+  // returns a handle to the identifier of the next pool to be allocated.
+  inline uint32_t& next_pool_id() { return mNextPoolId; }
 
-    // Returns the transimission encoder.
-    // TODO(qining): To support multithreaded uses, mutex is required to manage
-    // the access to this encoder.
-    std::shared_ptr<gapii::PackEncoder> getEncoder(uint8_t api) {
-        return should_trace(api) ? mEncoder : mNullEncoder;
-    }
+  // Returns the transimission encoder.
+  // TODO(qining): To support multithreaded uses, mutex is required to manage
+  // the access to this encoder.
+  std::shared_ptr<gapii::PackEncoder> getEncoder(uint8_t api) {
+    return should_trace(api) ? mEncoder : mNullEncoder;
+  }
 
-    std::shared_ptr<gapii::PackEncoder> nullEncoder() {
-        return mNullEncoder;
-    }
+  std::shared_ptr<gapii::PackEncoder> nullEncoder() { return mNullEncoder; }
 
-    // Returns true if we should observe application pool.
-    bool shouldObserveApplicationPool() { return mObserveApplicationPool; }
+  // Returns true if we should observe application pool.
+  bool shouldObserveApplicationPool() { return mObserveApplicationPool; }
 
-    // Returns true if this spy is suspended, i.e. We should not actually
-    // be sending any data across to the server yet.
-    bool is_suspended() const { return mIsSuspended; }
+  // Returns true if this spy is suspended, i.e. We should not actually
+  // be sending any data across to the server yet.
+  bool is_suspended() const { return mIsSuspended; }
 
-    void set_suspended(bool suspended) { mIsSuspended = suspended; }
+  void set_suspended(bool suspended) { mIsSuspended = suspended; }
 
-    bool should_trace(uint8_t api) {
-        return !is_suspended() && (api == kAllAPIs || (mWatchedApis & (1 << api)) != 0);
-    }
-    void set_valid_apis(uint32_t apis) { mWatchedApis = apis; }
+  bool should_trace(uint8_t api) {
+    return !is_suspended() &&
+           (api == kAllAPIs || (mWatchedApis & (1 << api)) != 0);
+  }
+  void set_valid_apis(uint32_t apis) { mWatchedApis = apis; }
 
-    void set_observing(bool observing) { mIsObserving = observing; }
-    bool is_observing() const { return mIsObserving; }
+  void set_observing(bool observing) { mIsObserving = observing; }
+  bool is_observing() const { return mIsObserving; }
 
-protected:
-    // lock begins the interception of a single command. It must be called
-    // before invoking any command on the spy. Blocks if any other thread
-    // is has called lock and not yet called unlock.
-    void lock(CallObserver* observer);
+ protected:
+  // lock begins the interception of a single command. It must be called
+  // before invoking any command on the spy. Blocks if any other thread
+  // is has called lock and not yet called unlock.
+  void lock(CallObserver* observer);
 
-    // unlock must be called after invoking any command.
-    // resets the buffers reused between commands.
-    void unlock();
+  // unlock must be called after invoking any command.
+  // resets the buffers reused between commands.
+  void unlock();
 
-    // make constructs and returns a Slice backed by a new pool.
-    template<typename T>
-    inline gapil::Slice<T> make(CallObserver* cb, uint64_t count);
+  // make constructs and returns a Slice backed by a new pool.
+  template <typename T>
+  inline gapil::Slice<T> make(CallObserver* cb, uint64_t count);
 
-    // slice returns a slice wrapping the application-pool pointer src, starting at elements s
-    // ending at one element before e.
-    template<typename T>
-    inline gapil::Slice<typename std::remove_const<T>::type>
-    slice(T* src, uint64_t s, uint64_t e) const;
+  // slice returns a slice wrapping the application-pool pointer src, starting
+  // at elements s ending at one element before e.
+  template <typename T>
+  inline gapil::Slice<typename std::remove_const<T>::type> slice(
+      T* src, uint64_t s, uint64_t e) const;
 
-    // slice returns a slice wrapping the application-pool pointer src, starting at s bytes
-    // from src and ending at one byte before e.
-    inline gapil::Slice<uint8_t> slice(const void* src, uint64_t s, uint64_t e) const;
-    inline gapil::Slice<uint8_t> slice(void* src, uint64_t s, uint64_t e) const;
+  // slice returns a slice wrapping the application-pool pointer src, starting
+  // at s bytes from src and ending at one byte before e.
+  inline gapil::Slice<uint8_t> slice(const void* src, uint64_t s,
+                                     uint64_t e) const;
+  inline gapil::Slice<uint8_t> slice(void* src, uint64_t s, uint64_t e) const;
 
-    // slice returns a gapil::Slice<char>, backed by a new pool, holding a copy of the string src.
-    // src is observed as a read operation.
-    inline gapil::Slice<char> slice(CallObserver* cb, const std::string& src);
+  // slice returns a gapil::Slice<char>, backed by a new pool, holding a copy of
+  // the string src. src is observed as a read operation.
+  inline gapil::Slice<char> slice(CallObserver* cb, const std::string& src);
 
-    // slice returns a sub-slice of src, starting at elements s and ending at one element before e.
-    template<typename T>
-    inline gapil::Slice<T> slice(const gapil::Slice<T>& src, uint64_t s, uint64_t e) const;
+  // slice returns a sub-slice of src, starting at elements s and ending at one
+  // element before e.
+  template <typename T>
+  inline gapil::Slice<T> slice(const gapil::Slice<T>& src, uint64_t s,
+                               uint64_t e) const;
 
-    // abort signals that the command should stop execution immediately.
-    void abort();
+  // abort signals that the command should stop execution immediately.
+  void abort();
 
-    // onPostDrawCall is after any command annotated with @draw_call
-    inline virtual void onPostDrawCall(CallObserver*, uint8_t) {}
+  // onPostDrawCall is after any command annotated with @draw_call
+  inline virtual void onPostDrawCall(CallObserver*, uint8_t) {}
 
-    // onPreStartOfFrame is before any command annotated with @frame_start
-    inline virtual void onPreStartOfFrame(CallObserver*, uint8_t) {}
+  // onPreStartOfFrame is before any command annotated with @frame_start
+  inline virtual void onPreStartOfFrame(CallObserver*, uint8_t) {}
 
-    // onPostStrartOfFrame is after any command annotated with @frame_start
-    inline virtual void onPostStartOfFrame() {}
+  // onPostStrartOfFrame is after any command annotated with @frame_start
+  inline virtual void onPostStartOfFrame() {}
 
-    // onPreEndOfFrame is before any command annotated with @frame_end
-    inline virtual void onPreEndOfFrame(CallObserver*, uint8_t) {}
+  // onPreEndOfFrame is before any command annotated with @frame_end
+  inline virtual void onPreEndOfFrame(CallObserver*, uint8_t) {}
 
-    // onPostEndOfFrame is after any command annotated with @frame_end
-    inline virtual void onPostEndOfFrame() {}
+  // onPostEndOfFrame is after any command annotated with @frame_end
+  inline virtual void onPostEndOfFrame() {}
 
-    // onPostFence is called immediately after the driver call.
-    inline virtual void onPostFence(CallObserver* observer) {}
+  // onPostFence is called immediately after the driver call.
+  inline virtual void onPostFence(CallObserver* observer) {}
 
-    // The output stream encoder.
-    PackEncoder::SPtr mEncoder;
+  // The output stream encoder.
+  PackEncoder::SPtr mEncoder;
 
-    // setter of the tracing device info.
-    void set_device_instance(device::Instance* inst) {
-      mDeviceInstance.reset(inst);
-    }
-    // getters of the tracing device info.
-    device::Instance* device_instance() const { return mDeviceInstance.get(); }
+  // setter of the tracing device info.
+  void set_device_instance(device::Instance* inst) {
+    mDeviceInstance.reset(inst);
+  }
+  // getters of the tracing device info.
+  device::Instance* device_instance() const { return mDeviceInstance.get(); }
 
-    // setter of the tracing ABI info.
-    void set_current_abi(device::ABI* abi) { mCurrentABI.reset(abi); }
-    // getter of the tracing ABI info.
-    device::ABI* current_abi() const { return mCurrentABI.get(); }
+  // setter of the tracing ABI info.
+  void set_current_abi(device::ABI* abi) { mCurrentABI.reset(abi); }
+  // getter of the tracing ABI info.
+  device::ABI* current_abi() const { return mCurrentABI.get(); }
 
 #if COHERENT_TRACKING_ENABLED
-    track_memory::MemoryTracker mMemoryTracker;
-#endif // TARGET_OS
+  track_memory::MemoryTracker mMemoryTracker;
+#endif  // TARGET_OS
 
-private:
-    template <class T> bool shouldObserve(const gapil::Slice<T>& slice) const;
+ private:
+  template <class T>
+  bool shouldObserve(const gapil::Slice<T>& slice) const;
 
-    // Memory arena.
-    core::Arena mArena;
+  // Memory arena.
+  core::Arena mArena;
 
-    // The identifier of the next pool to be allocated.
-    uint32_t mNextPoolId;
+  // The identifier of the next pool to be allocated.
+  uint32_t mNextPoolId;
 
-    // The stream encoder that does nothing.
-    PackEncoder::SPtr mNullEncoder;
+  // The stream encoder that does nothing.
+  PackEncoder::SPtr mNullEncoder;
 
-    // The information about the current tracing device and ABI.
-    std::unique_ptr<device::Instance> mDeviceInstance;
-    std::unique_ptr<device::ABI> mCurrentABI;
+  // The information about the current tracing device and ABI.
+  std::unique_ptr<device::Instance> mDeviceInstance;
+  std::unique_ptr<device::ABI> mCurrentABI;
 
-    // The list of resources that have already been encoded and sent.
-    std::unordered_map<core::Id, int64_t> mResources;
-    std::mutex mResourcesMutex;
+  // The list of resources that have already been encoded and sent.
+  std::unordered_map<core::Id, int64_t> mResources;
+  std::mutex mResourcesMutex;
 
-    // The mutex that should be locked for the duration of each of the intercepted commands.
-    std::recursive_mutex mMutex;
+  // The mutex that should be locked for the duration of each of the intercepted
+  // commands.
+  std::recursive_mutex mMutex;
 
-    // True if we should observe the application pool.
-    bool mObserveApplicationPool;
+  // True if we should observe the application pool.
+  bool mObserveApplicationPool;
 
-    // True if we should not be currently tracing, false if we should be tracing.
-    bool mIsSuspended;
+  // True if we should not be currently tracing, false if we should be tracing.
+  bool mIsSuspended;
 
-    // This is the list of all Apis that are considered for tracing. This is a
-    // bit set of apis where bit (1 << api) is set if a particular api
-    // should be traced.
-    uint32_t mWatchedApis;
+  // This is the list of all Apis that are considered for tracing. This is a
+  // bit set of apis where bit (1 << api) is set if a particular api
+  // should be traced.
+  uint32_t mWatchedApis;
 
-    // This is true if we may be observing frame-buffers during the trace.
-    // For some API's this will require that we modify some of the
-    // image creation parameters
-    bool mIsObserving;
+  // This is true if we may be observing frame-buffers during the trace.
+  // For some API's this will require that we modify some of the
+  // image creation parameters
+  bool mIsObserving;
 };
 
 template <class T>
 bool SpyBase::shouldObserve(const gapil::Slice<T>& slice) const {
-    return mObserveApplicationPool && slice.is_app_pool();
+  return mObserveApplicationPool && slice.is_app_pool();
 }
 
 inline void SpyBase::setObserveApplicationPool(bool observeApplicationPool) {
-    mObserveApplicationPool = observeApplicationPool;
+  mObserveApplicationPool = observeApplicationPool;
 }
 
-template<typename T>
+template <typename T>
 inline gapil::Slice<T> SpyBase::make(CallObserver* cb, uint64_t count) {
-    return gapil::Slice<T>::create(cb, count);
+  return gapil::Slice<T>::create(cb, count);
 }
 
-template<typename T>
-inline gapil::Slice<typename std::remove_const<T>::type>
-SpyBase::slice(T* src, uint64_t s, uint64_t e) const {
-    // We don't want to have implement a ConstSlice...
-    typedef typename std::remove_const<T>::type R;
-    auto ptr = const_cast<R*>(src);
-    return gapil::Slice<R>(ptr+s, e-s);
+template <typename T>
+inline gapil::Slice<typename std::remove_const<T>::type> SpyBase::slice(
+    T* src, uint64_t s, uint64_t e) const {
+  // We don't want to have implement a ConstSlice...
+  typedef typename std::remove_const<T>::type R;
+  auto ptr = const_cast<R*>(src);
+  return gapil::Slice<R>(ptr + s, e - s);
 }
 
-inline gapil::Slice<uint8_t> SpyBase::slice(const void* src, uint64_t s, uint64_t e) const {
-    auto ptr = reinterpret_cast<uint8_t*>(const_cast<void*>(src));
-    return slice<uint8_t>(ptr, s, e);
+inline gapil::Slice<uint8_t> SpyBase::slice(const void* src, uint64_t s,
+                                            uint64_t e) const {
+  auto ptr = reinterpret_cast<uint8_t*>(const_cast<void*>(src));
+  return slice<uint8_t>(ptr, s, e);
 }
 
-inline gapil::Slice<uint8_t> SpyBase::slice(void* src, uint64_t s, uint64_t e) const {
-    auto ptr = reinterpret_cast<uint8_t*>(const_cast<void*>(src));
-    return slice<uint8_t>(ptr, s, e);
+inline gapil::Slice<uint8_t> SpyBase::slice(void* src, uint64_t s,
+                                            uint64_t e) const {
+  auto ptr = reinterpret_cast<uint8_t*>(const_cast<void*>(src));
+  return slice<uint8_t>(ptr, s, e);
 }
 
-inline gapil::Slice<char> SpyBase::slice(CallObserver* cb, const std::string& src) {
-    gapil::Slice<char> dst = make<char>(cb, src.length());
-    for (uint64_t i = 0; i < src.length(); i++) {
-        dst[i] = src[i];
-    }
-    return dst;
+inline gapil::Slice<char> SpyBase::slice(CallObserver* cb,
+                                         const std::string& src) {
+  gapil::Slice<char> dst = make<char>(cb, src.length());
+  for (uint64_t i = 0; i < src.length(); i++) {
+    dst[i] = src[i];
+  }
+  return dst;
 }
 
-template<typename T>
-inline gapil::Slice<T> SpyBase::slice(const gapil::Slice<T>& src, uint64_t s, uint64_t e) const {
-    return src(s, e);
+template <typename T>
+inline gapil::Slice<T> SpyBase::slice(const gapil::Slice<T>& src, uint64_t s,
+                                      uint64_t e) const {
+  return src(s, e);
 }
 
 }  // namespace gapii
 
-#endif // GAPII_SPY_BASE_H
+#endif  // GAPII_SPY_BASE_H

--- a/gapii/cc/state_serializer.cpp
+++ b/gapii/cc/state_serializer.cpp
@@ -25,7 +25,7 @@ void StateSerializer::prepareForState(
 
   serialize_buffers(this);
 
-  mObserver->on_slice_encoded([&] (slice_t* slice) {
+  mObserver->on_slice_encoded([&](slice_t* slice) {
     auto p = slice->pool;
     if (p != nullptr && mSeenPools.count(p->id) == 0) {
       mSeenPools.insert(p->id);
@@ -38,11 +38,12 @@ void StateSerializer::prepareForState(
   });
 }
 
-pool_t* StateSerializer::createPool(uint64_t pool_size,
+pool_t* StateSerializer::createPool(
+    uint64_t pool_size,
     std::function<void(memory::Observation*)> init_observation) {
   auto arena = mSpy->arena();
   auto pool = arena->create<pool_t>();
-  pool->arena = reinterpret_cast<arena_t *>(arena);
+  pool->arena = reinterpret_cast<arena_t*>(arena);
   pool->id = (*mObserver->next_pool_id)++;
   pool->size = pool_size;
   pool->ref_count = 1;

--- a/gapii/cc/state_serializer.h
+++ b/gapii/cc/state_serializer.h
@@ -28,21 +28,21 @@ namespace gapii {
 
 class StateSerializer {
  public:
-  StateSerializer(SpyBase* spy, uint8_t api, CallObserver* observer) :
-     mSpy(spy), mApi(api), mObserver(observer) {
-  }
+  StateSerializer(SpyBase* spy, uint8_t api, CallObserver* observer)
+      : mSpy(spy), mApi(api), mObserver(observer) {}
 
   // Serializes the given state to the underlying CallObserver.
-  template<typename T, typename = CallObserver::enable_if_encodable<T> >
-  inline void encodeState(const T& state,
-      std::function<void(StateSerializer*)> serialize_buffers);
+  template <typename T, typename = CallObserver::enable_if_encodable<T> >
+  inline void encodeState(
+      const T& state, std::function<void(StateSerializer*)> serialize_buffers);
 
   // Creates and returns a new slice backed by a new virtual pool of the given
   // size. A memory observation is attached to the underlying CallObserver. If
   // init_observation is non-null, it is called to construct the observation,
   // otherwhise an empty observation is used.
-  template<typename T>
-  inline gapil::Slice<T> encodeBuffer(uint64_t pool_size,
+  template <typename T>
+  inline gapil::Slice<T> encodeBuffer(
+      uint64_t pool_size,
       std::function<void(memory::Observation*)> init_observation);
 
   // Encodes the given data using the given observation. If sendObservation is
@@ -50,11 +50,12 @@ class StateSerializer {
   // CallObserver, otherwhise the observation is simply updated  with the data
   // resource pointers.
   inline void sendData(memory::Observation* observation, bool sendObservation,
-      const void* data, size_t size);
+                       const void* data, size_t size);
 
  private:
   void prepareForState(std::function<void(StateSerializer*)> serialize_buffers);
-  pool_t* createPool(uint64_t pool_size,
+  pool_t* createPool(
+      uint64_t pool_size,
       std::function<void(memory::Observation*)> init_observation);
 
   SpyBase* mSpy;
@@ -64,23 +65,25 @@ class StateSerializer {
   int64_t mEmptyIndex = -1;
 };
 
-template<typename T, typename /* = CallObserver::enable_if_encodable<T> */ >
-inline void StateSerializer::encodeState(const T& state,
-    std::function<void(StateSerializer*)> serialize_buffers) {
+template <typename T, typename /* = CallObserver::enable_if_encodable<T> */>
+inline void StateSerializer::encodeState(
+    const T& state, std::function<void(StateSerializer*)> serialize_buffers) {
   prepareForState(serialize_buffers);
   mObserver->encode(state);
   mObserver->on_slice_encoded(nullptr);
 }
 
-template<typename T>
-inline gapil::Slice<T> StateSerializer::encodeBuffer(uint64_t pool_size,
-      std::function<void(memory::Observation*)> init_observation) {
-  return gapil::Slice<T>::create(
-      createPool(pool_size, init_observation), false);
+template <typename T>
+inline gapil::Slice<T> StateSerializer::encodeBuffer(
+    uint64_t pool_size,
+    std::function<void(memory::Observation*)> init_observation) {
+  return gapil::Slice<T>::create(createPool(pool_size, init_observation),
+                                 false);
 }
 
 inline void StateSerializer::sendData(memory::Observation* observation,
-    bool sendObservation, const void* data, size_t size) {
+                                      bool sendObservation, const void* data,
+                                      size_t size) {
   auto index = mSpy->sendResource(mApi, data, size);
   observation->set_size(size);
   observation->set_resindex(index);

--- a/gapii/cc/vulkan_extras.cpp
+++ b/gapii/cc/vulkan_extras.cpp
@@ -13,429 +13,446 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "gapii/cc/vulkan_spy.h"
 #include "gapii/cc/vulkan_layer_extras.h"
+#include "gapii/cc/vulkan_spy.h"
 
 namespace gapii {
 
 struct destroyer {
-    destroyer(const std::function<void(void)>& f) {
-        destroy = f;
-    }
-    ~destroyer() {
-        destroy();
-    }
-    std::function<void(void)> destroy;
+  destroyer(const std::function<void(void)>& f) { destroy = f; }
+  ~destroyer() { destroy(); }
+  std::function<void(void)> destroy;
 };
 
 // Declared in api_spy.h.tmpl
-bool VulkanSpy::observeFramebuffer(CallObserver* observer,
-        uint32_t* w, uint32_t* h, std::vector<uint8_t>* data) {
-    gapil::Ref<ImageObject> image;
-    uint32_t frame_buffer_img_level = 0;
-    uint32_t frame_buffer_img_layer = 0;
-    if (mState.LastSubmission == LastSubmissionType::SUBMIT) {
-        if (!mState.LastBoundQueue) {
-            return false;
-        }
-        if (!mState.LastDrawInfos.contains(mState.LastBoundQueue->mVulkanHandle)) {
-            return false;
-        }
-        auto& lastDrawInfo = *mState.LastDrawInfos[mState.LastBoundQueue->mVulkanHandle];
-        if (!lastDrawInfo.mRenderPass) {
-            return false;
-        }
-        if (!lastDrawInfo.mFramebuffer) {
-            return false;
-        }
-        if (lastDrawInfo.mLastSubpass >=
-            lastDrawInfo.mRenderPass->mSubpassDescriptions.count()) {
-            return false;
-        }
-        if (lastDrawInfo.mRenderPass->mSubpassDescriptions[lastDrawInfo.mLastSubpass].mColorAttachments.empty()) {
-            return false;
-        }
-
-        uint32_t color_attachment_index = lastDrawInfo.mRenderPass->mSubpassDescriptions[lastDrawInfo.mLastSubpass].mColorAttachments[0].mAttachment;
-        if (!lastDrawInfo.mFramebuffer->mImageAttachments.contains(color_attachment_index)) {
-            return false;
-        }
-
-        auto& imageView = lastDrawInfo.mFramebuffer->mImageAttachments[color_attachment_index];
-        image = imageView->mImage;
-        *w = lastDrawInfo.mFramebuffer->mWidth;
-        *h = lastDrawInfo.mFramebuffer->mHeight;
-        // If the image view is to be used as framebuffer attachment, it must
-        // contains only one level.
-        frame_buffer_img_level = imageView->mSubresourceRange.mbaseMipLevel;
-        // There might be more layers, but we only show the first layer.
-        // TODO: support multi-layer rendering.
-        frame_buffer_img_layer = imageView->mSubresourceRange.mbaseArrayLayer;
-    } else {
-        if (mState.LastPresentInfo.mPresentImageCount == 0) {
-            return false;
-        }
-        image = mState.LastPresentInfo.mPresentImages[0];
-        *w = image->mInfo.mExtent.mWidth;
-        *h = image->mInfo.mExtent.mHeight;
-        // Swapchain images have only one miplevel.
-        frame_buffer_img_level = 0;
-        // There might be more than one array layers for swapchain images,
-        // currently we only show the data at layer 0
-        // TODO: support multi-layer swapchain images.
-        frame_buffer_img_layer = 0;
+bool VulkanSpy::observeFramebuffer(CallObserver* observer, uint32_t* w,
+                                   uint32_t* h, std::vector<uint8_t>* data) {
+  gapil::Ref<ImageObject> image;
+  uint32_t frame_buffer_img_level = 0;
+  uint32_t frame_buffer_img_layer = 0;
+  if (mState.LastSubmission == LastSubmissionType::SUBMIT) {
+    if (!mState.LastBoundQueue) {
+      return false;
+    }
+    if (!mState.LastDrawInfos.contains(mState.LastBoundQueue->mVulkanHandle)) {
+      return false;
+    }
+    auto& lastDrawInfo =
+        *mState.LastDrawInfos[mState.LastBoundQueue->mVulkanHandle];
+    if (!lastDrawInfo.mRenderPass) {
+      return false;
+    }
+    if (!lastDrawInfo.mFramebuffer) {
+      return false;
+    }
+    if (lastDrawInfo.mLastSubpass >=
+        lastDrawInfo.mRenderPass->mSubpassDescriptions.count()) {
+      return false;
+    }
+    if (lastDrawInfo.mRenderPass
+            ->mSubpassDescriptions[lastDrawInfo.mLastSubpass]
+            .mColorAttachments.empty()) {
+      return false;
     }
 
-    // TODO: Handle multisampled images. This is only a concern for
-    // draw-level observations.
-
-    VkDevice device = image->mDevice;
-    VkPhysicalDevice physical_device = mState.Devices[device]->mPhysicalDevice;
-    VkInstance instance = mState.PhysicalDevices[physical_device]->mInstance;
-    VkQueue queue = image->mLastBoundQueue->mVulkanHandle;
-    uint32_t queue_family = image->mLastBoundQueue->mFamily;
-    auto& instance_fn = mImports.mVkInstanceFunctions[instance];
-
-    VkPhysicalDeviceMemoryProperties memory_properties(arena());
-    instance_fn.vkGetPhysicalDeviceMemoryProperties(physical_device,
-        &memory_properties);
-
-    auto& fn = mImports.mVkDeviceFunctions[device];
-
-    VkImageCreateInfo create_info {
-        VkStructureType::VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO, // sType
-        nullptr,                                              // pNext
-        0,                                                    // flags
-        VkImageType::VK_IMAGE_TYPE_2D,                        // imageType
-        VkFormat::VK_FORMAT_R8G8B8A8_UNORM,                   // format
-        VkExtent3D{*w, *h, 1},                                // extent
-        1,                                                    // mipLevels
-        1,                                                    // arrayLayers
-        VkSampleCountFlagBits::VK_SAMPLE_COUNT_1_BIT,         // samples
-        VkImageTiling::VK_IMAGE_TILING_OPTIMAL,               // tiling
-        VkImageUsageFlagBits::VK_IMAGE_USAGE_TRANSFER_SRC_BIT |
-        VkImageUsageFlagBits::VK_IMAGE_USAGE_TRANSFER_DST_BIT, // usage
-        VkSharingMode::VK_SHARING_MODE_EXCLUSIVE,             // sharingMode
-        0,                                                    // queueFamilyIndexCount
-        nullptr,                                              // queueFamilyIndices
-        VkImageLayout::VK_IMAGE_LAYOUT_UNDEFINED              // layout
-    };
-
-    VkImage resolve_image;
-    VkDeviceMemory image_memory;
-
-    if (VkResult::VK_SUCCESS != fn.vkCreateImage(device, &create_info, nullptr, &resolve_image)) {
-        return false;
-    }
-    destroyer image_destroyer([&]() {
-        fn.vkDestroyImage(device, resolve_image, nullptr);
-    });
-
-
-    VkMemoryRequirements image_reqs(arena());
-    fn.vkGetImageMemoryRequirements(device, resolve_image, &image_reqs);
-
-    uint32_t image_memory_req = 0xFFFFFFFF;
-    for (size_t i = 0; i < 32; ++i) {
-        if (image_reqs.mmemoryTypeBits & (1 << i)) {
-            image_memory_req = i;
-            break;
-        }
+    uint32_t color_attachment_index =
+        lastDrawInfo.mRenderPass
+            ->mSubpassDescriptions[lastDrawInfo.mLastSubpass]
+            .mColorAttachments[0]
+            .mAttachment;
+    if (!lastDrawInfo.mFramebuffer->mImageAttachments.contains(
+            color_attachment_index)) {
+      return false;
     }
 
-    if (image_memory_req == 0xFFFFFFFF) {
-        return false;
+    auto& imageView =
+        lastDrawInfo.mFramebuffer->mImageAttachments[color_attachment_index];
+    image = imageView->mImage;
+    *w = lastDrawInfo.mFramebuffer->mWidth;
+    *h = lastDrawInfo.mFramebuffer->mHeight;
+    // If the image view is to be used as framebuffer attachment, it must
+    // contains only one level.
+    frame_buffer_img_level = imageView->mSubresourceRange.mbaseMipLevel;
+    // There might be more layers, but we only show the first layer.
+    // TODO: support multi-layer rendering.
+    frame_buffer_img_layer = imageView->mSubresourceRange.mbaseArrayLayer;
+  } else {
+    if (mState.LastPresentInfo.mPresentImageCount == 0) {
+      return false;
     }
+    image = mState.LastPresentInfo.mPresentImages[0];
+    *w = image->mInfo.mExtent.mWidth;
+    *h = image->mInfo.mExtent.mHeight;
+    // Swapchain images have only one miplevel.
+    frame_buffer_img_level = 0;
+    // There might be more than one array layers for swapchain images,
+    // currently we only show the data at layer 0
+    // TODO: support multi-layer swapchain images.
+    frame_buffer_img_layer = 0;
+  }
 
-    VkMemoryAllocateInfo allocate {
-        VkStructureType::VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO, // sType
-        nullptr,                                                 // pNext
-        image_reqs.msize,                                        // allocationSize
-        image_memory_req                                         // memoryTypeIndex
-    };
-    if (VkResult::VK_SUCCESS != fn.vkAllocateMemory(device, &allocate, nullptr, &image_memory)) {
-        return false;
+  // TODO: Handle multisampled images. This is only a concern for
+  // draw-level observations.
+
+  VkDevice device = image->mDevice;
+  VkPhysicalDevice physical_device = mState.Devices[device]->mPhysicalDevice;
+  VkInstance instance = mState.PhysicalDevices[physical_device]->mInstance;
+  VkQueue queue = image->mLastBoundQueue->mVulkanHandle;
+  uint32_t queue_family = image->mLastBoundQueue->mFamily;
+  auto& instance_fn = mImports.mVkInstanceFunctions[instance];
+
+  VkPhysicalDeviceMemoryProperties memory_properties(arena());
+  instance_fn.vkGetPhysicalDeviceMemoryProperties(physical_device,
+                                                  &memory_properties);
+
+  auto& fn = mImports.mVkDeviceFunctions[device];
+
+  VkImageCreateInfo create_info{
+      VkStructureType::VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO,  // sType
+      nullptr,                                               // pNext
+      0,                                                     // flags
+      VkImageType::VK_IMAGE_TYPE_2D,                         // imageType
+      VkFormat::VK_FORMAT_R8G8B8A8_UNORM,                    // format
+      VkExtent3D{*w, *h, 1},                                 // extent
+      1,                                                     // mipLevels
+      1,                                                     // arrayLayers
+      VkSampleCountFlagBits::VK_SAMPLE_COUNT_1_BIT,          // samples
+      VkImageTiling::VK_IMAGE_TILING_OPTIMAL,                // tiling
+      VkImageUsageFlagBits::VK_IMAGE_USAGE_TRANSFER_SRC_BIT |
+          VkImageUsageFlagBits::VK_IMAGE_USAGE_TRANSFER_DST_BIT,  // usage
+      VkSharingMode::VK_SHARING_MODE_EXCLUSIVE,                   // sharingMode
+      0,                                        // queueFamilyIndexCount
+      nullptr,                                  // queueFamilyIndices
+      VkImageLayout::VK_IMAGE_LAYOUT_UNDEFINED  // layout
+  };
+
+  VkImage resolve_image;
+  VkDeviceMemory image_memory;
+
+  if (VkResult::VK_SUCCESS !=
+      fn.vkCreateImage(device, &create_info, nullptr, &resolve_image)) {
+    return false;
+  }
+  destroyer image_destroyer(
+      [&]() { fn.vkDestroyImage(device, resolve_image, nullptr); });
+
+  VkMemoryRequirements image_reqs(arena());
+  fn.vkGetImageMemoryRequirements(device, resolve_image, &image_reqs);
+
+  uint32_t image_memory_req = 0xFFFFFFFF;
+  for (size_t i = 0; i < 32; ++i) {
+    if (image_reqs.mmemoryTypeBits & (1 << i)) {
+      image_memory_req = i;
+      break;
     }
-    destroyer image_memory_destroyer([&]() {
-        fn.vkFreeMemory(device, image_memory, nullptr);
-    });
+  }
 
-    fn.vkBindImageMemory(device, resolve_image, image_memory, 0);
+  if (image_memory_req == 0xFFFFFFFF) {
+    return false;
+  }
 
-    VkBuffer buffer;
-    VkDeviceMemory buffer_memory;
-    VkBufferCreateInfo buffer_info = {
-        VkStructureType::VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO,   // sType
-        nullptr,                                                 // pNext
-        0,                                                       // flags
-        *w * *h * 4,                                             // size
-        VkBufferUsageFlagBits::VK_BUFFER_USAGE_TRANSFER_DST_BIT, // usage
-        VkSharingMode::VK_SHARING_MODE_EXCLUSIVE,                // sharingMode
-        0,                                                       // queueFamilyIndexCountg
-        nullptr                                                  // queueFamilyIndices
-    };
+  VkMemoryAllocateInfo allocate{
+      VkStructureType::VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO,  // sType
+      nullptr,                                                  // pNext
+      image_reqs.msize,  // allocationSize
+      image_memory_req   // memoryTypeIndex
+  };
+  if (VkResult::VK_SUCCESS !=
+      fn.vkAllocateMemory(device, &allocate, nullptr, &image_memory)) {
+    return false;
+  }
+  destroyer image_memory_destroyer(
+      [&]() { fn.vkFreeMemory(device, image_memory, nullptr); });
 
-    if (VkResult::VK_SUCCESS != fn.vkCreateBuffer(device, &buffer_info, nullptr, &buffer)) {
-        return false;
+  fn.vkBindImageMemory(device, resolve_image, image_memory, 0);
+
+  VkBuffer buffer;
+  VkDeviceMemory buffer_memory;
+  VkBufferCreateInfo buffer_info = {
+      VkStructureType::VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO,    // sType
+      nullptr,                                                  // pNext
+      0,                                                        // flags
+      *w * *h * 4,                                              // size
+      VkBufferUsageFlagBits::VK_BUFFER_USAGE_TRANSFER_DST_BIT,  // usage
+      VkSharingMode::VK_SHARING_MODE_EXCLUSIVE,                 // sharingMode
+      0,       // queueFamilyIndexCountg
+      nullptr  // queueFamilyIndices
+  };
+
+  if (VkResult::VK_SUCCESS !=
+      fn.vkCreateBuffer(device, &buffer_info, nullptr, &buffer)) {
+    return false;
+  }
+  destroyer buffer_destroyer(
+      [&]() { fn.vkDestroyBuffer(device, buffer, nullptr); });
+
+  VkMemoryRequirements buffer_reqs(arena());
+  fn.vkGetBufferMemoryRequirements(device, buffer, &buffer_reqs);
+
+  uint32_t buffer_memory_req = 0;
+  while (buffer_reqs.mmemoryTypeBits) {
+    if (buffer_reqs.mmemoryTypeBits & 0x1) {
+      if (memory_properties.mmemoryTypes[buffer_memory_req].mpropertyFlags &
+          VkMemoryPropertyFlagBits::VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT) {
+        break;
+      }
     }
-    destroyer buffer_destroyer([&]() {
-        fn.vkDestroyBuffer(device, buffer, nullptr);
-    });
+    buffer_reqs.mmemoryTypeBits >>= 1;
+    ++buffer_memory_req;
+  }
+  if (!buffer_reqs.mmemoryTypeBits) {
+    return false;
+  }
+  allocate.mallocationSize = buffer_reqs.msize;
+  allocate.mmemoryTypeIndex = buffer_memory_req;
+  if (VkResult::VK_SUCCESS !=
+      fn.vkAllocateMemory(device, &allocate, nullptr, &buffer_memory)) {
+    return false;
+  }
+  destroyer buffer_memory_destroyer(
+      [&]() { fn.vkFreeMemory(device, buffer_memory, nullptr); });
 
-    VkMemoryRequirements buffer_reqs(arena());
-    fn.vkGetBufferMemoryRequirements(device, buffer, &buffer_reqs);
+  fn.vkBindBufferMemory(device, buffer, buffer_memory, 0);
 
-    uint32_t buffer_memory_req = 0;
-    while(buffer_reqs.mmemoryTypeBits) {
-        if (buffer_reqs.mmemoryTypeBits & 0x1) {
-            if (memory_properties.mmemoryTypes[buffer_memory_req].mpropertyFlags &
-                    VkMemoryPropertyFlagBits::VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT) {
-                break;
-            }
-        }
-        buffer_reqs.mmemoryTypeBits >>= 1;
-        ++buffer_memory_req;
-    }
-    if (!buffer_reqs.mmemoryTypeBits) {
-        return false;
-    }
-    allocate.mallocationSize = buffer_reqs.msize;
-    allocate.mmemoryTypeIndex = buffer_memory_req;
-    if (VkResult::VK_SUCCESS != fn.vkAllocateMemory(device, &allocate, nullptr, &buffer_memory)) {
-        return false;
-    }
-    destroyer buffer_memory_destroyer([&]() {
-        fn.vkFreeMemory(device, buffer_memory, nullptr);
-    });
+  VkCommandPoolCreateInfo command_pool_info = {
+      VkStructureType::VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO,  // sType
+      nullptr,                                                      // pNext
+      0,                                                            // flags
+      queue_family  // queueFamilyIndex
+  };
 
-    fn.vkBindBufferMemory(device, buffer, buffer_memory, 0);
+  VkCommandPool command_pool;
+  if (VkResult::VK_SUCCESS != fn.vkCreateCommandPool(device, &command_pool_info,
+                                                     nullptr, &command_pool)) {
+    return false;
+  }
+  destroyer command_pool_destroyer(
+      [&]() { fn.vkDestroyCommandPool(device, command_pool, nullptr); });
 
-    VkCommandPoolCreateInfo command_pool_info = {
-        VkStructureType::VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO, // sType
-        nullptr,                                                     // pNext
-        0,                                                           // flags
-        queue_family                                                 // queueFamilyIndex
-    };
+  VkCommandBufferAllocateInfo command_buffer_info = {
+      VkStructureType::VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO,  // sType
+      nullptr,                                                          // pNext
+      command_pool,                                                     // pool
+      VkCommandBufferLevel::VK_COMMAND_BUFFER_LEVEL_PRIMARY,            // level
+      1  // commandBufferCount
+  };
 
-    VkCommandPool command_pool;
-    if (VkResult::VK_SUCCESS != fn.vkCreateCommandPool(device, &command_pool_info, nullptr, &command_pool)){
-        return false;
-    }
-    destroyer command_pool_destroyer([&]() {
-        fn.vkDestroyCommandPool(device, command_pool, nullptr);
-    });
+  VkCommandBuffer command_buffer;
+  if (VkResult::VK_SUCCESS != fn.vkAllocateCommandBuffers(device,
+                                                          &command_buffer_info,
+                                                          &command_buffer)) {
+    return false;
+  }
 
-    VkCommandBufferAllocateInfo command_buffer_info = {
-        VkStructureType::VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO, // sType
-        nullptr,                                                         // pNext
-        command_pool,                                                    // pool
-        VkCommandBufferLevel::VK_COMMAND_BUFFER_LEVEL_PRIMARY,           // level
-        1                                                                // commandBufferCount
-    };
+  VkImageMemoryBarrier barriers[2] = {
+      {VkStructureType::VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,  // sType
+       nullptr,                                                  // pNext
+       (VkAccessFlagBits::VK_ACCESS_MEMORY_WRITE_BIT << 1) -
+           1,                                          // srcAccessMask
+       VkAccessFlagBits::VK_ACCESS_TRANSFER_READ_BIT,  // dstAccessMask
+       image->mAspects[VkImageAspectFlagBits::VK_IMAGE_ASPECT_COLOR_BIT]
+           ->mLayers[frame_buffer_img_layer]
+           ->mLevels[frame_buffer_img_level]
+           ->mLayout,                                        // srcLayout
+       VkImageLayout::VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,  // dstLayout
+       0xFFFFFFFF,                                           // srcQueueFamily
+       0xFFFFFFFF,                                           // dstQueueFamily
+       image->mVulkanHandle,                                 // image
+       {
+           // subresourcerange
+           VkImageAspectFlagBits::VK_IMAGE_ASPECT_COLOR_BIT,  // aspectMask
+           0,                                                 // baseMipLevel
+           1,                                                 // mipLevelCount
+           0,                                                 // baseArrayLayer
+           1,                                                 // layerCount
+       }},
+      {VkStructureType::VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,  // sType
+       nullptr,                                                  // pNext
+       (VkAccessFlagBits::VK_ACCESS_MEMORY_WRITE_BIT << 1) -
+           1,                                                // srcAccessMask
+       VkAccessFlagBits::VK_ACCESS_TRANSFER_WRITE_BIT,       // dstAccessMask
+       VkImageLayout::VK_IMAGE_LAYOUT_UNDEFINED,             // srcLayout
+       VkImageLayout::VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,  // dstLayout
+       0xFFFFFFFF,                                           // srcQueueFamily
+       0xFFFFFFFF,                                           // dstQueueFamily
+       resolve_image,                                        // image
+       {
+           // subresourcerange
+           VkImageAspectFlagBits::VK_IMAGE_ASPECT_COLOR_BIT,  // aspectMask
+           0,                                                 // baseMipLevel
+           1,                                                 // mipLevelCount
+           0,                                                 // baseArrayLayer
+           1,                                                 // layerCount
+       }},
+  };
 
-    VkCommandBuffer command_buffer;
-    if (VkResult::VK_SUCCESS != fn.vkAllocateCommandBuffers(device, &command_buffer_info, &command_buffer)) {
-        return false;
-    }
+  fn.vkCmdPipelineBarrier(
+      command_buffer,
+      VkPipelineStageFlagBits::VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT,
+      VkPipelineStageFlagBits::VK_PIPELINE_STAGE_TRANSFER_BIT, 0, 0, nullptr, 0,
+      nullptr, 2, barriers);
+  VkImageBlit blit = {
+      {VkImageAspectFlagBits::VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1},
+      core::StaticArray<VkOffset3D, 2>::create(
+          {{0, 0, 0}, {static_cast<int32_t>(*w), static_cast<int32_t>(*h), 1}}),
+      {VkImageAspectFlagBits::VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1},
+      core::StaticArray<VkOffset3D, 2>::create(
+          {{0, 0, 0},
+           {static_cast<int32_t>(*w), static_cast<int32_t>(*h), 1}})};
+  fn.vkCmdBlitImage(command_buffer, image->mVulkanHandle,
+                    VkImageLayout::VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
+                    resolve_image,
+                    VkImageLayout::VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, 1,
+                    &blit, VkFilter::VK_FILTER_NEAREST);
 
-    VkImageMemoryBarrier barriers[2] = {{
-         VkStructureType::VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,  // sType
-         nullptr,                                                  // pNext
-         (VkAccessFlagBits::VK_ACCESS_MEMORY_WRITE_BIT << 1) - 1,  // srcAccessMask
-         VkAccessFlagBits::VK_ACCESS_TRANSFER_READ_BIT,            // dstAccessMask
-         image->mAspects[VkImageAspectFlagBits::VK_IMAGE_ASPECT_COLOR_BIT]
-             ->mLayers[frame_buffer_img_layer]
-             ->mLevels[frame_buffer_img_level]
-             ->mLayout,                                            // srcLayout
-         VkImageLayout::VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,      // dstLayout
-         0xFFFFFFFF,                                               // srcQueueFamily
-         0xFFFFFFFF,                                               // dstQueueFamily
-         image->mVulkanHandle,                                     // image
-         {
-             // subresourcerange
-             VkImageAspectFlagBits::VK_IMAGE_ASPECT_COLOR_BIT,     // aspectMask
-             0,                                                    // baseMipLevel
-             1,                                                    // mipLevelCount
-             0,                                                    // baseArrayLayer
-             1,                                                    // layerCount
-         }
-    }, {
-         VkStructureType::VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,  // sType
-         nullptr,                                                  // pNext
-         (VkAccessFlagBits::VK_ACCESS_MEMORY_WRITE_BIT << 1) - 1,  // srcAccessMask
-         VkAccessFlagBits::VK_ACCESS_TRANSFER_WRITE_BIT,           // dstAccessMask
-         VkImageLayout::VK_IMAGE_LAYOUT_UNDEFINED,                 // srcLayout
-         VkImageLayout::VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,      // dstLayout
-         0xFFFFFFFF,                                               // srcQueueFamily
-         0xFFFFFFFF,                                               // dstQueueFamily
-         resolve_image,                                            // image
-         {
-             // subresourcerange
-             VkImageAspectFlagBits::VK_IMAGE_ASPECT_COLOR_BIT,     // aspectMask
-             0,                                                    // baseMipLevel
-             1,                                                    // mipLevelCount
-             0,  // baseArrayLayer
-             1,  // layerCount
-         }
-    },
-    };
+  barriers[0].msrcAccessMask = VkAccessFlagBits::VK_ACCESS_TRANSFER_READ_BIT;
+  barriers[0].mdstAccessMask =
+      (VkAccessFlagBits::VK_ACCESS_MEMORY_WRITE_BIT << 1) - 1;
+  barriers[0].moldLayout = VkImageLayout::VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
+  barriers[0].mnewLayout =
+      image->mAspects[VkImageAspectFlagBits::VK_IMAGE_ASPECT_COLOR_BIT]
+          ->mLayers[frame_buffer_img_layer]
+          ->mLevels[frame_buffer_img_level]
+          ->mLayout;
+  barriers[1].msrcAccessMask = VkAccessFlagBits::VK_ACCESS_TRANSFER_WRITE_BIT;
+  barriers[1].mdstAccessMask = VkAccessFlagBits::VK_ACCESS_TRANSFER_READ_BIT;
+  barriers[1].moldLayout = VkImageLayout::VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
+  barriers[1].mnewLayout = VkImageLayout::VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
 
-    fn.vkCmdPipelineBarrier(command_buffer,
-        VkPipelineStageFlagBits::VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT,
-        VkPipelineStageFlagBits::VK_PIPELINE_STAGE_TRANSFER_BIT, 0, 0,
-        nullptr, 0, nullptr, 2, barriers);
-    VkImageBlit blit = {
-        {VkImageAspectFlagBits::VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1},
-        core::StaticArray<VkOffset3D,2>::create({{0, 0, 0}, {static_cast<int32_t>(*w), static_cast<int32_t>(*h), 1}}),
-        {VkImageAspectFlagBits::VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1},
-        core::StaticArray<VkOffset3D,2>::create({{0, 0, 0}, {static_cast<int32_t>(*w), static_cast<int32_t>(*h), 1}})
-    };
-    fn.vkCmdBlitImage(command_buffer, image->mVulkanHandle,
-        VkImageLayout::VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
-        resolve_image,
-        VkImageLayout::VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
-        1,
-        &blit, VkFilter::VK_FILTER_NEAREST);
+  fn.vkCmdPipelineBarrier(
+      command_buffer, VkPipelineStageFlagBits::VK_PIPELINE_STAGE_TRANSFER_BIT,
+      VkPipelineStageFlagBits::VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT, 0, 0,
+      nullptr, 0, nullptr, 2, barriers);
 
-    barriers[0].msrcAccessMask = VkAccessFlagBits::VK_ACCESS_TRANSFER_READ_BIT;
-    barriers[0].mdstAccessMask = (VkAccessFlagBits::VK_ACCESS_MEMORY_WRITE_BIT << 1) - 1;
-    barriers[0].moldLayout = VkImageLayout::VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
-    barriers[0].mnewLayout =
-        image->mAspects[VkImageAspectFlagBits::VK_IMAGE_ASPECT_COLOR_BIT]
-            ->mLayers[frame_buffer_img_layer]
-            ->mLevels[frame_buffer_img_level]
-            ->mLayout;
-    barriers[1].msrcAccessMask = VkAccessFlagBits::VK_ACCESS_TRANSFER_WRITE_BIT;
-    barriers[1].mdstAccessMask = VkAccessFlagBits::VK_ACCESS_TRANSFER_READ_BIT;
-    barriers[1].moldLayout = VkImageLayout::VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
-    barriers[1].mnewLayout = VkImageLayout::VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
+  VkBufferImageCopy copy_region = {
+      0,  // bufferOffset
+      0,  // bufferRowLength
+      0,  // bufferImageHeight
+      {VkImageAspectFlagBits::VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1},
+      {0, 0, 0},
+      {*w, *h, 1}};
+  fn.vkCmdCopyImageToBuffer(command_buffer, resolve_image,
+                            VkImageLayout::VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
+                            buffer, 1, &copy_region);
 
-    fn.vkCmdPipelineBarrier(command_buffer,
-        VkPipelineStageFlagBits::VK_PIPELINE_STAGE_TRANSFER_BIT,
-        VkPipelineStageFlagBits::VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT,
-        0, 0, nullptr, 0, nullptr, 2, barriers);
+  VkBufferMemoryBarrier buffer_barrier = {
+      VkStructureType::VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER,  // sType
+      nullptr,                                                   // pNext
+      VkAccessFlagBits::VK_ACCESS_TRANSFER_WRITE_BIT,  // srcAccessMask
+      VkAccessFlagBits::VK_ACCESS_HOST_READ_BIT,       // dstAccessMask
+      0xFFFFFFFF,                                      // srcqueueFamily
+      0xFFFFFFFF,                                      // dstQueueFamily
+      buffer,                                          // buffer
+      0,                                               // offset
+      0xFFFFFFFFFFFFFFFF                               // size
+  };
+  fn.vkCmdPipelineBarrier(
+      command_buffer, VkPipelineStageFlagBits::VK_PIPELINE_STAGE_TRANSFER_BIT,
+      VkPipelineStageFlagBits::VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT, 0, 0,
+      nullptr, 1, &buffer_barrier, 0, nullptr);
 
-    VkBufferImageCopy copy_region = {
-        0, // bufferOffset
-        0, // bufferRowLength
-        0, // bufferImageHeight
-        {VkImageAspectFlagBits::VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1},
-        {0, 0, 0},
-        {*w, *h, 1}
-    }
-    ;
-    fn.vkCmdCopyImageToBuffer(command_buffer, resolve_image,
-        VkImageLayout::VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
-        buffer, 1, &copy_region);
+  fn.vkEndCommandBuffer(command_buffer);
 
-    VkBufferMemoryBarrier buffer_barrier = {
-        VkStructureType::VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER, // sType
-        nullptr,                                                  // pNext
-        VkAccessFlagBits::VK_ACCESS_TRANSFER_WRITE_BIT,           // srcAccessMask
-        VkAccessFlagBits::VK_ACCESS_HOST_READ_BIT,                // dstAccessMask
-        0xFFFFFFFF,                                               // srcqueueFamily
-        0xFFFFFFFF,                                               // dstQueueFamily
-        buffer,                                                   // buffer
-        0,                                                        // offset
-        0xFFFFFFFFFFFFFFFF                                        // size
-    };
-    fn.vkCmdPipelineBarrier(command_buffer,
-        VkPipelineStageFlagBits::VK_PIPELINE_STAGE_TRANSFER_BIT,
-        VkPipelineStageFlagBits::VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT,
-        0, 0, nullptr, 1, &buffer_barrier, 0, nullptr);
+  VkSubmitInfo submit_info = {VkStructureType::VK_STRUCTURE_TYPE_SUBMIT_INFO,
+                              nullptr,
+                              0,
+                              nullptr,
+                              nullptr,
+                              1,
+                              &command_buffer,
+                              0,
+                              nullptr};
+  if (VkResult::VK_SUCCESS != fn.vkQueueSubmit(queue, 1, &submit_info, 0)) {
+    return false;
+  }
+  fn.vkQueueWaitIdle(queue);
+  char* image_data;
+  if (VkResult::VK_SUCCESS !=
+      fn.vkMapMemory(device, buffer_memory, 0, 0xFFFFFFFFFFFFFFFF, 0,
+                     reinterpret_cast<void**>(&image_data))) {
+    return false;
+  }
+  VkMappedMemoryRange range = {
+      VkStructureType::VK_STRUCTURE_TYPE_MAPPED_MEMORY_RANGE,  // sType
+      nullptr,                                                 // pNext
+      buffer_memory,                                           // memory
+      0,                                                       // offset
+      0xFFFFFFFFFFFFFFFF                                       // size
+  };
+  fn.vkInvalidateMappedMemoryRanges(device, 1, &range);
+  data->resize(*w * *h * 4);
+  // Flip the image because vulkan renders upside-down.
+  for (size_t i = 0; i < *h; ++i) {
+    memcpy(data->data() + i * (*w * 4), image_data + ((*h - i - 1) * (*w * 4)),
+           *w * 4);
+  }
 
-    fn.vkEndCommandBuffer(command_buffer);
-
-    VkSubmitInfo submit_info = {
-        VkStructureType::VK_STRUCTURE_TYPE_SUBMIT_INFO,
-        nullptr,
-        0, nullptr, nullptr, 1, &command_buffer, 0, nullptr
-    };
-    if (VkResult::VK_SUCCESS != fn.vkQueueSubmit(queue, 1, &submit_info, 0)) {
-        return false;
-    }
-    fn.vkQueueWaitIdle(queue);
-    char* image_data;
-    if (VkResult::VK_SUCCESS != fn.vkMapMemory(device, buffer_memory, 0,
-        0xFFFFFFFFFFFFFFFF, 0, reinterpret_cast<void**>(&image_data))) {
-        return false;
-    }
-    VkMappedMemoryRange range = {
-        VkStructureType::VK_STRUCTURE_TYPE_MAPPED_MEMORY_RANGE, // sType
-        nullptr,                                                // pNext
-        buffer_memory,                                          // memory
-        0,                                                      // offset
-        0xFFFFFFFFFFFFFFFF                                      // size
-    };
-    fn.vkInvalidateMappedMemoryRanges(device, 1, &range);
-    data->resize(*w * *h * 4);
-    // Flip the image because vulkan renders upside-down.
-    for (size_t i = 0 ; i < *h; ++i) {
-        memcpy(data->data() + i * (*w * 4),
-            image_data + ((*h - i - 1) * (*w * 4)),
-                *w * 4);
-    }
-
-    return true;
+  return true;
 }
 
 // Extern functions
-void VulkanSpy::trackMappedCoherentMemory(CallObserver*, uint64_t start, size_val size) {
+void VulkanSpy::trackMappedCoherentMemory(CallObserver*, uint64_t start,
+                                          size_val size) {
   // If the tracing not started yet, do not track the coherent memory
   if (is_suspended()) {
-      return;
+    return;
   }
 #if COHERENT_TRACKING_ENABLED
-    if (m_coherent_memory_tracking_enabled) {
-        void* start_addr = reinterpret_cast<void*>(start);
-        mMemoryTracker.AddTrackingRange(start_addr, size);
-    }
-#endif // COHERENT_TRACKING_ENABLED
+  if (m_coherent_memory_tracking_enabled) {
+    void* start_addr = reinterpret_cast<void*>(start);
+    mMemoryTracker.AddTrackingRange(start_addr, size);
+  }
+#endif  // COHERENT_TRACKING_ENABLED
 }
 
-void VulkanSpy::readMappedCoherentMemory(CallObserver *observer, VkDeviceMemory memory, uint64_t offset_in_mapped, size_val readSize) {
-    auto &memory_object = mState.DeviceMemories[memory];
-    const auto mapped_location = (uint64_t)(memory_object->mMappedLocation);
-    void *offset_addr = (void *)(offset_in_mapped + mapped_location);
+void VulkanSpy::readMappedCoherentMemory(CallObserver* observer,
+                                         VkDeviceMemory memory,
+                                         uint64_t offset_in_mapped,
+                                         size_val readSize) {
+  auto& memory_object = mState.DeviceMemories[memory];
+  const auto mapped_location = (uint64_t)(memory_object->mMappedLocation);
+  void* offset_addr = (void*)(offset_in_mapped + mapped_location);
 #if COHERENT_TRACKING_ENABLED
-    if (m_coherent_memory_tracking_enabled) {
-        const size_val page_size = mMemoryTracker.page_size();
-        // Get the valid mapped range
-        const auto dirty_pages = mMemoryTracker.GetAndResetDirtyPagesInRange(offset_addr, readSize);
-        for (const void *p : dirty_pages) {
-            uint64_t page_start = (uint64_t)(p);
-            observer->read(slice((uint8_t *)page_start, 0ULL, page_size));
-        }
-        return;
+  if (m_coherent_memory_tracking_enabled) {
+    const size_val page_size = mMemoryTracker.page_size();
+    // Get the valid mapped range
+    const auto dirty_pages =
+        mMemoryTracker.GetAndResetDirtyPagesInRange(offset_addr, readSize);
+    for (const void* p : dirty_pages) {
+      uint64_t page_start = (uint64_t)(p);
+      observer->read(slice((uint8_t*)page_start, 0ULL, page_size));
     }
-#endif // COHERENT_TRACKING_ENABLED
-    observer->read(slice((uint8_t *)offset_addr, 0ULL, readSize));
+    return;
+  }
+#endif  // COHERENT_TRACKING_ENABLED
+  observer->read(slice((uint8_t*)offset_addr, 0ULL, readSize));
 }
 
-void VulkanSpy::untrackMappedCoherentMemory(CallObserver*, uint64_t start, size_val size) {
+void VulkanSpy::untrackMappedCoherentMemory(CallObserver*, uint64_t start,
+                                            size_val size) {
 #if COHERENT_TRACKING_ENABLED
-    if (m_coherent_memory_tracking_enabled) {
-        void* start_addr = reinterpret_cast<void*>(start);
-        mMemoryTracker.RemoveTrackingRange(start_addr, size);
-    }
-#endif // COHERENT_TRACKING_ENABLED
+  if (m_coherent_memory_tracking_enabled) {
+    void* start_addr = reinterpret_cast<void*>(start);
+    mMemoryTracker.RemoveTrackingRange(start_addr, size);
+  }
+#endif  // COHERENT_TRACKING_ENABLED
 }
 
 void VulkanSpy::mapMemory(CallObserver*, void**, gapil::Slice<uint8_t>) {}
 void VulkanSpy::unmapMemory(CallObserver*, gapil::Slice<uint8_t>) {}
 
-bool VulkanSpy::hasDynamicProperty(
-        CallObserver* observer,
-        const VkPipelineDynamicStateCreateInfo* info,
-        uint32_t state) {
-
-    if (!info) { return false; }
-    for (size_t i = 0; i < info->mdynamicStateCount; ++i) {
-        if (info->mpDynamicStates[i] == state) {
-            return true;
-        }
-    }
+bool VulkanSpy::hasDynamicProperty(CallObserver* observer,
+                                   const VkPipelineDynamicStateCreateInfo* info,
+                                   uint32_t state) {
+  if (!info) {
     return false;
+  }
+  for (size_t i = 0; i < info->mdynamicStateCount; ++i) {
+    if (info->mpDynamicStates[i] == state) {
+      return true;
+    }
+  }
+  return false;
 }
 
 void VulkanSpy::resetCmd(CallObserver* observer, VkCommandBuffer cmdBuf) {}
@@ -444,9 +461,11 @@ void VulkanSpy::leaveSubcontext(CallObserver*) {}
 void VulkanSpy::nextSubcontext(CallObserver*) {}
 void VulkanSpy::resetSubcontext(CallObserver*) {}
 void VulkanSpy::onPreSubcommand(CallObserver*, gapil::Ref<CommandReference>) {}
-void VulkanSpy::onPreProcessCommand(CallObserver*, gapil::Ref<CommandReference>) {}
+void VulkanSpy::onPreProcessCommand(CallObserver*,
+                                    gapil::Ref<CommandReference>) {}
 void VulkanSpy::onPostSubcommand(CallObserver*, gapil::Ref<CommandReference>) {}
-void VulkanSpy::onDeferSubcommand(CallObserver*, gapil::Ref<CommandReference>) {}
+void VulkanSpy::onDeferSubcommand(CallObserver*, gapil::Ref<CommandReference>) {
+}
 void VulkanSpy::onCommandAdded(CallObserver*, VkCommandBuffer) {}
 void VulkanSpy::postBindSparse(CallObserver*, gapil::Ref<QueuedSparseBinds>) {}
 void VulkanSpy::pushDebugMarker(CallObserver*, std::string) {}
@@ -469,11 +488,14 @@ VulkanSpy::fetchPhysicalDeviceProperties(CallObserver* observer,
   return props;
 }
 
-gapil::Ref<PhysicalDevicesMemoryProperties> VulkanSpy::fetchPhysicalDeviceMemoryProperties(
-    CallObserver *observer, VkInstance instance, gapil::Slice<VkPhysicalDevice> devs) {
+gapil::Ref<PhysicalDevicesMemoryProperties>
+VulkanSpy::fetchPhysicalDeviceMemoryProperties(
+    CallObserver* observer, VkInstance instance,
+    gapil::Slice<VkPhysicalDevice> devs) {
   auto props = gapil::Ref<PhysicalDevicesMemoryProperties>::create(arena());
   for (VkPhysicalDevice dev : devs) {
-    props->mPhyDevToMemoryProperties[dev] = VkPhysicalDeviceMemoryProperties(arena());
+    props->mPhyDevToMemoryProperties[dev] =
+        VkPhysicalDeviceMemoryProperties(arena());
     mImports.mVkInstanceFunctions[instance].vkGetPhysicalDeviceMemoryProperties(
         dev, &props->mPhyDevToMemoryProperties[dev]);
   }
@@ -522,7 +544,8 @@ gapil::Ref<LinearImageLayouts> VulkanSpy::fetchLinearImageSubresourceLayouts(
   auto layouts = gapil::Ref<LinearImageLayouts>::create(arena());
   walkImageSubRng(
       image, rng,
-      [&layouts, device, &image, this](uint32_t aspect_bit, uint32_t layer, uint32_t level) {
+      [&layouts, device, &image, this](uint32_t aspect_bit, uint32_t layer,
+                                       uint32_t level) {
         VkImageSubresource subres(VkImageAspectFlags(aspect_bit),  // aspectMask
                                   level,                           // mipLevel
                                   layer                            // arrayLayer
@@ -554,120 +577,132 @@ gapil::Ref<LinearImageLayouts> VulkanSpy::fetchLinearImageSubresourceLayouts(
 // SpyOverride_vkCreateInstance() and SpyOverride_vkCreateDevice() require
 // the their function table to be created through the template system, so they
 // won't be defined here, but vk_spy_helpers.cpp.tmpl
-uint32_t VulkanSpy::SpyOverride_vkEnumerateInstanceLayerProperties(uint32_t *pCount, VkLayerProperties *pProperties) {
-    if (pProperties == NULL) {
-        *pCount = 1;
-        return VkResult::VK_SUCCESS;
-    }
-    if (pCount == 0) {
-        return VkResult::VK_INCOMPLETE;
-    }
+uint32_t VulkanSpy::SpyOverride_vkEnumerateInstanceLayerProperties(
+    uint32_t* pCount, VkLayerProperties* pProperties) {
+  if (pProperties == NULL) {
     *pCount = 1;
-    memset(pProperties, 0x00, sizeof(*pProperties));
-    strcpy((char*)pProperties->mlayerName, "VkGraphicsSpy");
-    pProperties->mspecVersion = VK_VERSION_MAJOR(1) | VK_VERSION_MINOR(0) | 5;
-    pProperties->mimplementationVersion = 1;
-    strcpy((char*)pProperties->mdescription, "vulkan_trace");
     return VkResult::VK_SUCCESS;
+  }
+  if (pCount == 0) {
+    return VkResult::VK_INCOMPLETE;
+  }
+  *pCount = 1;
+  memset(pProperties, 0x00, sizeof(*pProperties));
+  strcpy((char*)pProperties->mlayerName, "VkGraphicsSpy");
+  pProperties->mspecVersion = VK_VERSION_MAJOR(1) | VK_VERSION_MINOR(0) | 5;
+  pProperties->mimplementationVersion = 1;
+  strcpy((char*)pProperties->mdescription, "vulkan_trace");
+  return VkResult::VK_SUCCESS;
 }
 
-uint32_t VulkanSpy::SpyOverride_vkEnumerateDeviceLayerProperties(VkPhysicalDevice dev, uint32_t *pCount, VkLayerProperties *pProperties) {
-    if (pProperties == NULL) {
-       *pCount = 1;
-       return VkResult::VK_SUCCESS;
-    }
-    if (pCount == 0) {
-       return VkResult::VK_INCOMPLETE;
-    }
+uint32_t VulkanSpy::SpyOverride_vkEnumerateDeviceLayerProperties(
+    VkPhysicalDevice dev, uint32_t* pCount, VkLayerProperties* pProperties) {
+  if (pProperties == NULL) {
     *pCount = 1;
-    memset(pProperties, 0x00, sizeof(*pProperties));
-    strcpy((char*)pProperties->mlayerName, "VkGraphicsSpy");
-    pProperties->mspecVersion = VK_VERSION_MAJOR(1) | VK_VERSION_MINOR(0) | 5;
-    pProperties->mimplementationVersion = 1;
-    strcpy((char*)pProperties->mdescription, "vulkan_trace");
     return VkResult::VK_SUCCESS;
+  }
+  if (pCount == 0) {
+    return VkResult::VK_INCOMPLETE;
+  }
+  *pCount = 1;
+  memset(pProperties, 0x00, sizeof(*pProperties));
+  strcpy((char*)pProperties->mlayerName, "VkGraphicsSpy");
+  pProperties->mspecVersion = VK_VERSION_MAJOR(1) | VK_VERSION_MINOR(0) | 5;
+  pProperties->mimplementationVersion = 1;
+  strcpy((char*)pProperties->mdescription, "vulkan_trace");
+  return VkResult::VK_SUCCESS;
 }
-uint32_t VulkanSpy::SpyOverride_vkEnumerateInstanceExtensionProperties(const char *pLayerName, uint32_t *pCount, VkExtensionProperties *pProperties) {
-    *pCount = 0;
-    return VkResult::VK_SUCCESS;
+uint32_t VulkanSpy::SpyOverride_vkEnumerateInstanceExtensionProperties(
+    const char* pLayerName, uint32_t* pCount,
+    VkExtensionProperties* pProperties) {
+  *pCount = 0;
+  return VkResult::VK_SUCCESS;
 }
 
-uint32_t VulkanSpy::SpyOverride_vkEnumerateDeviceExtensionProperties(VkPhysicalDevice physicalDevice, const char *pLayerName, uint32_t *pCount, VkExtensionProperties *pProperties) {
-    gapii::VulkanImports::PFNVKENUMERATEDEVICEEXTENSIONPROPERTIES next_layer_enumerate_extensions = NULL;
-    auto phy_dev_iter = mState.PhysicalDevices.find(physicalDevice);
-    if (phy_dev_iter != mState.PhysicalDevices.end()) {
-        auto inst_func_iter = mImports.mVkInstanceFunctions.find(phy_dev_iter->second->mInstance);
-        if (inst_func_iter != mImports.mVkInstanceFunctions.end()) {
-            next_layer_enumerate_extensions = reinterpret_cast<gapii::VulkanImports::PFNVKENUMERATEDEVICEEXTENSIONPROPERTIES>(
-                inst_func_iter->second.vkEnumerateDeviceExtensionProperties);
-        }
+uint32_t VulkanSpy::SpyOverride_vkEnumerateDeviceExtensionProperties(
+    VkPhysicalDevice physicalDevice, const char* pLayerName, uint32_t* pCount,
+    VkExtensionProperties* pProperties) {
+  gapii::VulkanImports::PFNVKENUMERATEDEVICEEXTENSIONPROPERTIES
+      next_layer_enumerate_extensions = NULL;
+  auto phy_dev_iter = mState.PhysicalDevices.find(physicalDevice);
+  if (phy_dev_iter != mState.PhysicalDevices.end()) {
+    auto inst_func_iter =
+        mImports.mVkInstanceFunctions.find(phy_dev_iter->second->mInstance);
+    if (inst_func_iter != mImports.mVkInstanceFunctions.end()) {
+      next_layer_enumerate_extensions = reinterpret_cast<
+          gapii::VulkanImports::PFNVKENUMERATEDEVICEEXTENSIONPROPERTIES>(
+          inst_func_iter->second.vkEnumerateDeviceExtensionProperties);
     }
+  }
 
-    uint32_t next_layer_count = 0;
-    uint32_t next_layer_result;
-    if (next_layer_enumerate_extensions) {
-        next_layer_result = next_layer_enumerate_extensions(physicalDevice, pLayerName, &next_layer_count, NULL);
-        if (next_layer_result != VkResult::VK_SUCCESS) {
-            return next_layer_result;
-        }
+  uint32_t next_layer_count = 0;
+  uint32_t next_layer_result;
+  if (next_layer_enumerate_extensions) {
+    next_layer_result = next_layer_enumerate_extensions(
+        physicalDevice, pLayerName, &next_layer_count, NULL);
+    if (next_layer_result != VkResult::VK_SUCCESS) {
+      return next_layer_result;
     }
-    std::vector<VkExtensionProperties> properties(next_layer_count, VkExtensionProperties{arena()});
-    if (next_layer_enumerate_extensions) {
-        next_layer_result = next_layer_enumerate_extensions(physicalDevice, pLayerName, &next_layer_count, properties.data());
-        if (next_layer_result != VkResult::VK_SUCCESS) {
-            return next_layer_result;
-        }
+  }
+  std::vector<VkExtensionProperties> properties(next_layer_count,
+                                                VkExtensionProperties{arena()});
+  if (next_layer_enumerate_extensions) {
+    next_layer_result = next_layer_enumerate_extensions(
+        physicalDevice, pLayerName, &next_layer_count, properties.data());
+    if (next_layer_result != VkResult::VK_SUCCESS) {
+      return next_layer_result;
     }
-    bool has_debug_marker_ext = false;
-    for (VkExtensionProperties& ext : properties) {
-        // TODO: Check the spec version and emit warning if not match.
-        // TODO: refer to VK_EXT_DEBUG_MARKER_EXTENSION_NAME
-        if (!strcmp(ext.mextensionName, "VK_EXT_debug_marker")) {
-            has_debug_marker_ext = true;
-            break;
-        }
+  }
+  bool has_debug_marker_ext = false;
+  for (VkExtensionProperties& ext : properties) {
+    // TODO: Check the spec version and emit warning if not match.
+    // TODO: refer to VK_EXT_DEBUG_MARKER_EXTENSION_NAME
+    if (!strcmp(ext.mextensionName, "VK_EXT_debug_marker")) {
+      has_debug_marker_ext = true;
+      break;
     }
-    if (!has_debug_marker_ext) {
-        // TODO: refer to VK_EXT_DEBUG_MARKER_EXTENSION_NAME and VK_EXT_DEBUG_MARKER_SPEC_VERSION
-        char debug_marker_extension_name[] = "VK_EXT_debug_marker";
-        uint32_t debug_marker_spec_version = 4;
-        properties.emplace_back(VkExtensionProperties{debug_marker_extension_name, debug_marker_spec_version});
-    }
-    if (pProperties == NULL) {
-        *pCount = properties.size();
-        return VkResult::VK_SUCCESS;
-    }
-    uint32_t copy_count = properties.size() < *pCount ? properties.size():*pCount;
-    memcpy(pProperties, properties.data(), copy_count * sizeof(VkExtensionProperties));
-    if (*pCount < properties.size()) {
-        return VkResult::VK_INCOMPLETE;
-    }
+  }
+  if (!has_debug_marker_ext) {
+    // TODO: refer to VK_EXT_DEBUG_MARKER_EXTENSION_NAME and
+    // VK_EXT_DEBUG_MARKER_SPEC_VERSION
+    char debug_marker_extension_name[] = "VK_EXT_debug_marker";
+    uint32_t debug_marker_spec_version = 4;
+    properties.emplace_back(VkExtensionProperties{debug_marker_extension_name,
+                                                  debug_marker_spec_version});
+  }
+  if (pProperties == NULL) {
     *pCount = properties.size();
     return VkResult::VK_SUCCESS;
+  }
+  uint32_t copy_count =
+      properties.size() < *pCount ? properties.size() : *pCount;
+  memcpy(pProperties, properties.data(),
+         copy_count * sizeof(VkExtensionProperties));
+  if (*pCount < properties.size()) {
+    return VkResult::VK_INCOMPLETE;
+  }
+  *pCount = properties.size();
+  return VkResult::VK_SUCCESS;
 }
 
 void VulkanSpy::SpyOverride_vkDestroyInstance(
-        VkInstance                   instance,
-        const VkAllocationCallbacks* pAllocator) {
-
-    // First we have to find the function to chain to, then we have to
-    // remove this instance from our list, then we forward the call.
-    auto it = mImports.mVkInstanceFunctions.find(instance);
-    gapii::VulkanImports::PFNVKDESTROYINSTANCE destroy_instance =
-        it == mImports.mVkInstanceFunctions.end() ? nullptr :
-        it->second.vkDestroyInstance;
-    if (destroy_instance) {
-      destroy_instance(instance, pAllocator);
-    }
-    mImports.mVkInstanceFunctions.erase(mImports.mVkInstanceFunctions.find(instance));
+    VkInstance instance, const VkAllocationCallbacks* pAllocator) {
+  // First we have to find the function to chain to, then we have to
+  // remove this instance from our list, then we forward the call.
+  auto it = mImports.mVkInstanceFunctions.find(instance);
+  gapii::VulkanImports::PFNVKDESTROYINSTANCE destroy_instance =
+      it == mImports.mVkInstanceFunctions.end() ? nullptr
+                                                : it->second.vkDestroyInstance;
+  if (destroy_instance) {
+    destroy_instance(instance, pAllocator);
+  }
+  mImports.mVkInstanceFunctions.erase(
+      mImports.mVkInstanceFunctions.find(instance));
 }
 
 uint32_t VulkanSpy::SpyOverride_vkCreateBuffer(
-    VkDevice                     device,
-    const VkBufferCreateInfo*    pCreateInfo,
-    const VkAllocationCallbacks* pAllocator,
-    VkBuffer*                    pBuffer) {
-
+    VkDevice device, const VkBufferCreateInfo* pCreateInfo,
+    const VkAllocationCallbacks* pAllocator, VkBuffer* pBuffer) {
   if (is_suspended()) {
     VkBufferCreateInfo override_create_info = *pCreateInfo;
     override_create_info.musage |=
@@ -681,11 +716,8 @@ uint32_t VulkanSpy::SpyOverride_vkCreateBuffer(
 }
 
 uint32_t VulkanSpy::SpyOverride_vkCreateImage(
-    VkDevice                     device,
-    const VkImageCreateInfo*     pCreateInfo,
-    const VkAllocationCallbacks* pAllocator,
-    VkImage*                     pImage) {
-
+    VkDevice device, const VkImageCreateInfo* pCreateInfo,
+    const VkAllocationCallbacks* pAllocator, VkImage* pImage) {
   if (is_suspended() || is_observing()) {
     VkImageCreateInfo override_create_info = *pCreateInfo;
     override_create_info.musage |=
@@ -699,53 +731,59 @@ uint32_t VulkanSpy::SpyOverride_vkCreateImage(
 }
 
 uint32_t VulkanSpy::SpyOverride_vkCreateSwapchainKHR(
-        VkDevice                         device,
-        const VkSwapchainCreateInfoKHR*  pCreateInfo,
-        const VkAllocationCallbacks*     pAllocator,
-        VkSwapchainKHR*                  pImage) {
-    if (is_observing() || is_suspended()) {
-        VkSwapchainCreateInfoKHR override_create_info = *pCreateInfo;
-        override_create_info.mimageUsage |= VkImageUsageFlagBits::VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
-        return  mImports.mVkDeviceFunctions[device].vkCreateSwapchainKHR(device, &override_create_info, pAllocator, pImage);
-    } else {
-        return  mImports.mVkDeviceFunctions[device].vkCreateSwapchainKHR(device, pCreateInfo, pAllocator, pImage);
-    }
+    VkDevice device, const VkSwapchainCreateInfoKHR* pCreateInfo,
+    const VkAllocationCallbacks* pAllocator, VkSwapchainKHR* pImage) {
+  if (is_observing() || is_suspended()) {
+    VkSwapchainCreateInfoKHR override_create_info = *pCreateInfo;
+    override_create_info.mimageUsage |=
+        VkImageUsageFlagBits::VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
+    return mImports.mVkDeviceFunctions[device].vkCreateSwapchainKHR(
+        device, &override_create_info, pAllocator, pImage);
+  } else {
+    return mImports.mVkDeviceFunctions[device].vkCreateSwapchainKHR(
+        device, pCreateInfo, pAllocator, pImage);
+  }
 }
 
-void VulkanSpy::SpyOverride_vkDestroyDevice(VkDevice device, const VkAllocationCallbacks* pAllocator) {
-    // First we have to find the function to chain to, then we have to
-    // remove this instance from our list, then we forward the call.
-    auto it = mImports.mVkDeviceFunctions.find(device);
-    gapii::VulkanImports::PFNVKDESTROYDEVICE destroy_device =
-        it == mImports.mVkDeviceFunctions.end()
-            ? nullptr
-            : it->second.vkDestroyDevice;
-    if (destroy_device) {
-        destroy_device(device, pAllocator);
-    }
-    mImports.mVkDeviceFunctions.erase(mImports.mVkDeviceFunctions.find(device));
+void VulkanSpy::SpyOverride_vkDestroyDevice(
+    VkDevice device, const VkAllocationCallbacks* pAllocator) {
+  // First we have to find the function to chain to, then we have to
+  // remove this instance from our list, then we forward the call.
+  auto it = mImports.mVkDeviceFunctions.find(device);
+  gapii::VulkanImports::PFNVKDESTROYDEVICE destroy_device =
+      it == mImports.mVkDeviceFunctions.end() ? nullptr
+                                              : it->second.vkDestroyDevice;
+  if (destroy_device) {
+    destroy_device(device, pAllocator);
+  }
+  mImports.mVkDeviceFunctions.erase(mImports.mVkDeviceFunctions.find(device));
 }
 
 uint32_t VulkanSpy::SpyOverride_vkAllocateMemory(
-        VkDevice                     device,
-        const VkMemoryAllocateInfo*  pAllocateInfo,
-        const VkAllocationCallbacks* pAllocator,
-        VkDeviceMemory*              pMemory) {
-
-    uint32_t r = mImports.mVkDeviceFunctions[device].vkAllocateMemory(device, pAllocateInfo, pAllocator, pMemory);
-    auto l_physical_device = mState.PhysicalDevices[mState.Devices[device]->mPhysicalDevice];
-    if (0 != (l_physical_device->mMemoryProperties.mmemoryTypes[pAllocateInfo->mmemoryTypeIndex].mpropertyFlags &
-        ((uint32_t)(VkMemoryPropertyFlagBits::VK_MEMORY_PROPERTY_HOST_COHERENT_BIT)))) {
-        // This is host-coherent memory. Some drivers actually allocate these pages on-demand.
-        // This forces all of the pages to be created.
-        // This is needed as our coherent memory tracker relies on page-faults which interferes with the
-        // on-demand allocation.
-        char* memory;
-        mImports.mVkDeviceFunctions[device].vkMapMemory(device, *pMemory, 0, pAllocateInfo->mallocationSize, 0, reinterpret_cast<void**>(&memory));
-        memset(memory, 0x00, pAllocateInfo->mallocationSize);
-        mImports.mVkDeviceFunctions[device].vkUnmapMemory(device, *pMemory);
-    }
-    return r;
+    VkDevice device, const VkMemoryAllocateInfo* pAllocateInfo,
+    const VkAllocationCallbacks* pAllocator, VkDeviceMemory* pMemory) {
+  uint32_t r = mImports.mVkDeviceFunctions[device].vkAllocateMemory(
+      device, pAllocateInfo, pAllocator, pMemory);
+  auto l_physical_device =
+      mState.PhysicalDevices[mState.Devices[device]->mPhysicalDevice];
+  if (0 !=
+      (l_physical_device->mMemoryProperties
+           .mmemoryTypes[pAllocateInfo->mmemoryTypeIndex]
+           .mpropertyFlags &
+       ((uint32_t)(
+           VkMemoryPropertyFlagBits::VK_MEMORY_PROPERTY_HOST_COHERENT_BIT)))) {
+    // This is host-coherent memory. Some drivers actually allocate these pages
+    // on-demand. This forces all of the pages to be created. This is needed as
+    // our coherent memory tracker relies on page-faults which interferes with
+    // the on-demand allocation.
+    char* memory;
+    mImports.mVkDeviceFunctions[device].vkMapMemory(
+        device, *pMemory, 0, pAllocateInfo->mallocationSize, 0,
+        reinterpret_cast<void**>(&memory));
+    memset(memory, 0x00, pAllocateInfo->mallocationSize);
+    mImports.mVkDeviceFunctions[device].vkUnmapMemory(device, *pMemory);
+  }
+  return r;
 }
 
 // Utility functions
@@ -753,7 +791,8 @@ uint32_t VulkanSpy::numberOfPNext(CallObserver* observer, const void* pNext) {
   uint32_t counter = 0;
   while (pNext) {
     counter++;
-    pNext = reinterpret_cast<const void*>(reinterpret_cast<const uintptr_t*>(pNext)[1]);
+    pNext = reinterpret_cast<const void*>(
+        reinterpret_cast<const uintptr_t*>(pNext)[1]);
   }
   return counter;
 }
@@ -790,4 +829,4 @@ void VulkanSpy::walkImageSubRng(
     }
   }
 }
-}
+}  // namespace gapii

--- a/gapii/cc/vulkan_layer_extras.h
+++ b/gapii/cc/vulkan_layer_extras.h
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-// Functionality in this file was generated from vulkan_layer.h with the following license.
+// Functionality in this file was generated from vulkan_layer.h with the
+// following license.
 /*
  * Copyright (c) 2015-2016 The Khronos Group Inc.
  * Copyright (c) 2015-2016 Valve Corporation
@@ -33,15 +34,14 @@
  * limitations under the License.
  */
 
-
 #ifndef GAPII_VULKAN_LAYER_EXTRAS_H
 #define GAPII_VULKAN_LAYER_EXTRAS_H
 
 #include "gapii/cc/vulkan_exports.h"
 #include "gapii/cc/vulkan_extras.h"
-#include "gapii/cc/vulkan_types.h"
 #include "gapii/cc/vulkan_imports.h"
 #include "gapii/cc/vulkan_spy.h"
+#include "gapii/cc/vulkan_types.h"
 
 namespace gapii {
 namespace {
@@ -50,9 +50,9 @@ namespace {
 // CreateInstance and CreateDevice support structures
 
 typedef enum VkLayerFunction_ {
-    VK_LAYER_LINK_INFO = 0,
-    VK_LAYER_DEVICE_INFO = 1,
-    VK_LAYER_INSTANCE_INFO = 2
+  VK_LAYER_LINK_INFO = 0,
+  VK_LAYER_DEVICE_INFO = 1,
+  VK_LAYER_INSTANCE_INFO = 2
 } VkLayerFunction;
 
 /*
@@ -63,13 +63,13 @@ typedef enum VkLayerFunction_ {
  * exact instance being used.
  */
 typedef struct VkLayerInstanceInfo_ {
-    void *instance_info;
-    gapii::VulkanImports::PFNVKGETINSTANCEPROCADDR pfnNextGetInstanceProcAddr;
+  void *instance_info;
+  gapii::VulkanImports::PFNVKGETINSTANCEPROCADDR pfnNextGetInstanceProcAddr;
 } VkLayerInstanceInfo;
 
 typedef struct VkLayerInstanceLink_ {
-    struct VkLayerInstanceLink_ *pNext;
-    gapii::VulkanImports::PFNVKGETINSTANCEPROCADDR pfnNextGetInstanceProcAddr;
+  struct VkLayerInstanceLink_ *pNext;
+  gapii::VulkanImports::PFNVKGETINSTANCEPROCADDR pfnNextGetInstanceProcAddr;
 } VkLayerInstanceLink;
 
 /*
@@ -80,34 +80,34 @@ typedef struct VkLayerInstanceLink_ {
  * exact instance being used.
  */
 typedef struct VkLayerDeviceInfo_ {
-    void *device_info;
-    gapii::VulkanImports::PFNVKGETINSTANCEPROCADDR pfnNextGetInstanceProcAddr;
+  void *device_info;
+  gapii::VulkanImports::PFNVKGETINSTANCEPROCADDR pfnNextGetInstanceProcAddr;
 } VkLayerDeviceInfo;
 
 typedef struct {
-    uint32_t sType; // VK_STRUCTURE_TYPE_LAYER_INSTANCE_CREATE_INFO
-    const void *pNext;
-    VkLayerFunction function;
-    union {
-        VkLayerInstanceLink *pLayerInfo;
-        VkLayerInstanceInfo instanceInfo;
-    } u;
+  uint32_t sType;  // VK_STRUCTURE_TYPE_LAYER_INSTANCE_CREATE_INFO
+  const void *pNext;
+  VkLayerFunction function;
+  union {
+    VkLayerInstanceLink *pLayerInfo;
+    VkLayerInstanceInfo instanceInfo;
+  } u;
 } VkLayerInstanceCreateInfo;
 
 typedef struct VkLayerDeviceLink_ {
-    struct VkLayerDeviceLink_ *pNext;
-    gapii::VulkanImports::PFNVKGETINSTANCEPROCADDR pfnNextGetInstanceProcAddr;
-    gapii::VulkanImports::PFNVKGETDEVICEPROCADDR pfnNextGetDeviceProcAddr;
+  struct VkLayerDeviceLink_ *pNext;
+  gapii::VulkanImports::PFNVKGETINSTANCEPROCADDR pfnNextGetInstanceProcAddr;
+  gapii::VulkanImports::PFNVKGETDEVICEPROCADDR pfnNextGetDeviceProcAddr;
 } VkLayerDeviceLink;
 
 typedef struct {
-    uint32_t sType; // VK_STRUCTURE_TYPE_LAYER_DEVICE_CREATE_INFO
-    const void *pNext;
-    VkLayerFunction function;
-    union {
-        VkLayerDeviceLink *pLayerInfo;
-        VkLayerDeviceInfo deviceInfo;
-    } u;
+  uint32_t sType;  // VK_STRUCTURE_TYPE_LAYER_DEVICE_CREATE_INFO
+  const void *pNext;
+  VkLayerFunction function;
+  union {
+    VkLayerDeviceLink *pLayerInfo;
+    VkLayerDeviceInfo deviceInfo;
+  } u;
 } VkLayerDeviceCreateInfo;
 
 // Vulkan 1.0 version number
@@ -115,10 +115,10 @@ typedef struct {
 
 #define VK_VERSION_MAJOR(version) ((uint32_t)(version) >> 22)
 #define VK_VERSION_MINOR(version) (((uint32_t)(version) >> 12) & 0x3ff)
-#define VK_VERSION_PATCH(version) ((uint32_t)(version) & 0xfff)
+#define VK_VERSION_PATCH(version) ((uint32_t)(version)&0xfff)
 
-#if defined (_WIN32)
-#define VK_LAYER_EXPORT  __declspec(dllexport)
+#if defined(_WIN32)
+#define VK_LAYER_EXPORT __declspec(dllexport)
 #elif defined(__GNUC__) && __GNUC__ >= 4
 #define VK_LAYER_EXPORT __attribute__((visibility("default")))
 #elif defined(__SUNPRO_C) && (__SUNPRO_C >= 0x590)
@@ -130,17 +130,16 @@ typedef struct {
 // ------------------------------------------------------------------------------------------------
 // API functions
 
-
 template <typename T>
 struct link_info_traits {
-  const static bool is_instance =
-      std::is_same<T, VkInstanceCreateInfo>::value;
+  const static bool is_instance = std::is_same<T, VkInstanceCreateInfo>::value;
   using layer_info_type =
       typename std::conditional<is_instance, VkLayerInstanceCreateInfo,
                                 VkLayerDeviceCreateInfo>::type;
   const static uint32_t sType =
-      is_instance ? VkStructureType::VK_STRUCTURE_TYPE_LOADER_INSTANCE_CREATE_INFO
-                  : VkStructureType::VK_STRUCTURE_TYPE_LOADER_DEVICE_CREATE_INFO;
+      is_instance
+          ? VkStructureType::VK_STRUCTURE_TYPE_LOADER_INSTANCE_CREATE_INFO
+          : VkStructureType::VK_STRUCTURE_TYPE_LOADER_DEVICE_CREATE_INFO;
 };
 
 // Get layer_specific data for this layer.
@@ -165,7 +164,7 @@ typename link_info_traits<T>::layer_info_type *get_layer_link_info(
   }
   return layer_info;
 }
-}
-}
+}  // namespace
+}  // namespace gapii
 
 #endif

--- a/gapii/cc/vulkan_mid_execution.cpp
+++ b/gapii/cc/vulkan_mid_execution.cpp
@@ -228,8 +228,9 @@ class StagingCommandBuffer {
     // dispatchable handle to the new child dispatchable handle. This is
     // necessary as lower layers may use that key to find the dispatch table,
     // and a child handle should share the same dispatch table key.
-    // Ref: https://github.com/KhronosGroup/Vulkan-LoaderAndValidationLayers/blob/master/loader/LoaderAndLayerInterface.md#creating-new-dispatchable-objects
-    *((const void**)command_buffer_) = *((const void**)device_);
+    // Ref:
+    // https://github.com/KhronosGroup/Vulkan-LoaderAndValidationLayers/blob/master/loader/LoaderAndLayerInterface.md#creating-new-dispatchable-objects
+    *((const void **)command_buffer_) = *((const void **)device_);
 
     VkCommandBufferBeginInfo begin_info = {
         VkStructureType::VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO,  // sType
@@ -273,7 +274,7 @@ class StagingCommandBuffer {
   VkCommandBuffer command_buffer_;
 };
 
-void VulkanSpy::serializeGPUBuffers(StateSerializer* serializer) {
+void VulkanSpy::serializeGPUBuffers(StateSerializer *serializer) {
   for (auto &device : mState.Devices) {
     auto &device_functions =
         mImports.mVkDeviceFunctions[device.second->mVulkanHandle];
@@ -316,8 +317,8 @@ void VulkanSpy::serializeGPUBuffers(StateSerializer* serializer) {
 
   for (auto &mem : mState.DeviceMemories) {
     auto &memory = mem.second;
-    memory->mData = serializer->encodeBuffer<uint8_t>(
-        memory->mAllocationSize, nullptr);
+    memory->mData =
+        serializer->encodeBuffer<uint8_t>(memory->mAllocationSize, nullptr);
     if (memory->mMappedLocation != nullptr) {
       if (subIsMemoryCoherent(nullptr, nullptr, memory)) {
         trackMappedCoherentMemory(
@@ -434,7 +435,8 @@ void VulkanSpy::serializeGPUBuffers(StateSerializer* serializer) {
                                    bool in_buffer) -> uint32_t {
       switch (aspect_bit) {
         case VkImageAspectFlagBits::VK_IMAGE_ASPECT_COLOR_BIT:
-          return subGetElementAndTexelBlockSize(nullptr, nullptr, format).mElementSize;
+          return subGetElementAndTexelBlockSize(nullptr, nullptr, format)
+              .mElementSize;
         case VkImageAspectFlagBits::VK_IMAGE_ASPECT_DEPTH_BIT:
           return subGetDepthElementSize(nullptr, nullptr, format, in_buffer);
         case VkImageAspectFlagBits::VK_IMAGE_ASPECT_STENCIL_BIT:
@@ -518,21 +520,17 @@ void VulkanSpy::serializeGPUBuffers(StateSerializer* serializer) {
       const uint32_t height_in_blocks =
           subRoundUpTo(nullptr, nullptr, height, texel_height);
       const uint32_t element_size = get_element_size(format, aspect_bit, false);
-      const uint32_t element_size_in_buf = get_element_size(format, aspect_bit, true);
+      const uint32_t element_size_in_buf =
+          get_element_size(format, aspect_bit, true);
       const size_t size =
           width_in_blocks * height_in_blocks * depth * element_size;
       const size_t size_in_buf =
           width_in_blocks * height_in_blocks * depth * element_size_in_buf;
 
-      return byte_size_and_extent{
-        size,
-        next_multiple_of_8(size),
-        size_in_buf,
-        next_multiple_of_8(size_in_buf),
-        width,
-        height,
-        depth
-      };
+      return byte_size_and_extent{size,        next_multiple_of_8(size),
+                                  size_in_buf, next_multiple_of_8(size_in_buf),
+                                  width,       height,
+                                  depth};
     };
 
     VkImageSubresourceRange img_whole_rng = VkImageSubresourceRange{
@@ -544,17 +542,17 @@ void VulkanSpy::serializeGPUBuffers(StateSerializer* serializer) {
     };
 
     std::unordered_map<ImageLevel *, byte_size_and_extent> level_sizes;
-    walkImageSubRng(
-        img, img_whole_rng,
-        [&serializer, &level_size, &img, &level_sizes](
-            uint32_t aspect, uint32_t layer, uint32_t level) {
-          auto img_level =
-              img->mAspects[aspect]->mLayers[layer]->mLevels[level];
-          level_sizes[img_level.get()] =
-              level_size(img->mInfo.mExtent, img->mInfo.mFormat, level, aspect);
-          img_level->mData = serializer->encodeBuffer<uint8_t>(
-              level_sizes[img_level.get()].level_size, nullptr);
-        });
+    walkImageSubRng(img, img_whole_rng,
+                    [&serializer, &level_size, &img, &level_sizes](
+                        uint32_t aspect, uint32_t layer, uint32_t level) {
+                      auto img_level =
+                          img->mAspects[aspect]->mLayers[layer]->mLevels[level];
+                      level_sizes[img_level.get()] =
+                          level_size(img->mInfo.mExtent, img->mInfo.mFormat,
+                                     level, aspect);
+                      img_level->mData = serializer->encodeBuffer<uint8_t>(
+                          level_sizes[img_level.get()].level_size, nullptr);
+                    });
 
     if (img->mIsSwapchainImage) {
       // Don't bind and fill swapchain images memory here
@@ -619,16 +617,16 @@ void VulkanSpy::serializeGPUBuffers(StateSerializer* serializer) {
       uint32_t level;
     };
     std::vector<opaque_piece> opaque_pieces;
-    auto append_image_level_to_opaque_pieces = [&img, &opaque_pieces](
-                                                   uint32_t aspect_bit,
-                                                   uint32_t layer,
-                                                   uint32_t level) {
-      auto& img_level = img->mAspects[aspect_bit]->mLayers[layer]->mLevels[level];
-      if (img_level->mLayout == VkImageLayout::VK_IMAGE_LAYOUT_UNDEFINED) {
-        return;
-      }
-      opaque_pieces.push_back(opaque_piece{aspect_bit, layer, level});
-    };
+    auto append_image_level_to_opaque_pieces =
+        [&img, &opaque_pieces](uint32_t aspect_bit, uint32_t layer,
+                               uint32_t level) {
+          auto &img_level =
+              img->mAspects[aspect_bit]->mLayers[layer]->mLevels[level];
+          if (img_level->mLayout == VkImageLayout::VK_IMAGE_LAYOUT_UNDEFINED) {
+            return;
+          }
+          opaque_pieces.push_back(opaque_piece{aspect_bit, layer, level});
+        };
     if (denseBound || !sparseResidency) {
       walkImageSubRng(img, img_whole_rng, append_image_level_to_opaque_pieces);
     } else {
@@ -650,7 +648,8 @@ void VulkanSpy::serializeGPUBuffers(StateSerializer* serializer) {
                 0,                                     // baseArrayLayer
                 image_info.mArrayLayers,               // layerCount
             };
-            walkImageSubRng(img, bound_rng, append_image_level_to_opaque_pieces);
+            walkImageSubRng(img, bound_rng,
+                            append_image_level_to_opaque_pieces);
           } else {
             for (uint32_t i = 0; i < uint32_t(image_info.mArrayLayers); i++) {
               VkDeviceSize offset = req.second.mimageMipTailOffset +
@@ -666,7 +665,8 @@ void VulkanSpy::serializeGPUBuffers(StateSerializer* serializer) {
                   i,
                   1,
               };
-              walkImageSubRng(img, bound_rng, append_image_level_to_opaque_pieces);
+              walkImageSubRng(img, bound_rng,
+                              append_image_level_to_opaque_pieces);
             }
           }
         }
@@ -704,7 +704,9 @@ void VulkanSpy::serializeGPUBuffers(StateSerializer* serializer) {
       }
 
       if (sparseResidency) {
-        for (auto& aspect_i : subUnpackImageAspectFlags(nullptr, nullptr,img->mImageAspect)->mBits) {
+        for (auto &aspect_i :
+             subUnpackImageAspectFlags(nullptr, nullptr, img->mImageAspect)
+                 ->mBits) {
           uint32_t aspect_bit = aspect_i.second;
           if (img->mSparseImageMemoryBindings.find(aspect_bit) !=
               img->mSparseImageMemoryBindings.end()) {
@@ -745,25 +747,26 @@ void VulkanSpy::serializeGPUBuffers(StateSerializer* serializer) {
 
       std::vector<VkImageMemoryBarrier> img_barriers;
       std::vector<uint32_t> old_layouts;
-      walkImageSubRng(img, img_whole_rng,
+      walkImageSubRng(
+          img, img_whole_rng,
           [&img, &img_barriers, &old_layouts](uint32_t aspect_bit,
                                               uint32_t layer, uint32_t level) {
             auto &img_level =
                 img->mAspects[aspect_bit]->mLayers[layer]->mLevels[level];
-        img_barriers.push_back(VkImageMemoryBarrier{
-            VkStructureType::VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
-            nullptr,
-            (VkAccessFlagBits::VK_ACCESS_MEMORY_WRITE_BIT << 1) - 1,
-            VkAccessFlagBits::VK_ACCESS_TRANSFER_READ_BIT,
-            img_level->mLayout,
-            VkImageLayout::VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
-            0xFFFFFFFF,
-            0xFFFFFFFF,
-            img->mVulkanHandle,
-            {VkImageAspectFlags(aspect_bit), level, 1, layer, 1},
-        });
-        old_layouts.push_back(img_level->mLayout);
-      });
+            img_barriers.push_back(VkImageMemoryBarrier{
+                VkStructureType::VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
+                nullptr,
+                (VkAccessFlagBits::VK_ACCESS_MEMORY_WRITE_BIT << 1) - 1,
+                VkAccessFlagBits::VK_ACCESS_TRANSFER_READ_BIT,
+                img_level->mLayout,
+                VkImageLayout::VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
+                0xFFFFFFFF,
+                0xFFFFFFFF,
+                img->mVulkanHandle,
+                {VkImageAspectFlags(aspect_bit), level, 1, layer, 1},
+            });
+            old_layouts.push_back(img_level->mLayout);
+          });
 
       device_functions.vkCmdPipelineBarrier(
           commandBuffer.GetBuffer(),
@@ -816,11 +819,10 @@ void VulkanSpy::serializeGPUBuffers(StateSerializer* serializer) {
             (i == copies.size() - 1) ? offset : copies[i + 1].mbufferOffset;
         const uint32_t aspect_bit =
             (uint32_t)copy.mimageSubresource.maspectMask;
-        byte_size_and_extent e = level_size(
-            copy.mimageExtent, image_info.mFormat, 0, aspect_bit);
-        auto bp =
-            block_pitch(copy.mimageExtent, image_info.mFormat,
-                        copy.mimageSubresource.mmipLevel, aspect_bit);
+        byte_size_and_extent e =
+            level_size(copy.mimageExtent, image_info.mFormat, 0, aspect_bit);
+        auto bp = block_pitch(copy.mimageExtent, image_info.mFormat,
+                              copy.mimageSubresource.mmipLevel, aspect_bit);
 
         if ((copy.mimageOffset.mx % bp.texel_width != 0) ||
             (copy.mimageOffset.my % bp.texel_height != 0)) {
@@ -868,8 +870,8 @@ void VulkanSpy::serializeGPUBuffers(StateSerializer* serializer) {
                                  ->mLayers[array_layer]
                                  ->mLevels[mip_level]
                                  ->mData.pool_id());
-        serializer->sendData(
-            &observation, true, pData + new_offset, e.level_size);
+        serializer->sendData(&observation, true, pData + new_offset,
+                             e.level_size);
         new_offset = next_offset;
       }
     }

--- a/gapii/cc/windows/wgl.cpp
+++ b/gapii/cc/windows/wgl.cpp
@@ -23,37 +23,37 @@ namespace gapii {
 namespace wgl {
 
 void getFramebufferInfo(void* hdcUntyped, FramebufferInfo& info) {
-    const ::HDC hdc = reinterpret_cast<::HDC>(hdcUntyped);
-    const HWND hWnd = WindowFromDC(hdc);
-    RECT rect;
-    GetClientRect(hWnd, &rect);
-    info.width = rect.right - rect.left;
-    info.height = rect.bottom - rect.top;
+  const ::HDC hdc = reinterpret_cast<::HDC>(hdcUntyped);
+  const HWND hWnd = WindowFromDC(hdc);
+  RECT rect;
+  GetClientRect(hWnd, &rect);
+  info.width = rect.right - rect.left;
+  info.height = rect.bottom - rect.top;
 
-    PIXELFORMATDESCRIPTOR pfd;
-    DescribePixelFormat(hdc, GetPixelFormat(hdc), sizeof(pfd), &pfd);
+  PIXELFORMATDESCRIPTOR pfd;
+  DescribePixelFormat(hdc, GetPixelFormat(hdc), sizeof(pfd), &pfd);
 
-    int r = pfd.cRedBits;
-    int g = pfd.cGreenBits;
-    int b = pfd.cBlueBits;
-    int a = pfd.cAlphaBits;
+  int r = pfd.cRedBits;
+  int g = pfd.cGreenBits;
+  int b = pfd.cBlueBits;
+  int a = pfd.cAlphaBits;
 
-    if (r == 8 && g == 8 && b == 8 && a == 8) {
-        info.colorFormat = GLenum::GL_RGBA8;
-    } else if (r == 4 && g == 4 && b == 4 && a == 4) {
-        info.colorFormat = GLenum::GL_RGBA4;
-    } else if (r == 5 && g == 5 && b == 5 && a == 1) {
-        info.colorFormat = GLenum::GL_RGB5_A1;
-    } else if (r == 5 && g == 6 && b == 5 && a == 0) {
-        info.colorFormat = GLenum::GL_RGB565;
-    } else {
-        info.colorFormat = GLenum::GL_RGBA8;
-    }
+  if (r == 8 && g == 8 && b == 8 && a == 8) {
+    info.colorFormat = GLenum::GL_RGBA8;
+  } else if (r == 4 && g == 4 && b == 4 && a == 4) {
+    info.colorFormat = GLenum::GL_RGBA4;
+  } else if (r == 5 && g == 5 && b == 5 && a == 1) {
+    info.colorFormat = GLenum::GL_RGB5_A1;
+  } else if (r == 5 && g == 6 && b == 5 && a == 0) {
+    info.colorFormat = GLenum::GL_RGB565;
+  } else {
+    info.colorFormat = GLenum::GL_RGBA8;
+  }
 
-    // No options for these yet.
-    info.stencilFormat = GLenum::GL_DEPTH24_STENCIL8;
-    info.depthFormat = GLenum::GL_DEPTH24_STENCIL8;
+  // No options for these yet.
+  info.stencilFormat = GLenum::GL_DEPTH24_STENCIL8;
+  info.depthFormat = GLenum::GL_DEPTH24_STENCIL8;
 }
 
-} // namespace wgl
-} // namespace gapii
+}  // namespace wgl
+}  // namespace gapii

--- a/gapii/cc/windows/wgl.h
+++ b/gapii/cc/windows/wgl.h
@@ -23,16 +23,16 @@ namespace gapii {
 namespace wgl {
 
 struct FramebufferInfo {
-    int width;
-    int height;
-    uint32_t colorFormat;
-    uint32_t depthFormat;
-    uint32_t stencilFormat;
+  int width;
+  int height;
+  uint32_t colorFormat;
+  uint32_t depthFormat;
+  uint32_t stencilFormat;
 };
 
 void getFramebufferInfo(void* hdc, FramebufferInfo& info);
 
-} // namespace wgl
-} // namespace gapii
+}  // namespace wgl
+}  // namespace gapii
 
-#endif // GAPII_WGL_H
+#endif  // GAPII_WGL_H

--- a/gapii/vulkan/vk_graphics_spy/cc/layer.cpp
+++ b/gapii/vulkan/vk_graphics_spy/cc/layer.cpp
@@ -16,40 +16,39 @@
 
 #include "vulkan/vulkan.h"
 
-#if defined (_WIN32)
+#if defined(_WIN32)
 #define VK_LAYER_EXPORT __declspec(dllexport)
 #elif defined(__GNUC__)
 #define VK_LAYER_EXPORT __attribute__((visibility("default")))
 #else
-#define VK_LAYER_EXPORT 
+#define VK_LAYER_EXPORT
 #endif
 
 extern "C" {
 
-typedef void* (*eglGetProcAddress)(char const * procname);
+typedef void *(*eglGetProcAddress)(char const *procname);
 
 #ifdef _WIN32
 #include <windows.h>
 #include <cstdio>
-// On windows we do not have linker namespaces, we also don't have a 
+// On windows we do not have linker namespaces, we also don't have a
 // convenient way to have already loaded libgapii.dll. In this case
 // we can just LoadModule(libgapii.dll) and get the pointers from there.
-#define PROC(name) \
+#define PROC(name)                                          \
   static PFN_##name fn = (PFN_##name)getProcAddress(#name); \
-  if (fn != nullptr) \
-    return fn
+  if (fn != nullptr) return fn
 
 HMODULE LoadGAPIIDLL() {
-  char path[MAX_PATH] = { '\0' };
+  char path[MAX_PATH] = {'\0'};
   HMODULE this_module = GetModuleHandle("libVkLayer_GraphicsSpy.dll");
   const char libgapii[] = "libgapii.dll";
-  if(this_module == NULL) {
+  if (this_module == NULL) {
     fprintf(stderr, "Could not find libVkLayer_GraphicsSpy.dll\n");
     return 0;
   }
   SetLastError(0);
   DWORD num_characters = GetModuleFileName(this_module, path, MAX_PATH);
-  if(GetLastError() != 0) {
+  if (GetLastError() != 0) {
     fprintf(stderr, "Could not the path to libVkLayer_GraphicsSpy.dll\n");
     return 0;
   }
@@ -70,10 +69,10 @@ HMODULE LoadGAPIIDLL() {
   return LoadLibrary(path);
 }
 
-FARPROC getProcAddress(const char* name) {
+FARPROC getProcAddress(const char *name) {
   static HMODULE libgapii = LoadGAPIIDLL();
   if (libgapii != NULL) {
-    return GetProcAddress(libgapii, name); 
+    return GetProcAddress(libgapii, name);
   }
   return NULL;
 }
@@ -82,17 +81,17 @@ FARPROC getProcAddress(const char* name) {
 
 #include <dlfcn.h>
 
-#define PROC(name) \
+#define PROC(name)                                                       \
   static PFN_##name fn = (PFN_##name)(getProcAddress()("gapid_" #name)); \
-  if (fn != nullptr) \
-    return fn
+  if (fn != nullptr) return fn
 
 // On android due to linker namespaces we cannot open libgapii.so,
 // but since we already have it loaded, and libEGL.so hooked,
 // we can use eglGetProcAddress to find the functions.
 eglGetProcAddress getProcAddress() {
-  static void* libegl = dlopen("libEGL.so", RTLD_NOW);
-  static eglGetProcAddress pa = (eglGetProcAddress)dlsym(libegl, "eglGetProcAddress");
+  static void *libegl = dlopen("libEGL.so", RTLD_NOW);
+  static eglGetProcAddress pa =
+      (eglGetProcAddress)dlsym(libegl, "eglGetProcAddress");
   return pa;
 }
 #endif
@@ -128,7 +127,7 @@ vkEnumerateInstanceExtensionProperties(const char *pLayerName, uint32_t *pCount,
 }
 
 VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateDeviceLayerProperties(
-    VkPhysicalDevice device, uint32_t *pCount, VkLayerProperties * pProperties) {
+    VkPhysicalDevice device, uint32_t *pCount, VkLayerProperties *pProperties) {
   PROC(vkEnumerateDeviceLayerProperties)(device, pCount, pProperties);
   *pCount = 0;
   return VK_SUCCESS;
@@ -140,9 +139,9 @@ VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL
 vkEnumerateDeviceExtensionProperties(VkPhysicalDevice device,
                                      const char *pLayerName, uint32_t *pCount,
                                      VkExtensionProperties *pProperties) {
-  PROC(vkEnumerateDeviceExtensionProperties)(device, pLayerName, pCount,
-                                                      pProperties);
+  PROC(vkEnumerateDeviceExtensionProperties)
+  (device, pLayerName, pCount, pProperties);
   *pCount = 0;
   return VK_SUCCESS;
 }
-} // extern "C"
+}  // extern "C"

--- a/gapil/compiler/plugins/encoder/test/test.cpp
+++ b/gapil/compiler/plugins/encoder/test/test.cpp
@@ -16,56 +16,56 @@
 
 #include "core/memory/arena/cc/arena.h"
 
-#include "gapil/runtime/cc/runtime.h"
-#include "gapil/runtime/cc/string.h"
 #include "gapil/runtime/cc/map.inc"
 #include "gapil/runtime/cc/ref.inc"
+#include "gapil/runtime/cc/runtime.h"
+#include "gapil/runtime/cc/string.h"
 
 namespace {
 
 template <typename T>
 void create_map(arena* arena, map** p) {
-    auto a = reinterpret_cast<core::Arena*>(arena);
-    auto m = reinterpret_cast<T*>(p);
-    new(m) T(a);
+  auto a = reinterpret_cast<core::Arena*>(arena);
+  auto m = reinterpret_cast<T*>(p);
+  new (m) T(a);
 }
 
 template <typename T>
 T* create_ref(arena* arena, ref** p) {
-    auto a = reinterpret_cast<core::Arena*>(arena);
-    auto ref = new(p) gapil::Ref<T>();
-    *ref = gapil::Ref<T>::create(a);
-    return ref->get();
+  auto a = reinterpret_cast<core::Arena*>(arena);
+  auto ref = new (p) gapil::Ref<T>();
+  *ref = gapil::Ref<T>::create(a);
+  return ref->get();
 }
 
-}  // namespace {
+}  // namespace
 
 extern "C" {
 
 void create_map_u32(arena* arena, map** p) {
-    create_map< gapil::Map<uint32_t, uint32_t> >(arena, p);
+  create_map<gapil::Map<uint32_t, uint32_t> >(arena, p);
 }
 
 void insert_map_u32(map* m, uint32_t k, uint32_t v) {
-    auto& map = *reinterpret_cast<gapil::Map<uint32_t, uint32_t>*>(&m);
-    map[k] = v;
+  auto& map = *reinterpret_cast<gapil::Map<uint32_t, uint32_t>*>(&m);
+  map[k] = v;
 }
 
 void create_map_string(arena* arena, map** p) {
-    create_map< gapil::Map<string_t, string_t> >(arena, p);
+  create_map<gapil::Map<string_t, string_t> >(arena, p);
 }
 
 void insert_map_string(map* m, const char* k, const char* v) {
-    auto& map = *reinterpret_cast<gapil::Map<gapil::String, gapil::String>*>(&m);
-    map[gapil::String(map.arena(), k)] = gapil::String(map.arena(), v);
+  auto& map = *reinterpret_cast<gapil::Map<gapil::String, gapil::String>*>(&m);
+  map[gapil::String(map.arena(), k)] = gapil::String(map.arena(), v);
 }
 
 basic_types* create_basic_types_ref(arena* a, ref** p) {
-    return create_ref<basic_types>(a, p);
+  return create_ref<basic_types>(a, p);
 }
 
 inner_class* create_inner_class_ref(arena* a, ref** p) {
-    return create_ref<inner_class>(a, p);
+  return create_ref<inner_class>(a, p);
 }
 
-} // extern "C"
+}  // extern "C"

--- a/gapil/compiler/plugins/encoder/test/test.h
+++ b/gapil/compiler/plugins/encoder/test/test.h
@@ -21,116 +21,117 @@ extern "C" {
 #endif
 
 typedef struct cmd_ints_t {
-    uint64_t thread;
-    uint8_t  a;
-    int8_t   b;
-    uint16_t c;
-    int16_t  d;
-    uint32_t e;
-    int32_t  f;
-    uint64_t g;
-    int64_t  h;
+  uint64_t thread;
+  uint8_t a;
+  int8_t b;
+  uint16_t c;
+  int16_t d;
+  uint32_t e;
+  int32_t f;
+  uint64_t g;
+  int64_t h;
 } cmd_ints;
 
 typedef struct cmd_intsCall_t {
-    int64_t result;
+  int64_t result;
 } cmd_intsCall;
 
 typedef struct cmd_floats_t {
-    uint64_t thread;
-    float a;
-    double b;
+  uint64_t thread;
+  float a;
+  double b;
 } cmd_floats;
 
 typedef struct cmd_enums_t {
-    uint64_t thread;
-    uint32_t e;
-    int64_t  e_s64;
+  uint64_t thread;
+  uint32_t e;
+  int64_t e_s64;
 } cmd_enums;
 
 typedef struct cmd_arrays_t {
-    uint64_t thread;
-    uint8_t a[1];
-    int32_t b[2];
-    float   c[3];
+  uint64_t thread;
+  uint8_t a[1];
+  int32_t b[2];
+  float c[3];
 } cmd_arrays;
 
 typedef struct cmd_pointers_t {
-    uint64_t thread;
-    uint8_t* a;
-    int32_t* b;
-    float*   c;
+  uint64_t thread;
+  uint8_t* a;
+  int32_t* b;
+  float* c;
 } cmd_pointers;
 
 typedef struct cmd_strings_t {
-    uint64_t thread;
-    string*  a;
-    string*  b;
+  uint64_t thread;
+  string* a;
+  string* b;
 } cmd_strings;
 
 void cmd__cmd_ints__encode(cmd_ints* cmd, context* ctx, uint8_t is_group);
-void cmd__cmd_intsCall__encode(cmd_intsCall* cmd, context* ctx, uint8_t is_group);
+void cmd__cmd_intsCall__encode(cmd_intsCall* cmd, context* ctx,
+                               uint8_t is_group);
 void cmd__cmd_floats__encode(cmd_floats* cmd, context* ctx, uint8_t is_group);
 void cmd__cmd_enums__encode(cmd_enums* cmd, context* ctx, uint8_t is_group);
 void cmd__cmd_arrays__encode(cmd_arrays* cmd, context* ctx, uint8_t is_group);
-void cmd__cmd_pointers__encode(cmd_pointers* cmd, context* ctx, uint8_t is_group);
+void cmd__cmd_pointers__encode(cmd_pointers* cmd, context* ctx,
+                               uint8_t is_group);
 void cmd__cmd_strings__encode(cmd_strings* cmd, context* ctx, uint8_t is_group);
 
 typedef struct int_types_t {
-    uint8_t  a;
-    int8_t   b;
-    uint16_t c;
-    int16_t  d;
-    uint32_t f;
-    int32_t  g;
+  uint8_t a;
+  int8_t b;
+  uint16_t c;
+  int16_t d;
+  uint32_t f;
+  int32_t g;
 } int_types;
 
 #define INT_TYPES_SIZE sizeof(int_types)
 
 typedef struct basic_types_t {
-    uint8_t   a;
-    int8_t    b;
-    uint16_t  c;
-    int16_t   d;
-    float     e;
-    uint32_t  f;
-    int32_t   g;
-    double    h;
-    uint64_t  i;
-    int64_t   j;
-    uint8_t   k;
-    uint32_t  l;
-    uint32_t* m;
-    string*   n;
+  uint8_t a;
+  int8_t b;
+  uint16_t c;
+  int16_t d;
+  float e;
+  uint32_t f;
+  int32_t g;
+  double h;
+  uint64_t i;
+  int64_t j;
+  uint8_t k;
+  uint32_t l;
+  uint32_t* m;
+  string* n;
 } basic_types;
 
-
 typedef struct inner_class_t {
-    basic_types a;
+  basic_types a;
 } inner_class;
 
 typedef struct nested_classes_t {
-    inner_class a;
+  inner_class a;
 } nested_classes;
 
 typedef struct map_types_t {
-    map* a;
-    map* b;
-    map* c;
-    map* d;
+  map* a;
+  map* b;
+  map* c;
+  map* d;
 } map_types;
 
 typedef struct ref_types_t {
-    ref* a;
-    ref* b;
-    ref* c;
-    ref* d;
+  ref* a;
+  ref* b;
+  ref* c;
+  ref* d;
 } ref_types;
 
 typedef struct slice_types_t {
-    slice a;
-    slice b;
-    slice c;
+  slice a;
+  slice b;
+  slice c;
 } slice_types;
 
 void basic_types__encode(basic_types* c, context* ctx, uint8_t is_group);
@@ -149,5 +150,5 @@ basic_types* create_basic_types_ref(arena*, ref**);
 inner_class* create_inner_class_ref(arena*, ref**);
 
 #ifdef __cplusplus
-} // extern "C"
+}  // extern "C"
 #endif

--- a/gapil/runtime/cc/cloner.cpp
+++ b/gapil/runtime/cc/cloner.cpp
@@ -27,44 +27,47 @@
 namespace {
 
 struct tracker {
-    tracker(core::Arena* a) : arena(a), map(a) {}
-    core::Arena* arena;
-    gapil::Map<void*, void*> map;
+  tracker(core::Arena* a) : arena(a), map(a) {}
+  core::Arena* arena;
+  gapil::Map<void*, void*> map;
 };
 
-} // anonymous namespace
+}  // anonymous namespace
 
 extern "C" {
 
 void* gapil_create_clone_tracker(arena* arena) {
-    auto a = reinterpret_cast<core::Arena*>(arena);
-    auto out = a->create<tracker>(a);
-    DEBUG_PRINT("gapil_create_clone_tracker(arena: %p) -> %p", arena, out);
-    return out;
+  auto a = reinterpret_cast<core::Arena*>(arena);
+  auto out = a->create<tracker>(a);
+  DEBUG_PRINT("gapil_create_clone_tracker(arena: %p) -> %p", arena, out);
+  return out;
 }
 
 // gapil_destroy_clone_tracker deletes the tracker created by
 // gapil_create_clone_tracker.
 void gapil_destroy_clone_tracker(void* ct) {
-    DEBUG_PRINT("gapil_destroy_clone_tracker(tracker: %p)", ct);
-    auto t = reinterpret_cast<tracker*>(ct);
-    t->arena->destroy(t);
+  DEBUG_PRINT("gapil_destroy_clone_tracker(tracker: %p)", ct);
+  auto t = reinterpret_cast<tracker*>(ct);
+  t->arena->destroy(t);
 }
 
 // gapil_clone_tracker_lookup returns a pointer to the previously cloned object,
 // or nullptr if this object has not been cloned before.
 void* gapil_clone_tracker_lookup(void* t, void* object) {
-    DEBUG_PRINT("tracker count: %d", reinterpret_cast<tracker*>(t)->map.count());
-    auto out = reinterpret_cast<tracker*>(t)->map.findOrZero(object);
-    DEBUG_PRINT("gapil_clone_tracker_lookup(tracker: %p, object: %p) -> %p", t, object, out);
-    return out;
+  DEBUG_PRINT("tracker count: %d", reinterpret_cast<tracker*>(t)->map.count());
+  auto out = reinterpret_cast<tracker*>(t)->map.findOrZero(object);
+  DEBUG_PRINT("gapil_clone_tracker_lookup(tracker: %p, object: %p) -> %p", t,
+              object, out);
+  return out;
 }
 
 // gapil_clone_tracker_track associates the original object to its cloned
 // version.
 void gapil_clone_tracker_track(void* t, void* original, void* cloned) {
-    DEBUG_PRINT("gapil_clone_tracker_track(tracker: %p, original: %p, cloned: %p)", t, original, cloned);
-    reinterpret_cast<tracker*>(t)->map[original] = cloned;
+  DEBUG_PRINT(
+      "gapil_clone_tracker_track(tracker: %p, original: %p, cloned: %p)", t,
+      original, cloned);
+  reinterpret_cast<tracker*>(t)->map[original] = cloned;
 }
 
 }  // extern "C"

--- a/gapil/runtime/cc/cloner.h
+++ b/gapil/runtime/cc/cloner.h
@@ -19,7 +19,7 @@
 
 #ifdef __cplusplus
 extern "C" {
-#endif // __cplusplus
+#endif  // __cplusplus
 
 #ifndef DECL_GAPIL_CLONER_CB
 #define DECL_GAPIL_CLONER_CB(RETURN, NAME, ...) RETURN NAME(__VA_ARGS__)
@@ -35,16 +35,18 @@ DECL_GAPIL_CLONER_CB(void, gapil_destroy_clone_tracker, void* tracker);
 
 // gapil_clone_tracker_lookup returns a pointer to the previously cloned object,
 // or nullptr if this object has not been cloned before.
-DECL_GAPIL_CLONER_CB(void*, gapil_clone_tracker_lookup, void* tracker, void* object);
+DECL_GAPIL_CLONER_CB(void*, gapil_clone_tracker_lookup, void* tracker,
+                     void* object);
 
 // gapil_clone_tracker_track associates the original object to its cloned
 // version.
-DECL_GAPIL_CLONER_CB(void, gapil_clone_tracker_track, void* tracker, void* original, void* cloned);
+DECL_GAPIL_CLONER_CB(void, gapil_clone_tracker_track, void* tracker,
+                     void* original, void* cloned);
 
 #undef DECL_GAPIL_CLONER_CB
 
 #ifdef __cplusplus
-} // extern "C"
-#endif // __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
 
 #endif  // __GAPIL_RUNTIME_CLONER_H__

--- a/gapil/runtime/cc/encoder.h
+++ b/gapil/runtime/cc/encoder.h
@@ -19,7 +19,7 @@
 
 #ifdef __cplusplus
 extern "C" {
-#endif // __cplusplus
+#endif  // __cplusplus
 
 ////////////////////////////////////////////////////////////////////////////////
 // Serialization callbacks                                                    //
@@ -32,17 +32,21 @@ extern "C" {
 // gapil_encode_type returns a new positive unique reference identifer if
 // the type has not been encoded before in this scope, otherwise it returns the
 // negated ID of the previously encoded type identifier.
-DECL_GAPIL_ENCODER_CB(int64_t, gapil_encode_type, context* ctx, uint8_t* name, uint32_t desc_size, void* desc);
+DECL_GAPIL_ENCODER_CB(int64_t, gapil_encode_type, context* ctx, uint8_t* name,
+                      uint32_t desc_size, void* desc);
 
 // gapil_encode_object encodes the object.
 // If is_group is true, a new encoder will be returned for encoding sub-objects.
 // If is_group is false then gapil_encode_object will return null.
-DECL_GAPIL_ENCODER_CB(void*, gapil_encode_object, context* ctx, uint8_t is_group, uint32_t type, uint32_t data_size, void* data);
+DECL_GAPIL_ENCODER_CB(void*, gapil_encode_object, context* ctx,
+                      uint8_t is_group, uint32_t type, uint32_t data_size,
+                      void* data);
 
 // gapil_encode_backref returns a new positive unique reference identifer if
 // object has not been encoded before in this scope, otherwise it returns the
 // negated ID of the previously encoded object identifier.
-DECL_GAPIL_ENCODER_CB(int64_t, gapil_encode_backref, context* ctx, void* object);
+DECL_GAPIL_ENCODER_CB(int64_t, gapil_encode_backref, context* ctx,
+                      void* object);
 
 // gapil_slice_encoded is called whenever a slice is encoded. This callback
 // can be used to write the slice's data into the encoder's stream.
@@ -51,7 +55,7 @@ DECL_GAPIL_ENCODER_CB(void, gapil_slice_encoded, context* ctx, slice* slice);
 #undef DECL_GAPIL_ENCODER_CB
 
 #ifdef __cplusplus
-} // extern "C"
-#endif // __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
 
 #endif  // __GAPIL_RUNTIME_ENCODER_H__

--- a/gapil/runtime/cc/hash.h
+++ b/gapil/runtime/cc/hash.h
@@ -18,90 +18,88 @@
 #include <cstdint>
 #include <cstring>
 
-#include "string.h"
 #include "core/cc/assert.h"
+#include "string.h"
 
 // Note these implementations should match map.go
 namespace gapil {
 struct fixedValue {
-    uint64_t fixed64;
+  uint64_t fixed64;
 };
 
-template<typename T, typename Enable=void>
+template <typename T, typename Enable = void>
 struct hash {
-    uint64_t operator()(const T& t) {
-        GAPID_ASSERT_MSG(false, "unknown hash type");
-        return 0;
-    }
+  uint64_t operator()(const T& t) {
+    GAPID_ASSERT_MSG(false, "unknown hash type");
+    return 0;
+  }
 };
 
 inline uint64_t rotate_right(const uint64_t& v, const uint64_t bits) {
-    return (v >> bits) | (v << (64-bits));
+  return (v >> bits) | (v << (64 - bits));
 }
 
 inline uint64_t shift_left(const uint64_t& v, const uint64_t bits) {
-    return v << bits;
+  return v << bits;
 }
 
-template<>
+template <>
 struct hash<fixedValue, void> {
-    uint64_t operator() (const fixedValue& val) {
-        uint64_t v = val.fixed64;
-        v += shift_left(v, 21);
-        v ^= rotate_right(v, 24);
-        v += shift_left(v, 3) + shift_left(v, 8);
-        v ^= rotate_right(v, 14);
-        v += shift_left(v, 2) + shift_left(v, 4);
-        v ^= rotate_right(v, 28);
-        v += shift_left(v, 31);
-        return v;
-    }
+  uint64_t operator()(const fixedValue& val) {
+    uint64_t v = val.fixed64;
+    v += shift_left(v, 21);
+    v ^= rotate_right(v, 24);
+    v += shift_left(v, 3) + shift_left(v, 8);
+    v ^= rotate_right(v, 14);
+    v += shift_left(v, 2) + shift_left(v, 4);
+    v ^= rotate_right(v, 28);
+    v += shift_left(v, 31);
+    return v;
+  }
 };
 
-template<>
+template <>
 struct hash<float, void> {
-    uint64_t operator() (const float& f) {
-        uint32_t val;
-        memcpy(&val, &f, sizeof(uint32_t));
-        return hash<fixedValue>()(fixedValue{static_cast<uint64_t>(val)});
-    }
+  uint64_t operator()(const float& f) {
+    uint32_t val;
+    memcpy(&val, &f, sizeof(uint32_t));
+    return hash<fixedValue>()(fixedValue{static_cast<uint64_t>(val)});
+  }
 };
 
-template<>
+template <>
 struct hash<double, void> {
-    uint64_t operator() (const double& f) {
-        uint64_t val;
-        memcpy(&val, &f, sizeof(uint64_t));
-        return hash<fixedValue>()(fixedValue{val});
-    }
+  uint64_t operator()(const double& f) {
+    uint64_t val;
+    memcpy(&val, &f, sizeof(uint64_t));
+    return hash<fixedValue>()(fixedValue{val});
+  }
 };
 
-template<typename T>
+template <typename T>
 struct hash<T, typename std::enable_if<std::is_integral<T>::value>::type> {
-    uint64_t operator() (const T&  v) {
-        return static_cast<uint64_t>(v);
-    }
+  uint64_t operator()(const T& v) { return static_cast<uint64_t>(v); }
 };
 
-template<typename T>
+template <typename T>
 struct hash<T*, void> {
-    uint64_t operator() (const T* ptr) {
-        return static_cast<uint64_t>(reinterpret_cast<uintptr_t>(ptr) >> 2);
-    }
+  uint64_t operator()(const T* ptr) {
+    return static_cast<uint64_t>(reinterpret_cast<uintptr_t>(ptr) >> 2);
+  }
 };
 
-template<>
+template <>
 struct hash<gapil::String, void> {
-    uint64_t operator() (const gapil::String& str) {
-        uint64_t h = 0;
-        const char* c_str = str.c_str();
-        for (size_t i = 0; i < str.length(); ++i) {
-            h += (h << 6) + (h << 16) + c_str[i];
-        }
-        return h;
+  uint64_t operator()(const gapil::String& str) {
+    uint64_t h = 0;
+    const char* c_str = str.c_str();
+    for (size_t i = 0; i < str.length(); ++i) {
+      h += (h << 6) + (h << 16) + c_str[i];
     }
+    return h;
+  }
 };
 
-} // namespace gapil
+}  // namespace gapil
 
-#endif // __GAPIL_RUNTIME_HASH_H__
+#endif  // __GAPIL_RUNTIME_HASH_H__

--- a/gapil/runtime/cc/maker_test.cpp
+++ b/gapil/runtime/cc/maker_test.cpp
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 #include "maker.h"
 
 #include "core/memory/arena/cc/arena.h"
@@ -20,35 +19,32 @@
 #include <gtest/gtest.h>
 
 class MakerTest : public ::testing::Test {
-    void TearDown() {
-        EXPECT_EQ(0, arena.num_allocations());
-        EXPECT_EQ(0, arena.num_bytes_allocated());
-    }
+  void TearDown() {
+    EXPECT_EQ(0, arena.num_allocations());
+    EXPECT_EQ(0, arena.num_bytes_allocated());
+  }
 
-public:
-    core::Arena arena;
+ public:
+  core::Arena arena;
 };
 
 TEST_F(MakerTest, make_pointer) {
-    printf("arena: %p\n", &this->MakerTest::arena);
-    EXPECT_EQ(nullptr, gapil::make<void*>(&this->MakerTest::arena));
-    EXPECT_EQ(nullptr, gapil::make<const void*>(&this->MakerTest::arena));
-    EXPECT_EQ(nullptr, gapil::make<int*>(&this->MakerTest::arena));
-    EXPECT_EQ(nullptr, gapil::make<const int*>(&this->MakerTest::arena));
+  printf("arena: %p\n", &this->MakerTest::arena);
+  EXPECT_EQ(nullptr, gapil::make<void*>(&this->MakerTest::arena));
+  EXPECT_EQ(nullptr, gapil::make<const void*>(&this->MakerTest::arena));
+  EXPECT_EQ(nullptr, gapil::make<int*>(&this->MakerTest::arena));
+  EXPECT_EQ(nullptr, gapil::make<const int*>(&this->MakerTest::arena));
 }
 
-template<typename T>
+template <typename T>
 class MakerTestInteger : public MakerTest {};
 
-using MakerTestIntegerTypes = ::testing::Types<
-    uint8_t,  int8_t,
-    uint16_t, int16_t,
-    uint32_t, int32_t,
-    uint64_t, int64_t
->;
+using MakerTestIntegerTypes =
+    ::testing::Types<uint8_t, int8_t, uint16_t, int16_t, uint32_t, int32_t,
+                     uint64_t, int64_t>;
 
 TYPED_TEST_CASE(MakerTestInteger, MakerTestIntegerTypes);
 
 TYPED_TEST(MakerTestInteger, make_integer) {
-    EXPECT_EQ(0, gapil::make<TypeParam>(&this->MakerTest::arena));
+  EXPECT_EQ(0, gapil::make<TypeParam>(&this->MakerTest::arena));
 }

--- a/gapil/runtime/cc/map.h
+++ b/gapil/runtime/cc/map.h
@@ -29,154 +29,155 @@ namespace gapil {
 // share the same underlying data.
 // Search, insertion, and removal of elements are O(1).
 // Like std::unordered_map, elements are stored in no particular order.
-template<typename K, typename V>
+template <typename K, typename V>
 class Map {
-private:
-    struct Allocation;
-public:
-    struct element {
-        uint64_t used;
-        K first;
-        V second;
-    };
+ private:
+  struct Allocation;
 
-    using key_type = K;
-    using value_type = V;
+ public:
+  struct element {
+    uint64_t used;
+    K first;
+    V second;
+  };
 
-    class iterator {
-    public:
-        inline iterator(const iterator& it);
+  using key_type = K;
+  using value_type = V;
 
-        inline bool operator == (const iterator& other);
+  class iterator {
+   public:
+    inline iterator(const iterator& it);
 
-        inline bool operator != (const iterator& other);
+    inline bool operator==(const iterator& other);
 
-        inline element& operator*();
+    inline bool operator!=(const iterator& other);
 
-        inline element* operator->();
+    inline element& operator*();
 
-        inline const iterator& operator++();
+    inline element* operator->();
 
-        inline iterator operator++(int);
+    inline const iterator& operator++();
 
-    private:
-        friend class Map<K, V>;
-        element* elem;
-        Allocation* map;
+    inline iterator operator++(int);
 
-        inline iterator(element* elem, Allocation* map);
-    };
+   private:
+    friend class Map<K, V>;
+    element* elem;
+    Allocation* map;
 
-    class const_iterator {
-    public:
-        inline const_iterator(const iterator& it);
+    inline iterator(element* elem, Allocation* map);
+  };
 
-        inline bool operator == (const const_iterator& other);
+  class const_iterator {
+   public:
+    inline const_iterator(const iterator& it);
 
-        inline bool operator != (const const_iterator& other);
+    inline bool operator==(const const_iterator& other);
 
-        inline const element& operator*();
+    inline bool operator!=(const const_iterator& other);
 
-        inline const element* operator->();
+    inline const element& operator*();
 
-        inline const_iterator& operator++();
+    inline const element* operator->();
 
-        inline const_iterator operator++(int);
+    inline const_iterator& operator++();
 
-    private:
-        friend class Map<K, V>;
-        const element* elem;
-        const Allocation* map;
+    inline const_iterator operator++(int);
 
-        inline const_iterator(const element* elem, const Allocation* map);
-    };
+   private:
+    friend class Map<K, V>;
+    const element* elem;
+    const Allocation* map;
 
-    // Constructs a new empty map.
-    Map(core::Arena*);
+    inline const_iterator(const element* elem, const Allocation* map);
+  };
 
-    // Constructs a map which shares the data with other.
-    Map(const Map<K,V>& other);
+  // Constructs a new empty map.
+  Map(core::Arena*);
 
-    Map(Map<K, V>&&);
-    ~Map();
+  // Constructs a map which shares the data with other.
+  Map(const Map<K, V>& other);
 
-    // Returns a copy of this map with the same elements.
-    Map<K, V> clone() const;
+  Map(Map<K, V>&&);
+  ~Map();
 
-    // Makes this map refer to the RHS map.
-    Map<K,V>& operator = (const Map<K,V>&);
+  // Returns a copy of this map with the same elements.
+  Map<K, V> clone() const;
 
-    // Returns the arena this map belongs to.
-    inline core::Arena* arena() const;
+  // Makes this map refer to the RHS map.
+  Map<K, V>& operator=(const Map<K, V>&);
 
-    // Returns the number of elements that can be held in the map before
-    // Re-allocating the internal buffer.
-    inline uint64_t capacity() const;
+  // Returns the arena this map belongs to.
+  inline core::Arena* arena() const;
 
-    // Returns the number of elements currently held in the map.
-    inline uint64_t count() const;
+  // Returns the number of elements that can be held in the map before
+  // Re-allocating the internal buffer.
+  inline uint64_t capacity() const;
 
-    // Returns true if the map has no elements.
-    inline bool empty() const;
+  // Returns the number of elements currently held in the map.
+  inline uint64_t count() const;
 
-    // Returns true if the map contains the given key.
-    inline bool contains(const K&) const;
+  // Returns true if the map has no elements.
+  inline bool empty() const;
 
-    // Returns a constant iterator to the beginning.
-    inline const const_iterator begin() const;
+  // Returns true if the map contains the given key.
+  inline bool contains(const K&) const;
 
-    // Returns an iterator to the beginning.
-    inline iterator begin();
+  // Returns a constant iterator to the beginning.
+  inline const const_iterator begin() const;
 
-    // Returns a constant iterator to the end.
-    inline const_iterator end() const;
+  // Returns an iterator to the beginning.
+  inline iterator begin();
 
-    // Returns an iterator to the end.
-    inline iterator end();
+  // Returns a constant iterator to the end.
+  inline const_iterator end() const;
 
-    // Removes the element with the given key from the map.
-    inline void erase(const K& k);
+  // Returns an iterator to the end.
+  inline iterator end();
 
-    // Removes the element with the given key from the map.
-    inline void erase(const_iterator it);
+  // Removes the element with the given key from the map.
+  inline void erase(const K& k);
 
-    // Returns a reference to the element with the given key, creating and
-    // adding an element if one did not exist.
-    template<typename T>
-    inline V& operator[](const T& key);
+  // Removes the element with the given key from the map.
+  inline void erase(const_iterator it);
 
-    // Returns an iterator to an element with the given key.
-    // If no such element is found, the end iterator is returned.
-    inline iterator find(const K& key);
+  // Returns a reference to the element with the given key, creating and
+  // adding an element if one did not exist.
+  template <typename T>
+  inline V& operator[](const T& key);
 
-    // Returns an iterator to an element with the given key.
-    // If no such element is found, the end iterator is returned.
-    inline const_iterator find(const K& k) const;
+  // Returns an iterator to an element with the given key.
+  // If no such element is found, the end iterator is returned.
+  inline iterator find(const K& key);
 
-    // finds a key in the map and returns the value. If no value is present
-    // Returns the zero for that type.
-    inline V findOrZero(const K& key) const;
+  // Returns an iterator to an element with the given key.
+  // If no such element is found, the end iterator is returned.
+  inline const_iterator find(const K& k) const;
 
-    // instance_ptr returns an opaque pointer to the underlying map data.
-    // This can be used for map equality.
-    inline const void* instance_ptr() const;
+  // finds a key in the map and returns the value. If no value is present
+  // Returns the zero for that type.
+  inline V findOrZero(const K& key) const;
 
-private:
-    struct Allocation : public map_t {
-        // The following methods must match those generated by the gapil compiler.
-        bool contains(K);
-        V*   index(K, bool);
-        V    lookup(K);
-        void remove(K);
-        void clear();
-        void reference();
-        void release();
+  // instance_ptr returns an opaque pointer to the underlying map data.
+  // This can be used for map equality.
+  inline const void* instance_ptr() const;
 
-        inline const element* els() const;
-        inline element* els();
-    };
+ private:
+  struct Allocation : public map_t {
+    // The following methods must match those generated by the gapil compiler.
+    bool contains(K);
+    V* index(K, bool);
+    V lookup(K);
+    void remove(K);
+    void clear();
+    void reference();
+    void release();
 
-    Allocation* ptr;
+    inline const element* els() const;
+    inline element* els();
+  };
+
+  Allocation* ptr;
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -184,53 +185,53 @@ private:
 ////////////////////////////////////////////////////////////////////////////////
 
 template <typename K, typename V>
-Map<K, V>::iterator::iterator(element* elem, Allocation* map) :
-        elem(elem), map(map) {}
+Map<K, V>::iterator::iterator(element* elem, Allocation* map)
+    : elem(elem), map(map) {}
 
 template <typename K, typename V>
-Map<K, V>::iterator::iterator(const iterator& it) :
-        elem(it.elem), map(it.map) {}
+Map<K, V>::iterator::iterator(const iterator& it)
+    : elem(it.elem), map(it.map) {}
 
 template <typename K, typename V>
 bool Map<K, V>::iterator::operator==(const iterator& other) {
-    return map == other.map && elem == other.elem;
+  return map == other.map && elem == other.elem;
 }
 
 template <typename K, typename V>
-bool Map<K, V>::iterator::operator!=(const iterator& other){
-    return !(*this == other);
+bool Map<K, V>::iterator::operator!=(const iterator& other) {
+  return !(*this == other);
 }
 
 template <typename K, typename V>
 typename Map<K, V>::element& Map<K, V>::iterator::operator*() {
-    return *elem;
+  return *elem;
 }
 
 template <typename K, typename V>
 typename Map<K, V>::element* Map<K, V>::iterator::operator->() {
-    return elem;
+  return elem;
 }
 
 template <typename K, typename V>
 const typename Map<K, V>::iterator& Map<K, V>::iterator::operator++() {
-    size_t offset = elem - reinterpret_cast<element*>(map->elements);
-    for (size_t i = offset; i < map->capacity; ++i) {
-        ++elem;
-        if (i == map->capacity - 1) {
-            break;
-        }
-        if (elem->used == GAPIL_MAP_ELEMENT_FULL) {
-            break;
-        }
+  size_t offset = elem - reinterpret_cast<element*>(map->elements);
+  for (size_t i = offset; i < map->capacity; ++i) {
+    ++elem;
+    if (i == map->capacity - 1) {
+      break;
     }
-    return *this;
+    if (elem->used == GAPIL_MAP_ELEMENT_FULL) {
+      break;
+    }
+  }
+  return *this;
 }
 
 template <typename K, typename V>
 typename Map<K, V>::iterator Map<K, V>::iterator::operator++(int) {
-    iterator ret = *this;
-    ++(*this);
-    return ret;
+  iterator ret = *this;
+  ++(*this);
+  return ret;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -238,54 +239,54 @@ typename Map<K, V>::iterator Map<K, V>::iterator::operator++(int) {
 ////////////////////////////////////////////////////////////////////////////////
 
 template <typename K, typename V>
-Map<K, V>::const_iterator::const_iterator(const element* elem, const Allocation* map):
-    elem(elem), map(map) {}
+Map<K, V>::const_iterator::const_iterator(const element* elem,
+                                          const Allocation* map)
+    : elem(elem), map(map) {}
 
 template <typename K, typename V>
-Map<K, V>::const_iterator::const_iterator(const iterator& it):
-    elem(it.elem), map(it.map) {
-}
+Map<K, V>::const_iterator::const_iterator(const iterator& it)
+    : elem(it.elem), map(it.map) {}
 
 template <typename K, typename V>
 bool Map<K, V>::const_iterator::operator==(const const_iterator& other) {
-    return map == other.map && elem == other.elem;
+  return map == other.map && elem == other.elem;
 }
 
 template <typename K, typename V>
-bool Map<K, V>::const_iterator::operator!=(const const_iterator& other){
-    return !(*this == other);
+bool Map<K, V>::const_iterator::operator!=(const const_iterator& other) {
+  return !(*this == other);
 }
 
 template <typename K, typename V>
 const typename Map<K, V>::element& Map<K, V>::const_iterator::operator*() {
-    return *elem;
+  return *elem;
 }
 
 template <typename K, typename V>
 const typename Map<K, V>::element* Map<K, V>::const_iterator::operator->() {
-    return elem;
+  return elem;
 }
 
 template <typename K, typename V>
 typename Map<K, V>::const_iterator& Map<K, V>::const_iterator::operator++() {
-    size_t offset = elem - reinterpret_cast<element*>(map->elements);
-    for (size_t i = offset; i < map->capacity; ++i) {
-        ++elem;
-        if (i == map->capacity - 1) {
-            break;
-        }
-        if (elem->used == GAPIL_MAP_ELEMENT_FULL) {
-            break;
-        }
+  size_t offset = elem - reinterpret_cast<element*>(map->elements);
+  for (size_t i = offset; i < map->capacity; ++i) {
+    ++elem;
+    if (i == map->capacity - 1) {
+      break;
     }
-    return *this;
+    if (elem->used == GAPIL_MAP_ELEMENT_FULL) {
+      break;
+    }
+  }
+  return *this;
 }
 
 template <typename K, typename V>
 typename Map<K, V>::const_iterator Map<K, V>::const_iterator::operator++(int) {
-    const_iterator ret = *this;
-    ++(*this);
-    return ret;
+  const_iterator ret = *this;
+  ++(*this);
+  return ret;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -294,115 +295,117 @@ typename Map<K, V>::const_iterator Map<K, V>::const_iterator::operator++(int) {
 
 template <typename K, typename V>
 core::Arena* Map<K, V>::arena() const {
-    return reinterpret_cast<core::Arena*>(ptr->arena);
+  return reinterpret_cast<core::Arena*>(ptr->arena);
 }
 
 template <typename K, typename V>
 uint64_t Map<K, V>::capacity() const {
-    return ptr->capacity;
+  return ptr->capacity;
 }
 
 template <typename K, typename V>
 uint64_t Map<K, V>::count() const {
-    return ptr->count;
+  return ptr->count;
 }
 
 template <typename K, typename V>
 bool Map<K, V>::empty() const {
-    return ptr->count == 0;
+  return ptr->count == 0;
 }
 
 template <typename K, typename V>
 bool Map<K, V>::contains(const K& key) const {
-    return ptr->contains(key);
+  return ptr->contains(key);
 }
 
 template <typename K, typename V>
 const typename Map<K, V>::const_iterator Map<K, V>::begin() const {
-    auto it = const_iterator{ptr->els(), ptr};
-    for (size_t i = 0; i < ptr->capacity; ++i) {
-        if (it.elem->used == GAPIL_MAP_ELEMENT_FULL) {
-            break;
-        }
-        it.elem++;
+  auto it = const_iterator{ptr->els(), ptr};
+  for (size_t i = 0; i < ptr->capacity; ++i) {
+    if (it.elem->used == GAPIL_MAP_ELEMENT_FULL) {
+      break;
     }
-    return it;
+    it.elem++;
+  }
+  return it;
 }
 
 template <typename K, typename V>
 typename Map<K, V>::iterator Map<K, V>::begin() {
-    auto it = iterator{ptr->els(), ptr};
-    for (size_t i = 0; i < ptr->capacity; ++i) {
-        if (it.elem->used == GAPIL_MAP_ELEMENT_FULL) {
-            break;
-        }
-        it.elem++;
+  auto it = iterator{ptr->els(), ptr};
+  for (size_t i = 0; i < ptr->capacity; ++i) {
+    if (it.elem->used == GAPIL_MAP_ELEMENT_FULL) {
+      break;
     }
-    return it;
+    it.elem++;
+  }
+  return it;
 }
 
 template <typename K, typename V>
 typename Map<K, V>::iterator Map<K, V>::end() {
-    return iterator{ptr->els() + capacity(), ptr};
+  return iterator{ptr->els() + capacity(), ptr};
 }
 
 template <typename K, typename V>
 typename Map<K, V>::const_iterator Map<K, V>::end() const {
-    return const_iterator{ptr->els() + capacity(), ptr};
+  return const_iterator{ptr->els() + capacity(), ptr};
 }
 
 template <typename K, typename V>
 void Map<K, V>::erase(const K& k) {
-    ptr->remove(k);
+  ptr->remove(k);
 }
 
 template <typename K, typename V>
 void Map<K, V>::erase(const_iterator it) {
-    ptr->remove(it->first);
+  ptr->remove(it->first);
 }
 
 template <typename K, typename V>
 template <typename T>
 V& Map<K, V>::operator[](const T& key) {
-    V* v = ptr->index(key, true);
-    return *v;
+  V* v = ptr->index(key, true);
+  return *v;
 }
 
 template <typename K, typename V>
 typename Map<K, V>::iterator Map<K, V>::find(const K& key) {
-    V* idx = ptr->index(key, false);
-    if (idx == nullptr) {
-        return end();
-    }
-    size_t offs =
-        (reinterpret_cast<uintptr_t>(idx) - reinterpret_cast<uintptr_t>(ptr->els())) / sizeof(element);
-    return iterator{ptr->els() + offs, ptr};
+  V* idx = ptr->index(key, false);
+  if (idx == nullptr) {
+    return end();
+  }
+  size_t offs = (reinterpret_cast<uintptr_t>(idx) -
+                 reinterpret_cast<uintptr_t>(ptr->els())) /
+                sizeof(element);
+  return iterator{ptr->els() + offs, ptr};
 }
 
 template <typename K, typename V>
 typename Map<K, V>::const_iterator Map<K, V>::find(const K& k) const {
-    const V* idx = ptr->index(k, false);
-    if (idx == nullptr) {
-        return end();
-    }
-    size_t offs =
-        (reinterpret_cast<uintptr_t>(idx) - reinterpret_cast<uintptr_t>(ptr->els())) / sizeof(element);
-    return const_iterator{ptr->els() + offs, ptr};
+  const V* idx = ptr->index(k, false);
+  if (idx == nullptr) {
+    return end();
+  }
+  size_t offs = (reinterpret_cast<uintptr_t>(idx) -
+                 reinterpret_cast<uintptr_t>(ptr->els())) /
+                sizeof(element);
+  return const_iterator{ptr->els() + offs, ptr};
 }
 
 template <typename K, typename V>
 V Map<K, V>::findOrZero(const K& key) const {
-    auto it = find(key);
-    if (it == end()) {
-        auto arena = reinterpret_cast<core::Arena*>(ptr->arena);
-        return make<V>(arena);
-    }
-    return it->second;
+  auto it = find(key);
+  if (it == end()) {
+    auto arena = reinterpret_cast<core::Arena*>(ptr->arena);
+    return make<V>(arena);
+  }
+  return it->second;
 }
 
 template <typename K, typename V>
 inline const void* Map<K, V>::instance_ptr() const {
-    return ptr;
+  return ptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -411,12 +414,12 @@ inline const void* Map<K, V>::instance_ptr() const {
 
 template <typename K, typename V>
 const typename Map<K, V>::element* Map<K, V>::Allocation::els() const {
-    return reinterpret_cast<const element*>(map_t::elements);
+  return reinterpret_cast<const element*>(map_t::elements);
 }
 
 template <typename K, typename V>
 typename Map<K, V>::element* Map<K, V>::Allocation::els() {
-    return reinterpret_cast<element*>(map_t::elements);
+  return reinterpret_cast<element*>(map_t::elements);
 }
 
 }  // namespace gapil

--- a/gapil/runtime/cc/map_test.cpp
+++ b/gapil/runtime/cc/map_test.cpp
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 #include "map.inc"
 
 #include "string.h"
@@ -21,260 +20,258 @@
 
 #include <gtest/gtest.h>
 
-template<typename T>
+template <typename T>
 class MapTest : public ::testing::Test {
-    void TearDown() {
-        EXPECT_EQ(0, arena.num_allocations());
-        EXPECT_EQ(0, arena.num_bytes_allocated());
-    }
+  void TearDown() {
+    EXPECT_EQ(0, arena.num_allocations());
+    EXPECT_EQ(0, arena.num_bytes_allocated());
+  }
 
-public:
-    core::Arena arena;
+ public:
+  core::Arena arena;
 };
 
-using MapTestTypes = ::testing::Types<
-    gapil::Map<uint32_t, uint32_t>,
-    gapil::Map<uint16_t, uint32_t>,
-    gapil::Map<uint32_t, uint64_t>>;
+using MapTestTypes = ::testing::Types<gapil::Map<uint32_t, uint32_t>,
+                                      gapil::Map<uint16_t, uint32_t>,
+                                      gapil::Map<uint32_t, uint64_t>>;
 
 TYPED_TEST_CASE(MapTest, MapTestTypes);
 
 TYPED_TEST(MapTest, basic_insert) {
-    using key_type = typename TypeParam::key_type;
-    using value_type = typename TypeParam::value_type;
+  using key_type = typename TypeParam::key_type;
+  using value_type = typename TypeParam::value_type;
 
-    auto map = TypeParam(&this->TestFixture::arena);
+  auto map = TypeParam(&this->TestFixture::arena);
 
-    map[key_type(32)] = value_type(42);
-    EXPECT_EQ(1, map.count());
+  map[key_type(32)] = value_type(42);
+  EXPECT_EQ(1, map.count());
 
-    EXPECT_EQ(42, map.findOrZero(32));
-    EXPECT_EQ(0, map.findOrZero(42));
+  EXPECT_EQ(42, map.findOrZero(32));
+  EXPECT_EQ(0, map.findOrZero(42));
 
-    EXPECT_EQ(42, map[key_type(32)]);
-    EXPECT_EQ(0, map[key_type(42)]);
-    EXPECT_EQ(2, map.count());
+  EXPECT_EQ(42, map[key_type(32)]);
+  EXPECT_EQ(0, map[key_type(42)]);
+  EXPECT_EQ(2, map.count());
 
-    EXPECT_EQ(GAPIL_MIN_MAP_SIZE, map.capacity());
+  EXPECT_EQ(GAPIL_MIN_MAP_SIZE, map.capacity());
 }
 
 TYPED_TEST(MapTest, multi_insert) {
-    using key_type = typename TypeParam::key_type;
-    using value_type = typename TypeParam::value_type;
+  using key_type = typename TypeParam::key_type;
+  using value_type = typename TypeParam::value_type;
 
-    auto map = TypeParam(&this->TestFixture::arena);
+  auto map = TypeParam(&this->TestFixture::arena);
 
-    uint64_t resize_threshold = static_cast<uint64_t>(GAPIL_MIN_MAP_SIZE * GAPIL_MAP_MAX_CAPACITY);
-    for (uint64_t i = 0; i <= resize_threshold; ++i) {
-        map[key_type(i)] = value_type(i);
-    }
-    EXPECT_EQ(resize_threshold+1, map.count());
-    EXPECT_EQ(GAPIL_MIN_MAP_SIZE, map.capacity());
+  uint64_t resize_threshold =
+      static_cast<uint64_t>(GAPIL_MIN_MAP_SIZE * GAPIL_MAP_MAX_CAPACITY);
+  for (uint64_t i = 0; i <= resize_threshold; ++i) {
+    map[key_type(i)] = value_type(i);
+  }
+  EXPECT_EQ(resize_threshold + 1, map.count());
+  EXPECT_EQ(GAPIL_MIN_MAP_SIZE, map.capacity());
 
+  for (uint64_t i = 0; i < resize_threshold + 1; ++i) {
+    EXPECT_EQ(value_type(i), map[key_type(i)]);
+  }
 
-    for (uint64_t i = 0; i < resize_threshold + 1; ++i) {
-        EXPECT_EQ(value_type(i), map[key_type(i)]);
-    }
+  map[key_type(resize_threshold + 1)] = value_type(resize_threshold + 1);
+  EXPECT_EQ(resize_threshold + 2, map.count());
+  EXPECT_EQ(GAPIL_MIN_MAP_SIZE * GAPIL_MAP_GROW_MULTIPLIER, map.capacity());
 
-    map[key_type(resize_threshold + 1)] = value_type(resize_threshold + 1);
-    EXPECT_EQ(resize_threshold + 2, map.count());
-    EXPECT_EQ(GAPIL_MIN_MAP_SIZE * GAPIL_MAP_GROW_MULTIPLIER, map.capacity());
-
-    for (uint64_t i = 0; i < resize_threshold + 1; ++i) {
-        EXPECT_EQ(value_type(i), map[key_type(i)]);
-    }
+  for (uint64_t i = 0; i < resize_threshold + 1; ++i) {
+    EXPECT_EQ(value_type(i), map[key_type(i)]);
+  }
 }
 
 TYPED_TEST(MapTest, erase) {
-    using key_type = typename TypeParam::key_type;
-    using value_type = typename TypeParam::value_type;
-    auto map = TypeParam(&this->TestFixture::arena);
+  using key_type = typename TypeParam::key_type;
+  using value_type = typename TypeParam::value_type;
+  auto map = TypeParam(&this->TestFixture::arena);
 
-    uint64_t resize_threshold = static_cast<uint64_t>(GAPIL_MIN_MAP_SIZE * GAPIL_MAP_MAX_CAPACITY);
-    for (uint64_t i = 0; i <= resize_threshold; ++i) {
-        map[key_type(i)] = value_type(i);
-    }
-    EXPECT_EQ(resize_threshold+1, map.count());
-    EXPECT_EQ(GAPIL_MIN_MAP_SIZE, map.capacity());
+  uint64_t resize_threshold =
+      static_cast<uint64_t>(GAPIL_MIN_MAP_SIZE * GAPIL_MAP_MAX_CAPACITY);
+  for (uint64_t i = 0; i <= resize_threshold; ++i) {
+    map[key_type(i)] = value_type(i);
+  }
+  EXPECT_EQ(resize_threshold + 1, map.count());
+  EXPECT_EQ(GAPIL_MIN_MAP_SIZE, map.capacity());
 
+  for (uint64_t i = 0; i < resize_threshold + 1; ++i) {
+    EXPECT_EQ(value_type(i), map[key_type(i)]);
+  }
 
-    for (uint64_t i = 0; i < resize_threshold + 1; ++i) {
-        EXPECT_EQ(value_type(i), map[key_type(i)]);
-    }
+  map[key_type(resize_threshold + 1)] = value_type(resize_threshold + 1);
+  EXPECT_EQ(resize_threshold + 2, map.count());
+  EXPECT_EQ(GAPIL_MIN_MAP_SIZE * GAPIL_MAP_GROW_MULTIPLIER, map.capacity());
 
-    map[key_type(resize_threshold + 1)] = value_type(resize_threshold + 1);
-    EXPECT_EQ(resize_threshold + 2, map.count());
-    EXPECT_EQ(GAPIL_MIN_MAP_SIZE * GAPIL_MAP_GROW_MULTIPLIER, map.capacity());
+  for (uint64_t i = 0; i < resize_threshold + 1; ++i) {
+    EXPECT_EQ(value_type(i), map[key_type(i)]);
+  }
 
-    for (uint64_t i = 0; i < resize_threshold + 1; ++i) {
-        EXPECT_EQ(value_type(i), map[key_type(i)]);
-    }
-
-    map.erase(key_type(10));
-    EXPECT_EQ(0, map[key_type(10)]);
+  map.erase(key_type(10));
+  EXPECT_EQ(0, map[key_type(10)]);
 }
 
 TYPED_TEST(MapTest, range) {
-    using key_type = typename TypeParam::key_type;
-    using value_type = typename TypeParam::value_type;
+  using key_type = typename TypeParam::key_type;
+  using value_type = typename TypeParam::value_type;
 
-    auto map = TypeParam(&this->TestFixture::arena);
+  auto map = TypeParam(&this->TestFixture::arena);
 
-    std::vector<value_type> result_vector;
-    result_vector.resize(16);
+  std::vector<value_type> result_vector;
+  result_vector.resize(16);
 
-    for (uint64_t i = 0; i < 16; ++i) {
-        map[key_type(i)] = value_type(i);
-    }
+  for (uint64_t i = 0; i < 16; ++i) {
+    map[key_type(i)] = value_type(i);
+  }
 
-    uint64_t old_allocations = TestFixture::arena.num_allocations();
+  uint64_t old_allocations = TestFixture::arena.num_allocations();
 
-    for (auto& val: map) {
-        result_vector[val.first] = val.second;
-    }
+  for (auto& val : map) {
+    result_vector[val.first] = val.second;
+  }
 
-    // Ranging over a map should not have caused any allocations.
-    EXPECT_EQ(old_allocations, TestFixture::arena.num_allocations());
+  // Ranging over a map should not have caused any allocations.
+  EXPECT_EQ(old_allocations, TestFixture::arena.num_allocations());
 
-    for (uint64_t i = 0; i < 16; ++i) {
-        EXPECT_EQ(result_vector[i], value_type(i));
-    }
+  for (uint64_t i = 0; i < 16; ++i) {
+    EXPECT_EQ(result_vector[i], value_type(i));
+  }
 }
 
 class CppMapTest : public ::testing::Test {
-    void TearDown() {
-        EXPECT_EQ(0, arena.num_allocations());
-        EXPECT_EQ(0, arena.num_bytes_allocated());
-    }
+  void TearDown() {
+    EXPECT_EQ(0, arena.num_allocations());
+    EXPECT_EQ(0, arena.num_bytes_allocated());
+  }
 
-public:
-    core::Arena arena;
+ public:
+  core::Arena arena;
 };
 
 TEST_F(CppMapTest, string_as_value) {
-    auto map = gapil::Map<uint32_t, gapil::String>(&arena);
+  auto map = gapil::Map<uint32_t, gapil::String>(&arena);
 
-    EXPECT_EQ(0, map.count());
+  EXPECT_EQ(0, map.count());
 
-    map[1] = gapil::String(&arena, "one");
-    map[2] = gapil::String(&arena, "two");
-    map[3] = gapil::String(&arena, "three");
+  map[1] = gapil::String(&arena, "one");
+  map[2] = gapil::String(&arena, "two");
+  map[3] = gapil::String(&arena, "three");
 
-    EXPECT_EQ(3, map.count());
+  EXPECT_EQ(3, map.count());
 
-    EXPECT_STREQ(map[1].c_str(), "one");
-    EXPECT_STREQ(map[2].c_str(), "two");
-    EXPECT_STREQ(map[3].c_str(), "three");
+  EXPECT_STREQ(map[1].c_str(), "one");
+  EXPECT_STREQ(map[2].c_str(), "two");
+  EXPECT_STREQ(map[3].c_str(), "three");
 }
 
-
 class non_movable_object {
-public:
-    non_movable_object() {
-        size = 0;
-        v = nullptr;
-        arena = nullptr;
-    }
+ public:
+  non_movable_object() {
+    size = 0;
+    v = nullptr;
+    arena = nullptr;
+  }
 
-    non_movable_object(arena_t* a, uint64_t i) {
-        size = i;
-        v = gapil_alloc(a, i, 1);
-        arena = a;
-    }
+  non_movable_object(arena_t* a, uint64_t i) {
+    size = i;
+    v = gapil_alloc(a, i, 1);
+    arena = a;
+  }
 
-    non_movable_object& operator=(const non_movable_object& _other) {
-        size = _other.size;
-        arena = _other.arena;
-        v = gapil_alloc(arena, size, 1);
-        return *this;
-    }
+  non_movable_object& operator=(const non_movable_object& _other) {
+    size = _other.size;
+    arena = _other.arena;
+    v = gapil_alloc(arena, size, 1);
+    return *this;
+  }
 
-    ~non_movable_object() {
-        if (arena != nullptr) {
-            gapil_free(arena, v);
-        }
+  ~non_movable_object() {
+    if (arena != nullptr) {
+      gapil_free(arena, v);
     }
-    non_movable_object(const non_movable_object& _other) {
-        v = gapil_alloc(_other.arena, _other.size, 1);
-        arena = _other.arena;
-        size = _other.size;
-    }
+  }
+  non_movable_object(const non_movable_object& _other) {
+    v = gapil_alloc(_other.arena, _other.size, 1);
+    arena = _other.arena;
+    size = _other.size;
+  }
 
-private:
-    void * v;
-    uint64_t size;
-    arena_t* arena;
+ private:
+  void* v;
+  uint64_t size;
+  arena_t* arena;
 };
 
 TEST_F(CppMapTest, non_movable_object) {
-    auto map = gapil::Map<uint32_t, non_movable_object>(&arena);
+  auto map = gapil::Map<uint32_t, non_movable_object>(&arena);
 
-    auto a = reinterpret_cast<arena_t*>(&arena);
+  auto a = reinterpret_cast<arena_t*>(&arena);
 
-    uint64_t resize_threshold = static_cast<uint64_t>(GAPIL_MIN_MAP_SIZE * GAPIL_MAP_MAX_CAPACITY);
-    for (uint64_t i = 0; i <= resize_threshold; ++i) {
-        map[i] = non_movable_object(a, i + 10);
-    }
-    EXPECT_EQ(resize_threshold+1, map.count());
-    EXPECT_EQ(GAPIL_MIN_MAP_SIZE, map.capacity());
+  uint64_t resize_threshold =
+      static_cast<uint64_t>(GAPIL_MIN_MAP_SIZE * GAPIL_MAP_MAX_CAPACITY);
+  for (uint64_t i = 0; i <= resize_threshold; ++i) {
+    map[i] = non_movable_object(a, i + 10);
+  }
+  EXPECT_EQ(resize_threshold + 1, map.count());
+  EXPECT_EQ(GAPIL_MIN_MAP_SIZE, map.capacity());
 
-    map[resize_threshold + 1] = non_movable_object(a, 10 + resize_threshold + 1);
-    EXPECT_EQ(resize_threshold + 2, map.count());
-    EXPECT_EQ(GAPIL_MIN_MAP_SIZE * GAPIL_MAP_GROW_MULTIPLIER, map.capacity());
+  map[resize_threshold + 1] = non_movable_object(a, 10 + resize_threshold + 1);
+  EXPECT_EQ(resize_threshold + 2, map.count());
+  EXPECT_EQ(GAPIL_MIN_MAP_SIZE * GAPIL_MAP_GROW_MULTIPLIER, map.capacity());
 }
 
 class movable_object {
-public:
-    movable_object() {
-        size = 0;
-        v = nullptr;
-        arena = nullptr;
-    }
+ public:
+  movable_object() {
+    size = 0;
+    v = nullptr;
+    arena = nullptr;
+  }
 
-    movable_object(arena_t* a, uint64_t i) {
-        v = gapil_alloc(a, i, 1);
-        size = i;
-        arena = a;
-    }
+  movable_object(arena_t* a, uint64_t i) {
+    v = gapil_alloc(a, i, 1);
+    size = i;
+    arena = a;
+  }
 
-    movable_object& operator=(movable_object&& _other) {
-        v = _other.v;
-        size = _other.size;
-        arena = _other.arena;
-        _other.v = nullptr;
-        _other.size = 0;
-        _other.arena = nullptr;
-        return *this;
-    }
+  movable_object& operator=(movable_object&& _other) {
+    v = _other.v;
+    size = _other.size;
+    arena = _other.arena;
+    _other.v = nullptr;
+    _other.size = 0;
+    _other.arena = nullptr;
+    return *this;
+  }
 
-    ~movable_object() {
-        if (arena != nullptr) {
-            gapil_free(arena, v);
-        }
+  ~movable_object() {
+    if (arena != nullptr) {
+      gapil_free(arena, v);
     }
-    movable_object(movable_object&& _other) {
-        *this = std::move(_other);
-    }
+  }
+  movable_object(movable_object&& _other) { *this = std::move(_other); }
 
-private:
-    void * v;
-    uint64_t size;
-    arena_t* arena;
+ private:
+  void* v;
+  uint64_t size;
+  arena_t* arena;
 };
 
 TEST_F(CppMapTest, movable_object) {
-    auto map = gapil::Map<uint32_t, movable_object>(&arena);
+  auto map = gapil::Map<uint32_t, movable_object>(&arena);
 
-    auto a = reinterpret_cast<arena_t*>(&arena);
+  auto a = reinterpret_cast<arena_t*>(&arena);
 
-    uint64_t resize_threshold = static_cast<uint64_t>(GAPIL_MIN_MAP_SIZE * GAPIL_MAP_MAX_CAPACITY);
-    for (uint64_t i = 0; i <= resize_threshold; ++i) {
-        map[i] = movable_object(a, i + 10);
-    }
-    EXPECT_EQ(resize_threshold+1, map.count());
-    EXPECT_EQ(GAPIL_MIN_MAP_SIZE, map.capacity());
+  uint64_t resize_threshold =
+      static_cast<uint64_t>(GAPIL_MIN_MAP_SIZE * GAPIL_MAP_MAX_CAPACITY);
+  for (uint64_t i = 0; i <= resize_threshold; ++i) {
+    map[i] = movable_object(a, i + 10);
+  }
+  EXPECT_EQ(resize_threshold + 1, map.count());
+  EXPECT_EQ(GAPIL_MIN_MAP_SIZE, map.capacity());
 
-    map[resize_threshold + 1] = movable_object(a, 10 + resize_threshold + 1);
-    EXPECT_EQ(resize_threshold + 2, map.count());
-    EXPECT_EQ(GAPIL_MIN_MAP_SIZE * GAPIL_MAP_GROW_MULTIPLIER, map.capacity());
+  map[resize_threshold + 1] = movable_object(a, 10 + resize_threshold + 1);
+  EXPECT_EQ(resize_threshold + 2, map.count());
+  EXPECT_EQ(GAPIL_MIN_MAP_SIZE * GAPIL_MAP_GROW_MULTIPLIER, map.capacity());
 }

--- a/gapil/runtime/cc/ref.h
+++ b/gapil/runtime/cc/ref.h
@@ -20,79 +20,78 @@
 
 #include "core/memory/arena/cc/arena.h"
 
-#include <cstddef> // nullptr_t
+#include <cstddef>  // nullptr_t
 
 namespace gapil {
 
 // Ref is a smart pointer implementation that is compatible with the ref
 // shared pointers used by the gapil compiler. Several refs may share the same
 // object.
-template<typename T>
+template <typename T>
 class Ref {
-public:
-    using object_type = T;
+ public:
+  using object_type = T;
 
-    // Constructs a new ref that points to nothing.
-    Ref();
-    Ref(std::nullptr_t);
+  // Constructs a new ref that points to nothing.
+  Ref();
+  Ref(std::nullptr_t);
 
-    // Constructs a new ref that shares ownership other other's data.
-    Ref(const Ref& other);
+  // Constructs a new ref that shares ownership other other's data.
+  Ref(const Ref& other);
 
-    Ref(Ref&&);
-    ~Ref();
+  Ref(Ref&&);
+  ~Ref();
 
-    // Returns a ref that owns a new T constructed with the given arguments.
-    template <typename ...ARGS>
-    inline static Ref create(core::Arena* arena, ARGS&&...);
+  // Returns a ref that owns a new T constructed with the given arguments.
+  template <typename... ARGS>
+  inline static Ref create(core::Arena* arena, ARGS&&...);
 
-    // Replaces the object owned by ref with the one owned by other.
-    Ref& operator = (const Ref& other);
+  // Replaces the object owned by ref with the one owned by other.
+  Ref& operator=(const Ref& other);
 
-    // Returns true if the object owned by this is the same as the one owned by
-    // other.
-    bool operator == (const Ref& other) const;
+  // Returns true if the object owned by this is the same as the one owned by
+  // other.
+  bool operator==(const Ref& other) const;
 
-    // Returns true if the object owned by this is not the same as the one owned
-    // by other.
-    bool operator != (const Ref& other) const;
+  // Returns true if the object owned by this is not the same as the one owned
+  // by other.
+  bool operator!=(const Ref& other) const;
 
-    // Returns a raw-pointer to the owned object.
-    T* get() const;
+  // Returns a raw-pointer to the owned object.
+  T* get() const;
 
-    // Dereferences the stored pointer. The behavior is undefined if the stored
-    // pointer is null.
-    T* operator->() const;
-    T& operator*() const;
+  // Dereferences the stored pointer. The behavior is undefined if the stored
+  // pointer is null.
+  T* operator->() const;
+  T& operator*() const;
 
-    // Returns true if the ref points to an object (is non-null).
-    operator bool() const;
+  // Returns true if the ref points to an object (is non-null).
+  operator bool() const;
 
-private:
-    struct Allocation {
-        uint32_t ref_count;
-        arena_t* arena; // arena that owns this object allocation.
-        T        object;
+ private:
+  struct Allocation {
+    uint32_t ref_count;
+    arena_t* arena;  // arena that owns this object allocation.
+    T object;
 
-        void reference();
-        void release();
-    };
+    void reference();
+    void release();
+  };
 
-    Ref(Allocation*);
+  Ref(Allocation*);
 
-    Allocation* ptr;
+  Allocation* ptr;
 };
 
-
-template<typename T>
-template<typename ...ARGS>
+template <typename T>
+template <typename... ARGS>
 Ref<T> Ref<T>::create(core::Arena* arena, ARGS&&... args) {
-    auto buf = arena->allocate(sizeof(Allocation), alignof(Allocation));
-    auto ptr = reinterpret_cast<Allocation*>(buf);
-    ptr->ref_count = 1;
-    ptr->arena = reinterpret_cast<arena_t*>(arena);
-    inplace_new(&ptr->object, arena, std::forward<ARGS>(args)...);
-    return Ref(ptr);
+  auto buf = arena->allocate(sizeof(Allocation), alignof(Allocation));
+  auto ptr = reinterpret_cast<Allocation*>(buf);
+  ptr->ref_count = 1;
+  ptr->arena = reinterpret_cast<arena_t*>(arena);
+  inplace_new(&ptr->object, arena, std::forward<ARGS>(args)...);
+  return Ref(ptr);
 }
 
 }  // namespace gapil

--- a/gapil/runtime/cc/ref_test.cpp
+++ b/gapil/runtime/cc/ref_test.cpp
@@ -12,75 +12,75 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 #include "ref.inc"
 
 #include "core/memory/arena/cc/arena.h"
 
 #include <gtest/gtest.h>
 
-template<typename T>
+template <typename T>
 class RefTest : public ::testing::Test {};
 
-using RefTestTypes = ::testing::Types<
-    gapil::Ref<uint32_t>,
-    gapil::Ref<uint16_t>,
-    gapil::Ref<uint64_t>>;
+using RefTestTypes =
+    ::testing::Types<gapil::Ref<uint32_t>, gapil::Ref<uint16_t>,
+                     gapil::Ref<uint64_t>>;
 
 TYPED_TEST_CASE(RefTest, RefTestTypes);
 
 TYPED_TEST(RefTest, null) {
-    auto ref = TypeParam();
+  auto ref = TypeParam();
 
-    EXPECT_EQ(ref, ref);
-    EXPECT_EQ(ref, TypeParam());
+  EXPECT_EQ(ref, ref);
+  EXPECT_EQ(ref, TypeParam());
 
-    EXPECT_EQ(ref.get(), nullptr);
+  EXPECT_EQ(ref.get(), nullptr);
 }
 
 TYPED_TEST(RefTest, create) {
-    core::Arena arena;
+  core::Arena arena;
 
-    {
-        auto ref = TypeParam::create(&arena);
+  {
+    auto ref = TypeParam::create(&arena);
 
-        *ref = 5;
+    *ref = 5;
 
-        EXPECT_EQ(ref, ref);
-        EXPECT_NE(ref, TypeParam());
+    EXPECT_EQ(ref, ref);
+    EXPECT_NE(ref, TypeParam());
 
-        EXPECT_EQ(1, arena.num_allocations()); // single allocation for the ref object
-    }
+    EXPECT_EQ(1,
+              arena.num_allocations());  // single allocation for the ref object
+  }
 
-    // ref has now fallen out of scope
-    EXPECT_EQ(0, arena.num_allocations());
-    EXPECT_EQ(0, arena.num_bytes_allocated());
+  // ref has now fallen out of scope
+  EXPECT_EQ(0, arena.num_allocations());
+  EXPECT_EQ(0, arena.num_bytes_allocated());
 }
 
 TYPED_TEST(RefTest, assignment) {
-    core::Arena arena;
+  core::Arena arena;
 
-    {
-        auto refA = TypeParam::create(&arena);
+  {
+    auto refA = TypeParam::create(&arena);
 
-        EXPECT_EQ(arena.num_allocations(), 1); // refA owns 1 allocation
+    EXPECT_EQ(arena.num_allocations(), 1);  // refA owns 1 allocation
 
-        TypeParam refB;
+    TypeParam refB;
 
-        EXPECT_EQ(arena.num_allocations(), 1); // refB has made no allocations
+    EXPECT_EQ(arena.num_allocations(), 1);  // refB has made no allocations
 
-        refB = refA;
+    refB = refA;
 
-        EXPECT_EQ(arena.num_allocations(), 1); // refB is sharing refA's allocation
+    EXPECT_EQ(arena.num_allocations(), 1);  // refB is sharing refA's allocation
 
-        refA = TypeParam();
+    refA = TypeParam();
 
-        EXPECT_EQ(arena.num_allocations(), 1); // refB now exclusively owns the allocation
+    EXPECT_EQ(arena.num_allocations(),
+              1);  // refB now exclusively owns the allocation
 
-        refB = refB;
+    refB = refB;
 
-        EXPECT_EQ(arena.num_allocations(), 1);
-    }
+    EXPECT_EQ(arena.num_allocations(), 1);
+  }
 
-    EXPECT_EQ(arena.num_allocations(), 0);
+  EXPECT_EQ(arena.num_allocations(), 0);
 }

--- a/gapil/runtime/cc/runtime.cpp
+++ b/gapil/runtime/cc/runtime.cpp
@@ -18,9 +18,9 @@
 #include "core/cc/log.h"
 #include "core/memory/arena/cc/arena.h"
 
+#include <stdarg.h>
 #include <stddef.h>
 #include <stdlib.h>
-#include <stdarg.h>
 
 #if TARGET_OS == GAPID_OS_ANDROID
 // for snprintf
@@ -42,8 +42,9 @@ using core::Arena;
 
 namespace {
 
-void* default_pointer_remapper(context* ctx, uintptr_t pointer, uint64_t length) {
-    return reinterpret_cast<void*>(pointer);
+void* default_pointer_remapper(context* ctx, uintptr_t pointer,
+                               uint64_t length) {
+  return reinterpret_cast<void*>(pointer);
 }
 
 void default_code_locator(context* ctx, char** file, uint32_t* line) {}
@@ -51,206 +52,225 @@ void default_code_locator(context* ctx, char** file, uint32_t* line) {}
 static gapil_pointer_remapper* pointer_remapper = &default_pointer_remapper;
 static gapil_get_code_location* code_locator = &default_code_locator;
 
-} // anonymous namespace
+}  // anonymous namespace
 
 extern "C" {
 
 // sets the pointer remapper callback used to remap serialized pointers to a
 // pointer in an allocated buffer.
 void gapil_set_pointer_remapper(gapil_pointer_remapper* cb) {
-    pointer_remapper = cb != nullptr ? cb : &default_pointer_remapper;
+  pointer_remapper = cb != nullptr ? cb : &default_pointer_remapper;
 }
 
 // sets the callback used to fetch the file and line location for the current
 // source location within the .api file.
 void gapil_set_code_locator(gapil_get_code_location* cb) {
-    code_locator = cb != nullptr ? cb : &default_code_locator;
+  code_locator = cb != nullptr ? cb : &default_code_locator;
 }
 
 void gapil_logf(context* ctx, uint8_t severity, uint8_t* fmt, ...) {
-    severity = 5 - severity; // core/log/severity.go is in reverse order to log.h! :(
-    if GAPID_SHOULD_LOG(severity) {
-        va_list args;
-        va_start(args, fmt);
-        char* file = nullptr;
-        uint32_t line = 0;
-        code_locator(ctx, &file, &line);
+  // core/log/severity.go is in reverse order to log.h! :(
+  severity = 5 - severity;
+  if (GAPID_SHOULD_LOG(severity)) {
+    va_list args;
+    va_start(args, fmt);
+    char* file = nullptr;
+    uint32_t line = 0;
+    code_locator(ctx, &file, &line);
 #if TARGET_OS == GAPID_OS_ANDROID
-        char buf[2048];
-        snprintf(buf, sizeof(buf), "[%s:%u] %s", file ? file : "<unknown>", line, fmt);
-        __android_log_vprint(severity, "GAPID", buf, args);
+    char buf[2048];
+    snprintf(buf, sizeof(buf), "[%s:%u] %s", file ? file : "<unknown>", line,
+             fmt);
+    __android_log_vprint(severity, "GAPID", buf, args);
 #else
-        ::core::Logger::instance().vlogf(severity, file ? file : "<unknown>", line, reinterpret_cast<const char*>(fmt), args);
-#endif // TARGET_OS
-        if (file != nullptr) {
-            free(file);
-        }
-        va_end(args);
+    ::core::Logger::instance().vlogf(severity, file ? file : "<unknown>", line,
+                                     reinterpret_cast<const char*>(fmt), args);
+#endif  // TARGET_OS
+    if (file != nullptr) {
+      free(file);
     }
+    va_end(args);
+  }
 }
 
 void* gapil_alloc(arena_t* a, uint64_t size, uint64_t align) {
-    Arena* arena = reinterpret_cast<Arena*>(a);
-    void* ptr = arena->allocate(size, align);
-    DEBUG_PRINT("gapil_alloc(size: 0x%" PRIx64 ", align: 0x%" PRIx64 ") -> %p", size, align, ptr);
-    return ptr;
+  Arena* arena = reinterpret_cast<Arena*>(a);
+  void* ptr = arena->allocate(size, align);
+  DEBUG_PRINT("gapil_alloc(size: 0x%" PRIx64 ", align: 0x%" PRIx64 ") -> %p",
+              size, align, ptr);
+  return ptr;
 }
 
 void* gapil_realloc(arena_t* a, void* ptr, uint64_t size, uint64_t align) {
-    Arena* arena = reinterpret_cast<Arena*>(a);
-    void* retptr = arena->reallocate(ptr, size, align);
-    DEBUG_PRINT("gapil_realloc(ptr: %p, 0x%" PRIx64 ", align: 0x%" PRIx64 ") -> %p", ptr, size, align, retptr);
-    return retptr;
+  Arena* arena = reinterpret_cast<Arena*>(a);
+  void* retptr = arena->reallocate(ptr, size, align);
+  DEBUG_PRINT("gapil_realloc(ptr: %p, 0x%" PRIx64 ", align: 0x%" PRIx64
+              ") -> %p",
+              ptr, size, align, retptr);
+  return retptr;
 }
 
 void gapil_free(arena_t* a, void* ptr) {
-    DEBUG_PRINT("gapil_free(ptr: %p)", ptr);
+  DEBUG_PRINT("gapil_free(ptr: %p)", ptr);
 
-    Arena* arena = reinterpret_cast<Arena*>(a);
-    arena->free(ptr);
+  Arena* arena = reinterpret_cast<Arena*>(a);
+  arena->free(ptr);
 }
 
 pool* gapil_make_pool(context* ctx, uint64_t size) {
-    Arena* arena = reinterpret_cast<Arena*>(ctx->arena);
+  Arena* arena = reinterpret_cast<Arena*>(ctx->arena);
 
-    void* buffer = arena->allocate(size, 16);
-    memset(buffer, 0, size);
+  void* buffer = arena->allocate(size, 16);
+  memset(buffer, 0, size);
 
-    auto pool = arena->create<pool_t>();
-    pool->arena = ctx->arena;
-    pool->id = (*ctx->next_pool_id)++;
-    pool->size = size;
-    pool->ref_count = 1;
-    pool->buffer = buffer;
+  auto pool = arena->create<pool_t>();
+  pool->arena = ctx->arena;
+  pool->id = (*ctx->next_pool_id)++;
+  pool->size = size;
+  pool->ref_count = 1;
+  pool->buffer = buffer;
 
-    DEBUG_PRINT("gapil_make_pool(size: 0x%" PRIx64 ") -> [pool: %p, buffer: %p]", size, pool, buffer);
-    return pool;
+  DEBUG_PRINT("gapil_make_pool(size: 0x%" PRIx64 ") -> [pool: %p, buffer: %p]",
+              size, pool, buffer);
+  return pool;
 }
 
 void gapil_free_pool(pool* pool) {
-    DEBUG_PRINT("gapil_free_pool(pool: %p)", pool);
+  DEBUG_PRINT("gapil_free_pool(pool: %p)", pool);
 
-    if (pool == nullptr) { // Application pool.
-        // TODO: Panic?
-        return;
-    }
+  if (pool == nullptr) {  // Application pool.
+    // TODO: Panic?
+    return;
+  }
 
-    Arena* arena = reinterpret_cast<Arena*>(pool->arena);
-    arena->free(pool->buffer);
-    arena->destroy(pool);
+  Arena* arena = reinterpret_cast<Arena*>(pool->arena);
+  arena->free(pool->buffer);
+  arena->destroy(pool);
 }
 
 void gapil_copy_slice(context* ctx, slice* dst, slice* src) {
-    DEBUG_PRINT("gapil_copy_slice(ctx: %p,\n"
-                "                 dst: [pool: %p, root: %p, base: %p, size: 0x%" PRIx64 "],\n"
-                "                 src: [pool: %p, root: %p, base: %p, size: 0x%" PRIx64 "])",
-            ctx,
-            dst->pool, dst->root, dst->base, dst->size,
-            src->pool, src->root, src->base, src->size);
+  DEBUG_PRINT(
+      "gapil_copy_slice(ctx: %p,\n"
+      "    dst: [pool: %p, root: %p, base: %p, size: 0x%" PRIx64
+      "],\n"
+      "    src: [pool: %p, root: %p, base: %p, size: 0x%" PRIx64 "])",
+      ctx, dst->pool, dst->root, dst->base, dst->size, src->pool, src->root,
+      src->base, src->size);
 
-    auto size = std::min(dst->size, src->size);
-    memcpy(dst->base, src->base, size);
+  auto size = std::min(dst->size, src->size);
+  memcpy(dst->base, src->base, size);
 }
 
-void gapil_pointer_to_slice(context* ctx, uintptr_t ptr, uint64_t offset, uint64_t size, uint64_t count, slice* out) {
-    DEBUG_PRINT("gapil_pointer_to_slice(ptr: 0x%" PRIx64 ", offset: 0x%" PRIx64 ", size: 0x%" PRIx64 ", count: 0x%" PRIx64 ")",
-            ptr, offset, size, count);
+void gapil_pointer_to_slice(context* ctx, uintptr_t ptr, uint64_t offset,
+                            uint64_t size, uint64_t count, slice* out) {
+  DEBUG_PRINT("gapil_pointer_to_slice(ptr: 0x%" PRIx64 ", offset: 0x%" PRIx64
+              ", size: 0x%" PRIx64 ", count: 0x%" PRIx64 ")",
+              ptr, offset, size, count);
 
-    auto end = ptr + offset + size;
-    auto root = reinterpret_cast<uint8_t*>(pointer_remapper(ctx, ptr, end - ptr));
-    auto base = root + offset;
+  auto end = ptr + offset + size;
+  auto root = reinterpret_cast<uint8_t*>(pointer_remapper(ctx, ptr, end - ptr));
+  auto base = root + offset;
 
-    out->pool = nullptr; // application pool
-    out->root = root;
-    out->base = base;
-    out->size = size;
-    out->count = count;
+  out->pool = nullptr;  // application pool
+  out->root = root;
+  out->base = base;
+  out->size = size;
+  out->count = count;
 }
 
 string* gapil_pointer_to_string(context* ctx, uintptr_t ptr) {
-    DEBUG_PRINT("gapil_pointer_to_string(ptr: 0x%" PRIx64 ")", ptr);
+  DEBUG_PRINT("gapil_pointer_to_string(ptr: 0x%" PRIx64 ")", ptr);
 
-    auto data = reinterpret_cast<char*>(pointer_remapper(ctx, ptr, 1));
-    auto len = strlen(data);
+  auto data = reinterpret_cast<char*>(pointer_remapper(ctx, ptr, 1));
+  auto len = strlen(data);
 
-    return gapil_make_string(ctx->arena, len, data);
+  return gapil_make_string(ctx->arena, len, data);
 }
 
 string* gapil_make_string(arena* a, uint64_t length, void* data) {
-    Arena* arena = reinterpret_cast<Arena*>(a);
+  Arena* arena = reinterpret_cast<Arena*>(a);
 
-    auto str = reinterpret_cast<string_t*>(arena->allocate(sizeof(string_t) + length + 1, 1));
-    str->arena = a;
-    str->ref_count = 1;
-    str->length = length;
+  auto str = reinterpret_cast<string_t*>(
+      arena->allocate(sizeof(string_t) + length + 1, 1));
+  str->arena = a;
+  str->ref_count = 1;
+  str->length = length;
 
-    if (data != nullptr) {
-        memcpy(str->data, data, length);
-        str->data[length] = 0;
-    } else {
-        memset(str->data, 0, length + 1);
-    }
+  if (data != nullptr) {
+    memcpy(str->data, data, length);
+    str->data[length] = 0;
+  } else {
+    memset(str->data, 0, length + 1);
+  }
 
-    DEBUG_PRINT("gapil_make_string(arena: %p, length: %" PRIu64 ", data: '%s') -> %p",
-            a, length, data, str);
+  DEBUG_PRINT("gapil_make_string(arena: %p, length: %" PRIu64
+              ", data: '%s') -> %p",
+              a, length, data, str);
 
-    return str;
+  return str;
 }
 
 void gapil_free_string(string* str) {
-    DEBUG_PRINT("gapil_free_string(str: %p, ref_count: %" PRIu32 ", len: %" PRIu64 ", str: '%s' (%p))",
-            str, str->ref_count, str->length, str->data, str->data);
+  DEBUG_PRINT("gapil_free_string(str: %p, ref_count: %" PRIu32 ", len: %" PRIu64
+              ", str: '%s' (%p))",
+              str, str->ref_count, str->length, str->data, str->data);
 
-    Arena* arena = reinterpret_cast<Arena*>(str->arena);
-    arena->free(str);
+  Arena* arena = reinterpret_cast<Arena*>(str->arena);
+  arena->free(str);
 }
 
 string* gapil_slice_to_string(context* ctx, slice* slice) {
-    DEBUG_PRINT("gapil_slice_to_string(base: %p, size: 0x%" PRIx64 ", pool: %p)",
-            slice->base, slice->size, slice->pool);
+  DEBUG_PRINT("gapil_slice_to_string(base: %p, size: 0x%" PRIx64 ", pool: %p)",
+              slice->base, slice->size, slice->pool);
 
-    return gapil_make_string(ctx->arena, slice->size, slice->base);
+  return gapil_make_string(ctx->arena, slice->size, slice->base);
 }
 
 void gapil_string_to_slice(context* ctx, string* str, slice* out) {
-    DEBUG_PRINT("gapil_string_to_slice(str: '%s')", str->data);
+  DEBUG_PRINT("gapil_string_to_slice(str: '%s')", str->data);
 
-    auto pool = gapil_make_pool(ctx, str->length);
+  auto pool = gapil_make_pool(ctx, str->length);
 
-    memcpy(pool->buffer, str->data, str->length);
+  memcpy(pool->buffer, str->data, str->length);
 
-    out->pool = pool;
-    out->base = pool->buffer;
-    out->root = pool->buffer;
-    out->size = str->length;
-    out->count = str->length;
+  out->pool = pool;
+  out->base = pool->buffer;
+  out->root = pool->buffer;
+  out->size = str->length;
+  out->count = str->length;
 }
 
 string* gapil_string_concat(string* a, string* b) {
-    DEBUG_PRINT("gapil_string_concat(a: '%s', b: '%s')", a->data, b->data);
+  DEBUG_PRINT("gapil_string_concat(a: '%s', b: '%s')", a->data, b->data);
 
-    if (a->length == 0) { b->ref_count++; return b; }
-    if (b->length == 0) { a->ref_count++; return a; }
+  if (a->length == 0) {
+    b->ref_count++;
+    return b;
+  }
+  if (b->length == 0) {
+    a->ref_count++;
+    return a;
+  }
 
-    GAPID_ASSERT_MSG(a->arena != nullptr, "string concat using string with no arena");
-    GAPID_ASSERT_MSG(b->arena != nullptr, "string concat using string with no arena");
+  GAPID_ASSERT_MSG(a->arena != nullptr,
+                   "string concat using string with no arena");
+  GAPID_ASSERT_MSG(b->arena != nullptr,
+                   "string concat using string with no arena");
 
-    auto str = gapil_make_string(a->arena, a->length + b->length, nullptr);
-    memcpy(str->data, a->data, a->length);
-    memcpy(str->data + a->length, b->data, b->length);
-    return str;
+  auto str = gapil_make_string(a->arena, a->length + b->length, nullptr);
+  memcpy(str->data, a->data, a->length);
+  memcpy(str->data + a->length, b->data, b->length);
+  return str;
 }
 
 int32_t gapil_string_compare(string* a, string* b) {
-    DEBUG_PRINT("gapil_string_compare(a: '%s', b: '%s')", a->data, b->data);
-    if (a == b) {
-        return 0;
-    }
-    return strncmp(
-        reinterpret_cast<const char*>(a->data),
-        reinterpret_cast<const char*>(b->data),
-        std::max(a->length, b->length)
-    );
+  DEBUG_PRINT("gapil_string_compare(a: '%s', b: '%s')", a->data, b->data);
+  if (a == b) {
+    return 0;
+  }
+  return strncmp(reinterpret_cast<const char*>(a->data),
+                 reinterpret_cast<const char*>(b->data),
+                 std::max(a->length, b->length));
 }
 
 }  // extern "C"

--- a/gapil/runtime/cc/runtime.h
+++ b/gapil/runtime/cc/runtime.h
@@ -15,106 +15,107 @@
 #ifndef __GAPIL_RUNTIME_H__
 #define __GAPIL_RUNTIME_H__
 
-#include <stdint.h>
 #include <stddef.h>
+#include <stdint.h>
 
 #ifdef __cplusplus
 extern "C" {
-#endif // __cplusplus
+#endif  // __cplusplus
 
-typedef struct arena_t   arena;
-typedef struct pool_t    pool;
+typedef struct arena_t arena;
+typedef struct pool_t pool;
 typedef struct globals_t globals;
-typedef struct string_t  string;
+typedef struct string_t string;
 
 #define GAPIL_ERR_SUCCESS 0
 #define GAPIL_ERR_ABORTED 1
 
 #define GAPIL_MAP_ELEMENT_EMPTY 0
-#define GAPIL_MAP_ELEMENT_FULL  1
-#define GAPIL_MAP_ELEMENT_USED  2
+#define GAPIL_MAP_ELEMENT_FULL 1
+#define GAPIL_MAP_ELEMENT_USED 2
 
 #define GAPIL_MAP_GROW_MULTIPLIER 2
-#define GAPIL_MIN_MAP_SIZE        16
-#define GAPIL_MAP_MAX_CAPACITY    0.8f
+#define GAPIL_MIN_MAP_SIZE 16
+#define GAPIL_MAP_MAX_CAPACITY 0.8f
 
 // context contains information about the environment in which a function is
 // executing.
 typedef struct context_t {
-	uint32_t    id;            // the context identifier. Can be treated as user-data.
-	uint32_t    location;      // the API source location.
-	uint64_t    cmd_id;        // the current command identifier.
-	uint32_t*   next_pool_id;  // the identifier of the next pool to be created.
-	globals*    globals;       // a pointer to the global state.
-	arena*      arena;         // the memory arena used for allocations.
-	void*       arguments;     // the arguments to the currently executing command.
-	// additional data used by compiler plugins goes here.
+  uint32_t id;        // the context identifier. Can be treated as user-data.
+  uint32_t location;  // the API source location.
+  uint64_t cmd_id;    // the current command identifier.
+  uint32_t* next_pool_id;  // the identifier of the next pool to be created.
+  globals* globals;        // a pointer to the global state.
+  arena* arena;            // the memory arena used for allocations.
+  void* arguments;         // the arguments to the currently executing command.
+  // additional data used by compiler plugins goes here.
 } context;
 
 // pool describes the underlying buffer that may be used by one or more slices.
 typedef struct pool_t {
-	uint32_t ref_count; // number of owners of this pool.
-	uint32_t id;        // unique identifier of this pool.
-	uint64_t size;      // total size of the pool in bytes.
-	arena*   arena;     // arena that owns the allocation of this pool and its buffer.
-	void*    buffer;    // nullptr for application pool
+  uint32_t ref_count;  // number of owners of this pool.
+  uint32_t id;         // unique identifier of this pool.
+  uint64_t size;       // total size of the pool in bytes.
+  arena* arena;  // arena that owns the allocation of this pool and its buffer.
+  void* buffer;  // nullptr for application pool
 } pool;
 
 // slice is the data of a gapil slice type (elty foo[]).
 typedef struct slice_t {
-	pool*    pool;  // the underlying pool. nullptr represents the application pool.
-	void*    root;  // original pointer this slice derives from.
-	void*    base;  // address of first element.
-	uint64_t size;  // size in bytes of the slice.
-	uint64_t count; // total number of elements in the slice.
+  pool* pool;  // the underlying pool. nullptr represents the application pool.
+  void* root;  // original pointer this slice derives from.
+  void* base;  // address of first element.
+  uint64_t size;   // size in bytes of the slice.
+  uint64_t count;  // total number of elements in the slice.
 } slice;
 
 // string is the shared data of a gapil string type.
 // A string is a pointer to this struct.
 typedef struct string_t {
-	uint32_t ref_count; // number of owners of this string.
-	arena*   arena;     // arena that owns this string allocation.
-	uint64_t length;    // size in bytes of this string (including null-terminator).
-	uint8_t  data[1];   // the null-terminated string bytes.
+  uint32_t ref_count;  // number of owners of this string.
+  arena* arena;        // arena that owns this string allocation.
+  uint64_t length;  // size in bytes of this string (including null-terminator).
+  uint8_t data[1];  // the null-terminated string bytes.
 } string;
 
 // map is the shared data of a gapil map type.
 // A map is a pointer to this struct.
 typedef struct map_t {
-	uint32_t ref_count; // number of owners of this map.
-	arena*   arena;     // arena that owns this map allocation and its elements buffer.
-	uint64_t count;     // number of elements in the map.
-	uint64_t capacity;  // size of the elements buffer.
-	void*    elements;  // pointer to the elements buffer.
+  uint32_t ref_count;  // number of owners of this map.
+  arena* arena;  // arena that owns this map allocation and its elements buffer.
+  uint64_t count;     // number of elements in the map.
+  uint64_t capacity;  // size of the elements buffer.
+  void* elements;     // pointer to the elements buffer.
 } map;
 
 // ref is the shared data of a gapil ref!T type.
 // A ref is a pointer to this struct.
 typedef struct ref_t {
-	uint32_t ref_count; // number of owners of this ref.
-	arena*   arena;     // arena that owns this ref allocation.
-	/* T */             // referenced object immediately follows.
+  uint32_t ref_count;  // number of owners of this ref.
+  arena* arena;        // arena that owns this ref allocation.
+  /* T */              // referenced object immediately follows.
 } ref;
 
 // buffer is a structure used to hold a variable size byte array.
 // buffer is used internally by the compiler to write out variable length data.
 typedef struct buffer_t {
-	uint8_t* data;      // buffer data.
-	uint32_t capacity;  // total capacity of the buffer.
-	uint32_t size;      // current size of the buffer.
+  uint8_t* data;      // buffer data.
+  uint32_t capacity;  // total capacity of the buffer.
+  uint32_t size;      // current size of the buffer.
 } buffer;
 
 typedef uint8_t GAPIL_BOOL;
 
 #define GAPIL_FALSE 0
-#define GAPIL_TRUE  1
+#define GAPIL_TRUE 1
 
 ////////////////////////////////////////////////////////////////////////////////
 // Functions to be implemented by the user of the runtime                     //
 ////////////////////////////////////////////////////////////////////////////////
 
 // callback to map the serialized pointer to a pointer in an allocated buffer.
-typedef void* gapil_pointer_remapper(context* ctx, uintptr_t pointer, uint64_t length);
+typedef void* gapil_pointer_remapper(context* ctx, uintptr_t pointer,
+                                     uint64_t length);
 
 // assigns to file and line the current source location within the .api file.
 // if there is no current source location then file and line are unassigned.
@@ -148,7 +149,6 @@ void gapil_set_pointer_remapper(gapil_pointer_remapper*);
 // source location within the .api file.
 void gapil_set_code_locator(gapil_get_code_location*);
 
-
 #ifndef DECL_GAPIL_CB
 #define DECL_GAPIL_CB(RETURN, NAME, ...) RETURN NAME(__VA_ARGS__)
 #endif
@@ -158,7 +158,8 @@ DECL_GAPIL_CB(void*, gapil_alloc, arena*, uint64_t size, uint64_t align);
 
 // re-allocates a buffer previously allocated with the arena to a new size and
 // alignment.
-DECL_GAPIL_CB(void*, gapil_realloc, arena*, void* ptr, uint64_t size, uint64_t align);
+DECL_GAPIL_CB(void*, gapil_realloc, arena*, void* ptr, uint64_t size,
+              uint64_t align);
 
 // frees a buffer previously allocated with gapil_alloc or gapil_realloc.
 DECL_GAPIL_CB(void, gapil_free, arena*, void* ptr);
@@ -168,7 +169,8 @@ DECL_GAPIL_CB(pool*, gapil_make_pool, context* ctx, uint64_t size);
 
 // allocates a new slice and underlying pool filled with data from the given
 // base pointer, offset and size.
-DECL_GAPIL_CB(void, gapil_pointer_to_slice, context* ctx, uintptr_t ptr, uint64_t offset, uint64_t size, uint64_t count, slice* out);
+DECL_GAPIL_CB(void, gapil_pointer_to_slice, context* ctx, uintptr_t ptr,
+              uint64_t offset, uint64_t size, uint64_t count, slice* out);
 
 // frees a pool previously allocated with gapil_make_pool, gapil_string_to_slice
 // or gapil_pointer_to_slice.
@@ -178,7 +180,8 @@ DECL_GAPIL_CB(void, gapil_free_pool, pool*);
 DECL_GAPIL_CB(void, gapil_copy_slice, context* ctx, slice* dst, slice* src);
 
 // allocates a new slice and underlying pool filled with the data of string.
-DECL_GAPIL_CB(void, gapil_string_to_slice, context* ctx, string* string, slice* out);
+DECL_GAPIL_CB(void, gapil_string_to_slice, context* ctx, string* string,
+              slice* out);
 
 // allocates a new string with the given data and length.
 // length excludes a null-pointer.
@@ -211,16 +214,18 @@ DECL_GAPIL_CB(void, gapil_apply_writes, context* ctx);
 
 // calls an extern function with the given name and pointer to arguments.
 // If the extern returns a value, this is placed in res.
-DECL_GAPIL_CB(void, gapil_call_extern, context* ctx, string* name, void* args, void* res);
+DECL_GAPIL_CB(void, gapil_call_extern, context* ctx, string* name, void* args,
+              void* res);
 
 // logs a message to the current logger.
 // fmt is a printf-style message.
-DECL_GAPIL_CB(void, gapil_logf, context* ctx, uint8_t severity, uint8_t* fmt, ...);
+DECL_GAPIL_CB(void, gapil_logf, context* ctx, uint8_t severity, uint8_t* fmt,
+              ...);
 
 #undef DECL_GAPIL_CB
 
 #ifdef __cplusplus
-} // extern "C"
-#endif // __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
 
 #endif  // __GAPIL_RUNTIME_H__

--- a/gapil/runtime/cc/slice.h
+++ b/gapil/runtime/cc/slice.h
@@ -31,81 +31,85 @@ namespace gapil {
 // underlying data.
 template <typename T>
 class Slice {
-public:
-    // Constructs a slice that points to nothing.
-    inline Slice();
+ public:
+  // Constructs a slice that points to nothing.
+  inline Slice();
 
-    // Constructs a slice which shares ownership over the data with other.
-    inline Slice(const Slice<T>& other);
+  // Constructs a slice which shares ownership over the data with other.
+  inline Slice(const Slice<T>& other);
 
-    // Constructs a new slice and pool sized to the given number of elements.
-    inline Slice(T* base, uint64_t count);
+  // Constructs a new slice and pool sized to the given number of elements.
+  inline Slice(T* base, uint64_t count);
 
-    // Constructs a new slice given the full explicit parameters.
-    inline Slice(pool_t* pool, void* root, void* base, uint64_t size, uint64_t count, bool add_ref = true);
+  // Constructs a new slice given the full explicit parameters.
+  inline Slice(pool_t* pool, void* root, void* base, uint64_t size,
+               uint64_t count, bool add_ref = true);
 
-    // Creates and returns a new slice wrapping the given pool.
-    // If add_ref is true then the pool's reference count will be incremented.
-    inline static Slice create(pool_t* pool, bool add_ref);
+  // Creates and returns a new slice wrapping the given pool.
+  // If add_ref is true then the pool's reference count will be incremented.
+  inline static Slice create(pool_t* pool, bool add_ref);
 
-    // Creates and returns a new slice and pool sized to the given number of
-    // elements.
-    inline static Slice create(context_t* ctx, uint64_t count);
+  // Creates and returns a new slice and pool sized to the given number of
+  // elements.
+  inline static Slice create(context_t* ctx, uint64_t count);
 
-    inline Slice(Slice<T>&&);
-    inline ~Slice();
+  inline Slice(Slice<T>&&);
+  inline ~Slice();
 
-    // Copy assignment
-    inline Slice<T>& operator = (const Slice<T>& other);
+  // Copy assignment
+  inline Slice<T>& operator=(const Slice<T>& other);
 
-    // Equality operator.
-    inline bool operator == (const Slice<T>& other) const;
+  // Equality operator.
+  inline bool operator==(const Slice<T>& other) const;
 
-    // Returns the number of elements in the slice.
-    inline uint64_t count() const;
+  // Returns the number of elements in the slice.
+  inline uint64_t count() const;
 
-    // Returns the size of the slice in bytes.
-    inline uint64_t size() const;
+  // Returns the size of the slice in bytes.
+  inline uint64_t size() const;
 
-    // Returns true if this is a slice on the application pool (external memory).
-    inline bool is_app_pool() const;
+  // Returns true if this is a slice on the application pool (external memory).
+  inline bool is_app_pool() const;
 
-    // Returns the underlying pool identifier.
-    inline uint32_t pool_id() const;
+  // Returns the underlying pool identifier.
+  inline uint32_t pool_id() const;
 
-    // Returns the underlying pool.
-    inline const pool_t* pool() const;
+  // Returns the underlying pool.
+  inline const pool_t* pool() const;
 
-    // Returns true if the slice contains the specified value.
-    inline bool contains(const T& value) const;
+  // Returns true if the slice contains the specified value.
+  inline bool contains(const T& value) const;
 
-    // Returns a new subset slice from this slice.
-    inline Slice<T> operator()(uint64_t start, uint64_t end) const;
+  // Returns a new subset slice from this slice.
+  inline Slice<T> operator()(uint64_t start, uint64_t end) const;
 
-    // Returns a reference to a single element in the slice.
-    // Care must be taken to not mutate data in the application pool.
-    inline T& operator[](uint64_t index) const;
+  // Returns a reference to a single element in the slice.
+  // Care must be taken to not mutate data in the application pool.
+  inline T& operator[](uint64_t index) const;
 
-    // Copies count elements starting at start into the dst Slice starting at
-    // dstStart.
-    inline void copy(const Slice<T>& dst, uint64_t start, uint64_t count, uint64_t dstStart) const;
+  // Copies count elements starting at start into the dst Slice starting at
+  // dstStart.
+  inline void copy(const Slice<T>& dst, uint64_t start, uint64_t count,
+                   uint64_t dstStart) const;
 
-    // Casts this slice to a slice of type U.
-    // The return slice length will be calculated so that the returned slice length is no longer
-    // (in bytes) than this slice.
-    template<typename U> inline Slice<U> as() const;
+  // Casts this slice to a slice of type U.
+  // The return slice length will be calculated so that the returned slice
+  // length is no longer (in bytes) than this slice.
+  template <typename U>
+  inline Slice<U> as() const;
 
-    // Support for range-based for looping
-    inline T* begin() const;
-    inline T* end() const;
+  // Support for range-based for looping
+  inline T* begin() const;
+  inline T* end() const;
 
-private:
-    void init(pool_t* pool, void* root, void* base, uint64_t size, uint64_t count, bool add_ref = true);
+ private:
+  void init(pool_t* pool, void* root, void* base, uint64_t size, uint64_t count,
+            bool add_ref = true);
 
-    void reference() const;
-    void release();
+  void reference() const;
+  void release();
 
-    slice_t data;
+  slice_t data;
 };
 
 }  // namespace gapil

--- a/gapil/runtime/cc/slice_test.cpp
+++ b/gapil/runtime/cc/slice_test.cpp
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 #include "slice.inc"
 
 #include "core/memory/arena/cc/arena.h"
@@ -20,49 +19,49 @@
 #include <gtest/gtest.h>
 
 TEST(SliceTest, empty) {
-    gapil::Slice<uint8_t> sli;
+  gapil::Slice<uint8_t> sli;
 
-    EXPECT_EQ(sli.count(), 0);
-    EXPECT_EQ(sli.size(), 0);
-    EXPECT_EQ(sli.is_app_pool(), true);
-    EXPECT_EQ(sli.contains(0), false);
+  EXPECT_EQ(sli.count(), 0);
+  EXPECT_EQ(sli.size(), 0);
+  EXPECT_EQ(sli.is_app_pool(), true);
+  EXPECT_EQ(sli.contains(0), false);
 }
 
 TEST(SliceTest, app_pool) {
-    uint32_t data[] = { 2, 4, 8, 16 };
+  uint32_t data[] = {2, 4, 8, 16};
 
-    gapil::Slice<uint32_t> sli(data, 4);
+  gapil::Slice<uint32_t> sli(data, 4);
 
-    EXPECT_EQ(sli.count(), 4);
-    EXPECT_EQ(sli.size(), 16);
-    EXPECT_EQ(sli.is_app_pool(), true);
-    EXPECT_EQ(sli.contains(0), false);
-    EXPECT_EQ(sli.contains(4), true);
+  EXPECT_EQ(sli.count(), 4);
+  EXPECT_EQ(sli.size(), 16);
+  EXPECT_EQ(sli.is_app_pool(), true);
+  EXPECT_EQ(sli.contains(0), false);
+  EXPECT_EQ(sli.contains(4), true);
 }
 
 TEST(SliceTest, new_pool) {
-    core::Arena arena;
-    context_t ctx;
-    ctx.arena = reinterpret_cast<arena_t*>(&arena);
-    ctx.next_pool_id = arena.create<uint32_t>(1);
+  core::Arena arena;
+  context_t ctx;
+  ctx.arena = reinterpret_cast<arena_t*>(&arena);
+  ctx.next_pool_id = arena.create<uint32_t>(1);
 
-    auto initial_allocs = arena.num_allocations();
+  auto initial_allocs = arena.num_allocations();
 
-    {
-        auto sli = gapil::Slice<uint32_t>::create(&ctx, 4);
-        EXPECT_NE(arena.num_allocations(), initial_allocs);
+  {
+    auto sli = gapil::Slice<uint32_t>::create(&ctx, 4);
+    EXPECT_NE(arena.num_allocations(), initial_allocs);
 
-        sli[0] = 2;
-        sli[1] = 4;
-        sli[2] = 8;
-        sli[3] = 16;
+    sli[0] = 2;
+    sli[1] = 4;
+    sli[2] = 8;
+    sli[3] = 16;
 
-        EXPECT_EQ(sli.count(), 4);
-        EXPECT_EQ(sli.size(), 16);
-        EXPECT_EQ(sli.is_app_pool(), false);
-        EXPECT_EQ(sli.contains(0), false);
-        EXPECT_EQ(sli.contains(4), true);
-    }
+    EXPECT_EQ(sli.count(), 4);
+    EXPECT_EQ(sli.size(), 16);
+    EXPECT_EQ(sli.is_app_pool(), false);
+    EXPECT_EQ(sli.contains(0), false);
+    EXPECT_EQ(sli.contains(4), true);
+  }
 
-    EXPECT_EQ(arena.num_allocations(), initial_allocs); // nothing leaked
+  EXPECT_EQ(arena.num_allocations(), initial_allocs);  // nothing leaked
 }

--- a/gapil/runtime/cc/string.cpp
+++ b/gapil/runtime/cc/string.cpp
@@ -21,114 +21,118 @@
 
 namespace gapil {
 
-string_t String::EMPTY = { 1, nullptr, 0, {0} };
+string_t String::EMPTY = {1, nullptr, 0, {0}};
 
 String::String() {
-    ptr = &EMPTY;
-    reference();
+  ptr = &EMPTY;
+  reference();
 }
 
 String::String(const String& s) {
-    ptr = s.ptr;
-    reference();
+  ptr = s.ptr;
+  reference();
 }
 
 String::String(String&& s) {
-    ptr = s.ptr;
-    s.ptr = nullptr;
+  ptr = s.ptr;
+  s.ptr = nullptr;
 }
 
 String::String(core::Arena* arena, const char* s) {
-    auto len = strlen(s);
-    ptr = gapil_make_string(reinterpret_cast<arena_t*>(arena), len, const_cast<char*>(s));
+  auto len = strlen(s);
+  ptr = gapil_make_string(reinterpret_cast<arena_t*>(arena), len,
+                          const_cast<char*>(s));
 }
 
 String::String(core::Arena* arena, std::initializer_list<char> s) {
-    ptr = gapil_make_string(reinterpret_cast<arena_t*>(arena), s.size(), const_cast<char*>(s.begin()));
+  ptr = gapil_make_string(reinterpret_cast<arena_t*>(arena), s.size(),
+                          const_cast<char*>(s.begin()));
 }
 
 String::String(core::Arena* arena, const char* start, const char* end) {
-    auto len = end - start;
-    ptr = gapil_make_string(reinterpret_cast<arena_t*>(arena), len, const_cast<char*>(start));
+  auto len = end - start;
+  ptr = gapil_make_string(reinterpret_cast<arena_t*>(arena), len,
+                          const_cast<char*>(start));
 }
 
 String::String(core::Arena* arena, const char* s, size_t len) {
-    ptr = gapil_make_string(reinterpret_cast<arena_t*>(arena), len, const_cast<char*>(s));
+  ptr = gapil_make_string(reinterpret_cast<arena_t*>(arena), len,
+                          const_cast<char*>(s));
 }
 
 String::String(string_t* p) : ptr(p) {}
 
 String::~String() {
-    if (ptr != nullptr) { // note: nullptr is only valid in the case of a move
-        release();
-    }
+  if (ptr != nullptr) {  // note: nullptr is only valid in the case of a move
+    release();
+  }
 }
 
-String& String::operator = (const String& other) {
-    GAPID_ASSERT_MSG(other.ptr->ref_count > 0, "attempting to reference freed string (%s)", other.ptr->data);
-    if (ptr != other.ptr) {
-        release();
-        ptr = other.ptr;
-        reference();
-    }
-    return *this;
+String& String::operator=(const String& other) {
+  GAPID_ASSERT_MSG(other.ptr->ref_count > 0,
+                   "attempting to reference freed string (%s)",
+                   other.ptr->data);
+  if (ptr != other.ptr) {
+    release();
+    ptr = other.ptr;
+    reference();
+  }
+  return *this;
 }
 
-String& String::operator += (const String& other) {
-    auto res = gapil_string_concat(ptr, other.ptr);
-    return *this = String(res);
+String& String::operator+=(const String& other) {
+  auto res = gapil_string_concat(ptr, other.ptr);
+  return *this = String(res);
 }
 
-bool String::operator == (const String& other) const {
-    return gapil_string_compare(ptr, other.ptr) == 0;
+bool String::operator==(const String& other) const {
+  return gapil_string_compare(ptr, other.ptr) == 0;
 }
 
-bool String::operator != (const String& other) const {
-    return gapil_string_compare(ptr, other.ptr) != 0;
+bool String::operator!=(const String& other) const {
+  return gapil_string_compare(ptr, other.ptr) != 0;
 }
 
-bool String::operator < (const String& other) const {
-    return gapil_string_compare(ptr, other.ptr) < 0;
+bool String::operator<(const String& other) const {
+  return gapil_string_compare(ptr, other.ptr) < 0;
 }
 
-bool String::operator <= (const String& other) const {
-    return gapil_string_compare(ptr, other.ptr) <= 0;
+bool String::operator<=(const String& other) const {
+  return gapil_string_compare(ptr, other.ptr) <= 0;
 }
 
-bool String::operator > (const String& other) const {
-    return gapil_string_compare(ptr, other.ptr) > 0;
+bool String::operator>(const String& other) const {
+  return gapil_string_compare(ptr, other.ptr) > 0;
 }
 
-bool String::operator >= (const String& other) const {
-    return gapil_string_compare(ptr, other.ptr) >= 0;
+bool String::operator>=(const String& other) const {
+  return gapil_string_compare(ptr, other.ptr) >= 0;
 }
 
-size_t String::length() const {
-    return ptr->length;
-}
+size_t String::length() const { return ptr->length; }
 
-const char* String::c_str() const {
-    return reinterpret_cast<char*>(ptr->data);
-}
+const char* String::c_str() const { return reinterpret_cast<char*>(ptr->data); }
 
 void String::clear() {
-    release();
-    ptr = &EMPTY;
-    reference();
+  release();
+  ptr = &EMPTY;
+  reference();
 }
 
 void String::release() {
-    GAPID_ASSERT_MSG(ptr->ref_count > 0, "attempting to release freed string (%s)", ptr->data);
-    ptr->ref_count--;
-    if (ptr->ref_count == 0) {
-        gapil_free_string(ptr);
-    }
-    ptr = nullptr;
+  GAPID_ASSERT_MSG(ptr->ref_count > 0,
+                   "attempting to release freed string (%s)", ptr->data);
+  ptr->ref_count--;
+  if (ptr->ref_count == 0) {
+    gapil_free_string(ptr);
+  }
+  ptr = nullptr;
 }
 
 void String::reference() {
-    GAPID_ASSERT_MSG(ptr->ref_count > 0, "attempting to reference freed string (%s)", ptr->data);
-    ptr->ref_count++;
+  GAPID_ASSERT_MSG(ptr->ref_count > 0,
+                   "attempting to reference freed string (%s)", ptr->data);
+  ptr->ref_count++;
 }
 
 }  // namespace gapil

--- a/gapil/runtime/cc/string.h
+++ b/gapil/runtime/cc/string.h
@@ -29,82 +29,82 @@ namespace gapil {
 // the gapil compiler. Strings hold references to their data, and several
 // strings may share the same underlying data.
 class String {
-public:
-    // Constructs a zero length string.
-    String();
+ public:
+  // Constructs a zero length string.
+  String();
 
-    // Constructs a string which shares the data with other.
-    String(const String& other);
+  // Constructs a string which shares the data with other.
+  String(const String& other);
 
-    // Constructs a new string with the given data.
-    String(core::Arena* arena, const char*);
-    String(core::Arena* arena, std::initializer_list<char>);
-    String(core::Arena* arena, const char* start, const char* end);
-    String(core::Arena* arena, const char* start, size_t len);
+  // Constructs a new string with the given data.
+  String(core::Arena* arena, const char*);
+  String(core::Arena* arena, std::initializer_list<char>);
+  String(core::Arena* arena, const char* start, const char* end);
+  String(core::Arena* arena, const char* start, size_t len);
 
-    String(String&&);
-    ~String();
+  String(String&&);
+  ~String();
 
-    // Makes this string refer to the RHS string.
-    String& operator = (const String&);
+  // Makes this string refer to the RHS string.
+  String& operator=(const String&);
 
-    // Appends data to this string.
-    String& operator += (const String&);
+  // Appends data to this string.
+  String& operator+=(const String&);
 
-    // Comparison operators. Strings are compared using their underlying data.
-    bool operator == (const String& other) const;
-    bool operator != (const String& other) const;
-    bool operator < (const String& other) const;
-    bool operator <= (const String& other) const;
-    bool operator > (const String& other) const;
-    bool operator >= (const String& other) const;
+  // Comparison operators. Strings are compared using their underlying data.
+  bool operator==(const String& other) const;
+  bool operator!=(const String& other) const;
+  bool operator<(const String& other) const;
+  bool operator<=(const String& other) const;
+  bool operator>(const String& other) const;
+  bool operator>=(const String& other) const;
 
-    // Returns the length of the string in bytes.
-    size_t length() const;
+  // Returns the length of the string in bytes.
+  size_t length() const;
 
-    // Returns a c-style string.
-    const char* c_str() const;
+  // Returns a c-style string.
+  const char* c_str() const;
 
-    // Sets this string to a zero length string.
-    void clear();
+  // Sets this string to a zero length string.
+  void clear();
 
-    // Returns the arena that owns this string's underlying data.
-    inline core::Arena* arena() const;
+  // Returns the arena that owns this string's underlying data.
+  inline core::Arena* arena() const;
 
-private:
-    static string_t EMPTY;
+ private:
+  static string_t EMPTY;
 
-    String(string_t*);
+  String(string_t*);
 
-    void reference();
-    void release();
+  void reference();
+  void release();
 
-    string_t* ptr;
+  string_t* ptr;
 };
 
 inline core::Arena* String::arena() const {
-    return reinterpret_cast<core::Arena*>(ptr->arena);
+  return reinterpret_cast<core::Arena*>(ptr->arena);
 }
 
 }  // namespace gapil
 
-
 namespace std {
-template <> struct hash<gapil::String> {
-    typedef gapil::String argument_type;
-    typedef std::size_t result_type;
-    result_type operator()(const argument_type& s) const noexcept {
-        auto len = s.length();
-        result_type hash = 0x32980321;
-        if (auto p = s.c_str()) {
-            for (size_t i = 0; i < len; i++) {
-                hash = hash * 33 ^ p[i];
-            }
-        }
-        return hash;
+template <>
+struct hash<gapil::String> {
+  typedef gapil::String argument_type;
+  typedef std::size_t result_type;
+  result_type operator()(const argument_type& s) const noexcept {
+    auto len = s.length();
+    result_type hash = 0x32980321;
+    if (auto p = s.c_str()) {
+      for (size_t i = 0; i < len; i++) {
+        hash = hash * 33 ^ p[i];
+      }
     }
+    return hash;
+  }
 };
 
-} // namespace std
+}  // namespace std
 
 #endif  // __GAPIL_RUNTIME_STRING_H__

--- a/gapil/runtime/cc/string_test.cpp
+++ b/gapil/runtime/cc/string_test.cpp
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 #include "string.h"
 
 #include "core/memory/arena/cc/arena.h"
@@ -20,170 +19,171 @@
 #include <gtest/gtest.h>
 
 TEST(StringTest, empty) {
-    gapil::String str;
+  gapil::String str;
 
-    EXPECT_EQ(str.length(), 0);
+  EXPECT_EQ(str.length(), 0);
 
-    EXPECT_EQ(str, gapil::String());
+  EXPECT_EQ(str, gapil::String());
 
-    EXPECT_STREQ(str.c_str(), "");
+  EXPECT_STREQ(str.c_str(), "");
 }
 
 TEST(StringTest, constructors) {
-    auto abc123 = "abc123";
-    core::Arena arena;
-    {
-        gapil::String str;
-        EXPECT_EQ(str.length(), 0);
-        EXPECT_STREQ(str.c_str(), "");
-    }
-    {
-        gapil::String strA(&arena, abc123);
-        gapil::String strB(strA);
-        EXPECT_EQ(strB.length(), 6);
-        EXPECT_STREQ(strB.c_str(), abc123);
-    }
-    {
-        gapil::String strA(&arena, abc123);
-        gapil::String strB(std::move(strA));
-        EXPECT_EQ(strB.length(), 6);
-        EXPECT_STREQ(strB.c_str(), abc123);
-    }
-    {
-        gapil::String str(&arena, abc123);
-        EXPECT_EQ(str.length(), 6);
-        EXPECT_STREQ(str.c_str(), abc123);
-    }
-    {
-        gapil::String str(&arena, {'a', 'b', 'c'});
-        EXPECT_EQ(str.length(), 3);
-        EXPECT_STREQ(str.c_str(), "abc");
-    }
-    {
-        gapil::String str(&arena, &abc123[2], &abc123[4]);
-        EXPECT_EQ(str.length(), 2);
-        EXPECT_STREQ(str.c_str(), "c1");
-    }
-    {
-        gapil::String str(&arena, &abc123[2], 3);
-        EXPECT_EQ(str.length(), 3);
-        EXPECT_STREQ(str.c_str(), "c12");
-    }
+  auto abc123 = "abc123";
+  core::Arena arena;
+  {
+    gapil::String str;
+    EXPECT_EQ(str.length(), 0);
+    EXPECT_STREQ(str.c_str(), "");
+  }
+  {
+    gapil::String strA(&arena, abc123);
+    gapil::String strB(strA);
+    EXPECT_EQ(strB.length(), 6);
+    EXPECT_STREQ(strB.c_str(), abc123);
+  }
+  {
+    gapil::String strA(&arena, abc123);
+    gapil::String strB(std::move(strA));
+    EXPECT_EQ(strB.length(), 6);
+    EXPECT_STREQ(strB.c_str(), abc123);
+  }
+  {
+    gapil::String str(&arena, abc123);
+    EXPECT_EQ(str.length(), 6);
+    EXPECT_STREQ(str.c_str(), abc123);
+  }
+  {
+    gapil::String str(&arena, {'a', 'b', 'c'});
+    EXPECT_EQ(str.length(), 3);
+    EXPECT_STREQ(str.c_str(), "abc");
+  }
+  {
+    gapil::String str(&arena, &abc123[2], &abc123[4]);
+    EXPECT_EQ(str.length(), 2);
+    EXPECT_STREQ(str.c_str(), "c1");
+  }
+  {
+    gapil::String str(&arena, &abc123[2], 3);
+    EXPECT_EQ(str.length(), 3);
+    EXPECT_STREQ(str.c_str(), "c12");
+  }
 
-    EXPECT_EQ(arena.num_allocations(), 0); // nothing leaked
+  EXPECT_EQ(arena.num_allocations(), 0);  // nothing leaked
 }
 
 TEST(StringTest, allocs) {
-    core::Arena arena;
+  core::Arena arena;
 
-    {
-        gapil::String str(&arena, "hello world");
+  {
+    gapil::String str(&arena, "hello world");
 
-        EXPECT_EQ(arena.num_allocations(), 1); // str owns 1 allocation
+    EXPECT_EQ(arena.num_allocations(), 1);  // str owns 1 allocation
 
-        EXPECT_EQ(str.length(), 11);
+    EXPECT_EQ(str.length(), 11);
 
-        EXPECT_EQ(str, gapil::String(&arena, "hello world"));
+    EXPECT_EQ(str, gapil::String(&arena, "hello world"));
 
-        EXPECT_EQ(arena.num_allocations(), 1); // temporary has been freed
+    EXPECT_EQ(arena.num_allocations(), 1);  // temporary has been freed
 
-        EXPECT_STREQ(str.c_str(), "hello world");
-    }
+    EXPECT_STREQ(str.c_str(), "hello world");
+  }
 
-    EXPECT_EQ(arena.num_allocations(), 0); // str has fallen out of scope
+  EXPECT_EQ(arena.num_allocations(), 0);  // str has fallen out of scope
 }
 
 TEST(StringTest, assignment) {
-    core::Arena arena;
+  core::Arena arena;
 
-    {
-        gapil::String strA(&arena, "hello world");
+  {
+    gapil::String strA(&arena, "hello world");
 
-        EXPECT_EQ(arena.num_allocations(), 1); // strA owns 1 allocation
+    EXPECT_EQ(arena.num_allocations(), 1);  // strA owns 1 allocation
 
-        gapil::String strB;
+    gapil::String strB;
 
-        EXPECT_EQ(arena.num_allocations(), 1); // strB has made no allocations
+    EXPECT_EQ(arena.num_allocations(), 1);  // strB has made no allocations
 
-        strB = strA;
+    strB = strA;
 
-        EXPECT_EQ(arena.num_allocations(), 1); // strB is sharing strA's allocation
+    EXPECT_EQ(arena.num_allocations(), 1);  // strB is sharing strA's allocation
 
-        strA = gapil::String();
+    strA = gapil::String();
 
-        EXPECT_EQ(arena.num_allocations(), 1); // strB now exclusively owns the allocation
+    EXPECT_EQ(arena.num_allocations(),
+              1);  // strB now exclusively owns the allocation
 
-        strB = strB;
+    strB = strB;
 
-        EXPECT_EQ(arena.num_allocations(), 1);
+    EXPECT_EQ(arena.num_allocations(), 1);
 
-        EXPECT_STREQ(strB.c_str(), "hello world");
-    }
+    EXPECT_STREQ(strB.c_str(), "hello world");
+  }
 
-    EXPECT_EQ(arena.num_allocations(), 0);
+  EXPECT_EQ(arena.num_allocations(), 0);
 }
 
 TEST(StringTest, concat) {
-    core::Arena arena;
+  core::Arena arena;
 
-    {
-        gapil::String str(&arena, "hello");
-
-        EXPECT_EQ(arena.num_allocations(), 1);
-
-        str += gapil::String(&arena, " world");
-
-        EXPECT_EQ(arena.num_allocations(), 1);
-        EXPECT_EQ(str.length(), 11);
-        EXPECT_STREQ(str.c_str(), "hello world");
-    }
-
-    {
-        gapil::String str(&arena, "meow");
-
-        str += gapil::String();
-
-        EXPECT_EQ(arena.num_allocations(), 1);
-        EXPECT_EQ(str.length(), 4);
-        EXPECT_STREQ(str.c_str(), "meow");
-    }
-
-    {
-        gapil::String str;
-
-        str += gapil::String(&arena, "meow");
-
-        EXPECT_EQ(arena.num_allocations(), 1);
-        EXPECT_EQ(str.length(), 4);
-        EXPECT_STREQ(str.c_str(), "meow");
-    }
-
-    EXPECT_EQ(arena.num_allocations(), 0);
-}
-
-TEST(StringTest, compare) {
-    core::Arena arena;
-
-    gapil::String strA(&arena, "meow");
-    gapil::String strB(&arena, "woof");
-
-    EXPECT_FALSE(strA == strB);
-    EXPECT_TRUE(strA != strB);
-    EXPECT_TRUE(strA <  strB);
-    EXPECT_TRUE(strA <= strB);
-    EXPECT_TRUE(strB >  strA);
-    EXPECT_TRUE(strB >= strA);
-}
-
-TEST(StringTest, clear) {
-    core::Arena arena;
-
+  {
     gapil::String str(&arena, "hello");
 
     EXPECT_EQ(arena.num_allocations(), 1);
 
-    str.clear();
+    str += gapil::String(&arena, " world");
 
-    EXPECT_EQ(arena.num_allocations(), 0);
-    EXPECT_STREQ(str.c_str(), "");
+    EXPECT_EQ(arena.num_allocations(), 1);
+    EXPECT_EQ(str.length(), 11);
+    EXPECT_STREQ(str.c_str(), "hello world");
+  }
+
+  {
+    gapil::String str(&arena, "meow");
+
+    str += gapil::String();
+
+    EXPECT_EQ(arena.num_allocations(), 1);
+    EXPECT_EQ(str.length(), 4);
+    EXPECT_STREQ(str.c_str(), "meow");
+  }
+
+  {
+    gapil::String str;
+
+    str += gapil::String(&arena, "meow");
+
+    EXPECT_EQ(arena.num_allocations(), 1);
+    EXPECT_EQ(str.length(), 4);
+    EXPECT_STREQ(str.c_str(), "meow");
+  }
+
+  EXPECT_EQ(arena.num_allocations(), 0);
+}
+
+TEST(StringTest, compare) {
+  core::Arena arena;
+
+  gapil::String strA(&arena, "meow");
+  gapil::String strB(&arena, "woof");
+
+  EXPECT_FALSE(strA == strB);
+  EXPECT_TRUE(strA != strB);
+  EXPECT_TRUE(strA < strB);
+  EXPECT_TRUE(strA <= strB);
+  EXPECT_TRUE(strB > strA);
+  EXPECT_TRUE(strB >= strA);
+}
+
+TEST(StringTest, clear) {
+  core::Arena arena;
+
+  gapil::String str(&arena, "hello");
+
+  EXPECT_EQ(arena.num_allocations(), 1);
+
+  str.clear();
+
+  EXPECT_EQ(arena.num_allocations(), 0);
+  EXPECT_STREQ(str.c_str(), "");
 }

--- a/gapir/cc/android/gles_renderer.cpp
+++ b/gapir/cc/android/gles_renderer.cpp
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#include "gapir/cc/gles_gfx_api.h"
 #include "gapir/cc/gles_renderer.h"
+#include "gapir/cc/gles_gfx_api.h"
 
 #include "core/cc/gl/formats.h"
 #include "core/cc/log.h"
@@ -26,229 +26,231 @@ namespace gapir {
 namespace {
 
 class GlesRendererImpl : public GlesRenderer {
-public:
-    GlesRendererImpl();
-    virtual ~GlesRendererImpl() override;
+ public:
+  GlesRendererImpl();
+  virtual ~GlesRendererImpl() override;
 
-    virtual Api* api() override;
-    virtual void setBackbuffer(Backbuffer backbuffer) override;
-    virtual void bind() override;
-    virtual void unbind() override;
-    virtual const char* name() override;
-    virtual const char* extensions() override;
-    virtual const char* vendor() override;
-    virtual const char* version() override;
+  virtual Api* api() override;
+  virtual void setBackbuffer(Backbuffer backbuffer) override;
+  virtual void bind() override;
+  virtual void unbind() override;
+  virtual const char* name() override;
+  virtual const char* extensions() override;
+  virtual const char* vendor() override;
+  virtual const char* version() override;
 
-private:
-    void reset();
+ private:
+  void reset();
 
-    Backbuffer mBackbuffer;
-    bool mBound;
-    bool mNeedsResolve;
-    Gles mApi;
+  Backbuffer mBackbuffer;
+  bool mBound;
+  bool mNeedsResolve;
+  Gles mApi;
 
-    EGLContext mContext;
-    EGLSurface mSurface;
-    EGLDisplay mDisplay;
+  EGLContext mContext;
+  EGLSurface mSurface;
+  EGLDisplay mDisplay;
 };
 
 GlesRendererImpl::GlesRendererImpl()
-        : mBound(false)
-        , mNeedsResolve(true)
-        , mContext(EGL_NO_CONTEXT)
-        , mSurface(EGL_NO_SURFACE) {
+    : mBound(false),
+      mNeedsResolve(true),
+      mContext(EGL_NO_CONTEXT),
+      mSurface(EGL_NO_SURFACE) {
+  mDisplay = eglGetDisplay(EGL_DEFAULT_DISPLAY);
+  EGLint error = eglGetError();
+  if (error != EGL_SUCCESS) {
+    GAPID_FATAL("Failed to get EGL display: %d", error);
+  }
 
-    mDisplay = eglGetDisplay(EGL_DEFAULT_DISPLAY);
-    EGLint error = eglGetError();
-    if (error != EGL_SUCCESS) {
-        GAPID_FATAL("Failed to get EGL display: %d", error);
-    }
+  eglInitialize(mDisplay, nullptr, nullptr);
+  error = eglGetError();
+  if (error != EGL_SUCCESS) {
+    GAPID_FATAL("Failed to initialize EGL: %d", error);
+  }
 
-    eglInitialize(mDisplay, nullptr, nullptr);
-    error = eglGetError();
-    if (error != EGL_SUCCESS) {
-        GAPID_FATAL("Failed to initialize EGL: %d", error);
-    }
+  eglBindAPI(EGL_OPENGL_ES_API);
+  error = eglGetError();
+  if (error != EGL_SUCCESS) {
+    GAPID_FATAL("Failed to bind EGL API: %d", error);
+  }
 
-    eglBindAPI(EGL_OPENGL_ES_API);
-    error = eglGetError();
-    if (error != EGL_SUCCESS) {
-        GAPID_FATAL("Failed to bind EGL API: %d", error);
-    }
-
-    // Initialize with a default target.
-    setBackbuffer(Backbuffer(
-          8, 8,
-          core::gl::GL_RGBA8,
-          core::gl::GL_DEPTH24_STENCIL8,
-          core::gl::GL_DEPTH24_STENCIL8));
+  // Initialize with a default target.
+  setBackbuffer(Backbuffer(8, 8, core::gl::GL_RGBA8,
+                           core::gl::GL_DEPTH24_STENCIL8,
+                           core::gl::GL_DEPTH24_STENCIL8));
 }
 
 GlesRendererImpl::~GlesRendererImpl() {
-    reset();
+  reset();
 
-    eglTerminate(mDisplay);
-    EGLint error = eglGetError();
-    if (error != EGL_SUCCESS) {
-        GAPID_WARNING("Failed to terminate EGL: %d", error);
-    }
+  eglTerminate(mDisplay);
+  EGLint error = eglGetError();
+  if (error != EGL_SUCCESS) {
+    GAPID_WARNING("Failed to terminate EGL: %d", error);
+  }
 
-    eglReleaseThread();
-    error = eglGetError();
-    if (error != EGL_SUCCESS) {
-        GAPID_WARNING("Failed to release EGL thread: %d", error);
-    }
+  eglReleaseThread();
+  error = eglGetError();
+  if (error != EGL_SUCCESS) {
+    GAPID_WARNING("Failed to release EGL thread: %d", error);
+  }
 }
 
-Api* GlesRendererImpl::api() {
-  return &mApi;
-}
+Api* GlesRendererImpl::api() { return &mApi; }
 
 void GlesRendererImpl::reset() {
-    unbind();
+  unbind();
 
-    if (mSurface != EGL_NO_SURFACE) {
-        eglDestroySurface(mDisplay, mSurface);
-        EGLint error = eglGetError();
-        if (error != EGL_SUCCESS) {
-            GAPID_WARNING("Failed to destroy EGL surface: %d", error);
-        }
-        mSurface = EGL_NO_SURFACE;
+  if (mSurface != EGL_NO_SURFACE) {
+    eglDestroySurface(mDisplay, mSurface);
+    EGLint error = eglGetError();
+    if (error != EGL_SUCCESS) {
+      GAPID_WARNING("Failed to destroy EGL surface: %d", error);
     }
+    mSurface = EGL_NO_SURFACE;
+  }
 
-    if (mContext != EGL_NO_CONTEXT) {
-        eglDestroyContext(mDisplay, mContext);
-        EGLint error = eglGetError();
-        if (error != EGL_SUCCESS) {
-            GAPID_WARNING("Failed to destroy EGL context: %d", error);
-        }
-        mContext = EGL_NO_CONTEXT;
+  if (mContext != EGL_NO_CONTEXT) {
+    eglDestroyContext(mDisplay, mContext);
+    EGLint error = eglGetError();
+    if (error != EGL_SUCCESS) {
+      GAPID_WARNING("Failed to destroy EGL context: %d", error);
     }
+    mContext = EGL_NO_CONTEXT;
+  }
 
-    mBackbuffer = Backbuffer();
+  mBackbuffer = Backbuffer();
 }
 
 void GlesRendererImpl::setBackbuffer(Backbuffer backbuffer) {
-    if (mContext != EGL_NO_CONTEXT && mBackbuffer == backbuffer) {
-        // No change
-        return;
-    }
+  if (mContext != EGL_NO_CONTEXT && mBackbuffer == backbuffer) {
+    // No change
+    return;
+  }
 
-    // TODO: Check for and handle resizing path.
+  // TODO: Check for and handle resizing path.
 
-    const bool wasBound = mBound;
+  const bool wasBound = mBound;
 
-    reset();
+  reset();
 
-    int r = 8, g = 8, b = 8, a = 8, d = 24, s = 8;
-    core::gl::getColorBits(backbuffer.format.color, r, g, b, a);
-    core::gl::getDepthBits(backbuffer.format.depth, d);
-    core::gl::getStencilBits(backbuffer.format.stencil, s);
+  int r = 8, g = 8, b = 8, a = 8, d = 24, s = 8;
+  core::gl::getColorBits(backbuffer.format.color, r, g, b, a);
+  core::gl::getDepthBits(backbuffer.format.depth, d);
+  core::gl::getStencilBits(backbuffer.format.stencil, s);
 
-    // Find a supported EGL context config.
-    const int configAttribList[] = {
-        EGL_RED_SIZE, r,
-        EGL_GREEN_SIZE, g,
-        EGL_BLUE_SIZE, b,
-        EGL_ALPHA_SIZE, a,
-        EGL_BUFFER_SIZE, r+g+b+a,
-        EGL_DEPTH_SIZE, d,
-        EGL_STENCIL_SIZE, s,
-        EGL_SURFACE_TYPE, EGL_PBUFFER_BIT,
-        EGL_RENDERABLE_TYPE, EGL_OPENGL_ES2_BIT,
-        EGL_NONE
-    };
-    int one = 1;
-    EGLConfig eglConfig;
-    eglChooseConfig(mDisplay, configAttribList, &eglConfig, 1, &one);
-    EGLint error = eglGetError();
-    if (error != EGL_SUCCESS) {
-        GAPID_FATAL("Failed to choose EGL config: %d", error);
-    }
+  // Find a supported EGL context config.
+  const int configAttribList[] = {
+      // clang-format off
+      EGL_RED_SIZE, r,
+      EGL_GREEN_SIZE, g,
+      EGL_BLUE_SIZE, b,
+      EGL_ALPHA_SIZE, a,
+      EGL_BUFFER_SIZE, r+g+b+a,
+      EGL_DEPTH_SIZE, d,
+      EGL_STENCIL_SIZE, s,
+      EGL_SURFACE_TYPE, EGL_PBUFFER_BIT,
+      EGL_RENDERABLE_TYPE, EGL_OPENGL_ES2_BIT,
+      EGL_NONE
+      // clang-format on
+  };
+  int one = 1;
+  EGLConfig eglConfig;
+  eglChooseConfig(mDisplay, configAttribList, &eglConfig, 1, &one);
+  EGLint error = eglGetError();
+  if (error != EGL_SUCCESS) {
+    GAPID_FATAL("Failed to choose EGL config: %d", error);
+  }
 
-    // Create an EGL context.
-    const int contextAttribList[] = {
-        EGL_CONTEXT_CLIENT_VERSION, 2,
-        EGL_NONE
-    };
-    mContext = eglCreateContext(mDisplay, eglConfig, EGL_NO_CONTEXT, contextAttribList);
-    error = eglGetError();
-    if (error != EGL_SUCCESS) {
-        GAPID_FATAL("Failed to create EGL context: %d", error);
-    }
+  // Create an EGL context.
+  const int contextAttribList[] = {
+      // clang-format off
+      EGL_CONTEXT_CLIENT_VERSION, 2,
+      EGL_NONE
+      // clang-format on
+  };
+  mContext =
+      eglCreateContext(mDisplay, eglConfig, EGL_NO_CONTEXT, contextAttribList);
+  error = eglGetError();
+  if (error != EGL_SUCCESS) {
+    GAPID_FATAL("Failed to create EGL context: %d", error);
+  }
 
-    // Create an EGL surface for the read/draw framebuffer.
-    const int surfaceAttribList[] = {
-        EGL_WIDTH, backbuffer.width,
-        EGL_HEIGHT, backbuffer.height,
-        EGL_NONE
-    };
-    mSurface = eglCreatePbufferSurface(mDisplay, eglConfig, surfaceAttribList);
-    error = eglGetError();
-    if (error != EGL_SUCCESS) {
-        GAPID_FATAL("Failed to create EGL pbuffer surface: %d", error);
-    }
+  // Create an EGL surface for the read/draw framebuffer.
+  const int surfaceAttribList[] = {
+      // clang-format off
+      EGL_WIDTH, backbuffer.width,
+      EGL_HEIGHT, backbuffer.height,
+      EGL_NONE
+      // clang-format on
+  };
+  mSurface = eglCreatePbufferSurface(mDisplay, eglConfig, surfaceAttribList);
+  error = eglGetError();
+  if (error != EGL_SUCCESS) {
+    GAPID_FATAL("Failed to create EGL pbuffer surface: %d", error);
+  }
 
-    mBackbuffer = backbuffer;
-    mNeedsResolve = true;
+  mBackbuffer = backbuffer;
+  mNeedsResolve = true;
 
-    if (wasBound) {
-        bind();
-    }
+  if (wasBound) {
+    bind();
+  }
 }
 
 void GlesRendererImpl::bind() {
-    if (!mBound) {
-        eglMakeCurrent(mDisplay, mSurface, mSurface, mContext);
-        EGLint error = eglGetError();
-        if (error != EGL_SUCCESS) {
-            GAPID_FATAL("Failed to make EGL current: %d", error);
-        }
-
-        mBound = true;
-
-        if (mNeedsResolve) {
-            mNeedsResolve = false;
-            mApi.resolve();
-        }
+  if (!mBound) {
+    eglMakeCurrent(mDisplay, mSurface, mSurface, mContext);
+    EGLint error = eglGetError();
+    if (error != EGL_SUCCESS) {
+      GAPID_FATAL("Failed to make EGL current: %d", error);
     }
+
+    mBound = true;
+
+    if (mNeedsResolve) {
+      mNeedsResolve = false;
+      mApi.resolve();
+    }
+  }
 }
 
 void GlesRendererImpl::unbind() {
-    if (mBound) {
-        eglMakeCurrent(mDisplay, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT);
-        EGLint error = eglGetError();
-        if (error != EGL_SUCCESS) {
-            GAPID_WARNING("Failed to release EGL context: %d", error);
-        }
-        mBound = false;
+  if (mBound) {
+    eglMakeCurrent(mDisplay, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT);
+    EGLint error = eglGetError();
+    if (error != EGL_SUCCESS) {
+      GAPID_WARNING("Failed to release EGL context: %d", error);
     }
+    mBound = false;
+  }
 }
 
 const char* GlesRendererImpl::name() {
-    return reinterpret_cast<const char*>(
-        mApi.mFunctionStubs.glGetString(Gles::GLenum::GL_RENDERER));
+  return reinterpret_cast<const char*>(
+      mApi.mFunctionStubs.glGetString(Gles::GLenum::GL_RENDERER));
 }
 
 const char* GlesRendererImpl::extensions() {
-    return reinterpret_cast<const char*>(
-        mApi.mFunctionStubs.glGetString(Gles::GLenum::GL_EXTENSIONS));
+  return reinterpret_cast<const char*>(
+      mApi.mFunctionStubs.glGetString(Gles::GLenum::GL_EXTENSIONS));
 }
 
 const char* GlesRendererImpl::vendor() {
-    return reinterpret_cast<const char*>(
-        mApi.mFunctionStubs.glGetString(Gles::GLenum::GL_VENDOR));
+  return reinterpret_cast<const char*>(
+      mApi.mFunctionStubs.glGetString(Gles::GLenum::GL_VENDOR));
 }
 
 const char* GlesRendererImpl::version() {
-    return reinterpret_cast<const char*>(
-        mApi.mFunctionStubs.glGetString(Gles::GLenum::GL_VERSION));
+  return reinterpret_cast<const char*>(
+      mApi.mFunctionStubs.glGetString(Gles::GLenum::GL_VERSION));
 }
 
-} // anonymous namespace
+}  // anonymous namespace
 
 GlesRenderer* GlesRenderer::create(GlesRenderer* sharedContext) {
-    return new GlesRendererImpl();
+  return new GlesRendererImpl();
 }
 
 }  // namespace gapir

--- a/gapir/cc/android/vulkan_renderer.cpp
+++ b/gapir/cc/android/vulkan_renderer.cpp
@@ -14,43 +14,37 @@
  * limitations under the License.
  */
 
-#include "gapir/cc/vulkan_gfx_api.h"
 #include "gapir/cc/vulkan_renderer.h"
+#include "gapir/cc/vulkan_gfx_api.h"
 
 namespace gapir {
 namespace {
 
 class VulkanRendererImpl : public VulkanRenderer {
-public:
-    VulkanRendererImpl();
-    virtual ~VulkanRendererImpl() override;
+ public:
+  VulkanRendererImpl();
+  virtual ~VulkanRendererImpl() override;
 
-    virtual Api* api() override;
+  virtual Api* api() override;
 
-    virtual bool isValid() override;
-private:
-    Vulkan mApi;
+  virtual bool isValid() override;
+
+ private:
+  Vulkan mApi;
 };
 
-VulkanRendererImpl::VulkanRendererImpl() {
-    mApi.resolve();
-}
+VulkanRendererImpl::VulkanRendererImpl() { mApi.resolve(); }
 
-VulkanRendererImpl::~VulkanRendererImpl() {
-}
+VulkanRendererImpl::~VulkanRendererImpl() {}
 
-Api* VulkanRendererImpl::api() {
-  return &mApi;
-}
+Api* VulkanRendererImpl::api() { return &mApi; }
 
 bool VulkanRendererImpl::isValid() {
- return mApi.mFunctionStubs.vkCreateInstance != nullptr;
+  return mApi.mFunctionStubs.vkCreateInstance != nullptr;
 }
 
-} // anonymous namespace
+}  // anonymous namespace
 
-VulkanRenderer* VulkanRenderer::create() {
-    return new VulkanRendererImpl();
-}
+VulkanRenderer* VulkanRenderer::create() { return new VulkanRendererImpl(); }
 
 }  // namespace gapir

--- a/gapir/cc/base_type.cpp
+++ b/gapir/cc/base_type.cpp
@@ -21,75 +21,75 @@
 namespace gapir {
 
 uint32_t baseTypeSize(BaseType type) {
-    static_assert(sizeof(uint8_t) == 1, "Size of a uint8_t must be 1!");
-    switch (type) {
-        case BaseType::Bool:
-            return sizeof(bool);
-        case BaseType::Int8:
-            return sizeof(int8_t);
-        case BaseType::Int16:
-            return sizeof(int16_t);
-        case BaseType::Int32:
-            return sizeof(int32_t);
-        case BaseType::Int64:
-            return sizeof(int64_t);
-        case BaseType::Uint8:
-            return sizeof(uint8_t);
-        case BaseType::Uint16:
-            return sizeof(uint16_t);
-        case BaseType::Uint32:
-            return sizeof(uint32_t);
-        case BaseType::Uint64:
-            return sizeof(uint64_t);
-        case BaseType::Float:
-            return sizeof(float);
-        case BaseType::Double:
-            return sizeof(double);
-        case BaseType::AbsolutePointer:
-            return sizeof(void*);
-        case BaseType::ConstantPointer:
-        case BaseType::VolatilePointer:
-            return sizeof(uint32_t);
-        default:
-            GAPID_FATAL("Invalid BaseType: %d", int(type));
-            return 0;
-    }
+  static_assert(sizeof(uint8_t) == 1, "Size of a uint8_t must be 1!");
+  switch (type) {
+    case BaseType::Bool:
+      return sizeof(bool);
+    case BaseType::Int8:
+      return sizeof(int8_t);
+    case BaseType::Int16:
+      return sizeof(int16_t);
+    case BaseType::Int32:
+      return sizeof(int32_t);
+    case BaseType::Int64:
+      return sizeof(int64_t);
+    case BaseType::Uint8:
+      return sizeof(uint8_t);
+    case BaseType::Uint16:
+      return sizeof(uint16_t);
+    case BaseType::Uint32:
+      return sizeof(uint32_t);
+    case BaseType::Uint64:
+      return sizeof(uint64_t);
+    case BaseType::Float:
+      return sizeof(float);
+    case BaseType::Double:
+      return sizeof(double);
+    case BaseType::AbsolutePointer:
+      return sizeof(void*);
+    case BaseType::ConstantPointer:
+    case BaseType::VolatilePointer:
+      return sizeof(uint32_t);
+    default:
+      GAPID_FATAL("Invalid BaseType: %d", int(type));
+      return 0;
+  }
 }
 
 const char* baseTypeName(BaseType type) {
-    switch (type) {
-        case BaseType::Bool:
-            return "bool";
-        case BaseType::Int8:
-            return "int8";
-        case BaseType::Int16:
-            return "int16";
-        case BaseType::Int32:
-            return "int32";
-        case BaseType::Int64:
-            return "int64";
-        case BaseType::Uint8:
-            return "uint8";
-        case BaseType::Uint16:
-            return "uint16";
-        case BaseType::Uint32:
-            return "uint32";
-        case BaseType::Uint64:
-            return "uint64";
-        case BaseType::Float:
-            return "float";
-        case BaseType::Double:
-            return "double";
-        case BaseType::AbsolutePointer:
-            return "absolute pointer";
-        case BaseType::ConstantPointer:
-            return "constant pointer";
-        case BaseType::VolatilePointer:
-            return "volatile pointer";
-        default:
-            GAPID_FATAL("Invalid BaseType: %d", int(type));
-            return "unknown";
-    }
+  switch (type) {
+    case BaseType::Bool:
+      return "bool";
+    case BaseType::Int8:
+      return "int8";
+    case BaseType::Int16:
+      return "int16";
+    case BaseType::Int32:
+      return "int32";
+    case BaseType::Int64:
+      return "int64";
+    case BaseType::Uint8:
+      return "uint8";
+    case BaseType::Uint16:
+      return "uint16";
+    case BaseType::Uint32:
+      return "uint32";
+    case BaseType::Uint64:
+      return "uint64";
+    case BaseType::Float:
+      return "float";
+    case BaseType::Double:
+      return "double";
+    case BaseType::AbsolutePointer:
+      return "absolute pointer";
+    case BaseType::ConstantPointer:
+      return "constant pointer";
+    case BaseType::VolatilePointer:
+      return "volatile pointer";
+    default:
+      GAPID_FATAL("Invalid BaseType: %d", int(type));
+      return "unknown";
+  }
 }
 
 }  // namespace gapir

--- a/gapir/cc/base_type.h
+++ b/gapir/cc/base_type.h
@@ -22,23 +22,24 @@
 
 namespace gapir {
 
-// Unique ID for each supported data type. The ID have to fit into 6 bits (0-63) to fit into the
-// opcode stream and the values have to be consistent with the values on the server side
+// Unique ID for each supported data type. The ID have to fit into 6 bits (0-63)
+// to fit into the opcode stream and the values have to be consistent with the
+// values on the server side
 enum class BaseType : uint8_t {
-    Bool            = 0,
-    Int8            = 1,
-    Int16           = 2,
-    Int32           = 3,
-    Int64           = 4,
-    Uint8           = 5,
-    Uint16          = 6,
-    Uint32          = 7,
-    Uint64          = 8,
-    Float           = 9,
-    Double          = 10,
-    AbsolutePointer = 11,
-    ConstantPointer = 12,
-    VolatilePointer = 13,
+  Bool = 0,
+  Int8 = 1,
+  Int16 = 2,
+  Int32 = 3,
+  Int64 = 4,
+  Uint8 = 5,
+  Uint16 = 6,
+  Uint32 = 7,
+  Uint64 = 8,
+  Float = 9,
+  Double = 10,
+  AbsolutePointer = 11,
+  ConstantPointer = 12,
+  VolatilePointer = 13,
 };
 
 // Return the size of the underlying type for the given BaseType
@@ -54,27 +55,63 @@ inline bool isValid(BaseType type) {
 // Provide the BaseType value corresponding to the type specified in T.
 // For pointers the corresponding base type is AbsolutePointer
 // For enums the corresponding base type is uint32_t
-template<typename T, typename = void> struct TypeToBaseType;
+template <typename T, typename = void>
+struct TypeToBaseType;
 
-template<typename T> struct TypeToBaseType<T*> {
-    static const BaseType type = BaseType::AbsolutePointer;
+template <typename T>
+struct TypeToBaseType<T*> {
+  static const BaseType type = BaseType::AbsolutePointer;
 };
 
-template<> struct TypeToBaseType<bool>     { static const BaseType type = BaseType::Bool; };
-template<> struct TypeToBaseType<int8_t>   { static const BaseType type = BaseType::Int8; };
-template<> struct TypeToBaseType<int16_t>  { static const BaseType type = BaseType::Int16; };
-template<> struct TypeToBaseType<int32_t>  { static const BaseType type = BaseType::Int32; };
-template<> struct TypeToBaseType<int64_t>  { static const BaseType type = BaseType::Int64; };
-template<> struct TypeToBaseType<uint8_t>  { static const BaseType type = BaseType::Uint8; };
-template<> struct TypeToBaseType<uint16_t> { static const BaseType type = BaseType::Uint16; };
-template<> struct TypeToBaseType<uint32_t> { static const BaseType type = BaseType::Uint32; };
-template<> struct TypeToBaseType<uint64_t> { static const BaseType type = BaseType::Uint64; };
-template<> struct TypeToBaseType<float>    { static const BaseType type = BaseType::Float; };
-template<> struct TypeToBaseType<double>   { static const BaseType type = BaseType::Double; };
+template <>
+struct TypeToBaseType<bool> {
+  static const BaseType type = BaseType::Bool;
+};
+template <>
+struct TypeToBaseType<int8_t> {
+  static const BaseType type = BaseType::Int8;
+};
+template <>
+struct TypeToBaseType<int16_t> {
+  static const BaseType type = BaseType::Int16;
+};
+template <>
+struct TypeToBaseType<int32_t> {
+  static const BaseType type = BaseType::Int32;
+};
+template <>
+struct TypeToBaseType<int64_t> {
+  static const BaseType type = BaseType::Int64;
+};
+template <>
+struct TypeToBaseType<uint8_t> {
+  static const BaseType type = BaseType::Uint8;
+};
+template <>
+struct TypeToBaseType<uint16_t> {
+  static const BaseType type = BaseType::Uint16;
+};
+template <>
+struct TypeToBaseType<uint32_t> {
+  static const BaseType type = BaseType::Uint32;
+};
+template <>
+struct TypeToBaseType<uint64_t> {
+  static const BaseType type = BaseType::Uint64;
+};
+template <>
+struct TypeToBaseType<float> {
+  static const BaseType type = BaseType::Float;
+};
+template <>
+struct TypeToBaseType<double> {
+  static const BaseType type = BaseType::Double;
+};
 
-template<typename T>
-struct TypeToBaseType<T, typename std::enable_if<std::is_enum<T>::value>::type> {
-    static const BaseType type = BaseType::Uint32;
+template <typename T>
+struct TypeToBaseType<T,
+                      typename std::enable_if<std::is_enum<T>::value>::type> {
+  static const BaseType type = BaseType::Uint32;
 };
 
 // isPointerType returns true if values of 'type' translate to a pointer.

--- a/gapir/cc/context.cpp
+++ b/gapir/cc/context.cpp
@@ -16,21 +16,21 @@
 
 #include "context.h"
 #include "gapir/cc/gles_gfx_api.h"
+#include "gapir/cc/vulkan_gfx_api.h"
 #include "gles_renderer.h"
 #include "interpreter.h"
 #include "memory_manager.h"
 #include "post_buffer.h"
 #include "replay_connection.h"
 #include "replay_request.h"
-#include "resource_provider.h"
 #include "resource_in_memory_cache.h"
+#include "resource_provider.h"
 #include "stack.h"
-#include "gapir/cc/vulkan_gfx_api.h"
 #include "vulkan_renderer.h"
 
+#include "core/cc/gl/formats.h"
 #include "core/cc/log.h"
 #include "core/cc/target.h"
-#include "core/cc/gl/formats.h"
 
 #define __STDC_FORMAT_MACROS
 #include <inttypes.h>
@@ -41,114 +41,115 @@
 
 namespace gapir {
 
-std::unique_ptr<Context> Context::create(
-        ReplayConnection* conn,
-        core::CrashHandler& crash_handler,
-        ResourceProvider* resource_provider,
-        MemoryManager* memory_manager) {
+std::unique_ptr<Context> Context::create(ReplayConnection* conn,
+                                         core::CrashHandler& crash_handler,
+                                         ResourceProvider* resource_provider,
+                                         MemoryManager* memory_manager) {
+  std::unique_ptr<Context> context(
+      new Context(conn, crash_handler, resource_provider, memory_manager));
 
-    std::unique_ptr<Context> context(new Context(
-        conn, crash_handler, resource_provider, memory_manager));
-
-    if (context->initialize()) {
-        GAPID_DEBUG("Replay context initialized successfully");
-        return context;
-    } else {
-        GAPID_ERROR("Replay context initialization failed");
-        return nullptr;
-    }
+  if (context->initialize()) {
+    GAPID_DEBUG("Replay context initialized successfully");
+    return context;
+  } else {
+    GAPID_ERROR("Replay context initialization failed");
+    return nullptr;
+  }
 }
 
 // TODO: Make the PostBuffer size dynamic? It currently holds 2MB of data.
-Context::Context(
-        ReplayConnection* conn,
-        core::CrashHandler& crash_handler,
-        ResourceProvider* resource_provider,
-        MemoryManager* memory_manager) :
+Context::Context(ReplayConnection* conn, core::CrashHandler& crash_handler,
+                 ResourceProvider* resource_provider,
+                 MemoryManager* memory_manager)
+    :
 
-        mConnection(conn),
-        mCrashHandler(crash_handler),
-        mResourceProvider(resource_provider),
-        mMemoryManager(memory_manager),
-        mVulkanRenderer(nullptr),
-        mPostBuffer(new PostBuffer(POST_BUFFER_SIZE, [this](std::unique_ptr<ReplayConnection::Posts> posts) -> bool {
+      mConnection(conn),
+      mCrashHandler(crash_handler),
+      mResourceProvider(resource_provider),
+      mMemoryManager(memory_manager),
+      mVulkanRenderer(nullptr),
+      mPostBuffer(new PostBuffer(
+          POST_BUFFER_SIZE,
+          [this](std::unique_ptr<ReplayConnection::Posts> posts) -> bool {
             if (mConnection != nullptr) {
-                return mConnection->sendPostData(std::move(posts));
+              return mConnection->sendPostData(std::move(posts));
             }
             return false;
           })),
-        mNumSentDebugMessages(0) {
-}
+      mNumSentDebugMessages(0) {}
 
 Context::~Context() {
-    for (auto it = mGlesRenderers.begin(); it != mGlesRenderers.end(); it++) {
-        delete it->second;
-    }
-    delete mVulkanRenderer;
+  for (auto it = mGlesRenderers.begin(); it != mGlesRenderers.end(); it++) {
+    delete it->second;
+  }
+  delete mVulkanRenderer;
 }
 
 bool Context::initialize() {
-    mReplayRequest = ReplayRequest::create(mConnection, mMemoryManager);
-    if (mReplayRequest == nullptr) {
-        GAPID_ERROR("Replay request creation failed");
-        return false;
-    }
+  mReplayRequest = ReplayRequest::create(mConnection, mMemoryManager);
+  if (mReplayRequest == nullptr) {
+    GAPID_ERROR("Replay request creation failed");
+    return false;
+  }
 
-    GAPID_DEBUG("ReplayRequest created successfully");
-    if (!mMemoryManager->setVolatileMemory(mReplayRequest->getVolatileMemorySize())) {
-        GAPID_WARNING("Setting the volatile memory size failed (size: %u)",
-                     mReplayRequest->getVolatileMemorySize());
-        return false;
-    }
+  GAPID_DEBUG("ReplayRequest created successfully");
+  if (!mMemoryManager->setVolatileMemory(
+          mReplayRequest->getVolatileMemorySize())) {
+    GAPID_WARNING("Setting the volatile memory size failed (size: %u)",
+                  mReplayRequest->getVolatileMemorySize());
+    return false;
+  }
 
-    // Constant memory already set with ReplayData
-    return true;
+  // Constant memory already set with ReplayData
+  return true;
 }
 
-
 void Context::prefetch(ResourceInMemoryCache* cache) const {
-    auto cacheSize = static_cast<uint32_t>(
-            static_cast<uint8_t*>(mMemoryManager->getVolatileAddress()) -
-            static_cast<uint8_t*>(mMemoryManager->getBaseAddress()));
-    cache->resize(cacheSize);
+  auto cacheSize = static_cast<uint32_t>(
+      static_cast<uint8_t*>(mMemoryManager->getVolatileAddress()) -
+      static_cast<uint8_t*>(mMemoryManager->getBaseAddress()));
+  cache->resize(cacheSize);
 
-    auto resources = mReplayRequest->getResources();
-    if (resources.size() > 0) {
-        GAPID_INFO("Prefetching %zu resources...", resources.size());
-        mResourceProvider->prefetch(resources.data(), resources.size(), mConnection,
-                                    mMemoryManager->getVolatileAddress(),
-                                    mReplayRequest->getVolatileMemorySize());
-    }
+  auto resources = mReplayRequest->getResources();
+  if (resources.size() > 0) {
+    GAPID_INFO("Prefetching %zu resources...", resources.size());
+    mResourceProvider->prefetch(resources.data(), resources.size(), mConnection,
+                                mMemoryManager->getVolatileAddress(),
+                                mReplayRequest->getVolatileMemorySize());
+  }
 }
 
 bool Context::interpret() {
-    Interpreter::ApiRequestCallback callback =
-        [this](Interpreter* interpreter, uint8_t api_index) -> bool {
-            if (api_index == gapir::Vulkan::INDEX) {
-                // There is only one vulkan "renderer" so we create it when requested.
-                mVulkanRenderer = VulkanRenderer::create();
-                if (mVulkanRenderer->isValid()) {
-                    mVulkanRenderer->setListener(this);
-                    Api* api = mVulkanRenderer->api();
-                    interpreter->setRendererFunctions(api->index(), &api->mFunctions);
-                    GAPID_INFO("Bound Vulkan renderer");
-                    return true;
-                }
-            }
-            return false;
-        };
+  Interpreter::ApiRequestCallback callback = [this](Interpreter* interpreter,
+                                                    uint8_t api_index) -> bool {
+    if (api_index == gapir::Vulkan::INDEX) {
+      // There is only one vulkan "renderer" so we create it when requested.
+      mVulkanRenderer = VulkanRenderer::create();
+      if (mVulkanRenderer->isValid()) {
+        mVulkanRenderer->setListener(this);
+        Api* api = mVulkanRenderer->api();
+        interpreter->setRendererFunctions(api->index(), &api->mFunctions);
+        GAPID_INFO("Bound Vulkan renderer");
+        return true;
+      }
+    }
+    return false;
+  };
 
-    mInterpreter.reset(new Interpreter(mCrashHandler, mMemoryManager, mReplayRequest->getStackSize(), std::move(callback)));
-    registerCallbacks(mInterpreter.get());
-    auto instAndCount = mReplayRequest->getInstructionList();
-    auto res = mInterpreter->run(instAndCount.first, instAndCount.second) &&
-               mPostBuffer->flush();
-    mInterpreter.reset(nullptr);
-    return res;
+  mInterpreter.reset(new Interpreter(mCrashHandler, mMemoryManager,
+                                     mReplayRequest->getStackSize(),
+                                     std::move(callback)));
+  registerCallbacks(mInterpreter.get());
+  auto instAndCount = mReplayRequest->getInstructionList();
+  auto res = mInterpreter->run(instAndCount.first, instAndCount.second) &&
+             mPostBuffer->flush();
+  mInterpreter.reset(nullptr);
+  return res;
 }
 
 // onDebugMessage implements the Renderer::Listener interface.
-void Context::onDebugMessage(uint32_t severity, uint8_t api_index, const char* msg) {
+void Context::onDebugMessage(uint32_t severity, uint8_t api_index,
+                             const char* msg) {
   auto label = mInterpreter->getLabel();
   // Remove tailing new-line from the message (if any)
   std::string str_msg;
@@ -176,97 +177,116 @@ void Context::onDebugMessage(uint32_t severity, uint8_t api_index, const char* m
 }
 
 void Context::registerCallbacks(Interpreter* interpreter) {
-    // Custom function for posting and fetching resources to and from the server
-    interpreter->registerBuiltin(Interpreter::GLOBAL_INDEX, Interpreter::POST_FUNCTION_ID,
-                                 [this](uint32_t label, Stack* stack, bool) { return this->postData(stack); });
-    interpreter->registerBuiltin(Interpreter::GLOBAL_INDEX, Interpreter::RESOURCE_FUNCTION_ID,
-                                 [this](uint32_t label, Stack* stack, bool) { return this->loadResource(stack); });
+  // Custom function for posting and fetching resources to and from the server
+  interpreter->registerBuiltin(Interpreter::GLOBAL_INDEX,
+                               Interpreter::POST_FUNCTION_ID,
+                               [this](uint32_t label, Stack* stack, bool) {
+                                 return this->postData(stack);
+                               });
+  interpreter->registerBuiltin(Interpreter::GLOBAL_INDEX,
+                               Interpreter::RESOURCE_FUNCTION_ID,
+                               [this](uint32_t label, Stack* stack, bool) {
+                                 return this->loadResource(stack);
+                               });
 
-    // Registering custom synthetic functions
-    interpreter->registerBuiltin(Gles::INDEX, Builtins::StartTimer,
-                                 [this](uint32_t label, Stack* stack, bool) { return this->startTimer(stack); });
-    interpreter->registerBuiltin(Gles::INDEX, Builtins::StopTimer,
-                                 [this](uint32_t label, Stack* stack, bool pushReturn) {
+  // Registering custom synthetic functions
+  interpreter->registerBuiltin(Gles::INDEX, Builtins::StartTimer,
+                               [this](uint32_t label, Stack* stack, bool) {
+                                 return this->startTimer(stack);
+                               });
+  interpreter->registerBuiltin(
+      Gles::INDEX, Builtins::StopTimer,
+      [this](uint32_t label, Stack* stack, bool pushReturn) {
         return this->stopTimer(stack, pushReturn);
-    });
-    interpreter->registerBuiltin(Gles::INDEX, Builtins::FlushPostBuffer, [this](uint32_t label, Stack* stack, bool) {
-        return this->flushPostBuffer(stack);
-    });
+      });
+  interpreter->registerBuiltin(Gles::INDEX, Builtins::FlushPostBuffer,
+                               [this](uint32_t label, Stack* stack, bool) {
+                                 return this->flushPostBuffer(stack);
+                               });
 
-    interpreter->registerBuiltin(Gles::INDEX, Builtins::ReplayCreateRenderer, [this](uint32_t label, Stack* stack, bool) {
+  interpreter->registerBuiltin(
+      Gles::INDEX, Builtins::ReplayCreateRenderer,
+      [this](uint32_t label, Stack* stack, bool) {
         uint32_t id = stack->pop<uint32_t>();
         if (stack->isValid()) {
-            GAPID_INFO("[%u]replayCreateRenderer(%u)", label, id);
-            auto existing = mGlesRenderers.find(id);
-            if (existing != mGlesRenderers.end()) {
-                delete existing->second;
-            }
-            // Share objects with the root GLES context.
-            // This will essentially make all objects shared between all contexts.
-            // It is ok since correct replay will only reference what it is supposed to.
+          GAPID_INFO("[%u]replayCreateRenderer(%u)", label, id);
+          auto existing = mGlesRenderers.find(id);
+          if (existing != mGlesRenderers.end()) {
+            delete existing->second;
+          }
+          // Share objects with the root GLES context.
+          // This will essentially make all objects shared between all contexts.
+          // It is ok since correct replay will only reference what it is
+          // supposed to.
+          if (!mRootGlesRenderer) {
+            mRootGlesRenderer.reset(GlesRenderer::create(nullptr));
             if (!mRootGlesRenderer) {
-                mRootGlesRenderer.reset(GlesRenderer::create(nullptr));
-                if (!mRootGlesRenderer) {
-                    GAPID_ERROR("Could not create GLES renderer on this device");
-                    return false;
-                }
-                mRootGlesRenderer->bind();
-                mRootGlesRenderer->setBackbuffer(GlesRenderer::Backbuffer(
-                    8, 8,
-                    core::gl::GL_RGBA8,
-                    core::gl::GL_DEPTH24_STENCIL8,
-                    core::gl::GL_DEPTH24_STENCIL8
-                ));
+              GAPID_ERROR("Could not create GLES renderer on this device");
+              return false;
             }
-            auto renderer = GlesRenderer::create(mRootGlesRenderer.get());
-            if (!renderer) {
-                GAPID_ERROR("Could not create GLES renderer on this device");
-                return false;
-            }
-            renderer->setListener(this);
-            mGlesRenderers[id] = renderer;
-            return true;
-        } else {
-            GAPID_WARNING("[%u]Error during calling function replayCreateRenderer", label);
+            mRootGlesRenderer->bind();
+            mRootGlesRenderer->setBackbuffer(GlesRenderer::Backbuffer(
+                8, 8, core::gl::GL_RGBA8, core::gl::GL_DEPTH24_STENCIL8,
+                core::gl::GL_DEPTH24_STENCIL8));
+          }
+          auto renderer = GlesRenderer::create(mRootGlesRenderer.get());
+          if (!renderer) {
+            GAPID_ERROR("Could not create GLES renderer on this device");
             return false;
+          }
+          renderer->setListener(this);
+          mGlesRenderers[id] = renderer;
+          return true;
+        } else {
+          GAPID_WARNING(
+              "[%u]Error during calling function replayCreateRenderer", label);
+          return false;
         }
-    });
+      });
 
-    interpreter->registerBuiltin(Gles::INDEX, Builtins::ReplayBindRenderer, [this, interpreter](uint32_t label, Stack* stack, bool) {
+  interpreter->registerBuiltin(
+      Gles::INDEX, Builtins::ReplayBindRenderer,
+      [this, interpreter](uint32_t label, Stack* stack, bool) {
         uint32_t id = stack->pop<uint32_t>();
         if (stack->isValid()) {
-            GAPID_INFO("[%u]replayBindRenderer(%u)", label, id);
-            auto renderer = mGlesRenderers[id];
-            renderer->bind();
-            Api* api = renderer->api();
-            interpreter->setRendererFunctions(api->index(), &api->mFunctions);
-            GAPID_DEBUG("[%u]Bound renderer %u: %s - %s", label, id, renderer->name(), renderer->version());
-            return true;
+          GAPID_INFO("[%u]replayBindRenderer(%u)", label, id);
+          auto renderer = mGlesRenderers[id];
+          renderer->bind();
+          Api* api = renderer->api();
+          interpreter->setRendererFunctions(api->index(), &api->mFunctions);
+          GAPID_DEBUG("[%u]Bound renderer %u: %s - %s", label, id,
+                      renderer->name(), renderer->version());
+          return true;
         } else {
-            GAPID_WARNING("[%u]Error during calling function replayBindRenderer", label);
-            return false;
+          GAPID_WARNING("[%u]Error during calling function replayBindRenderer",
+                        label);
+          return false;
         }
-    });
+      });
 
-    interpreter->registerBuiltin(Gles::INDEX, Builtins::ReplayUnbindRenderer, [this](uint32_t label, Stack* stack, bool) {
+  interpreter->registerBuiltin(
+      Gles::INDEX, Builtins::ReplayUnbindRenderer,
+      [this](uint32_t label, Stack* stack, bool) {
         uint32_t id = stack->pop<uint32_t>();
         if (stack->isValid()) {
-            GAPID_DEBUG("[%u]replayUnbindRenderer(%" PRIu32 ")", label, id);
-            auto renderer = mGlesRenderers[id];
-            renderer->unbind();
-            // TODO: Unbind renderer functions with the interpreter?
-            // Api* api = renderer->api();
-            // interpreter->setRendererFunctions(api->index(), nullptr);
-            GAPID_DEBUG("[%u]Unbound renderer %" PRIu32, label, id);
-            return true;
+          GAPID_DEBUG("[%u]replayUnbindRenderer(%" PRIu32 ")", label, id);
+          auto renderer = mGlesRenderers[id];
+          renderer->unbind();
+          // TODO: Unbind renderer functions with the interpreter?
+          // Api* api = renderer->api();
+          // interpreter->setRendererFunctions(api->index(), nullptr);
+          GAPID_DEBUG("[%u]Unbound renderer %" PRIu32, label, id);
+          return true;
+        } else {
+          GAPID_WARNING(
+              "[%u]Error during calling function replayUnbindRenderer", label);
+          return false;
         }
-        else {
-            GAPID_WARNING("[%u]Error during calling function replayUnbindRenderer", label);
-            return false;
-        }
-    });
+      });
 
-    interpreter->registerBuiltin(Gles::INDEX, Builtins::ReplayChangeBackbuffer, [this](uint32_t label, Stack* stack, bool) {
+  interpreter->registerBuiltin(
+      Gles::INDEX, Builtins::ReplayChangeBackbuffer,
+      [this](uint32_t label, Stack* stack, bool) {
         GlesRenderer::Backbuffer backbuffer;
 
         bool resetViewportScissor = stack->pop<bool>();
@@ -278,85 +298,92 @@ void Context::registerCallbacks(Interpreter* interpreter) {
         uint32_t id = stack->pop<uint32_t>();
 
         if (!stack->isValid()) {
-            GAPID_WARNING("[%u]Error during calling function replayCreateRenderer", label);
-            return false;
+          GAPID_WARNING(
+              "[%u]Error during calling function replayCreateRenderer", label);
+          return false;
         }
 
         if (stack->isValid()) {
-            GAPID_DEBUG("[%u]replayChangeBackbuffer(%d, %d, 0x%x, 0x%x, 0x%x, %s)",
-                    label,
-                    backbuffer.width,
-                    backbuffer.height,
-                    backbuffer.format.color,
-                    backbuffer.format.depth,
-                    backbuffer.format.stencil,
-                    resetViewportScissor ? "true" : "false");
-            auto renderer = mGlesRenderers[id];
-            if (renderer == nullptr) {
-                GAPID_WARNING("[%u]replayChangeBackbuffer called with unknown renderer %" PRIu32, label, id);
-                return false;
-            }
-            renderer->setBackbuffer(backbuffer);
-            auto gles = renderer->getApi<Gles>();
-            // TODO: This needs to change when we support other APIs.
-            GAPID_ASSERT(gles != nullptr);
-            if (resetViewportScissor) {
-                gles->mFunctionStubs.glViewport(0, 0, backbuffer.width, backbuffer.height);
-                gles->mFunctionStubs.glScissor(0, 0, backbuffer.width, backbuffer.height);
-            }
-            return true;
-        } else {
-            GAPID_WARNING("[%u]Error during calling function replayChangeBackbuffer", label);
+          GAPID_DEBUG(
+              "[%u]replayChangeBackbuffer(%d, %d, 0x%x, 0x%x, 0x%x, %s)", label,
+              backbuffer.width, backbuffer.height, backbuffer.format.color,
+              backbuffer.format.depth, backbuffer.format.stencil,
+              resetViewportScissor ? "true" : "false");
+          auto renderer = mGlesRenderers[id];
+          if (renderer == nullptr) {
+            GAPID_WARNING(
+                "[%u]replayChangeBackbuffer called with unknown renderer "
+                "%" PRIu32,
+                label, id);
             return false;
+          }
+          renderer->setBackbuffer(backbuffer);
+          auto gles = renderer->getApi<Gles>();
+          // TODO: This needs to change when we support other APIs.
+          GAPID_ASSERT(gles != nullptr);
+          if (resetViewportScissor) {
+            gles->mFunctionStubs.glViewport(0, 0, backbuffer.width,
+                                            backbuffer.height);
+            gles->mFunctionStubs.glScissor(0, 0, backbuffer.width,
+                                           backbuffer.height);
+          }
+          return true;
+        } else {
+          GAPID_WARNING(
+              "[%u]Error during calling function replayChangeBackbuffer",
+              label);
+          return false;
         }
-    });
+      });
 
-    interpreter->registerBuiltin(Vulkan::INDEX, Builtins::ReplayCreateVkInstance,
-                                 [this, interpreter](uint32_t label, Stack* stack, bool pushReturn) {
+  interpreter->registerBuiltin(
+      Vulkan::INDEX, Builtins::ReplayCreateVkInstance,
+      [this, interpreter](uint32_t label, Stack* stack, bool pushReturn) {
         GAPID_DEBUG("[%u]replayCreateVkInstance()", label);
 
-        if (mVulkanRenderer != nullptr || interpreter->registerApi(Vulkan::INDEX)) {
-            auto* api = mVulkanRenderer->getApi<Vulkan>();
-            auto* pInstance = stack->pop<Vulkan::VkInstance*>();
-            auto* pAllocator = stack->pop<Vulkan::VkAllocationCallbacks*>();
-            auto* pCreateInfo = stack->pop<Vulkan::VkInstanceCreateInfo*>();
-            if (!stack->isValid()) {
-                GAPID_ERROR("Error during calling funtion ReplayCreateVkInstance");
-                return false;
-            }
-            uint32_t result = Vulkan::VkResult::VK_SUCCESS;
-
-            if (api->replayCreateVkInstanceImpl(stack, pCreateInfo, pAllocator,
-                                                pInstance, false, &result)) {
-              if (result == Vulkan::VkResult::VK_SUCCESS) {
-                if (pushReturn) {
-                  stack->push(result);
-                }
-                return true;
-              }
-            }
-            // If validation layers and debug report extension are enabled,
-            // drop them and try to create VkInstance again.
-            if (Vulkan::hasValidationLayers(pCreateInfo->ppEnabledLayerNames,
-                                            pCreateInfo->enabledLayerCount) ||
-                Vulkan::hasDebugReportExtension(
-                    pCreateInfo->ppEnabledExtensionNames,
-                    pCreateInfo->enabledExtensionCount)) {
-              onDebugMessage(
-                  LOG_LEVEL_WARNING, Vulkan::INDEX,
-                  "Failed to create VkInstance with validation layers and "
-                  "debug report extension, drop them and try again");
-              if (api->replayCreateVkInstanceImpl(stack, pCreateInfo,
-                                                  pAllocator, pInstance, true,
-                                                  &result)) {
-                if (pushReturn) {
-                  stack->push(result);
-                }
-                return true;
-              }
-            }
-            onDebugMessage(LOG_LEVEL_FATAL, Vulkan::INDEX, "Failed to create 'VkInstance'");
+        if (mVulkanRenderer != nullptr ||
+            interpreter->registerApi(Vulkan::INDEX)) {
+          auto* api = mVulkanRenderer->getApi<Vulkan>();
+          auto* pInstance = stack->pop<Vulkan::VkInstance*>();
+          auto* pAllocator = stack->pop<Vulkan::VkAllocationCallbacks*>();
+          auto* pCreateInfo = stack->pop<Vulkan::VkInstanceCreateInfo*>();
+          if (!stack->isValid()) {
+            GAPID_ERROR("Error during calling funtion ReplayCreateVkInstance");
             return false;
+          }
+          uint32_t result = Vulkan::VkResult::VK_SUCCESS;
+
+          if (api->replayCreateVkInstanceImpl(stack, pCreateInfo, pAllocator,
+                                              pInstance, false, &result)) {
+            if (result == Vulkan::VkResult::VK_SUCCESS) {
+              if (pushReturn) {
+                stack->push(result);
+              }
+              return true;
+            }
+          }
+          // If validation layers and debug report extension are enabled,
+          // drop them and try to create VkInstance again.
+          if (Vulkan::hasValidationLayers(pCreateInfo->ppEnabledLayerNames,
+                                          pCreateInfo->enabledLayerCount) ||
+              Vulkan::hasDebugReportExtension(
+                  pCreateInfo->ppEnabledExtensionNames,
+                  pCreateInfo->enabledExtensionCount)) {
+            onDebugMessage(
+                LOG_LEVEL_WARNING, Vulkan::INDEX,
+                "Failed to create VkInstance with validation layers and "
+                "debug report extension, drop them and try again");
+            if (api->replayCreateVkInstanceImpl(stack, pCreateInfo, pAllocator,
+                                                pInstance, true, &result)) {
+              if (pushReturn) {
+                stack->push(result);
+              }
+              return true;
+            }
+          }
+          onDebugMessage(LOG_LEVEL_FATAL, Vulkan::INDEX,
+                         "Failed to create 'VkInstance'");
+          return false;
         } else {
           GAPID_WARNING(
               "[%u]replayCreateVkInstance called without a bound Vulkan "
@@ -364,329 +391,368 @@ void Context::registerCallbacks(Interpreter* interpreter) {
               label);
           return false;
         }
-    });
+      });
 
-    interpreter->registerBuiltin(Vulkan::INDEX, Builtins::ReplayCreateVkDevice,
-                                 [this](uint32_t label, Stack* stack, bool pushReturn) {
+  interpreter->registerBuiltin(
+      Vulkan::INDEX, Builtins::ReplayCreateVkDevice,
+      [this](uint32_t label, Stack* stack, bool pushReturn) {
         GAPID_DEBUG("[%u]replayCreateVkDevice()", label);
         if (mVulkanRenderer != nullptr) {
-            auto* api = mVulkanRenderer->getApi<Vulkan>();
-            auto pDevice = stack->pop<Vulkan::VkDevice*>();
-            auto pAllocator = stack->pop<Vulkan::VkAllocationCallbacks*>();
-            auto pCreateInfo = stack->pop<Vulkan::VkDeviceCreateInfo*>();
-            auto physicalDevice = static_cast<size_val>(stack->pop<size_val>());
-            if (!stack->isValid()) {
-                GAPID_ERROR("Error during calling funtion ReplayCreateVkDevice");
-                return false;
-            }
-            uint32_t result = Vulkan::VkResult::VK_SUCCESS;
+          auto* api = mVulkanRenderer->getApi<Vulkan>();
+          auto pDevice = stack->pop<Vulkan::VkDevice*>();
+          auto pAllocator = stack->pop<Vulkan::VkAllocationCallbacks*>();
+          auto pCreateInfo = stack->pop<Vulkan::VkDeviceCreateInfo*>();
+          auto physicalDevice = static_cast<size_val>(stack->pop<size_val>());
+          if (!stack->isValid()) {
+            GAPID_ERROR("Error during calling funtion ReplayCreateVkDevice");
+            return false;
+          }
+          uint32_t result = Vulkan::VkResult::VK_SUCCESS;
 
+          if (api->replayCreateVkDeviceImpl(stack, physicalDevice, pCreateInfo,
+                                            pAllocator, pDevice, false,
+                                            &result)) {
+            if (result == Vulkan::VkResult::VK_SUCCESS) {
+              if (pushReturn) {
+                stack->push(result);
+              }
+              return true;
+            }
+          }
+          // If validation layers are enabled, drop them and try to create
+          // VkInstance again.
+          if (Vulkan::hasValidationLayers(pCreateInfo->ppEnabledLayerNames,
+                                          pCreateInfo->enabledLayerCount)) {
+            onDebugMessage(LOG_LEVEL_WARNING, Vulkan::INDEX,
+                           "Failed to create VkDevice with validation layers, "
+                           "drop them and try again");
             if (api->replayCreateVkDeviceImpl(stack, physicalDevice,
                                               pCreateInfo, pAllocator, pDevice,
-                                              false, &result)) {
-              if (result == Vulkan::VkResult::VK_SUCCESS) {
-                if (pushReturn) {
-                  stack->push(result);
-                }
-                return true;
+                                              true, &result)) {
+              if (pushReturn) {
+                stack->push(result);
               }
+              return true;
             }
-            // If validation layers are enabled, drop them and try to create
-            // VkInstance again.
-            if (Vulkan::hasValidationLayers(pCreateInfo->ppEnabledLayerNames,
-                                            pCreateInfo->enabledLayerCount)) {
-              onDebugMessage(
-                  LOG_LEVEL_WARNING, Vulkan::INDEX,
-                  "Failed to create VkDevice with validation layers, "
-                  "drop them and try again");
-              if (api->replayCreateVkDeviceImpl(stack, physicalDevice,
-                                                pCreateInfo, pAllocator,
-                                                pDevice, true, &result)) {
-                if (pushReturn) {
-                  stack->push(result);
-                }
-                return true;
-              }
-            }
-            onDebugMessage(LOG_LEVEL_FATAL, Vulkan::INDEX, "Failed to create 'VkDevice'");
-            return false;
+          }
+          onDebugMessage(LOG_LEVEL_FATAL, Vulkan::INDEX,
+                         "Failed to create 'VkDevice'");
+          return false;
         } else {
           GAPID_WARNING(
               "[%u]replayCreateVkDevice called without a bound Vulkan renderer",
               label);
           return false;
         }
-    });
+      });
 
-    interpreter->registerBuiltin(Vulkan::INDEX, Builtins::ReplayRegisterVkInstance,
-                                 [this](uint32_t label, Stack* stack, bool) {
+  interpreter->registerBuiltin(
+      Vulkan::INDEX, Builtins::ReplayRegisterVkInstance,
+      [this](uint32_t label, Stack* stack, bool) {
         GAPID_DEBUG("[%u]replayRegisterVkInstance()", label);
         if (mVulkanRenderer != nullptr) {
-            auto* api = mVulkanRenderer->getApi<Vulkan>();
-            return api->replayRegisterVkInstance(stack);
+          auto* api = mVulkanRenderer->getApi<Vulkan>();
+          return api->replayRegisterVkInstance(stack);
         } else {
-            GAPID_WARNING("[%u]replayRegisterVkInstance called without a bound Vulkan renderer", label);
-            return false;
+          GAPID_WARNING(
+              "[%u]replayRegisterVkInstance called without a bound Vulkan "
+              "renderer",
+              label);
+          return false;
         }
-    });
+      });
 
-    interpreter->registerBuiltin(Vulkan::INDEX, Builtins::ReplayUnregisterVkInstance,
-                                 [this](uint32_t label, Stack* stack, bool) {
+  interpreter->registerBuiltin(
+      Vulkan::INDEX, Builtins::ReplayUnregisterVkInstance,
+      [this](uint32_t label, Stack* stack, bool) {
         GAPID_DEBUG("[%u]replayUnregisterVkInstance()", label);
         if (mVulkanRenderer != nullptr) {
-            auto* api = mVulkanRenderer->getApi<Vulkan>();
-            return api->replayUnregisterVkInstance(stack);
+          auto* api = mVulkanRenderer->getApi<Vulkan>();
+          return api->replayUnregisterVkInstance(stack);
         } else {
-            GAPID_WARNING("[%u]replayUnregisterVkInstance called without a bound Vulkan renderer", label);
-            return false;
+          GAPID_WARNING(
+              "[%u]replayUnregisterVkInstance called without a bound Vulkan "
+              "renderer",
+              label);
+          return false;
         }
-    });
+      });
 
-    interpreter->registerBuiltin(Vulkan::INDEX, Builtins::ReplayRegisterVkDevice,
-                                 [this](uint32_t label, Stack* stack, bool) {
+  interpreter->registerBuiltin(
+      Vulkan::INDEX, Builtins::ReplayRegisterVkDevice,
+      [this](uint32_t label, Stack* stack, bool) {
         GAPID_DEBUG("[%u]replayRegisterVkDevice()", label);
         if (mVulkanRenderer != nullptr) {
-            auto* api = mVulkanRenderer->getApi<Vulkan>();
-            return api->replayRegisterVkDevice(stack);
+          auto* api = mVulkanRenderer->getApi<Vulkan>();
+          return api->replayRegisterVkDevice(stack);
         } else {
-            GAPID_WARNING("[%u]replayRegisterVkDevice called without a bound Vulkan renderer", label);
-            return false;
+          GAPID_WARNING(
+              "[%u]replayRegisterVkDevice called without a bound Vulkan "
+              "renderer",
+              label);
+          return false;
         }
-    });
+      });
 
-    interpreter->registerBuiltin(Vulkan::INDEX, Builtins::ReplayUnregisterVkDevice,
-                                 [this](uint32_t label, Stack* stack, bool) {
+  interpreter->registerBuiltin(
+      Vulkan::INDEX, Builtins::ReplayUnregisterVkDevice,
+      [this](uint32_t label, Stack* stack, bool) {
         GAPID_DEBUG("[%u]replayUnregisterVkDevice()", label);
         if (mVulkanRenderer != nullptr) {
-            auto* api = mVulkanRenderer->getApi<Vulkan>();
-            return api->replayUnregisterVkDevice(stack);
+          auto* api = mVulkanRenderer->getApi<Vulkan>();
+          return api->replayUnregisterVkDevice(stack);
         } else {
-            GAPID_WARNING("[%u]replayUnregisterVkDevice called without a bound Vulkan renderer", label);
-            return false;
+          GAPID_WARNING(
+              "[%u]replayUnregisterVkDevice called without a bound Vulkan "
+              "renderer",
+              label);
+          return false;
         }
-    });
+      });
 
-    interpreter->registerBuiltin(Vulkan::INDEX, Builtins::ReplayRegisterVkCommandBuffers,
-                                 [this](uint32_t label, Stack* stack, bool) {
+  interpreter->registerBuiltin(
+      Vulkan::INDEX, Builtins::ReplayRegisterVkCommandBuffers,
+      [this](uint32_t label, Stack* stack, bool) {
         GAPID_DEBUG("[%u]replayRegisterVkCommandBuffers()", label);
         if (mVulkanRenderer != nullptr) {
-            auto* api = mVulkanRenderer->getApi<Vulkan>();
-            return api->replayRegisterVkCommandBuffers(stack);
+          auto* api = mVulkanRenderer->getApi<Vulkan>();
+          return api->replayRegisterVkCommandBuffers(stack);
         } else {
-            GAPID_WARNING("[%u]replayRegisterVkCommandBuffers called without a bound Vulkan renderer", label);
-            return false;
+          GAPID_WARNING(
+              "[%u]replayRegisterVkCommandBuffers called without a bound "
+              "Vulkan renderer",
+              label);
+          return false;
         }
-    });
+      });
 
-    interpreter->registerBuiltin(Vulkan::INDEX, Builtins::ReplayUnregisterVkCommandBuffers,
-                                 [this](uint32_t label, Stack* stack, bool) {
+  interpreter->registerBuiltin(
+      Vulkan::INDEX, Builtins::ReplayUnregisterVkCommandBuffers,
+      [this](uint32_t label, Stack* stack, bool) {
         GAPID_DEBUG("[%u]replayUnregisterVkCommandBuffers()", label);
         if (mVulkanRenderer != nullptr) {
-            auto* api = mVulkanRenderer->getApi<Vulkan>();
-            return api->replayUnregisterVkCommandBuffers(stack);
+          auto* api = mVulkanRenderer->getApi<Vulkan>();
+          return api->replayUnregisterVkCommandBuffers(stack);
         } else {
-            GAPID_WARNING("[%u]replayUnregisterVkCommandBuffers called without a bound Vulkan renderer", label);
-            return false;
+          GAPID_WARNING(
+              "[%u]replayUnregisterVkCommandBuffers called without a bound "
+              "Vulkan renderer",
+              label);
+          return false;
         }
-    });
+      });
 
-    interpreter->registerBuiltin(Vulkan::INDEX, Builtins::ReplayCreateSwapchain,
-                                    [this](uint32_t label, Stack* stack, bool pushReturn) {
+  interpreter->registerBuiltin(
+      Vulkan::INDEX, Builtins::ReplayCreateSwapchain,
+      [this](uint32_t label, Stack* stack, bool pushReturn) {
         GAPID_DEBUG("[%u]replayCreateSwapchain()", label);
         if (mVulkanRenderer != nullptr) {
-            auto* api = mVulkanRenderer->getApi<Vulkan>();
-            return api->replayCreateSwapchain(stack, pushReturn);
+          auto* api = mVulkanRenderer->getApi<Vulkan>();
+          return api->replayCreateSwapchain(stack, pushReturn);
         } else {
-            GAPID_WARNING("[%u]replayCreateSwapchain called without a bound Vulkan renderer", label);
-            return false;
+          GAPID_WARNING(
+              "[%u]replayCreateSwapchain called without a bound Vulkan "
+              "renderer",
+              label);
+          return false;
         }
-    });
+      });
 
-    interpreter->registerBuiltin(
-        Vulkan::INDEX,
-        Builtins::ReplayAllocateImageMemory,
-        [this](uint32_t label, Stack* stack, bool push_return) {
-            GAPID_DEBUG("[%u]replayAllocateImageMemory()", label);
-            if (mVulkanRenderer != nullptr) {
-                auto* api = mVulkanRenderer->getApi<Vulkan>();
-                return api->replayAllocateImageMemory(stack, push_return);
-            } else {
-                GAPID_WARNING("[%u]replayAllocateImageMemory called without a "
-                              "bound Vulkan renderer", label);
-                return false;
-            }
-        });
-    interpreter->registerBuiltin(
-        Vulkan::INDEX,
-        Builtins::ReplayEnumeratePhysicalDevices,
-        [this](uint32_t label, Stack* stack, bool push_return) {
-            GAPID_DEBUG("[%u]replayEnumeratePhysicalDevices()", label);
-            if (mVulkanRenderer != nullptr) {
-                auto* api = mVulkanRenderer->getApi<Vulkan>();
-                return api->replayEnumeratePhysicalDevices(stack, push_return);
-            } else {
-                GAPID_WARNING("[%u]replayEnumeratePhysicalDevices called without a "
-                              "bound Vulkan renderer", label);
-                return false;
-            }
-        });
+  interpreter->registerBuiltin(
+      Vulkan::INDEX, Builtins::ReplayAllocateImageMemory,
+      [this](uint32_t label, Stack* stack, bool push_return) {
+        GAPID_DEBUG("[%u]replayAllocateImageMemory()", label);
+        if (mVulkanRenderer != nullptr) {
+          auto* api = mVulkanRenderer->getApi<Vulkan>();
+          return api->replayAllocateImageMemory(stack, push_return);
+        } else {
+          GAPID_WARNING(
+              "[%u]replayAllocateImageMemory called without a "
+              "bound Vulkan renderer",
+              label);
+          return false;
+        }
+      });
+  interpreter->registerBuiltin(
+      Vulkan::INDEX, Builtins::ReplayEnumeratePhysicalDevices,
+      [this](uint32_t label, Stack* stack, bool push_return) {
+        GAPID_DEBUG("[%u]replayEnumeratePhysicalDevices()", label);
+        if (mVulkanRenderer != nullptr) {
+          auto* api = mVulkanRenderer->getApi<Vulkan>();
+          return api->replayEnumeratePhysicalDevices(stack, push_return);
+        } else {
+          GAPID_WARNING(
+              "[%u]replayEnumeratePhysicalDevices called without a "
+              "bound Vulkan renderer",
+              label);
+          return false;
+        }
+      });
 
-    interpreter->registerBuiltin(Vulkan::INDEX, Builtins::ReplayGetFenceStatus,
-                                 [this](uint32_t label, Stack* stack, bool push_return) {
+  interpreter->registerBuiltin(
+      Vulkan::INDEX, Builtins::ReplayGetFenceStatus,
+      [this](uint32_t label, Stack* stack, bool push_return) {
         GAPID_DEBUG("[%u]ReplayGetFenceStatus()", label);
         if (mVulkanRenderer != nullptr) {
-            auto* api = mVulkanRenderer->getApi<Vulkan>();
-            return api->replayGetFenceStatus(stack, push_return);
+          auto* api = mVulkanRenderer->getApi<Vulkan>();
+          return api->replayGetFenceStatus(stack, push_return);
         } else {
-            GAPID_WARNING("ReplayGetFenceStatus called without a bound Vulkan renderer");
-            return false;
+          GAPID_WARNING(
+              "ReplayGetFenceStatus called without a bound Vulkan renderer");
+          return false;
         }
-    });
+      });
 
-    interpreter->registerBuiltin(Vulkan::INDEX, Builtins::ReplayGetEventStatus,
-                                 [this](uint32_t label, Stack* stack, bool push_return) {
+  interpreter->registerBuiltin(
+      Vulkan::INDEX, Builtins::ReplayGetEventStatus,
+      [this](uint32_t label, Stack* stack, bool push_return) {
         GAPID_DEBUG("[%u]ReplayGetEventStatus()", label);
         if (mVulkanRenderer != nullptr) {
-            auto* api = mVulkanRenderer->getApi<Vulkan>();
-            return api->replayGetEventStatus(stack, push_return);
+          auto* api = mVulkanRenderer->getApi<Vulkan>();
+          return api->replayGetEventStatus(stack, push_return);
         } else {
-            GAPID_WARNING("ReplayGetEventStatus called without a bound Vulkan renderer");
-            return false;
+          GAPID_WARNING(
+              "ReplayGetEventStatus called without a bound Vulkan renderer");
+          return false;
         }
-    });
+      });
 
-    interpreter->registerBuiltin(
-        Vulkan::INDEX, Builtins::ReplayCreateVkDebugReportCallback,
-        [this](uint32_t label, Stack* stack, bool push_return) {
-          if (mVulkanRenderer != nullptr) {
-            auto* api = mVulkanRenderer->getApi<Vulkan>();
-            auto* handle = stack->pop<Vulkan::VkDebugReportCallbackEXT*>();
-            auto* create_info =
-                stack->pop<Vulkan::VkDebugReportCallbackCreateInfoEXT*>();
-            if (!stack->isValid()) {
-                GAPID_ERROR("Error during calling funtion ReplayCreateVkDebugReportCallback");
-                return false;
-            }
-
-            // Populate the create info
-            create_info->pfnCallback =
-                reinterpret_cast<void*>(Vulkan::replayDebugReportCallback);
-            create_info->pUserData = this;
-
-            stack->push(create_info);
-            stack->push(handle);
-            if(api->replayCreateVkDebugReportCallback(stack, true)) {
-                uint32_t result = stack->pop<uint32_t>();
-                if (result == Vulkan::VkResult::VK_SUCCESS) {
-                    GAPID_INFO("GAPID Debug report callback created");
-                } else {
-                  onDebugMessage(LOG_LEVEL_WARNING, Vulkan::INDEX,
-                      "Failed to create debug report callback, "
-                      "VK_EXT_debug_report extenion may be not supported on "
-                      "this replay device");
-                }
-                if (push_return) {
-                    stack->push(result);
-                }
-            }
-            return true;
-          } else {
-            GAPID_WARNING(
-                "ReplayCreateVkDebugReportCallback called without a bound "
-                "Vulkan renderer");
+  interpreter->registerBuiltin(
+      Vulkan::INDEX, Builtins::ReplayCreateVkDebugReportCallback,
+      [this](uint32_t label, Stack* stack, bool push_return) {
+        if (mVulkanRenderer != nullptr) {
+          auto* api = mVulkanRenderer->getApi<Vulkan>();
+          auto* handle = stack->pop<Vulkan::VkDebugReportCallbackEXT*>();
+          auto* create_info =
+              stack->pop<Vulkan::VkDebugReportCallbackCreateInfoEXT*>();
+          if (!stack->isValid()) {
+            GAPID_ERROR(
+                "Error during calling funtion "
+                "ReplayCreateVkDebugReportCallback");
             return false;
           }
-        });
 
-    interpreter->registerBuiltin(
-        Vulkan::INDEX, Builtins::ReplayDestroyVkDebugReportCallback,
-        [this](uint32_t label, Stack* stack, bool) {
-          GAPID_DEBUG("[%u]ReplayDestroyVkDebugReportCallback()", label);
-          if (mVulkanRenderer != nullptr) {
-            auto* api = mVulkanRenderer->getApi<Vulkan>();
-            return api->replayDestroyVkDebugReportCallback(stack);
-          } else {
-            GAPID_WARNING(
-                "ReplayDestroyVkDebugReportCallback called without a bound "
-                "Vulkan renderer");
-            return false;
+          // Populate the create info
+          create_info->pfnCallback =
+              reinterpret_cast<void*>(Vulkan::replayDebugReportCallback);
+          create_info->pUserData = this;
+
+          stack->push(create_info);
+          stack->push(handle);
+          if (api->replayCreateVkDebugReportCallback(stack, true)) {
+            uint32_t result = stack->pop<uint32_t>();
+            if (result == Vulkan::VkResult::VK_SUCCESS) {
+              GAPID_INFO("GAPID Debug report callback created");
+            } else {
+              onDebugMessage(
+                  LOG_LEVEL_WARNING, Vulkan::INDEX,
+                  "Failed to create debug report callback, "
+                  "VK_EXT_debug_report extenion may be not supported on "
+                  "this replay device");
+            }
+            if (push_return) {
+              stack->push(result);
+            }
           }
-        });
+          return true;
+        } else {
+          GAPID_WARNING(
+              "ReplayCreateVkDebugReportCallback called without a bound "
+              "Vulkan renderer");
+          return false;
+        }
+      });
+
+  interpreter->registerBuiltin(
+      Vulkan::INDEX, Builtins::ReplayDestroyVkDebugReportCallback,
+      [this](uint32_t label, Stack* stack, bool) {
+        GAPID_DEBUG("[%u]ReplayDestroyVkDebugReportCallback()", label);
+        if (mVulkanRenderer != nullptr) {
+          auto* api = mVulkanRenderer->getApi<Vulkan>();
+          return api->replayDestroyVkDebugReportCallback(stack);
+        } else {
+          GAPID_WARNING(
+              "ReplayDestroyVkDebugReportCallback called without a bound "
+              "Vulkan renderer");
+          return false;
+        }
+      });
 }
 
 bool Context::loadResource(Stack* stack) {
-    uint32_t resourceId = stack->pop<uint32_t>();
-    void* address = stack->pop<void*>();
+  uint32_t resourceId = stack->pop<uint32_t>();
+  void* address = stack->pop<void*>();
 
-    if (!stack->isValid()) {
-        GAPID_WARNING("Error during loadResource");
-        return false;
-    }
+  if (!stack->isValid()) {
+    GAPID_WARNING("Error during loadResource");
+    return false;
+  }
 
-    const auto& resource = mReplayRequest->getResources()[resourceId];
+  const auto& resource = mReplayRequest->getResources()[resourceId];
 
-    if (!mResourceProvider->get(&resource, 1, mConnection, address, resource.size)) {
-        GAPID_WARNING("Can't fetch resource: %s", resource.id.c_str());
-        return false;
-    }
+  if (!mResourceProvider->get(&resource, 1, mConnection, address,
+                              resource.size)) {
+    GAPID_WARNING("Can't fetch resource: %s", resource.id.c_str());
+    return false;
+  }
 
-    return true;
+  return true;
 }
 
 bool Context::postData(Stack* stack) {
-    const uint32_t count = stack->pop<uint32_t>();
-    const void* address = stack->pop<const void*>();
+  const uint32_t count = stack->pop<uint32_t>();
+  const void* address = stack->pop<const void*>();
 
-    if (!stack->isValid()) {
-        GAPID_WARNING("Error during postData");
-        return false;
-    }
+  if (!stack->isValid()) {
+    GAPID_WARNING("Error during postData");
+    return false;
+  }
 
-    return mPostBuffer->push(address, count);
+  return mPostBuffer->push(address, count);
 }
 
 bool Context::flushPostBuffer(Stack* stack) {
-    if (!stack->isValid()) {
-        GAPID_WARNING("Error during flushPostBuffer");
-        return false;
-    }
+  if (!stack->isValid()) {
+    GAPID_WARNING("Error during flushPostBuffer");
+    return false;
+  }
 
-    return mPostBuffer->flush();
+  return mPostBuffer->flush();
 }
 
 bool Context::startTimer(Stack* stack) {
-    size_t index = static_cast<size_t>(stack->pop<uint8_t>());
-    if (stack->isValid()) {
-        if (index < MAX_TIMERS) {
-            GAPID_INFO("startTimer(%zu)", index);
-            mTimers[index].Start();
-            return true;
-        } else {
-            GAPID_WARNING("StartTimer called with invalid index %zu", index);
-        }
+  size_t index = static_cast<size_t>(stack->pop<uint8_t>());
+  if (stack->isValid()) {
+    if (index < MAX_TIMERS) {
+      GAPID_INFO("startTimer(%zu)", index);
+      mTimers[index].Start();
+      return true;
     } else {
-        GAPID_WARNING("Error while calling function StartTimer");
+      GAPID_WARNING("StartTimer called with invalid index %zu", index);
     }
-    return false;
+  } else {
+    GAPID_WARNING("Error while calling function StartTimer");
+  }
+  return false;
 }
 
 bool Context::stopTimer(Stack* stack, bool pushReturn) {
-    size_t index = static_cast<size_t>(stack->pop<uint8_t>());
-    if (stack->isValid()) {
-        if (index < MAX_TIMERS) {
-            GAPID_INFO("stopTimer(%zu)", index);
-            uint64_t ns = mTimers[index].Stop();
-            if (pushReturn) {
-                stack->push(ns);
-            }
-            return true;
-        } else {
-            GAPID_WARNING("StopTimer called with invalid index %zu", index);
-        }
+  size_t index = static_cast<size_t>(stack->pop<uint8_t>());
+  if (stack->isValid()) {
+    if (index < MAX_TIMERS) {
+      GAPID_INFO("stopTimer(%zu)", index);
+      uint64_t ns = mTimers[index].Stop();
+      if (pushReturn) {
+        stack->push(ns);
+      }
+      return true;
     } else {
-        GAPID_WARNING("Error while calling function StopTimer");
+      GAPID_WARNING("StopTimer called with invalid index %zu", index);
     }
-    return false;
+  } else {
+    GAPID_WARNING("Error while calling function StopTimer");
+  }
+  return false;
 }
 
 }  // namespace gapir

--- a/gapir/cc/context.h
+++ b/gapir/cc/context.h
@@ -40,102 +40,106 @@ class ResourceProvider;
 class Stack;
 class VulkanRenderer;
 
-// Context object for the replay containing the Gl context, the memory manager and the replay
-// specific functions to handle network communication of the interpreter
+// Context object for the replay containing the Gl context, the memory manager
+// and the replay specific functions to handle network communication of the
+// interpreter
 class Context : private Renderer::Listener {
-public:
-    // Creates a new Context object and initialize it with loading the replay request, setting up
-    // the memory manager, setting up the caches and prefetching the resources
-    static std::unique_ptr<Context> create(
-            ReplayConnection* conn,
-            core::CrashHandler& crash_handler,
-            ResourceProvider* resource_provider,
-            MemoryManager* memory_manager);
+ public:
+  // Creates a new Context object and initialize it with loading the replay
+  // request, setting up the memory manager, setting up the caches and
+  // prefetching the resources
+  static std::unique_ptr<Context> create(ReplayConnection* conn,
+                                         core::CrashHandler& crash_handler,
+                                         ResourceProvider* resource_provider,
+                                         MemoryManager* memory_manager);
 
-    ~Context();
+  ~Context();
 
-    void prefetch(ResourceInMemoryCache* cache) const;
+  void prefetch(ResourceInMemoryCache* cache) const;
 
-    // Run the interpreter over the opcode stream of the replay request and returns true if the
-    // interpretation was successful false otherwise
-    bool interpret();
+  // Run the interpreter over the opcode stream of the replay request and
+  // returns true if the interpretation was successful false otherwise
+  bool interpret();
 
-    // Renderer::Listener compliance
-    virtual void onDebugMessage(uint32_t severity, uint8_t api_index, const char* msg) override;
+  // Renderer::Listener compliance
+  virtual void onDebugMessage(uint32_t severity, uint8_t api_index,
+                              const char* msg) override;
 
-private:
-    enum {
-        MAX_TIMERS       = 256,
-        POST_BUFFER_SIZE = 2*1024*1024,
-    };
+ private:
+  enum {
+    MAX_TIMERS = 256,
+    POST_BUFFER_SIZE = 2 * 1024 * 1024,
+  };
 
-    Context(ReplayConnection* conn,
-            core::CrashHandler& crash_handler,
-            ResourceProvider* resource_provider,
-            MemoryManager* memory_manager);
+  Context(ReplayConnection* conn, core::CrashHandler& crash_handler,
+          ResourceProvider* resource_provider, MemoryManager* memory_manager);
 
-    // Initialize the context object with loading the replay request, setting up the memory manager,
-    // setting up the caches and prefetching the resources
-    bool initialize();
+  // Initialize the context object with loading the replay request, setting up
+  // the memory manager, setting up the caches and prefetching the resources
+  bool initialize();
 
-    // Register the callbacks for the interpreter (Gl functions, load resource, post resource)
-    void registerCallbacks(Interpreter* interpreter);
+  // Register the callbacks for the interpreter (Gl functions, load resource,
+  // post resource)
+  void registerCallbacks(Interpreter* interpreter);
 
-    // Post a chunk of data where the number of bytes is on the top of the stack (uint32_t) and the
-    // address for the data is the second element on the stack (void*)
-    bool postData(Stack* stack);
+  // Post a chunk of data where the number of bytes is on the top of the stack
+  // (uint32_t) and the address for the data is the second element on the stack
+  // (void*)
+  bool postData(Stack* stack);
 
-    // Load a resource from the resource provider where the index of the resource is at the top of
-    // the stack (uint32_t) and the target address is at the second element of the stack (void*)
-    bool loadResource(Stack* stack);
+  // Load a resource from the resource provider where the index of the resource
+  // is at the top of the stack (uint32_t) and the target address is at the
+  // second element of the stack (void*)
+  bool loadResource(Stack* stack);
 
-    // Starts the timer identified by u8 index.
-    bool startTimer(Stack* stack);
+  // Starts the timer identified by u8 index.
+  bool startTimer(Stack* stack);
 
-    // Stops the timer identified by u8 index and returns u64 elapsed nanoseconds since its start.
-    bool stopTimer(Stack* stack, bool pushReturn);
+  // Stops the timer identified by u8 index and returns u64 elapsed nanoseconds
+  // since its start.
+  bool stopTimer(Stack* stack, bool pushReturn);
 
-    // Flushes any pending post data buffered from calling postData.
-    bool flushPostBuffer(Stack *stack);
+  // Flushes any pending post data buffered from calling postData.
+  bool flushPostBuffer(Stack* stack);
 
-    // Server connection object to fetch and post resources back to the server
-    ReplayConnection* mConnection;
+  // Server connection object to fetch and post resources back to the server
+  ReplayConnection* mConnection;
 
-    // The crash handler used for catching and reporting crashes.
-    core::CrashHandler& mCrashHandler;
+  // The crash handler used for catching and reporting crashes.
+  core::CrashHandler& mCrashHandler;
 
-    // Resource provider (possibly with caching) to fetch the resources required by the replay. It
-    // is owned by the creator of the Context object.
-    ResourceProvider* mResourceProvider;
+  // Resource provider (possibly with caching) to fetch the resources required
+  // by the replay. It is owned by the creator of the Context object.
+  ResourceProvider* mResourceProvider;
 
-    // Memory manager to manage the memory used by the replay and by the interpreter. Is is owned by
-    // the creator of the Context object.
-    MemoryManager* mMemoryManager;
+  // Memory manager to manage the memory used by the replay and by the
+  // interpreter. Is is owned by the creator of the Context object.
+  MemoryManager* mMemoryManager;
 
-    // The data of the request for this context belongs to
-    std::unique_ptr<ReplayRequest> mReplayRequest;
+  // The data of the request for this context belongs to
+  std::unique_ptr<ReplayRequest> mReplayRequest;
 
-    // An array of timers.
-    core::Timer mTimers[MAX_TIMERS];
+  // An array of timers.
+  core::Timer mTimers[MAX_TIMERS];
 
-    // GLES renderer used as reference for all context sharing.
-    std::unique_ptr<GlesRenderer> mRootGlesRenderer;
+  // GLES renderer used as reference for all context sharing.
+  std::unique_ptr<GlesRenderer> mRootGlesRenderer;
 
-    // The constructed GLES renderers.
-    std::unordered_map<uint32_t, GlesRenderer*> mGlesRenderers;
+  // The constructed GLES renderers.
+  std::unordered_map<uint32_t, GlesRenderer*> mGlesRenderers;
 
-    // The lazily-built Vulkan renderer.
-    VulkanRenderer* mVulkanRenderer;
+  // The lazily-built Vulkan renderer.
+  VulkanRenderer* mVulkanRenderer;
 
-    // A buffer for data to be sent back to the server.
-    std::unique_ptr<PostBuffer> mPostBuffer;
+  // A buffer for data to be sent back to the server.
+  std::unique_ptr<PostBuffer> mPostBuffer;
 
-    // The currently running interpreter.
-    // Only valid for the duration of interpret()
-    std::unique_ptr<Interpreter> mInterpreter;
+  // The currently running interpreter.
+  // Only valid for the duration of interpret()
+  std::unique_ptr<Interpreter> mInterpreter;
 
-    // The total number of debug messages sent to GAPIS.
-    uint64_t mNumSentDebugMessages;
+  // The total number of debug messages sent to GAPIS.
+  uint64_t mNumSentDebugMessages;
 };
 
 }  // namespace gapir

--- a/gapir/cc/context_test.cpp
+++ b/gapir/cc/context_test.cpp
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-#include "base_type.h"
 #include "context.h"
+#include "base_type.h"
 #include "interpreter.h"
 #include "memory_manager.h"
-#include "mock_resource_provider.h"
 #include "mock_replay_connection.h"
+#include "mock_resource_provider.h"
 #include "resource_provider.h"
 #include "test_utilities.h"
 
@@ -40,178 +40,214 @@ const ResourceId REPLAY_ID = "replay-id";
 const Resource A("A", 4);
 
 class ContextTest : public ::testing::Test {
-protected:
-    virtual void SetUp() {
-        std::vector<uint32_t> memorySizes = {MEMORY_SIZE};
-        mMemoryManager.reset(new MemoryManager(memorySizes));
-        mResourceProvider.reset(new StrictMock<MockResourceProvider>());
-        mConn.reset(new MockReplayConnection());
-    }
+ protected:
+  virtual void SetUp() {
+    std::vector<uint32_t> memorySizes = {MEMORY_SIZE};
+    mMemoryManager.reset(new MemoryManager(memorySizes));
+    mResourceProvider.reset(new StrictMock<MockResourceProvider>());
+    mConn.reset(new MockReplayConnection());
+  }
 
-    std::unique_ptr<MemoryManager> mMemoryManager;
-    std::unique_ptr<StrictMock<MockResourceProvider>> mResourceProvider;
-    std::unique_ptr<MockReplayConnection> mConn;
+  std::unique_ptr<MemoryManager> mMemoryManager;
+  std::unique_ptr<StrictMock<MockResourceProvider>> mResourceProvider;
+  std::unique_ptr<MockReplayConnection> mConn;
 };
 }  // anonymous namespace
 
 TEST_F(ContextTest, Create) {
-    auto payload = createPayload(0, 0, {}, {}, {});
+  auto payload = createPayload(0, 0, {}, {}, {});
 
-    EXPECT_CALL(*mConn, getPayload()).WillOnce(Return(ByMove(std::move(payload))));
-    core::CrashHandler crash_handler;
-    auto context = Context::create(mConn.get(), crash_handler, mResourceProvider.get(), mMemoryManager.get());
+  EXPECT_CALL(*mConn, getPayload())
+      .WillOnce(Return(ByMove(std::move(payload))));
+  core::CrashHandler crash_handler;
+  auto context = Context::create(mConn.get(), crash_handler,
+                                 mResourceProvider.get(), mMemoryManager.get());
 
-    EXPECT_THAT(context, NotNull());
+  EXPECT_THAT(context, NotNull());
 }
 
 TEST_F(ContextTest, CreateErrorReplayRequest) {
-    // Failed to load
-    EXPECT_CALL(*mConn, getPayload()).WillOnce(Return(ByMove(std::unique_ptr<ReplayConnection::Payload>(nullptr))));
+  // Failed to load
+  EXPECT_CALL(*mConn, getPayload())
+      .WillOnce(
+          Return(ByMove(std::unique_ptr<ReplayConnection::Payload>(nullptr))));
 
-    core::CrashHandler crash_handler;
-    auto context = Context::create(mConn.get(), crash_handler, mResourceProvider.get(), mMemoryManager.get());
+  core::CrashHandler crash_handler;
+  auto context = Context::create(mConn.get(), crash_handler,
+                                 mResourceProvider.get(), mMemoryManager.get());
 
-    EXPECT_THAT(context, IsNull());
+  EXPECT_THAT(context, IsNull());
 }
 
 TEST_F(ContextTest, CreateErrorVolatileMemory) {
-    auto payload = createPayload(0, MEMORY_SIZE+1, {}, {}, {});
+  auto payload = createPayload(0, MEMORY_SIZE + 1, {}, {}, {});
 
-    EXPECT_CALL(*mConn, getPayload()).WillOnce(Return(ByMove(std::move(payload))));
-    core::CrashHandler crash_handler;
-    auto context = Context::create(mConn.get(), crash_handler, mResourceProvider.get(), mMemoryManager.get());
+  EXPECT_CALL(*mConn, getPayload())
+      .WillOnce(Return(ByMove(std::move(payload))));
+  core::CrashHandler crash_handler;
+  auto context = Context::create(mConn.get(), crash_handler,
+                                 mResourceProvider.get(), mMemoryManager.get());
 
-    EXPECT_THAT(context, IsNull());
+  EXPECT_THAT(context, IsNull());
 }
 
 TEST_F(ContextTest, LoadResource) {
-    auto payload = createPayload(
-            128, 1024, {}, {A},
-            {instruction(Interpreter::InstructionCode::PUSH_I, BaseType::VolatilePointer, 0),
-             instruction(Interpreter::InstructionCode::RESOURCE, 0)});
-    std::vector<uint8_t> resourceA{1, 2, 3, 4};
+  auto payload =
+      createPayload(128, 1024, {}, {A},
+                    {instruction(Interpreter::InstructionCode::PUSH_I,
+                                 BaseType::VolatilePointer, 0),
+                     instruction(Interpreter::InstructionCode::RESOURCE, 0)});
+  std::vector<uint8_t> resourceA{1, 2, 3, 4};
 
-    EXPECT_CALL(*mConn, getPayload()).WillOnce(Return(ByMove(std::move(payload))));
-    EXPECT_CALL(*mResourceProvider, get(Pointee(Eq(A)), 1, _, _, 4))
-            .WillOnce(DoAll(WithArg<3>(SetVoidPointee(resourceA)), Return(true)));
+  EXPECT_CALL(*mConn, getPayload())
+      .WillOnce(Return(ByMove(std::move(payload))));
+  EXPECT_CALL(*mResourceProvider, get(Pointee(Eq(A)), 1, _, _, 4))
+      .WillOnce(DoAll(WithArg<3>(SetVoidPointee(resourceA)), Return(true)));
 
-    core::CrashHandler crash_handler;
-    auto context = Context::create(mConn.get(), crash_handler, mResourceProvider.get(), mMemoryManager.get());
+  core::CrashHandler crash_handler;
+  auto context = Context::create(mConn.get(), crash_handler,
+                                 mResourceProvider.get(), mMemoryManager.get());
 
-    EXPECT_THAT(context, NotNull());
-    EXPECT_TRUE(context->interpret());
-    auto res = (uint8_t*)mMemoryManager->volatileToAbsolute(0);
-    EXPECT_THAT(resourceA, ElementsAreArray(res, resourceA.size()));
+  EXPECT_THAT(context, NotNull());
+  EXPECT_TRUE(context->interpret());
+  auto res = (uint8_t*)mMemoryManager->volatileToAbsolute(0);
+  EXPECT_THAT(resourceA, ElementsAreArray(res, resourceA.size()));
 }
 
 TEST_F(ContextTest, LoadResourcePopFailed) {
-    auto payload = createPayload(128, 1024, {}, {A},
-                                       {instruction(Interpreter::InstructionCode::RESOURCE, 0)});
+  auto payload =
+      createPayload(128, 1024, {}, {A},
+                    {instruction(Interpreter::InstructionCode::RESOURCE, 0)});
 
-    EXPECT_CALL(*mConn, getPayload()).WillOnce(Return(ByMove(std::move(payload))));
-    core::CrashHandler crash_handler;
-    auto context = Context::create(mConn.get(), crash_handler, mResourceProvider.get(), mMemoryManager.get());
+  EXPECT_CALL(*mConn, getPayload())
+      .WillOnce(Return(ByMove(std::move(payload))));
+  core::CrashHandler crash_handler;
+  auto context = Context::create(mConn.get(), crash_handler,
+                                 mResourceProvider.get(), mMemoryManager.get());
 
-    EXPECT_THAT(context, NotNull());
-    EXPECT_FALSE(context->interpret());
+  EXPECT_THAT(context, NotNull());
+  EXPECT_FALSE(context->interpret());
 }
 
 TEST_F(ContextTest, LoadResourceGetFailed) {
-    auto payload = createPayload(
-            128, 1024, {}, {A},
-            {instruction(Interpreter::InstructionCode::PUSH_I, BaseType::VolatilePointer, 0),
-             instruction(Interpreter::InstructionCode::RESOURCE, 0)});
+  auto payload =
+      createPayload(128, 1024, {}, {A},
+                    {instruction(Interpreter::InstructionCode::PUSH_I,
+                                 BaseType::VolatilePointer, 0),
+                     instruction(Interpreter::InstructionCode::RESOURCE, 0)});
 
-    EXPECT_CALL(*mConn, getPayload()).WillOnce(Return(ByMove(std::move(payload))));
-    EXPECT_CALL(*mResourceProvider, get(Pointee(Eq(A)), 1, _, _, 4)).WillOnce(Return(false));
+  EXPECT_CALL(*mConn, getPayload())
+      .WillOnce(Return(ByMove(std::move(payload))));
+  EXPECT_CALL(*mResourceProvider, get(Pointee(Eq(A)), 1, _, _, 4))
+      .WillOnce(Return(false));
 
-    core::CrashHandler crash_handler;
-    auto context = Context::create(mConn.get(), crash_handler, mResourceProvider.get(), mMemoryManager.get());
+  core::CrashHandler crash_handler;
+  auto context = Context::create(mConn.get(), crash_handler,
+                                 mResourceProvider.get(), mMemoryManager.get());
 
-    EXPECT_THAT(context, NotNull());
-    EXPECT_FALSE(context->interpret());
+  EXPECT_THAT(context, NotNull());
+  EXPECT_FALSE(context->interpret());
 }
 
 TEST_F(ContextTest, PostData) {
-    auto payload = createPayload(
-            128, 1024, {0, 1, 2, 3, 4, 5, 6, 7}, {},
-            {instruction(Interpreter::InstructionCode::PUSH_I, BaseType::ConstantPointer, 1),
-             instruction(Interpreter::InstructionCode::PUSH_I, BaseType::Uint32, 6),
-             instruction(Interpreter::InstructionCode::POST)});
-    std::vector<uint8_t> expected;
-    pushBytes(&expected, {1, 2, 3, 4, 5, 6});
-    std::vector<uint8_t> actual;
+  auto payload = createPayload(
+      128, 1024, {0, 1, 2, 3, 4, 5, 6, 7}, {},
+      {instruction(Interpreter::InstructionCode::PUSH_I,
+                   BaseType::ConstantPointer, 1),
+       instruction(Interpreter::InstructionCode::PUSH_I, BaseType::Uint32, 6),
+       instruction(Interpreter::InstructionCode::POST)});
+  std::vector<uint8_t> expected;
+  pushBytes(&expected, {1, 2, 3, 4, 5, 6});
+  std::vector<uint8_t> actual;
 
-    EXPECT_CALL(*mConn, getPayload()).WillOnce(Return(ByMove(std::move(payload))));
-    EXPECT_CALL(*mConn, mockedSendPostData(NotNull())).WillOnce(Invoke([&actual](ReplayConnection::Posts* posts) -> bool {
+  EXPECT_CALL(*mConn, getPayload())
+      .WillOnce(Return(ByMove(std::move(payload))));
+  EXPECT_CALL(*mConn, mockedSendPostData(NotNull()))
+      .WillOnce(Invoke([&actual](ReplayConnection::Posts* posts) -> bool {
         for (size_t i = 0; i < posts->piece_count(); i++) {
-            actual.resize(actual.size() + posts->piece_size(i));
-            memcpy(&actual[actual.size() - posts->piece_size(i)], posts->piece_data(i), posts->piece_size(i));
+          actual.resize(actual.size() + posts->piece_size(i));
+          memcpy(&actual[actual.size() - posts->piece_size(i)],
+                 posts->piece_data(i), posts->piece_size(i));
         }
         return true;
-    }));
+      }));
 
-    core::CrashHandler crash_handler;
-    auto context = Context::create(mConn.get(), crash_handler, mResourceProvider.get(), mMemoryManager.get());
-    EXPECT_THAT(context, NotNull());
-    EXPECT_TRUE(context->interpret());
-    EXPECT_THAT(actual, ContainerEq(expected));
+  core::CrashHandler crash_handler;
+  auto context = Context::create(mConn.get(), crash_handler,
+                                 mResourceProvider.get(), mMemoryManager.get());
+  EXPECT_THAT(context, NotNull());
+  EXPECT_TRUE(context->interpret());
+  EXPECT_THAT(actual, ContainerEq(expected));
 }
 
 TEST_F(ContextTest, PostDataErrorPop) {
-    auto payload = createPayload(
-            128, 1024, {0, 1, 2, 3, 4, 5, 6, 7}, {},
-            {instruction(Interpreter::InstructionCode::PUSH_I, BaseType::ConstantPointer, 1),
-             instruction(Interpreter::InstructionCode::PUSH_I, BaseType::Uint8, 6),  // Wrong type
-             instruction(Interpreter::InstructionCode::POST)});
+  auto payload =
+      createPayload(128, 1024, {0, 1, 2, 3, 4, 5, 6, 7}, {},
+                    {instruction(Interpreter::InstructionCode::PUSH_I,
+                                 BaseType::ConstantPointer, 1),
+                     instruction(Interpreter::InstructionCode::PUSH_I,
+                                 BaseType::Uint8, 6),  // Wrong type
+                     instruction(Interpreter::InstructionCode::POST)});
 
-    EXPECT_CALL(*mConn, getPayload()).WillOnce(Return(ByMove(std::move(payload))));
-    core::CrashHandler crash_handler;
-    auto context = Context::create(mConn.get(), crash_handler, mResourceProvider.get(), mMemoryManager.get());
+  EXPECT_CALL(*mConn, getPayload())
+      .WillOnce(Return(ByMove(std::move(payload))));
+  core::CrashHandler crash_handler;
+  auto context = Context::create(mConn.get(), crash_handler,
+                                 mResourceProvider.get(), mMemoryManager.get());
 
-    EXPECT_THAT(context, NotNull());
-    EXPECT_FALSE(context->interpret());
+  EXPECT_THAT(context, NotNull());
+  EXPECT_FALSE(context->interpret());
 }
 
 TEST_F(ContextTest, PostDataErrorPost) {
-    auto payload = createPayload(
-            128, 1024, {0, 1, 2, 3, 4, 5, 6, 7}, {},
-            {instruction(Interpreter::InstructionCode::PUSH_I, BaseType::ConstantPointer, 1),
-             instruction(Interpreter::InstructionCode::PUSH_I, BaseType::Uint32, 6),
-             instruction(Interpreter::InstructionCode::POST)});
+  auto payload = createPayload(
+      128, 1024, {0, 1, 2, 3, 4, 5, 6, 7}, {},
+      {instruction(Interpreter::InstructionCode::PUSH_I,
+                   BaseType::ConstantPointer, 1),
+       instruction(Interpreter::InstructionCode::PUSH_I, BaseType::Uint32, 6),
+       instruction(Interpreter::InstructionCode::POST)});
 
-    EXPECT_CALL(*mConn, getPayload()).WillOnce(Return(ByMove(std::move(payload))));
-    EXPECT_CALL(*mConn, mockedSendPostData(NotNull())).WillOnce(Return(false));
+  EXPECT_CALL(*mConn, getPayload())
+      .WillOnce(Return(ByMove(std::move(payload))));
+  EXPECT_CALL(*mConn, mockedSendPostData(NotNull())).WillOnce(Return(false));
 
-    core::CrashHandler crash_handler;
-    auto context = Context::create(mConn.get(), crash_handler, mResourceProvider.get(), mMemoryManager.get());
-    EXPECT_THAT(context, NotNull());
-    EXPECT_FALSE(context->interpret());
+  core::CrashHandler crash_handler;
+  auto context = Context::create(mConn.get(), crash_handler,
+                                 mResourceProvider.get(), mMemoryManager.get());
+  EXPECT_THAT(context, NotNull());
+  EXPECT_FALSE(context->interpret());
 }
 
 TEST_F(ContextTest, Notification) {
-    const uint8_t api_index = 0xAB;
-    const int severity = LOG_LEVEL_ERROR;
-    const std::string msg = "notification test";
-    // Invoke onDebugMessage() during interpreting POST instruction.
-    auto payload = createPayload(
-            128, 1024, {0, 1, 2, 3, 4, 5, 6, 7}, {},
-            {instruction(Interpreter::InstructionCode::PUSH_I, BaseType::ConstantPointer, 1),
-             instruction(Interpreter::InstructionCode::PUSH_I, BaseType::Uint32, 6),
-             instruction(Interpreter::InstructionCode::POST)});
+  const uint8_t api_index = 0xAB;
+  const int severity = LOG_LEVEL_ERROR;
+  const std::string msg = "notification test";
+  // Invoke onDebugMessage() during interpreting POST instruction.
+  auto payload = createPayload(
+      128, 1024, {0, 1, 2, 3, 4, 5, 6, 7}, {},
+      {instruction(Interpreter::InstructionCode::PUSH_I,
+                   BaseType::ConstantPointer, 1),
+       instruction(Interpreter::InstructionCode::PUSH_I, BaseType::Uint32, 6),
+       instruction(Interpreter::InstructionCode::POST)});
 
-    EXPECT_CALL(*mConn, getPayload()).WillOnce(Return(ByMove(std::move(payload))));
-    core::CrashHandler crash_handler;
-    auto context = Context::create(mConn.get(), crash_handler, mResourceProvider.get(), mMemoryManager.get());
-    EXPECT_THAT(context, NotNull());
+  EXPECT_CALL(*mConn, getPayload())
+      .WillOnce(Return(ByMove(std::move(payload))));
+  core::CrashHandler crash_handler;
+  auto context = Context::create(mConn.get(), crash_handler,
+                                 mResourceProvider.get(), mMemoryManager.get());
+  EXPECT_THAT(context, NotNull());
 
-    EXPECT_CALL(*mConn, mockedSendPostData(NotNull())).WillOnce(Invoke([&context, &msg](ReplayConnection::Posts* posts) -> bool {
-        context->onDebugMessage(severity, api_index, msg.c_str());
-        return true;
-    }));
-    EXPECT_CALL(*mConn, sendNotification(0, severity, api_index, 0, msg, IsNull(), 0)).WillOnce(Return(true));
+  EXPECT_CALL(*mConn, mockedSendPostData(NotNull()))
+      .WillOnce(
+          Invoke([&context, &msg](ReplayConnection::Posts* posts) -> bool {
+            context->onDebugMessage(severity, api_index, msg.c_str());
+            return true;
+          }));
+  EXPECT_CALL(*mConn,
+              sendNotification(0, severity, api_index, 0, msg, IsNull(), 0))
+      .WillOnce(Return(true));
 
-    EXPECT_TRUE(context->interpret());
+  EXPECT_TRUE(context->interpret());
 }
 
 }  // namespace test

--- a/gapir/cc/crash_uploader.h
+++ b/gapir/cc/crash_uploader.h
@@ -25,18 +25,18 @@
 
 namespace gapir {
 
-// CrashUploader uploads crash minidumps from a CrashHandler to GAPIS via a ServerConnection.
+// CrashUploader uploads crash minidumps from a CrashHandler to GAPIS via a
+// ServerConnection.
 class CrashUploader {
-public:
+ public:
   CrashUploader(core::CrashHandler& crash_handler, ReplayConnection* conn);
   ~CrashUploader();
 
-private:
-
+ private:
   core::CrashHandler::Unregister mUnregister;
   ReplayConnection* mConnection;
 };
 
-} // namespace gapir
+}  // namespace gapir
 
-#endif // GAPIR_CRASH_REPORTER_H
+#endif  // GAPIR_CRASH_REPORTER_H

--- a/gapir/cc/function_table.h
+++ b/gapir/cc/function_table.h
@@ -29,43 +29,43 @@ class Stack;
 
 // FunctionTable provides a mapping of function id to a VM function.
 class FunctionTable {
-public:
-    // General signature for functions callable by the interpreter with a function call
-    // instruction. The first argument is a pointer to the stack of the Virtual Machine and the
-    // second argument is true if the caller expect the return value of the function to be pushed
-    // to the stack. The function should return true if the function call was successful, false
-    // otherwise.
-    typedef std::function<bool(uint32_t, Stack*, bool)> Function;
+ public:
+  // General signature for functions callable by the interpreter with a function
+  // call instruction. The first argument is a pointer to the stack of the
+  // Virtual Machine and the second argument is true if the caller expect the
+  // return value of the function to be pushed to the stack. The function should
+  // return true if the function call was successful, false otherwise.
+  typedef std::function<bool(uint32_t, Stack*, bool)> Function;
 
-    // The function identifier. These are part of the protocol between the server and the replay
-    // system, and so must remain consistent.
-    typedef uint16_t Id;
+  // The function identifier. These are part of the protocol between the server
+  // and the replay system, and so must remain consistent.
+  typedef uint16_t Id;
 
-    // Inserts a function into the table.
-    inline void insert(Id id, Function func);
+  // Inserts a function into the table.
+  inline void insert(Id id, Function func);
 
-    // Returns a function from the table, or nullptr if there is no function with the specified
-    // identifier.
-    inline Function* lookup(Id id);
+  // Returns a function from the table, or nullptr if there is no function with
+  // the specified identifier.
+  inline Function* lookup(Id id);
 
-private:
-    // Map of the supported function ids to the actual function implementations
-    std::unordered_map<Id, Function> mFunctions;
+ private:
+  // Map of the supported function ids to the actual function implementations
+  std::unordered_map<Id, Function> mFunctions;
 };
 
 inline FunctionTable::Function* FunctionTable::lookup(Id id) {
-    auto func = mFunctions.find(id);
-    if (func == mFunctions.end()) {
-        return nullptr;
-    }
-    return &func->second;
+  auto func = mFunctions.find(id);
+  if (func == mFunctions.end()) {
+    return nullptr;
+  }
+  return &func->second;
 }
 
 inline void FunctionTable::insert(Id id, Function func) {
-    if (mFunctions.count(id) != 0) {
-        GAPID_FATAL("Duplicate functions inserted into table");
-    }
-    mFunctions[id] = func;
+  if (mFunctions.count(id) != 0) {
+    GAPID_FATAL("Duplicate functions inserted into table");
+  }
+  mFunctions[id] = func;
 }
 
 }  // namespace gapir

--- a/gapir/cc/gfx_api.h
+++ b/gapir/cc/gfx_api.h
@@ -27,14 +27,14 @@ class Stack;
 
 // Api is the abstract base class to all graphics APIs.
 class Api {
-public:
-    // Returns the unique identifier of the graphics API.
-    // The pointer is guaranteed to be constant for all instances of the API.
-    virtual const char* id() const = 0;
-    // Returns the index of the graphics API.
-    virtual uint8_t index() const = 0;
-    // The function table for the API.
-    FunctionTable mFunctions;
+ public:
+  // Returns the unique identifier of the graphics API.
+  // The pointer is guaranteed to be constant for all instances of the API.
+  virtual const char* id() const = 0;
+  // Returns the index of the graphics API.
+  virtual uint8_t index() const = 0;
+  // The function table for the API.
+  FunctionTable mFunctions;
 };
 
 }  // namespace gapir

--- a/gapir/cc/gles_renderer.h
+++ b/gapir/cc/gles_renderer.h
@@ -21,76 +21,83 @@
 
 namespace gapir {
 
-// The GLES renderer implementation, which creates a OpenGL / GLES rendering context.
+// The GLES renderer implementation, which creates a OpenGL / GLES rendering
+// context.
 class GlesRenderer : public Renderer {
-public:
-    // Backbuffer describes a backbuffer dimensions and format.
-    struct Backbuffer {
-        struct Format {
-            inline Format();
-            inline Format(uint32_t c, uint32_t d, uint32_t s);
-            uint32_t color;
-            uint32_t depth;
-            uint32_t stencil;
-        };
-
-        inline Backbuffer();
-        inline Backbuffer(int w, int h, uint32_t c, uint32_t d, uint32_t s);
-
-        int     width;
-        int     height;
-        Format  format;
+ public:
+  // Backbuffer describes a backbuffer dimensions and format.
+  struct Backbuffer {
+    struct Format {
+      inline Format();
+      inline Format(uint32_t c, uint32_t d, uint32_t s);
+      uint32_t color;
+      uint32_t depth;
+      uint32_t stencil;
     };
 
-    // Construct and return an offscreen renderer.
-    static GlesRenderer* create(GlesRenderer* sharedContext);
+    inline Backbuffer();
+    inline Backbuffer(int w, int h, uint32_t c, uint32_t d, uint32_t s);
 
-    // Returns the renderer's API.
-    virtual Api* api() = 0;
+    int width;
+    int height;
+    Format format;
+  };
 
-    // Changes the back-buffer dimensions and format.
-    virtual void setBackbuffer(Backbuffer backbuffer) = 0;
+  // Construct and return an offscreen renderer.
+  static GlesRenderer* create(GlesRenderer* sharedContext);
 
-    // Makes the current renderer active.
-    virtual void bind() = 0;
+  // Returns the renderer's API.
+  virtual Api* api() = 0;
 
-    // Makes the current renderer inactive.
-    virtual void unbind() = 0;
+  // Changes the back-buffer dimensions and format.
+  virtual void setBackbuffer(Backbuffer backbuffer) = 0;
 
-    // Returns the name of the renderer's created graphics context.
-    virtual const char* name() = 0;
+  // Makes the current renderer active.
+  virtual void bind() = 0;
 
-    // Returns the list of extensions that the renderer's graphics context supports.
-    virtual const char* extensions() = 0;
+  // Makes the current renderer inactive.
+  virtual void unbind() = 0;
 
-    // Returns the name of the vendor that has implemented the renderer's graphics context.
-    virtual const char* vendor() = 0;
+  // Returns the name of the renderer's created graphics context.
+  virtual const char* name() = 0;
 
-    // Returns the version of the renderer's graphics context.
-    virtual const char* version() = 0;
+  // Returns the list of extensions that the renderer's graphics context
+  // supports.
+  virtual const char* extensions() = 0;
 
-    virtual bool isValid() { return true; }
+  // Returns the name of the vendor that has implemented the renderer's graphics
+  // context.
+  virtual const char* vendor() = 0;
+
+  // Returns the version of the renderer's graphics context.
+  virtual const char* version() = 0;
+
+  virtual bool isValid() { return true; }
 };
 
 inline GlesRenderer::Backbuffer::Format::Format()
     : color(0), depth(0), stencil(0) {}
 
-inline GlesRenderer::Backbuffer::Format::Format(uint32_t c, uint32_t d, uint32_t s)
+inline GlesRenderer::Backbuffer::Format::Format(uint32_t c, uint32_t d,
+                                                uint32_t s)
     : color(c), depth(d), stencil(s) {}
 
-inline bool operator == (const GlesRenderer::Backbuffer::Format& lhs,
-                         const GlesRenderer::Backbuffer::Format& rhs) {
-    return lhs.color == rhs.color && lhs.depth == rhs.depth && lhs.stencil == rhs.stencil;
+inline bool operator==(const GlesRenderer::Backbuffer::Format& lhs,
+                       const GlesRenderer::Backbuffer::Format& rhs) {
+  return lhs.color == rhs.color && lhs.depth == rhs.depth &&
+         lhs.stencil == rhs.stencil;
 }
 
-inline GlesRenderer::Backbuffer::Backbuffer()
-    : width(0), height(0) {}
+inline GlesRenderer::Backbuffer::Backbuffer() : width(0), height(0) {}
 
-inline GlesRenderer::Backbuffer::Backbuffer(int w, int h, uint32_t c, uint32_t d, uint32_t s)
+inline GlesRenderer::Backbuffer::Backbuffer(int w, int h, uint32_t c,
+                                            uint32_t d, uint32_t s)
     : width(w), height(h), format(c, d, s) {}
 
-inline bool operator == (const GlesRenderer::Backbuffer& lhs, const GlesRenderer::Backbuffer& rhs) {
-    return lhs.width == rhs.width && lhs.height == rhs.height && lhs.format == rhs.format;
+inline bool operator==(const GlesRenderer::Backbuffer& lhs,
+                       const GlesRenderer::Backbuffer& rhs) {
+  return lhs.width == rhs.width && lhs.height == rhs.height &&
+         lhs.format == rhs.format;
 }
 
 }  // namespace gapir

--- a/gapir/cc/interpreter.cpp
+++ b/gapir/cc/interpreter.cpp
@@ -17,8 +17,8 @@
 #include "interpreter.h"
 #include "memory_manager.h"
 
-#include "core/cc/log.h"
 #include "core/cc/crash_handler.h"
+#include "core/cc/log.h"
 
 #define __STDC_FORMAT_MACROS
 #include <inttypes.h>
@@ -27,7 +27,7 @@
 // If compiling with MSVC, (rather than MSYS)
 // unistd does not exist.
 #include <unistd.h>
-#endif // !defined(_MSC_VER) || defined(__GNUC__)
+#endif  // !defined(_MSC_VER) || defined(__GNUC__)
 
 #include <utility>
 #include <vector>
@@ -36,12 +36,17 @@ namespace gapir {
 
 namespace {
 
-template<typename T> inline T sum2(T a, T b) { return a + b; }
-template<typename T> inline T* sum2(T* a, T* b) {
-  return reinterpret_cast<T*>(reinterpret_cast<uintptr_t>(a) + reinterpret_cast<uintptr_t>(b));
+template <typename T>
+inline T sum2(T a, T b) {
+  return a + b;
+}
+template <typename T>
+inline T* sum2(T* a, T* b) {
+  return reinterpret_cast<T*>(reinterpret_cast<uintptr_t>(a) +
+                              reinterpret_cast<uintptr_t>(b));
 }
 
-template<typename T>
+template <typename T>
 inline bool sum(Stack& stack, uint32_t count) {
   T v = 0;
   for (uint32_t i = 0; i < count; i++) {
@@ -51,427 +56,474 @@ inline bool sum(Stack& stack, uint32_t count) {
   return stack.isValid();
 }
 
-} // anonymous namespace
+}  // anonymous namespace
 
-Interpreter::Interpreter(
-        core::CrashHandler& crash_handler,
-        const MemoryManager* memory_manager,
-        uint32_t stack_depth,
-        ApiRequestCallback callback) :
+Interpreter::Interpreter(core::CrashHandler& crash_handler,
+                         const MemoryManager* memory_manager,
+                         uint32_t stack_depth, ApiRequestCallback callback)
+    :
 
-        mCrashHandler(crash_handler),
-        mMemoryManager(memory_manager),
-        apiRequestCallback(std::move(callback)),
-        mStack(stack_depth, mMemoryManager),
-        mInstructions(nullptr),
-        mInstructionCount(0),
-        mCurrentInstruction(0),
-        mNextThread(0),
-        mLabel(0) {
-
-    registerBuiltin(GLOBAL_INDEX, PRINT_STACK_FUNCTION_ID, [](uint32_t, Stack* stack, bool) {
-        stack->printStack();
-        return true;
-    });
+      mCrashHandler(crash_handler),
+      mMemoryManager(memory_manager),
+      apiRequestCallback(std::move(callback)),
+      mStack(stack_depth, mMemoryManager),
+      mInstructions(nullptr),
+      mInstructionCount(0),
+      mCurrentInstruction(0),
+      mNextThread(0),
+      mLabel(0) {
+  registerBuiltin(GLOBAL_INDEX, PRINT_STACK_FUNCTION_ID,
+                  [](uint32_t, Stack* stack, bool) {
+                    stack->printStack();
+                    return true;
+                  });
 }
 
-void Interpreter::registerBuiltin(uint8_t api, FunctionTable::Id id, FunctionTable::Function func) {
-    mBuiltins[api].insert(id, func);
+void Interpreter::registerBuiltin(uint8_t api, FunctionTable::Id id,
+                                  FunctionTable::Function func) {
+  mBuiltins[api].insert(id, func);
 }
 
-void Interpreter::setRendererFunctions(uint8_t api, FunctionTable* functionTable) {
-    if (functionTable != nullptr) {
-        mRendererFunctions[api] = functionTable;
-    } else {
-        mRendererFunctions.erase(api);
-    }
+void Interpreter::setRendererFunctions(uint8_t api,
+                                       FunctionTable* functionTable) {
+  if (functionTable != nullptr) {
+    mRendererFunctions[api] = functionTable;
+  } else {
+    mRendererFunctions.erase(api);
+  }
 }
 
 bool Interpreter::run(const uint32_t* instructions, uint32_t count) {
-    GAPID_ASSERT(mInstructions == nullptr);
-    GAPID_ASSERT(mInstructionCount == 0);
-    GAPID_ASSERT(mCurrentInstruction == 0);
-    mInstructions = instructions;
-    mInstructionCount = count;
-    auto unregisterHandler = mCrashHandler.registerHandler(
-            [this](const std::string& minidumpPath, bool succeeded) {
-                GAPID_ERROR("--- CRASH DURING REPLAY ---");
-                GAPID_ERROR("LAST COMMAND:     %d", mLabel);
-                GAPID_ERROR("LAST INSTRUCTION: %d", mCurrentInstruction);
-            });
-    exec();
-    unregisterHandler();
-    return mExecResult.get_future().get() == SUCCESS;
+  GAPID_ASSERT(mInstructions == nullptr);
+  GAPID_ASSERT(mInstructionCount == 0);
+  GAPID_ASSERT(mCurrentInstruction == 0);
+  mInstructions = instructions;
+  mInstructionCount = count;
+  auto unregisterHandler = mCrashHandler.registerHandler(
+      [this](const std::string& minidumpPath, bool succeeded) {
+        GAPID_ERROR("--- CRASH DURING REPLAY ---");
+        GAPID_ERROR("LAST COMMAND:     %d", mLabel);
+        GAPID_ERROR("LAST INSTRUCTION: %d", mCurrentInstruction);
+      });
+  exec();
+  unregisterHandler();
+  return mExecResult.get_future().get() == SUCCESS;
 }
 
 void Interpreter::exec() {
-    for (; mCurrentInstruction < mInstructionCount; mCurrentInstruction++) {
-        switch (interpret(mInstructions[mCurrentInstruction])) {
-            case SUCCESS:
-                break;
-            case ERROR:
-                GAPID_WARNING(
-                    "Interpreter stopped because of an interpretation error at opcode %u (%u). "
-                    "Last reached label: %d",
-                    mCurrentInstruction, mInstructions[mCurrentInstruction], mLabel);
-                mExecResult.set_value(ERROR);
-                return;
-            case CHANGE_THREAD: {
-                auto next_thread = mNextThread;
-                mCurrentInstruction++;
-                mThreadPool.enqueue(next_thread, [this] { this->exec(); });
-                return;
-            }
-        }
+  for (; mCurrentInstruction < mInstructionCount; mCurrentInstruction++) {
+    switch (interpret(mInstructions[mCurrentInstruction])) {
+      case SUCCESS:
+        break;
+      case ERROR:
+        GAPID_WARNING(
+            "Interpreter stopped because of an interpretation error at opcode "
+            "%u (%u). "
+            "Last reached label: %d",
+            mCurrentInstruction, mInstructions[mCurrentInstruction], mLabel);
+        mExecResult.set_value(ERROR);
+        return;
+      case CHANGE_THREAD: {
+        auto next_thread = mNextThread;
+        mCurrentInstruction++;
+        mThreadPool.enqueue(next_thread, [this] { this->exec(); });
+        return;
+      }
     }
-    mExecResult.set_value(SUCCESS);
+  }
+  mExecResult.set_value(SUCCESS);
 }
 
 BaseType Interpreter::extractType(uint32_t opcode) const {
-    return BaseType((opcode & TYPE_MASK) >> TYPE_BIT_SHIFT);
+  return BaseType((opcode & TYPE_MASK) >> TYPE_BIT_SHIFT);
 }
 
 uint32_t Interpreter::extract20bitData(uint32_t opcode) const {
-    return opcode & DATA_MASK20;
+  return opcode & DATA_MASK20;
 }
 
 uint32_t Interpreter::extract26bitData(uint32_t opcode) const {
-    return opcode & DATA_MASK26;
+  return opcode & DATA_MASK26;
 }
 
 bool Interpreter::registerApi(uint8_t api) {
-    return apiRequestCallback(this, api);
+  return apiRequestCallback(this, api);
 }
 
 Interpreter::Result Interpreter::call(uint32_t opcode) {
-    auto id = opcode & FUNCTION_ID_MASK;
-    auto api = (opcode & API_INDEX_MASK) >> API_BIT_SHIFT;
-    auto func = mBuiltins[api].lookup(id);
-    auto label = getLabel();
-    if (func == nullptr) {
-        if (mRendererFunctions.count(api) > 0) {
-            func = mRendererFunctions[api]->lookup(id);
-        } else {
-            if (apiRequestCallback(this, api)) {
-                func = mRendererFunctions[api]->lookup(id);
-            } else {
-                GAPID_WARNING("[%u]Error setting up renderer functions for api: %u", label, api);
-            }
-        }
+  auto id = opcode & FUNCTION_ID_MASK;
+  auto api = (opcode & API_INDEX_MASK) >> API_BIT_SHIFT;
+  auto func = mBuiltins[api].lookup(id);
+  auto label = getLabel();
+  if (func == nullptr) {
+    if (mRendererFunctions.count(api) > 0) {
+      func = mRendererFunctions[api]->lookup(id);
+    } else {
+      if (apiRequestCallback(this, api)) {
+        func = mRendererFunctions[api]->lookup(id);
+      } else {
+        GAPID_WARNING("[%u]Error setting up renderer functions for api: %u",
+                      label, api);
+      }
     }
-    if (func == nullptr) {
-        GAPID_WARNING("[%u]Invalid function id(%u), in api(%d)", label, id, api);
-        return ERROR;
-    }
-    if (!(*func)(getLabel(), &mStack, (opcode & PUSH_RETURN_MASK) != 0)) {
-        GAPID_WARNING("[%u]Error raised when calling function with id: %u", label, id);
-        return ERROR;
-    }
-    return SUCCESS;
+  }
+  if (func == nullptr) {
+    GAPID_WARNING("[%u]Invalid function id(%u), in api(%d)", label, id, api);
+    return ERROR;
+  }
+  if (!(*func)(getLabel(), &mStack, (opcode & PUSH_RETURN_MASK) != 0)) {
+    GAPID_WARNING("[%u]Error raised when calling function with id: %u", label,
+                  id);
+    return ERROR;
+  }
+  return SUCCESS;
 }
 
 Interpreter::Result Interpreter::pushI(uint32_t opcode) {
-    BaseType type = extractType(opcode);
-    if (!isValid(type)) {
-        GAPID_WARNING("Error: pushI basic type invalid %d", (int)type);
-        return ERROR;
-    }
-    Stack::BaseValue data = extract20bitData(opcode);
-    switch (type) {
-        // Sign extension for signed types
-        case BaseType::Int32:
-        case BaseType::Int64:
-            if (data & 0x80000) {
-                data |= 0xfffffffffff00000ULL;
-            }
-            break;
-        // Shifting the value into the exponent for floating point types
-        case BaseType::Float:
-            data <<= 23;
-            break;
-        case BaseType::Double:
-            data <<= 52;
-            break;
-        default:
-            break;
-    }
-    mStack.pushValue(type, data);
-    return mStack.isValid() ? SUCCESS : ERROR;
+  BaseType type = extractType(opcode);
+  if (!isValid(type)) {
+    GAPID_WARNING("Error: pushI basic type invalid %d", (int)type);
+    return ERROR;
+  }
+  Stack::BaseValue data = extract20bitData(opcode);
+  switch (type) {
+    // Sign extension for signed types
+    case BaseType::Int32:
+    case BaseType::Int64:
+      if (data & 0x80000) {
+        data |= 0xfffffffffff00000ULL;
+      }
+      break;
+    // Shifting the value into the exponent for floating point types
+    case BaseType::Float:
+      data <<= 23;
+      break;
+    case BaseType::Double:
+      data <<= 52;
+      break;
+    default:
+      break;
+  }
+  mStack.pushValue(type, data);
+  return mStack.isValid() ? SUCCESS : ERROR;
 }
 
 Interpreter::Result Interpreter::loadC(uint32_t opcode) {
-    BaseType type = extractType(opcode);
-    if (!isValid(type)) {
-      GAPID_WARNING("Error: loadC basic type invalid %u", (unsigned int)type);
-      return ERROR;
-    }
-    const void* address = mMemoryManager->constantToAbsolute(extract20bitData(opcode));
-    if (!isConstantAddressForType(address, type)) {
-      GAPID_WARNING("Error: loadC not constant address %p", address);
-      return ERROR;
-    }
-    mStack.pushFrom(type, address);
-    return mStack.isValid() ? SUCCESS : ERROR;
+  BaseType type = extractType(opcode);
+  if (!isValid(type)) {
+    GAPID_WARNING("Error: loadC basic type invalid %u", (unsigned int)type);
+    return ERROR;
+  }
+  const void* address =
+      mMemoryManager->constantToAbsolute(extract20bitData(opcode));
+  if (!isConstantAddressForType(address, type)) {
+    GAPID_WARNING("Error: loadC not constant address %p", address);
+    return ERROR;
+  }
+  mStack.pushFrom(type, address);
+  return mStack.isValid() ? SUCCESS : ERROR;
 }
 
 Interpreter::Result Interpreter::loadV(uint32_t opcode) {
-    BaseType type = extractType(opcode);
-    if (!isValid(type)) {
-      GAPID_WARNING("Error: loadV basic type invalid %u", (unsigned int)type);
-      return ERROR;
-    }
-    const void* address = mMemoryManager->volatileToAbsolute(extract20bitData(opcode));
-    if (!isVolatileAddressForType(address, type)) {
-      GAPID_WARNING("Error: loadV not volatile address %p", address);
-      return ERROR;
-    }
-    mStack.pushFrom(type, address);
-    return mStack.isValid() ? SUCCESS : ERROR;
+  BaseType type = extractType(opcode);
+  if (!isValid(type)) {
+    GAPID_WARNING("Error: loadV basic type invalid %u", (unsigned int)type);
+    return ERROR;
+  }
+  const void* address =
+      mMemoryManager->volatileToAbsolute(extract20bitData(opcode));
+  if (!isVolatileAddressForType(address, type)) {
+    GAPID_WARNING("Error: loadV not volatile address %p", address);
+    return ERROR;
+  }
+  mStack.pushFrom(type, address);
+  return mStack.isValid() ? SUCCESS : ERROR;
 }
 
 Interpreter::Result Interpreter::load(uint32_t opcode) {
-    BaseType type = extractType(opcode);
-    if (!isValid(type)) {
-      GAPID_WARNING("Error: load basic type invalid %u", (unsigned int)type);
-      return ERROR;
-    }
-    const void* address = mStack.pop<const void*>();
-    if (!isReadAddress(address)) {
-      GAPID_WARNING("Error: load not readable address %p", address);
-      return ERROR;
-    }
-    mStack.pushFrom(type, address);
-    return mStack.isValid() ? SUCCESS : ERROR;
+  BaseType type = extractType(opcode);
+  if (!isValid(type)) {
+    GAPID_WARNING("Error: load basic type invalid %u", (unsigned int)type);
+    return ERROR;
+  }
+  const void* address = mStack.pop<const void*>();
+  if (!isReadAddress(address)) {
+    GAPID_WARNING("Error: load not readable address %p", address);
+    return ERROR;
+  }
+  mStack.pushFrom(type, address);
+  return mStack.isValid() ? SUCCESS : ERROR;
 }
 
 Interpreter::Result Interpreter::pop(uint32_t opcode) {
-    mStack.discard(extract26bitData(opcode));
-    return mStack.isValid() ? SUCCESS : ERROR;
+  mStack.discard(extract26bitData(opcode));
+  return mStack.isValid() ? SUCCESS : ERROR;
 }
 
 Interpreter::Result Interpreter::storeV(uint32_t opcode) {
-    void* address = mMemoryManager->volatileToAbsolute(extract26bitData(opcode));
-    if (!isVolatileAddressForType(address, mStack.getTopType())) {
-      GAPID_WARNING("Error: storeV not volatile address %p", address);
-      return ERROR;
-    }
+  void* address = mMemoryManager->volatileToAbsolute(extract26bitData(opcode));
+  if (!isVolatileAddressForType(address, mStack.getTopType())) {
+    GAPID_WARNING("Error: storeV not volatile address %p", address);
+    return ERROR;
+  }
 
-    mStack.popTo(address);
-    return mStack.isValid() ? SUCCESS : ERROR;
+  mStack.popTo(address);
+  return mStack.isValid() ? SUCCESS : ERROR;
 }
 
 Interpreter::Result Interpreter::store() {
-    void* address = mStack.pop<void*>();
-    if (!isWriteAddress(address)) {
-      GAPID_WARNING("Error: store not write address %p", address);
-      return ERROR;
-    }
-    mStack.popTo(address);
-    return mStack.isValid() ? SUCCESS : ERROR;
+  void* address = mStack.pop<void*>();
+  if (!isWriteAddress(address)) {
+    GAPID_WARNING("Error: store not write address %p", address);
+    return ERROR;
+  }
+  mStack.popTo(address);
+  return mStack.isValid() ? SUCCESS : ERROR;
 }
 
 Interpreter::Result Interpreter::resource(uint32_t opcode) {
-    mStack.push<uint32_t>(extract26bitData(opcode));
-    return this->call(Interpreter::RESOURCE_FUNCTION_ID);
+  mStack.push<uint32_t>(extract26bitData(opcode));
+  return this->call(Interpreter::RESOURCE_FUNCTION_ID);
 }
 
 Interpreter::Result Interpreter::post() {
-    return this->call(Interpreter::POST_FUNCTION_ID);
+  return this->call(Interpreter::POST_FUNCTION_ID);
 }
 
 Interpreter::Result Interpreter::copy(uint32_t opcode) {
-    uint32_t count = extract26bitData(opcode);
-    void* target = mStack.pop<void*>();
-    const void* source = mStack.pop<const void*>();
-    if (!isWriteAddress(target)) {
-        GAPID_WARNING("Error: copy target is invalid %p %" PRIu32, target, count);
-        return ERROR;
-    }
-    if (!isReadAddress(source)) {
-        GAPID_WARNING("Error: copy source is invalid %p %" PRIu32, target, count);
-        return ERROR;
-    }
-    if (source == nullptr) {
-        GAPID_WARNING("Error: copy source address is null");
-        return ERROR;
-    }
-    if (target == nullptr) {
-        GAPID_WARNING("Error: copy destination address is null");
-        return ERROR;
-    }
-    memcpy(target, source, count);
-    return mStack.isValid() ? SUCCESS : ERROR;
+  uint32_t count = extract26bitData(opcode);
+  void* target = mStack.pop<void*>();
+  const void* source = mStack.pop<const void*>();
+  if (!isWriteAddress(target)) {
+    GAPID_WARNING("Error: copy target is invalid %p %" PRIu32, target, count);
+    return ERROR;
+  }
+  if (!isReadAddress(source)) {
+    GAPID_WARNING("Error: copy source is invalid %p %" PRIu32, target, count);
+    return ERROR;
+  }
+  if (source == nullptr) {
+    GAPID_WARNING("Error: copy source address is null");
+    return ERROR;
+  }
+  if (target == nullptr) {
+    GAPID_WARNING("Error: copy destination address is null");
+    return ERROR;
+  }
+  memcpy(target, source, count);
+  return mStack.isValid() ? SUCCESS : ERROR;
 }
 
 Interpreter::Result Interpreter::clone(uint32_t opcode) {
-    mStack.clone(extract26bitData(opcode));
-    return mStack.isValid() ? SUCCESS : ERROR;
+  mStack.clone(extract26bitData(opcode));
+  return mStack.isValid() ? SUCCESS : ERROR;
 }
 
 Interpreter::Result Interpreter::strcpy(uint32_t opcode) {
-    uint32_t count = extract26bitData(opcode);
-    char* target = mStack.pop<char*>();
-    const char* source = mStack.pop<const char*>();
-    // Requires that the whole count is available, even if source is shorter.
-    if (!isWriteAddress(target)) {
-        GAPID_WARNING("Error: copy target is invalid %p %d", target, count);
-        return ERROR;
+  uint32_t count = extract26bitData(opcode);
+  char* target = mStack.pop<char*>();
+  const char* source = mStack.pop<const char*>();
+  // Requires that the whole count is available, even if source is shorter.
+  if (!isWriteAddress(target)) {
+    GAPID_WARNING("Error: copy target is invalid %p %d", target, count);
+    return ERROR;
+  }
+  if (!isReadAddress(source)) {
+    GAPID_WARNING("Error: copy source is invalid %p %d", target, count);
+    return ERROR;
+  }
+  if (source == nullptr) {
+    GAPID_WARNING("Error: strcpy source address is null");
+    return ERROR;
+  }
+  if (target == nullptr) {
+    GAPID_WARNING("Error: strcpy destination address is null");
+    return ERROR;
+  }
+  uint32_t i;
+  for (i = 0; i < count - 1; i++) {
+    char c = source[i];
+    if (c == 0) {
+      break;
     }
-    if (!isReadAddress(source)) {
-        GAPID_WARNING("Error: copy source is invalid %p %d", target, count);
-        return ERROR;
-    }
-    if (source == nullptr) {
-        GAPID_WARNING("Error: strcpy source address is null");
-        return ERROR;
-    }
-    if (target == nullptr) {
-        GAPID_WARNING("Error: strcpy destination address is null");
-        return ERROR;
-    }
-    uint32_t i;
-    for (i = 0; i < count - 1; i++) {
-        char c = source[i];
-        if (c == 0) {
-            break;
-        }
-        target[i] = c;
-    }
-    for (; i < count; i++) {
-        target[i] = 0;
-    }
-    return mStack.isValid() ? SUCCESS : ERROR;
+    target[i] = c;
+  }
+  for (; i < count; i++) {
+    target[i] = 0;
+  }
+  return mStack.isValid() ? SUCCESS : ERROR;
 }
 
 Interpreter::Result Interpreter::extend(uint32_t opcode) {
-    uint32_t data = extract26bitData(opcode);
-    auto type = mStack.getTopType();
-    auto value = mStack.popBaseValue();
-    switch (type) {
-        // Masking out the mantissa end extending it with the new bits for floating point types
-        case BaseType::Float: {
-            value |= (data & 0x007fffffULL);
-            break;
-        }
-        case BaseType::Double: {
-            uint64_t exponent = value & 0xfff0000000000000ULL;
-            value <<= 26;
-            value |= data;
-            value &= 0x000fffffffffffffULL;
-            value |= exponent;
-            break;
-        }
-        // Extending the value with 26 new LSB
-        default: {
-            value = (value << 26) | data;
-            break;
-        }
+  uint32_t data = extract26bitData(opcode);
+  auto type = mStack.getTopType();
+  auto value = mStack.popBaseValue();
+  switch (type) {
+    // Masking out the mantissa end extending it with the new bits for floating
+    // point types
+    case BaseType::Float: {
+      value |= (data & 0x007fffffULL);
+      break;
     }
-    mStack.pushValue(type, value);
-    return mStack.isValid() ? SUCCESS : ERROR;
+    case BaseType::Double: {
+      uint64_t exponent = value & 0xfff0000000000000ULL;
+      value <<= 26;
+      value |= data;
+      value &= 0x000fffffffffffffULL;
+      value |= exponent;
+      break;
+    }
+    // Extending the value with 26 new LSB
+    default: {
+      value = (value << 26) | data;
+      break;
+    }
+  }
+  mStack.pushValue(type, value);
+  return mStack.isValid() ? SUCCESS : ERROR;
 }
 
 Interpreter::Result Interpreter::add(uint32_t opcode) {
-    uint32_t count = extract26bitData(opcode);
-    if (count < 2) {
-        return mStack.isValid() ? SUCCESS : ERROR;
+  uint32_t count = extract26bitData(opcode);
+  if (count < 2) {
+    return mStack.isValid() ? SUCCESS : ERROR;
+  }
+  auto type = mStack.getTopType();
+  bool ok = false;
+  switch (type) {
+    case BaseType::Int8: {
+      ok = sum<int8_t>(mStack, count);
+      break;
     }
-    auto type = mStack.getTopType();
-    bool ok = false;
-    switch (type) {
-        case BaseType::Int8:             { ok = sum<int8_t>(mStack, count); break; }
-        case BaseType::Int16:            { ok = sum<int16_t>(mStack, count); break; }
-        case BaseType::Int32:            { ok = sum<int32_t>(mStack, count); break; }
-        case BaseType::Int64:            { ok = sum<int64_t>(mStack, count); break; }
-        case BaseType::Uint8:            { ok = sum<uint8_t>(mStack, count); break; }
-        case BaseType::Uint16:           { ok = sum<uint16_t>(mStack, count); break; }
-        case BaseType::Uint32:           { ok = sum<uint32_t>(mStack, count); break; }
-        case BaseType::Uint64:           { ok = sum<uint64_t>(mStack, count); break; }
-        case BaseType::Float:            { ok = sum<float>(mStack, count); break; }
-        case BaseType::Double:           { ok = sum<double>(mStack, count); break; }
-        case BaseType::AbsolutePointer:  { ok = sum<void*>(mStack, count); break; }
-        case BaseType::ConstantPointer:  { ok = sum<void*>(mStack, count); break; }
-        default:
-            GAPID_WARNING("Cannot add values of type %s", baseTypeName(type));
-            return ERROR;
+    case BaseType::Int16: {
+      ok = sum<int16_t>(mStack, count);
+      break;
     }
-    return ok ? SUCCESS : ERROR;
+    case BaseType::Int32: {
+      ok = sum<int32_t>(mStack, count);
+      break;
+    }
+    case BaseType::Int64: {
+      ok = sum<int64_t>(mStack, count);
+      break;
+    }
+    case BaseType::Uint8: {
+      ok = sum<uint8_t>(mStack, count);
+      break;
+    }
+    case BaseType::Uint16: {
+      ok = sum<uint16_t>(mStack, count);
+      break;
+    }
+    case BaseType::Uint32: {
+      ok = sum<uint32_t>(mStack, count);
+      break;
+    }
+    case BaseType::Uint64: {
+      ok = sum<uint64_t>(mStack, count);
+      break;
+    }
+    case BaseType::Float: {
+      ok = sum<float>(mStack, count);
+      break;
+    }
+    case BaseType::Double: {
+      ok = sum<double>(mStack, count);
+      break;
+    }
+    case BaseType::AbsolutePointer: {
+      ok = sum<void*>(mStack, count);
+      break;
+    }
+    case BaseType::ConstantPointer: {
+      ok = sum<void*>(mStack, count);
+      break;
+    }
+    default:
+      GAPID_WARNING("Cannot add values of type %s", baseTypeName(type));
+      return ERROR;
+  }
+  return ok ? SUCCESS : ERROR;
 }
 
 Interpreter::Result Interpreter::label(uint32_t opcode) {
-    mLabel = extract26bitData(opcode);
-    return SUCCESS;
+  mLabel = extract26bitData(opcode);
+  return SUCCESS;
 }
 
 Interpreter::Result Interpreter::switchThread(uint32_t opcode) {
-    auto thread = extract26bitData(opcode);
-    GAPID_DEBUG("Switch thread %d -> %d", mNextThread, thread);
-    mNextThread = thread;
-    return CHANGE_THREAD;
+  auto thread = extract26bitData(opcode);
+  GAPID_DEBUG("Switch thread %d -> %d", mNextThread, thread);
+  mNextThread = thread;
+  return CHANGE_THREAD;
 }
 
 #define DEBUG_OPCODE(name, value) GAPID_VERBOSE(name)
-#define DEBUG_OPCODE_26(name, value) GAPID_VERBOSE(name "(%#010x)", value & DATA_MASK26)
-#define DEBUG_OPCODE_TY_20(name, value) GAPID_VERBOSE(name "(%#010x, %s)", value & DATA_MASK20, baseTypeName(extractType(value)))
+#define DEBUG_OPCODE_26(name, value) \
+  GAPID_VERBOSE(name "(%#010x)", value& DATA_MASK26)
+#define DEBUG_OPCODE_TY_20(name, value)                  \
+  GAPID_VERBOSE(name "(%#010x, %s)", value& DATA_MASK20, \
+                baseTypeName(extractType(value)))
 
 Interpreter::Result Interpreter::interpret(uint32_t opcode) {
-    InstructionCode code = static_cast<InstructionCode>(opcode >> OPCODE_BIT_SHIFT);
-    switch (code) {
-        case InstructionCode::CALL:
-            DEBUG_OPCODE_26("CALL", opcode);
-            return this->call(opcode);
-        case InstructionCode::PUSH_I:
-            DEBUG_OPCODE_TY_20("PUSH_I", opcode);
-            return this->pushI(opcode);
-        case InstructionCode::LOAD_C:
-            DEBUG_OPCODE_TY_20("LOAD_C", opcode);
-            return this->loadC(opcode);
-        case InstructionCode::LOAD_V:
-            DEBUG_OPCODE_TY_20("LOAD_V", opcode);
-            return this->loadV(opcode);
-        case InstructionCode::LOAD:
-            DEBUG_OPCODE_TY_20("LOAD", opcode);
-            return this->load(opcode);
-        case InstructionCode::POP:
-            DEBUG_OPCODE_26("POP", opcode);
-            return this->pop(opcode);
-        case InstructionCode::STORE_V:
-            DEBUG_OPCODE_26("STORE_V", opcode);
-            return this->storeV(opcode);
-        case InstructionCode::STORE:
-            DEBUG_OPCODE("STORE", opcode);
-            return this->store();
-        case InstructionCode::RESOURCE:
-            DEBUG_OPCODE_26("RESOURCE", opcode);
-            return this->resource(opcode);
-        case InstructionCode::POST:
-            DEBUG_OPCODE("POST", opcode);
-            return this->post();
-        case InstructionCode::COPY:
-            DEBUG_OPCODE_26("COPY", opcode);
-            return this->copy(opcode);
-        case InstructionCode::CLONE:
-            DEBUG_OPCODE_26("CLONE", opcode);
-            return this->clone(opcode);
-        case InstructionCode::STRCPY:
-            DEBUG_OPCODE_26("STRCPY", opcode);
-            return this->strcpy(opcode);
-        case InstructionCode::EXTEND:
-            DEBUG_OPCODE_26("EXTEND", opcode);
-            return this->extend(opcode);
-        case InstructionCode::ADD:
-            DEBUG_OPCODE_26("ADD", opcode);
-            return this->add(opcode);
-        case InstructionCode::LABEL:
-            DEBUG_OPCODE_26("LABEL", opcode);
-            return this->label(opcode);
-        case InstructionCode::SWITCH_THREAD:
-            DEBUG_OPCODE_26("SWITCH_THREAD", opcode);
-            return this->switchThread(opcode);
-        default:
-            GAPID_WARNING("Unknown opcode! %#010x", opcode);
-            return ERROR;
-    }
+  InstructionCode code =
+      static_cast<InstructionCode>(opcode >> OPCODE_BIT_SHIFT);
+  switch (code) {
+    case InstructionCode::CALL:
+      DEBUG_OPCODE_26("CALL", opcode);
+      return this->call(opcode);
+    case InstructionCode::PUSH_I:
+      DEBUG_OPCODE_TY_20("PUSH_I", opcode);
+      return this->pushI(opcode);
+    case InstructionCode::LOAD_C:
+      DEBUG_OPCODE_TY_20("LOAD_C", opcode);
+      return this->loadC(opcode);
+    case InstructionCode::LOAD_V:
+      DEBUG_OPCODE_TY_20("LOAD_V", opcode);
+      return this->loadV(opcode);
+    case InstructionCode::LOAD:
+      DEBUG_OPCODE_TY_20("LOAD", opcode);
+      return this->load(opcode);
+    case InstructionCode::POP:
+      DEBUG_OPCODE_26("POP", opcode);
+      return this->pop(opcode);
+    case InstructionCode::STORE_V:
+      DEBUG_OPCODE_26("STORE_V", opcode);
+      return this->storeV(opcode);
+    case InstructionCode::STORE:
+      DEBUG_OPCODE("STORE", opcode);
+      return this->store();
+    case InstructionCode::RESOURCE:
+      DEBUG_OPCODE_26("RESOURCE", opcode);
+      return this->resource(opcode);
+    case InstructionCode::POST:
+      DEBUG_OPCODE("POST", opcode);
+      return this->post();
+    case InstructionCode::COPY:
+      DEBUG_OPCODE_26("COPY", opcode);
+      return this->copy(opcode);
+    case InstructionCode::CLONE:
+      DEBUG_OPCODE_26("CLONE", opcode);
+      return this->clone(opcode);
+    case InstructionCode::STRCPY:
+      DEBUG_OPCODE_26("STRCPY", opcode);
+      return this->strcpy(opcode);
+    case InstructionCode::EXTEND:
+      DEBUG_OPCODE_26("EXTEND", opcode);
+      return this->extend(opcode);
+    case InstructionCode::ADD:
+      DEBUG_OPCODE_26("ADD", opcode);
+      return this->add(opcode);
+    case InstructionCode::LABEL:
+      DEBUG_OPCODE_26("LABEL", opcode);
+      return this->label(opcode);
+    case InstructionCode::SWITCH_THREAD:
+      DEBUG_OPCODE_26("SWITCH_THREAD", opcode);
+      return this->switchThread(opcode);
+    default:
+      GAPID_WARNING("Unknown opcode! %#010x", opcode);
+      return ERROR;
+  }
 }
 
 #undef DEBUG_OPCODE

--- a/gapir/cc/interpreter_test.cpp
+++ b/gapir/cc/interpreter_test.cpp
@@ -31,355 +31,390 @@ const uint32_t STACK_SIZE = 128;
 
 template <typename T>
 struct CheckTopOfStack {
-    T expected_;
-    bool operator()(uint32_t, Stack* stack, bool) {
-        EXPECT_EQ(expected_, stack->pop<T>());
-        return true;
-    }
+  T expected_;
+  bool operator()(uint32_t, Stack* stack, bool) {
+    EXPECT_EQ(expected_, stack->pop<T>());
+    return true;
+  }
 };
 
 class InterpreterTest : public ::testing::Test {
-protected:
-    virtual void SetUp() {
-        std::vector<uint32_t> memorySizes = {MEMORY_SIZE};
-        mMemoryManager.reset(new MemoryManager(memorySizes));
-        auto callback = [](Interpreter*, uint8_t) { return false; };
-        mInterpreter.reset(new Interpreter(crash_handler, mMemoryManager.get(), STACK_SIZE, std::move(callback)));
-    }
+ protected:
+  virtual void SetUp() {
+    std::vector<uint32_t> memorySizes = {MEMORY_SIZE};
+    mMemoryManager.reset(new MemoryManager(memorySizes));
+    auto callback = [](Interpreter*, uint8_t) { return false; };
+    mInterpreter.reset(new Interpreter(crash_handler, mMemoryManager.get(),
+                                       STACK_SIZE, std::move(callback)));
+  }
 
-    core::CrashHandler crash_handler;
-    std::unique_ptr<MemoryManager> mMemoryManager;
-    std::unique_ptr<Interpreter> mInterpreter;
+  core::CrashHandler crash_handler;
+  std::unique_ptr<MemoryManager> mMemoryManager;
+  std::unique_ptr<Interpreter> mInterpreter;
 };
 }  // anonymous namespace
 
 TEST_F(InterpreterTest, PushIUint8) {
-    mInterpreter->registerBuiltin(0, 0, CheckTopOfStack<uint8_t>{210});
+  mInterpreter->registerBuiltin(0, 0, CheckTopOfStack<uint8_t>{210});
 
-    std::vector<uint32_t> instructions{
-            instruction(Interpreter::InstructionCode::PUSH_I, BaseType::Uint8, 210),
-            instruction(Interpreter::InstructionCode::CALL, 0)};
-    bool res = mInterpreter->run(instructions.data(), instructions.size());
-    EXPECT_TRUE(res);
+  std::vector<uint32_t> instructions{
+      instruction(Interpreter::InstructionCode::PUSH_I, BaseType::Uint8, 210),
+      instruction(Interpreter::InstructionCode::CALL, 0)};
+  bool res = mInterpreter->run(instructions.data(), instructions.size());
+  EXPECT_TRUE(res);
 }
 
 TEST_F(InterpreterTest, PushIInt16Minus1) {
-    mInterpreter->registerBuiltin(0, 0, CheckTopOfStack<int16_t>{-1});
+  mInterpreter->registerBuiltin(0, 0, CheckTopOfStack<int16_t>{-1});
 
-    std::vector<uint32_t> instructions{
-            instruction(Interpreter::InstructionCode::PUSH_I, BaseType::Int16, 0xffff),  // -1
-            instruction(Interpreter::InstructionCode::CALL, 0)};
-    bool res = mInterpreter->run(instructions.data(), instructions.size());
-    EXPECT_TRUE(res);
+  std::vector<uint32_t> instructions{
+      instruction(Interpreter::InstructionCode::PUSH_I, BaseType::Int16,
+                  0xffff),  // -1
+      instruction(Interpreter::InstructionCode::CALL, 0)};
+  bool res = mInterpreter->run(instructions.data(), instructions.size());
+  EXPECT_TRUE(res);
 }
 
 TEST_F(InterpreterTest, PushIInt32Minus1) {
-    mInterpreter->registerBuiltin(0, 0, CheckTopOfStack<int32_t>{-1});
+  mInterpreter->registerBuiltin(0, 0, CheckTopOfStack<int32_t>{-1});
 
-    std::vector<uint32_t> instructions{
-            instruction(Interpreter::InstructionCode::PUSH_I, BaseType::Int32, 0xfffff),  // -1
-            instruction(Interpreter::InstructionCode::CALL, 0)};
-    bool res = mInterpreter->run(instructions.data(), instructions.size());
-    EXPECT_TRUE(res);
+  std::vector<uint32_t> instructions{
+      instruction(Interpreter::InstructionCode::PUSH_I, BaseType::Int32,
+                  0xfffff),  // -1
+      instruction(Interpreter::InstructionCode::CALL, 0)};
+  bool res = mInterpreter->run(instructions.data(), instructions.size());
+  EXPECT_TRUE(res);
 }
 
 TEST_F(InterpreterTest, PushIFloat1) {
-    mInterpreter->registerBuiltin(0, 0, CheckTopOfStack<float>{1.0f});
+  mInterpreter->registerBuiltin(0, 0, CheckTopOfStack<float>{1.0f});
 
-    std::vector<uint32_t> instructions{
-            instruction(Interpreter::InstructionCode::PUSH_I, BaseType::Float, 0x7f),  // 1.0 exp
-            instruction(Interpreter::InstructionCode::CALL, 0)};
-    bool res = mInterpreter->run(instructions.data(), instructions.size());
-    EXPECT_TRUE(res);
+  std::vector<uint32_t> instructions{
+      instruction(Interpreter::InstructionCode::PUSH_I, BaseType::Float,
+                  0x7f),  // 1.0 exp
+      instruction(Interpreter::InstructionCode::CALL, 0)};
+  bool res = mInterpreter->run(instructions.data(), instructions.size());
+  EXPECT_TRUE(res);
 }
 
 TEST_F(InterpreterTest, PushIDouble1) {
-    mInterpreter->registerBuiltin(0, 0, CheckTopOfStack<double>{1.0});
+  mInterpreter->registerBuiltin(0, 0, CheckTopOfStack<double>{1.0});
 
-    std::vector<uint32_t> instructions{
-            instruction(Interpreter::InstructionCode::PUSH_I, BaseType::Double, 0x3ff),  // 1.0 exp
-            instruction(Interpreter::InstructionCode::CALL, 0)};
-    bool res = mInterpreter->run(instructions.data(), instructions.size());
-    EXPECT_TRUE(res);
+  std::vector<uint32_t> instructions{
+      instruction(Interpreter::InstructionCode::PUSH_I, BaseType::Double,
+                  0x3ff),  // 1.0 exp
+      instruction(Interpreter::InstructionCode::CALL, 0)};
+  bool res = mInterpreter->run(instructions.data(), instructions.size());
+  EXPECT_TRUE(res);
 }
 
 TEST_F(InterpreterTest, LoadC) {
-    mMemoryManager->setReplayDataSize(10, 0);
-    uint8_t constantMemory[7] = {0x00, 0x00, 0x12, 0x34, 0x56, 0x78, 0x9a};
-    uint8_t* constantBaseAddress = static_cast<uint8_t*>(mMemoryManager->getConstantAddress());
-    memcpy(constantBaseAddress, &constantMemory, sizeof(constantMemory));
+  mMemoryManager->setReplayDataSize(10, 0);
+  uint8_t constantMemory[7] = {0x00, 0x00, 0x12, 0x34, 0x56, 0x78, 0x9a};
+  uint8_t* constantBaseAddress =
+      static_cast<uint8_t*>(mMemoryManager->getConstantAddress());
+  memcpy(constantBaseAddress, &constantMemory, sizeof(constantMemory));
 
-    mInterpreter->registerBuiltin(0, 0, CheckTopOfStack<uint16_t>{0x7856});
+  mInterpreter->registerBuiltin(0, 0, CheckTopOfStack<uint16_t>{0x7856});
 
-    std::vector<uint32_t> instructions{
-            instruction(Interpreter::InstructionCode::LOAD_C, BaseType::Uint16, 4),
-            instruction(Interpreter::InstructionCode::CALL, 0)};
-    bool res = mInterpreter->run(instructions.data(), instructions.size());
-    EXPECT_TRUE(res);
+  std::vector<uint32_t> instructions{
+      instruction(Interpreter::InstructionCode::LOAD_C, BaseType::Uint16, 4),
+      instruction(Interpreter::InstructionCode::CALL, 0)};
+  bool res = mInterpreter->run(instructions.data(), instructions.size());
+  EXPECT_TRUE(res);
 }
 
 TEST_F(InterpreterTest, LoadV) {
-    *static_cast<int32_t*>(mMemoryManager->volatileToAbsolute(784)) = -987654321;
-    mInterpreter->registerBuiltin(0, 0, CheckTopOfStack<int32_t>{-987654321});
+  *static_cast<int32_t*>(mMemoryManager->volatileToAbsolute(784)) = -987654321;
+  mInterpreter->registerBuiltin(0, 0, CheckTopOfStack<int32_t>{-987654321});
 
-    std::vector<uint32_t> instructions{
-            instruction(Interpreter::InstructionCode::LOAD_V, BaseType::Int32, 784),
-            instruction(Interpreter::InstructionCode::CALL, 0)};
-    bool res = mInterpreter->run(instructions.data(), instructions.size());
-    EXPECT_TRUE(res);
+  std::vector<uint32_t> instructions{
+      instruction(Interpreter::InstructionCode::LOAD_V, BaseType::Int32, 784),
+      instruction(Interpreter::InstructionCode::CALL, 0)};
+  bool res = mInterpreter->run(instructions.data(), instructions.size());
+  EXPECT_TRUE(res);
 }
 
 TEST_F(InterpreterTest, LoadConstantAddress) {
-    mMemoryManager->setReplayDataSize(10, 0);
-    uint8_t constantMemory[7] = {0x00, 0x00, 0x12, 0x34, 0x56, 0x78, 0x9a};
-    uint8_t* constantBaseAddress = static_cast<uint8_t*>(mMemoryManager->getConstantAddress());
-    memcpy(constantBaseAddress, &constantMemory, 7);
+  mMemoryManager->setReplayDataSize(10, 0);
+  uint8_t constantMemory[7] = {0x00, 0x00, 0x12, 0x34, 0x56, 0x78, 0x9a};
+  uint8_t* constantBaseAddress =
+      static_cast<uint8_t*>(mMemoryManager->getConstantAddress());
+  memcpy(constantBaseAddress, &constantMemory, 7);
 
-    mInterpreter->registerBuiltin(0, 0, CheckTopOfStack<uint16_t>{0x7856});
+  mInterpreter->registerBuiltin(0, 0, CheckTopOfStack<uint16_t>{0x7856});
 
-    std::vector<uint32_t> instructions{
-            instruction(Interpreter::InstructionCode::PUSH_I, BaseType::ConstantPointer, 4),
-            instruction(Interpreter::InstructionCode::LOAD, BaseType::Uint16, 0),
-            instruction(Interpreter::InstructionCode::CALL, 0)};
-    bool res = mInterpreter->run(instructions.data(), instructions.size());
-    EXPECT_TRUE(res);
+  std::vector<uint32_t> instructions{
+      instruction(Interpreter::InstructionCode::PUSH_I,
+                  BaseType::ConstantPointer, 4),
+      instruction(Interpreter::InstructionCode::LOAD, BaseType::Uint16, 0),
+      instruction(Interpreter::InstructionCode::CALL, 0)};
+  bool res = mInterpreter->run(instructions.data(), instructions.size());
+  EXPECT_TRUE(res);
 }
 
 TEST_F(InterpreterTest, LoadVolatileAddress) {
-    *static_cast<int32_t*>(mMemoryManager->volatileToAbsolute(784)) = -987654321;
-    mInterpreter->registerBuiltin(0, 0, CheckTopOfStack<int32_t>{-987654321});
+  *static_cast<int32_t*>(mMemoryManager->volatileToAbsolute(784)) = -987654321;
+  mInterpreter->registerBuiltin(0, 0, CheckTopOfStack<int32_t>{-987654321});
 
-    std::vector<uint32_t> instructions{
-            instruction(Interpreter::InstructionCode::PUSH_I, BaseType::VolatilePointer, 784),
-            instruction(Interpreter::InstructionCode::LOAD, BaseType::Int32, 0),
-            instruction(Interpreter::InstructionCode::CALL, 0)};
-    bool res = mInterpreter->run(instructions.data(), instructions.size());
-    EXPECT_TRUE(res);
+  std::vector<uint32_t> instructions{
+      instruction(Interpreter::InstructionCode::PUSH_I,
+                  BaseType::VolatilePointer, 784),
+      instruction(Interpreter::InstructionCode::LOAD, BaseType::Int32, 0),
+      instruction(Interpreter::InstructionCode::CALL, 0)};
+  bool res = mInterpreter->run(instructions.data(), instructions.size());
+  EXPECT_TRUE(res);
 }
 
 TEST_F(InterpreterTest, Pop) {
-    mInterpreter->registerBuiltin(0, 0, CheckTopOfStack<uint32_t>{123456});
+  mInterpreter->registerBuiltin(0, 0, CheckTopOfStack<uint32_t>{123456});
 
-    std::vector<uint32_t> instructions{
-            instruction(Interpreter::InstructionCode::PUSH_I, BaseType::Uint32, 123456),
-            instruction(Interpreter::InstructionCode::PUSH_I, BaseType::Uint16, 987),
-            instruction(Interpreter::InstructionCode::PUSH_I, BaseType::Int8, -123),
-            instruction(Interpreter::InstructionCode::POP, 2),
-            instruction(Interpreter::InstructionCode::CALL, 0)};
-    bool res = mInterpreter->run(instructions.data(), instructions.size());
-    EXPECT_TRUE(res);
+  std::vector<uint32_t> instructions{
+      instruction(Interpreter::InstructionCode::PUSH_I, BaseType::Uint32,
+                  123456),
+      instruction(Interpreter::InstructionCode::PUSH_I, BaseType::Uint16, 987),
+      instruction(Interpreter::InstructionCode::PUSH_I, BaseType::Int8, -123),
+      instruction(Interpreter::InstructionCode::POP, 2),
+      instruction(Interpreter::InstructionCode::CALL, 0)};
+  bool res = mInterpreter->run(instructions.data(), instructions.size());
+  EXPECT_TRUE(res);
 }
 
 TEST_F(InterpreterTest, StoreV) {
-    std::vector<uint32_t> instructions{
-            instruction(Interpreter::InstructionCode::PUSH_I, BaseType::Uint32, 987654),
-            instruction(Interpreter::InstructionCode::STORE_V, 124)};
-    bool res = mInterpreter->run(instructions.data(), instructions.size());
-    EXPECT_TRUE(res);
+  std::vector<uint32_t> instructions{
+      instruction(Interpreter::InstructionCode::PUSH_I, BaseType::Uint32,
+                  987654),
+      instruction(Interpreter::InstructionCode::STORE_V, 124)};
+  bool res = mInterpreter->run(instructions.data(), instructions.size());
+  EXPECT_TRUE(res);
 
-    EXPECT_EQ(987654, *static_cast<uint32_t*>(mMemoryManager->volatileToAbsolute(124)));
+  EXPECT_EQ(987654,
+            *static_cast<uint32_t*>(mMemoryManager->volatileToAbsolute(124)));
 }
 
 TEST_F(InterpreterTest, Store) {
-    std::vector<uint32_t> instructions{
-            instruction(Interpreter::InstructionCode::PUSH_I, BaseType::Uint32, 987654),
-            instruction(Interpreter::InstructionCode::PUSH_I, BaseType::VolatilePointer, 260),
-            instruction(Interpreter::InstructionCode::STORE, 0)};
-    bool res = mInterpreter->run(instructions.data(), instructions.size());
-    EXPECT_TRUE(res);
+  std::vector<uint32_t> instructions{
+      instruction(Interpreter::InstructionCode::PUSH_I, BaseType::Uint32,
+                  987654),
+      instruction(Interpreter::InstructionCode::PUSH_I,
+                  BaseType::VolatilePointer, 260),
+      instruction(Interpreter::InstructionCode::STORE, 0)};
+  bool res = mInterpreter->run(instructions.data(), instructions.size());
+  EXPECT_TRUE(res);
 
-    EXPECT_EQ(987654, *static_cast<uint32_t*>(mMemoryManager->volatileToAbsolute(260)));
+  EXPECT_EQ(987654,
+            *static_cast<uint32_t*>(mMemoryManager->volatileToAbsolute(260)));
 }
 
 TEST_F(InterpreterTest, Copy) {
-    mMemoryManager->setReplayDataSize(20, 0);
-    uint8_t constantMemory[10] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
-    uint8_t* constantBaseAddress = static_cast<uint8_t*>(mMemoryManager->getConstantAddress());
-    memcpy(constantBaseAddress, &constantMemory, 10);
+  mMemoryManager->setReplayDataSize(20, 0);
+  uint8_t constantMemory[10] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+  uint8_t* constantBaseAddress =
+      static_cast<uint8_t*>(mMemoryManager->getConstantAddress());
+  memcpy(constantBaseAddress, &constantMemory, 10);
 
-    std::vector<uint32_t> instructions{
-            instruction(Interpreter::InstructionCode::PUSH_I, BaseType::ConstantPointer, 5),
-            instruction(Interpreter::InstructionCode::PUSH_I, BaseType::VolatilePointer, 987),
-            instruction(Interpreter::InstructionCode::COPY, 3)};
-    bool res = mInterpreter->run(instructions.data(), instructions.size());
-    EXPECT_TRUE(res);
+  std::vector<uint32_t> instructions{
+      instruction(Interpreter::InstructionCode::PUSH_I,
+                  BaseType::ConstantPointer, 5),
+      instruction(Interpreter::InstructionCode::PUSH_I,
+                  BaseType::VolatilePointer, 987),
+      instruction(Interpreter::InstructionCode::COPY, 3)};
+  bool res = mInterpreter->run(instructions.data(), instructions.size());
+  EXPECT_TRUE(res);
 
-    EXPECT_EQ(5, *static_cast<uint8_t*>(mMemoryManager->volatileToAbsolute(987)));
-    EXPECT_EQ(6, *static_cast<uint8_t*>(mMemoryManager->volatileToAbsolute(988)));
-    EXPECT_EQ(7, *static_cast<uint8_t*>(mMemoryManager->volatileToAbsolute(989)));
+  EXPECT_EQ(5, *static_cast<uint8_t*>(mMemoryManager->volatileToAbsolute(987)));
+  EXPECT_EQ(6, *static_cast<uint8_t*>(mMemoryManager->volatileToAbsolute(988)));
+  EXPECT_EQ(7, *static_cast<uint8_t*>(mMemoryManager->volatileToAbsolute(989)));
 }
 
 TEST_F(InterpreterTest, Clone) {
-    mInterpreter->registerBuiltin(0, 0, CheckTopOfStack<uint32_t>{123456});
+  mInterpreter->registerBuiltin(0, 0, CheckTopOfStack<uint32_t>{123456});
 
-    std::vector<uint32_t> instructions{
-            instruction(Interpreter::InstructionCode::PUSH_I, BaseType::Uint32, 123456),
-            instruction(Interpreter::InstructionCode::PUSH_I, BaseType::Uint16, 987),
-            instruction(Interpreter::InstructionCode::PUSH_I, BaseType::Int8, -123),
-            instruction(Interpreter::InstructionCode::CLONE, 2),
-            instruction(Interpreter::InstructionCode::CALL, 0),
-            instruction(Interpreter::InstructionCode::POP, 2),
-            instruction(Interpreter::InstructionCode::CALL, 0)};
-    bool res = mInterpreter->run(instructions.data(), instructions.size());
-    EXPECT_TRUE(res);
+  std::vector<uint32_t> instructions{
+      instruction(Interpreter::InstructionCode::PUSH_I, BaseType::Uint32,
+                  123456),
+      instruction(Interpreter::InstructionCode::PUSH_I, BaseType::Uint16, 987),
+      instruction(Interpreter::InstructionCode::PUSH_I, BaseType::Int8, -123),
+      instruction(Interpreter::InstructionCode::CLONE, 2),
+      instruction(Interpreter::InstructionCode::CALL, 0),
+      instruction(Interpreter::InstructionCode::POP, 2),
+      instruction(Interpreter::InstructionCode::CALL, 0)};
+  bool res = mInterpreter->run(instructions.data(), instructions.size());
+  EXPECT_TRUE(res);
 }
 
 TEST_F(InterpreterTest, ExtendInt32) {
-    mInterpreter->registerBuiltin(0, 0, CheckTopOfStack<int32_t>{0x76543210});
+  mInterpreter->registerBuiltin(0, 0, CheckTopOfStack<int32_t>{0x76543210});
 
-    std::vector<uint32_t> instructions{
-            instruction(Interpreter::InstructionCode::PUSH_I, BaseType::Int32, 0x1d),
-            instruction(Interpreter::InstructionCode::EXTEND, 0x2543210),
-            instruction(Interpreter::InstructionCode::CALL, 0)};
-    bool res = mInterpreter->run(instructions.data(), instructions.size());
-    EXPECT_TRUE(res);
+  std::vector<uint32_t> instructions{
+      instruction(Interpreter::InstructionCode::PUSH_I, BaseType::Int32, 0x1d),
+      instruction(Interpreter::InstructionCode::EXTEND, 0x2543210),
+      instruction(Interpreter::InstructionCode::CALL, 0)};
+  bool res = mInterpreter->run(instructions.data(), instructions.size());
+  EXPECT_TRUE(res);
 }
 
 TEST_F(InterpreterTest, ExtendFloat) {
-    mInterpreter->registerBuiltin(0, 0, CheckTopOfStack<float>{1.1f});
+  mInterpreter->registerBuiltin(0, 0, CheckTopOfStack<float>{1.1f});
 
-    std::vector<uint32_t> instructions{
-            instruction(Interpreter::InstructionCode::PUSH_I, BaseType::Float, 0x7f),
-            instruction(Interpreter::InstructionCode::EXTEND, 0x8ccccd),
-            instruction(Interpreter::InstructionCode::CALL, 0)};
-    bool res = mInterpreter->run(instructions.data(), instructions.size());
-    EXPECT_TRUE(res);
+  std::vector<uint32_t> instructions{
+      instruction(Interpreter::InstructionCode::PUSH_I, BaseType::Float, 0x7f),
+      instruction(Interpreter::InstructionCode::EXTEND, 0x8ccccd),
+      instruction(Interpreter::InstructionCode::CALL, 0)};
+  bool res = mInterpreter->run(instructions.data(), instructions.size());
+  EXPECT_TRUE(res);
 }
 
 TEST_F(InterpreterTest, ExtendDouble) {
-    mInterpreter->registerBuiltin(0, 0, CheckTopOfStack<double>{1.4});
+  mInterpreter->registerBuiltin(0, 0, CheckTopOfStack<double>{1.4});
 
-    std::vector<uint32_t> instructions{
-            instruction(Interpreter::InstructionCode::PUSH_I, BaseType::Double, 0x3ff),
-            instruction(Interpreter::InstructionCode::EXTEND, 0x1999999),
-            instruction(Interpreter::InstructionCode::EXTEND, 0x2666666),
-            instruction(Interpreter::InstructionCode::CALL, 0)};
-    bool res = mInterpreter->run(instructions.data(), instructions.size());
-    EXPECT_TRUE(res);
+  std::vector<uint32_t> instructions{
+      instruction(Interpreter::InstructionCode::PUSH_I, BaseType::Double,
+                  0x3ff),
+      instruction(Interpreter::InstructionCode::EXTEND, 0x1999999),
+      instruction(Interpreter::InstructionCode::EXTEND, 0x2666666),
+      instruction(Interpreter::InstructionCode::CALL, 0)};
+  bool res = mInterpreter->run(instructions.data(), instructions.size());
+  EXPECT_TRUE(res);
 }
 
 TEST_F(InterpreterTest, Add2xUint32) {
-    mInterpreter->registerBuiltin(0, 0, CheckTopOfStack<uint32_t>{15});
+  mInterpreter->registerBuiltin(0, 0, CheckTopOfStack<uint32_t>{15});
 
-    std::vector<uint32_t> instructions{
-            instruction(Interpreter::InstructionCode::PUSH_I, BaseType::Uint32, 5),
-            instruction(Interpreter::InstructionCode::PUSH_I, BaseType::Uint32, 10),
-            instruction(Interpreter::InstructionCode::ADD, 2),
-            instruction(Interpreter::InstructionCode::CALL, 0)};
-    bool res = mInterpreter->run(instructions.data(), instructions.size());
-    EXPECT_TRUE(res);
+  std::vector<uint32_t> instructions{
+      instruction(Interpreter::InstructionCode::PUSH_I, BaseType::Uint32, 5),
+      instruction(Interpreter::InstructionCode::PUSH_I, BaseType::Uint32, 10),
+      instruction(Interpreter::InstructionCode::ADD, 2),
+      instruction(Interpreter::InstructionCode::CALL, 0)};
+  bool res = mInterpreter->run(instructions.data(), instructions.size());
+  EXPECT_TRUE(res);
 }
 
 TEST_F(InterpreterTest, Add3xFloat) {
-    mInterpreter->registerBuiltin(0, 0, CheckTopOfStack<float>{3.5});
+  mInterpreter->registerBuiltin(0, 0, CheckTopOfStack<float>{3.5});
 
-    std::vector<uint32_t> instructions{
-            instruction(Interpreter::InstructionCode::PUSH_I, BaseType::Float, 0x7f),  // 1.0 exp
-            instruction(Interpreter::InstructionCode::PUSH_I, BaseType::Float, 0x7e),  // 0.5 exp
-            instruction(Interpreter::InstructionCode::PUSH_I, BaseType::Float, 0x80),  // 2.0 exp
-            instruction(Interpreter::InstructionCode::ADD, 3),
-            instruction(Interpreter::InstructionCode::CALL, 0)};
-    bool res = mInterpreter->run(instructions.data(), instructions.size());
-    EXPECT_TRUE(res);
+  std::vector<uint32_t> instructions{
+      instruction(Interpreter::InstructionCode::PUSH_I, BaseType::Float,
+                  0x7f),  // 1.0 exp
+      instruction(Interpreter::InstructionCode::PUSH_I, BaseType::Float,
+                  0x7e),  // 0.5 exp
+      instruction(Interpreter::InstructionCode::PUSH_I, BaseType::Float,
+                  0x80),  // 2.0 exp
+      instruction(Interpreter::InstructionCode::ADD, 3),
+      instruction(Interpreter::InstructionCode::CALL, 0)};
+  bool res = mInterpreter->run(instructions.data(), instructions.size());
+  EXPECT_TRUE(res);
 }
 
 TEST_F(InterpreterTest, Strcpy) {
-    mMemoryManager->setReplayDataSize(20, 0);
-    const char* constantMemory = "abc";
-    uint8_t* constantBaseAddress = static_cast<uint8_t*>(mMemoryManager->getConstantAddress());
-    memcpy(constantBaseAddress, constantMemory, 4);
+  mMemoryManager->setReplayDataSize(20, 0);
+  const char* constantMemory = "abc";
+  uint8_t* constantBaseAddress =
+      static_cast<uint8_t*>(mMemoryManager->getConstantAddress());
+  memcpy(constantBaseAddress, constantMemory, 4);
 
-    uint8_t* volatileMemory = static_cast<uint8_t*>(mMemoryManager->volatileToAbsolute(100));
+  uint8_t* volatileMemory =
+      static_cast<uint8_t*>(mMemoryManager->volatileToAbsolute(100));
 
-    memset(volatileMemory, 'x', 5);
+  memset(volatileMemory, 'x', 5);
 
-    std::vector<uint32_t> instructions{
-            instruction(Interpreter::InstructionCode::PUSH_I, BaseType::ConstantPointer, 0),
-            instruction(Interpreter::InstructionCode::PUSH_I, BaseType::VolatilePointer, 100),
-            instruction(Interpreter::InstructionCode::STRCPY, 10)};
-    bool res = mInterpreter->run(instructions.data(), instructions.size());
-    EXPECT_TRUE(res);
+  std::vector<uint32_t> instructions{
+      instruction(Interpreter::InstructionCode::PUSH_I,
+                  BaseType::ConstantPointer, 0),
+      instruction(Interpreter::InstructionCode::PUSH_I,
+                  BaseType::VolatilePointer, 100),
+      instruction(Interpreter::InstructionCode::STRCPY, 10)};
+  bool res = mInterpreter->run(instructions.data(), instructions.size());
+  EXPECT_TRUE(res);
 
-    EXPECT_EQ('a', volatileMemory[0]);
-    EXPECT_EQ('b', volatileMemory[1]);
-    EXPECT_EQ('c', volatileMemory[2]);
-    EXPECT_EQ(0x0, volatileMemory[3]);
-    EXPECT_EQ(0x0, volatileMemory[4]);
+  EXPECT_EQ('a', volatileMemory[0]);
+  EXPECT_EQ('b', volatileMemory[1]);
+  EXPECT_EQ('c', volatileMemory[2]);
+  EXPECT_EQ(0x0, volatileMemory[3]);
+  EXPECT_EQ(0x0, volatileMemory[4]);
 }
 
 TEST_F(InterpreterTest, StrcpyShortBuffer) {
-    mMemoryManager->setReplayDataSize(20, 0);
-    const char* constantMemory = "abcdef";
-    uint8_t* constantBaseAddress = static_cast<uint8_t*>(mMemoryManager->getConstantAddress());
-    memcpy(constantBaseAddress, constantMemory, 7);
+  mMemoryManager->setReplayDataSize(20, 0);
+  const char* constantMemory = "abcdef";
+  uint8_t* constantBaseAddress =
+      static_cast<uint8_t*>(mMemoryManager->getConstantAddress());
+  memcpy(constantBaseAddress, constantMemory, 7);
 
-    uint8_t* volatileMemory = static_cast<uint8_t*>(mMemoryManager->volatileToAbsolute(100));
+  uint8_t* volatileMemory =
+      static_cast<uint8_t*>(mMemoryManager->volatileToAbsolute(100));
 
-    memset(volatileMemory, 'x', 8);
+  memset(volatileMemory, 'x', 8);
 
-    std::vector<uint32_t> instructions{
-            instruction(Interpreter::InstructionCode::PUSH_I, BaseType::ConstantPointer, 0),
-            instruction(Interpreter::InstructionCode::PUSH_I, BaseType::VolatilePointer, 100),
-            instruction(Interpreter::InstructionCode::STRCPY, 5)};
-    bool res = mInterpreter->run(instructions.data(), instructions.size());
-    EXPECT_TRUE(res);
+  std::vector<uint32_t> instructions{
+      instruction(Interpreter::InstructionCode::PUSH_I,
+                  BaseType::ConstantPointer, 0),
+      instruction(Interpreter::InstructionCode::PUSH_I,
+                  BaseType::VolatilePointer, 100),
+      instruction(Interpreter::InstructionCode::STRCPY, 5)};
+  bool res = mInterpreter->run(instructions.data(), instructions.size());
+  EXPECT_TRUE(res);
 
-    EXPECT_EQ('a', volatileMemory[0]);
-    EXPECT_EQ('b', volatileMemory[1]);
-    EXPECT_EQ('c', volatileMemory[2]);
-    EXPECT_EQ('d', volatileMemory[3]);
-    EXPECT_EQ(0x0, volatileMemory[4]);
-    EXPECT_EQ('x', volatileMemory[5]);
+  EXPECT_EQ('a', volatileMemory[0]);
+  EXPECT_EQ('b', volatileMemory[1]);
+  EXPECT_EQ('c', volatileMemory[2]);
+  EXPECT_EQ('d', volatileMemory[3]);
+  EXPECT_EQ(0x0, volatileMemory[4]);
+  EXPECT_EQ('x', volatileMemory[5]);
 }
 
 TEST_F(InterpreterTest, Post) {
-    uint32_t callCount = 0;
-    auto post = [&callCount](uint32_t, Stack*, bool) {
-        ++callCount;
-        return true;
-    };
+  uint32_t callCount = 0;
+  auto post = [&callCount](uint32_t, Stack*, bool) {
+    ++callCount;
+    return true;
+  };
 
-    mInterpreter->registerBuiltin(0, Interpreter::POST_FUNCTION_ID, post);
+  mInterpreter->registerBuiltin(0, Interpreter::POST_FUNCTION_ID, post);
 
-    std::vector<uint32_t> instructions{instruction(Interpreter::InstructionCode::POST)};
-    bool res = mInterpreter->run(instructions.data(), instructions.size());
-    EXPECT_TRUE(res);
-    EXPECT_EQ(1, callCount);
+  std::vector<uint32_t> instructions{
+      instruction(Interpreter::InstructionCode::POST)};
+  bool res = mInterpreter->run(instructions.data(), instructions.size());
+  EXPECT_TRUE(res);
+  EXPECT_EQ(1, callCount);
 }
 
 TEST_F(InterpreterTest, Resource) {
-    uint32_t callCount = 0;
-    auto resource = [&callCount](uint32_t, Stack* stack, bool) {
-        ++callCount;
-        return true;
-    };
+  uint32_t callCount = 0;
+  auto resource = [&callCount](uint32_t, Stack* stack, bool) {
+    ++callCount;
+    return true;
+  };
 
-    mInterpreter->registerBuiltin(0, 0, CheckTopOfStack<uint32_t>{123});
-    mInterpreter->registerBuiltin(0, Interpreter::RESOURCE_FUNCTION_ID, resource);
+  mInterpreter->registerBuiltin(0, 0, CheckTopOfStack<uint32_t>{123});
+  mInterpreter->registerBuiltin(0, Interpreter::RESOURCE_FUNCTION_ID, resource);
 
-    std::vector<uint32_t> instructions{instruction(Interpreter::InstructionCode::RESOURCE, 123),
-                                       instruction(Interpreter::InstructionCode::CALL, 0)};
-    bool res = mInterpreter->run(instructions.data(), instructions.size());
-    EXPECT_TRUE(res);
-    EXPECT_EQ(1, callCount);
+  std::vector<uint32_t> instructions{
+      instruction(Interpreter::InstructionCode::RESOURCE, 123),
+      instruction(Interpreter::InstructionCode::CALL, 0)};
+  bool res = mInterpreter->run(instructions.data(), instructions.size());
+  EXPECT_TRUE(res);
+  EXPECT_EQ(1, callCount);
 }
 
 TEST_F(InterpreterTest, InvalidOpcode) {
-    std::vector<uint32_t> instructions{63U << 26};
-    bool res = mInterpreter->run(instructions.data(), instructions.size());
-    EXPECT_FALSE(res);
+  std::vector<uint32_t> instructions{63U << 26};
+  bool res = mInterpreter->run(instructions.data(), instructions.size());
+  EXPECT_FALSE(res);
 }
 
 TEST_F(InterpreterTest, InvalidFunctionId) {
-    std::vector<uint32_t> instructions{instruction(Interpreter::InstructionCode::CALL, 0xffff)};
-    bool res = mInterpreter->run(instructions.data(), instructions.size());
-    EXPECT_FALSE(res);
+  std::vector<uint32_t> instructions{
+      instruction(Interpreter::InstructionCode::CALL, 0xffff)};
+  bool res = mInterpreter->run(instructions.data(), instructions.size());
+  EXPECT_FALSE(res);
 }
 
 TEST_F(InterpreterTest, UnknownApi) {
-    std::vector<uint32_t> instructions{instruction(Interpreter::InstructionCode::CALL, 1 << 16)};
-    bool res = mInterpreter->run(instructions.data(), instructions.size());
-    EXPECT_FALSE(res);
+  std::vector<uint32_t> instructions{
+      instruction(Interpreter::InstructionCode::CALL, 1 << 16)};
+  bool res = mInterpreter->run(instructions.data(), instructions.size());
+  EXPECT_FALSE(res);
 }
 
 }  // namespace test

--- a/gapir/cc/linux/gles_renderer.cpp
+++ b/gapir/cc/linux/gles_renderer.cpp
@@ -14,129 +14,138 @@
  * limitations under the License.
  */
 
-#include "gapir/cc/gles_gfx_api.h"
 #include "gapir/cc/gles_renderer.h"
+#include "gapir/cc/gles_gfx_api.h"
 
+#include "core/cc/dl_loader.h"
+#include "core/cc/get_gles_proc_address.h"
 #include "core/cc/gl/formats.h"
 #include "core/cc/gl/versions.h"
 #include "core/cc/log.h"
-#include "core/cc/dl_loader.h"
-#include "core/cc/get_gles_proc_address.h"
 
-#include <cstring>
 #include <X11/Xresource.h>
+#include <cstring>
 
 namespace gapir {
 namespace {
 
 typedef XID GLXPbuffer;
 typedef XID GLXDrawable;
-typedef /*struct __GLXcontextRec*/ void *GLXContext;
-typedef /*struct __GLXFBConfigRec*/ void *GLXFBConfig;
+typedef /*struct __GLXcontextRec*/ void* GLXContext;
+typedef /*struct __GLXFBConfigRec*/ void* GLXFBConfig;
 
 enum {
-    // Used by glXChooseFBConfig.
-    GLX_RED_SIZE      = 8,
-    GLX_GREEN_SIZE    = 9,
-    GLX_BLUE_SIZE     = 10,
-    GLX_ALPHA_SIZE    = 11,
-    GLX_DEPTH_SIZE    = 12,
-    GLX_STENCIL_SIZE  = 13,
-    GLX_DRAWABLE_TYPE = 0x8010,
-    GLX_RENDER_TYPE   = 0x8011,
-    GLX_RGBA_BIT      = 0x00000001,
-    GLX_PBUFFER_BIT   = 0x00000004,
+  // Used by glXChooseFBConfig.
+  GLX_RED_SIZE = 8,
+  GLX_GREEN_SIZE = 9,
+  GLX_BLUE_SIZE = 10,
+  GLX_ALPHA_SIZE = 11,
+  GLX_DEPTH_SIZE = 12,
+  GLX_STENCIL_SIZE = 13,
+  GLX_DRAWABLE_TYPE = 0x8010,
+  GLX_RENDER_TYPE = 0x8011,
+  GLX_RGBA_BIT = 0x00000001,
+  GLX_PBUFFER_BIT = 0x00000004,
 
-    // Used by glXCreateNewContext.
-    GLX_RGBA_TYPE = 0x8014,
+  // Used by glXCreateNewContext.
+  GLX_RGBA_TYPE = 0x8014,
 
-    // Used by glXCreatePbuffer.
-    GLX_PBUFFER_HEIGHT = 0x8040,
-    GLX_PBUFFER_WIDTH  = 0x8041,
+  // Used by glXCreatePbuffer.
+  GLX_PBUFFER_HEIGHT = 0x8040,
+  GLX_PBUFFER_WIDTH = 0x8041,
 
-    // Attribute name for glXCreateContextAttribsARB.
-    GLX_CONTEXT_MAJOR_VERSION_ARB             = 0x2091,
-    GLX_CONTEXT_MINOR_VERSION_ARB             = 0x2092,
-    GLX_CONTEXT_FLAGS_ARB                     = 0x2094,
-    GLX_CONTEXT_PROFILE_MASK_ARB              = 0x9126,
+  // Attribute name for glXCreateContextAttribsARB.
+  GLX_CONTEXT_MAJOR_VERSION_ARB = 0x2091,
+  GLX_CONTEXT_MINOR_VERSION_ARB = 0x2092,
+  GLX_CONTEXT_FLAGS_ARB = 0x2094,
+  GLX_CONTEXT_PROFILE_MASK_ARB = 0x9126,
 
-    // Attribute value for glXCreateContextAttribsARB.
-    GLX_CONTEXT_DEBUG_BIT_ARB                 = 0x0001,
-    GLX_CONTEXT_FORWARD_COMPATIBLE_BIT_ARB    = 0x0002,
-    GLX_CONTEXT_CORE_PROFILE_BIT_ARB          = 0x0001,
-    GLX_CONTEXT_COMPATIBILITY_PROFILE_BIT_ARB = 0x0002,
+  // Attribute value for glXCreateContextAttribsARB.
+  GLX_CONTEXT_DEBUG_BIT_ARB = 0x0001,
+  GLX_CONTEXT_FORWARD_COMPATIBLE_BIT_ARB = 0x0002,
+  GLX_CONTEXT_CORE_PROFILE_BIT_ARB = 0x0001,
+  GLX_CONTEXT_COMPATIBILITY_PROFILE_BIT_ARB = 0x0002,
 };
 
 extern "C" {
 
-typedef GLXFBConfig* (*pfn_glXChooseFBConfig)(Display *dpy, int screen, const int *attrib_list, int *nelements);
-typedef GLXContext  (*pfn_glXCreateNewContext)(Display *dpy, GLXFBConfig config, int render_type,
-     GLXContext share_list, Bool direct);
-typedef GLXPbuffer  (*pfn_glXCreatePbuffer)(Display *dpy, GLXFBConfig config, const int *attrib_list);
-typedef void  (*pfn_glXDestroyPbuffer)(Display *dpy, GLXPbuffer pbuf);
-typedef Bool  (*pfn_glXMakeContextCurrent)(Display *dpy, GLXDrawable draw, GLXDrawable read, GLXContext ctx);
-typedef Bool  (*pfn_glXQueryVersion)(Display *dpy, int *maj, int *min);
-typedef void  (*pfn_glXDestroyContext)(Display *dpy, GLXContext ctx);
-typedef void*  (*pfn_glXGetProcAddress)(const char* procName);
-typedef GLXContext (*glXCreateContextAttribsARBProc)(Display *dpy, GLXFBConfig config, GLXContext share_context,
-                                                     Bool direct, const int *attrib_list);
+typedef GLXFBConfig* (*pfn_glXChooseFBConfig)(Display* dpy, int screen,
+                                              const int* attrib_list,
+                                              int* nelements);
+typedef GLXContext (*pfn_glXCreateNewContext)(Display* dpy, GLXFBConfig config,
+                                              int render_type,
+                                              GLXContext share_list,
+                                              Bool direct);
+typedef GLXPbuffer (*pfn_glXCreatePbuffer)(Display* dpy, GLXFBConfig config,
+                                           const int* attrib_list);
+typedef void (*pfn_glXDestroyPbuffer)(Display* dpy, GLXPbuffer pbuf);
+typedef Bool (*pfn_glXMakeContextCurrent)(Display* dpy, GLXDrawable draw,
+                                          GLXDrawable read, GLXContext ctx);
+typedef Bool (*pfn_glXQueryVersion)(Display* dpy, int* maj, int* min);
+typedef void (*pfn_glXDestroyContext)(Display* dpy, GLXContext ctx);
+typedef void* (*pfn_glXGetProcAddress)(const char* procName);
+typedef GLXContext (*glXCreateContextAttribsARBProc)(Display* dpy,
+                                                     GLXFBConfig config,
+                                                     GLXContext share_context,
+                                                     Bool direct,
+                                                     const int* attrib_list);
 
-typedef int(*pfn_XFree) (void*);
-typedef int(*pfn_XCloseDisplay)(Display*);
+typedef int (*pfn_XFree)(void*);
+typedef int (*pfn_XCloseDisplay)(Display*);
 typedef Display* (*pfn_XOpenDisplay)(_Xconst char*);
-typedef XErrorHandler (*pfn_XSetErrorHandler) (XErrorHandler);
+typedef XErrorHandler (*pfn_XSetErrorHandler)(XErrorHandler);
 typedef int (*pfn_XSync)(Display*, Bool);
 
-} // extern "C"
+}  // extern "C"
 
 class GlesRendererImpl : public GlesRenderer {
-public:
-    GlesRendererImpl(GlesRendererImpl* shared_context);
-    virtual ~GlesRendererImpl() override;
+ public:
+  GlesRendererImpl(GlesRendererImpl* shared_context);
+  virtual ~GlesRendererImpl() override;
 
-    virtual Api* api() override;
-    virtual void setBackbuffer(Backbuffer backbuffer) override;
-    virtual void bind() override;
-    virtual void unbind() override;
-    virtual const char* name() override;
-    virtual const char* extensions() override;
-    virtual const char* vendor() override;
-    virtual const char* version() override;
+  virtual Api* api() override;
+  virtual void setBackbuffer(Backbuffer backbuffer) override;
+  virtual void bind() override;
+  virtual void unbind() override;
+  virtual const char* name() override;
+  virtual const char* extensions() override;
+  virtual const char* vendor() override;
+  virtual const char* version() override;
 
-private:
-    void reset();
-    void createPbuffer(int width, int height);
+ private:
+  void reset();
+  void createPbuffer(int width, int height);
 
-    Backbuffer mBackbuffer;
-    bool mNeedsResolve;
-    Gles mApi;
-    std::string mExtensions;
-    bool mQueriedExtensions;
+  Backbuffer mBackbuffer;
+  bool mNeedsResolve;
+  Gles mApi;
+  std::string mExtensions;
+  bool mQueriedExtensions;
 
-    Display *mDisplay;
-    bool mOwnsDisplay; // True if we created mDisplay
-    GLXContext mContext;
-    GLXContext mSharedContext;
-    GLXPbuffer mPbuffer;
-    GLXFBConfig mFBConfig;
+  Display* mDisplay;
+  bool mOwnsDisplay;  // True if we created mDisplay
+  GLXContext mContext;
+  GLXContext mSharedContext;
+  GLXPbuffer mPbuffer;
+  GLXFBConfig mFBConfig;
 
-    static thread_local GlesRendererImpl* tlsBound;
+  static thread_local GlesRendererImpl* tlsBound;
 
-    pfn_XFree fn_XFree;
-    pfn_XCloseDisplay fn_XCloseDisplay;
-    pfn_XOpenDisplay fn_XOpenDisplay;
-    pfn_XSetErrorHandler fn_XSetErrorHandler;
-    pfn_XSync fn_XSync;
-    core::DlLoader libX;
+  pfn_XFree fn_XFree;
+  pfn_XCloseDisplay fn_XCloseDisplay;
+  pfn_XOpenDisplay fn_XOpenDisplay;
+  pfn_XSetErrorHandler fn_XSetErrorHandler;
+  pfn_XSync fn_XSync;
+  core::DlLoader libX;
 
-    pfn_glXChooseFBConfig fn_glXChooseFBConfig;
-    pfn_glXCreateNewContext fn_glXCreateNewContext;
-    pfn_glXCreatePbuffer fn_glXCreatePbuffer;
-    pfn_glXDestroyPbuffer fn_glXDestroyPbuffer;
-    pfn_glXMakeContextCurrent fn_glXMakeContextCurrent;
-    pfn_glXQueryVersion fn_glXQueryVersion;
-    pfn_glXDestroyContext fn_glXDestroyContext;
-    pfn_glXGetProcAddress fn_glXGetProcAddress;
+  pfn_glXChooseFBConfig fn_glXChooseFBConfig;
+  pfn_glXCreateNewContext fn_glXCreateNewContext;
+  pfn_glXCreatePbuffer fn_glXCreatePbuffer;
+  pfn_glXDestroyPbuffer fn_glXDestroyPbuffer;
+  pfn_glXMakeContextCurrent fn_glXMakeContextCurrent;
+  pfn_glXQueryVersion fn_glXQueryVersion;
+  pfn_glXDestroyContext fn_glXDestroyContext;
+  pfn_glXGetProcAddress fn_glXGetProcAddress;
 };
 
 thread_local GlesRendererImpl* GlesRendererImpl::tlsBound = nullptr;
@@ -146,287 +155,305 @@ thread_local GlesRendererImpl* GlesRendererImpl::tlsBound = nullptr;
 //     We create "root" context for this purpose so it is satisfied.
 //     TODO: Add assert/refcounting to enforce this.
 GlesRendererImpl::GlesRendererImpl(GlesRendererImpl* shared_context)
-        : mNeedsResolve(false)
-        , mDisplay(nullptr)
-        , mContext(nullptr)
-        , mSharedContext(shared_context != nullptr ? shared_context->mContext : 0)
-        , mPbuffer(0)
-        , libX("libX11.so") {
+    : mNeedsResolve(false),
+      mDisplay(nullptr),
+      mContext(nullptr),
+      mSharedContext(shared_context != nullptr ? shared_context->mContext : 0),
+      mPbuffer(0),
+      libX("libX11.so") {
+  fn_XFree = (pfn_XFree)libX.lookup("XFree");
+  fn_XCloseDisplay = (pfn_XCloseDisplay)libX.lookup("XCloseDisplay");
+  fn_XOpenDisplay = (pfn_XOpenDisplay)libX.lookup("XOpenDisplay");
+  fn_XSetErrorHandler = (pfn_XSetErrorHandler)libX.lookup("XSetErrorHandler");
+  fn_XSync = (pfn_XSync)libX.lookup("XSync");
 
-    
-    fn_XFree = (pfn_XFree)libX.lookup("XFree");
-    fn_XCloseDisplay = (pfn_XCloseDisplay)libX.lookup("XCloseDisplay");
-    fn_XOpenDisplay = (pfn_XOpenDisplay)libX.lookup("XOpenDisplay");
-    fn_XSetErrorHandler = (pfn_XSetErrorHandler)libX.lookup("XSetErrorHandler");
-    fn_XSync = (pfn_XSync)libX.lookup("XSync");
+  fn_glXChooseFBConfig = (pfn_glXChooseFBConfig)core::GetGlesProcAddress(
+      "glXChooseFBConfig", true);
+  fn_glXCreateNewContext = (pfn_glXCreateNewContext)core::GetGlesProcAddress(
+      "glXCreateNewContext", true);
+  fn_glXCreatePbuffer =
+      (pfn_glXCreatePbuffer)core::GetGlesProcAddress("glXCreatePbuffer", true);
+  fn_glXDestroyPbuffer = (pfn_glXDestroyPbuffer)core::GetGlesProcAddress(
+      "glXDestroyPbuffer", true);
+  fn_glXMakeContextCurrent =
+      (pfn_glXMakeContextCurrent)core::GetGlesProcAddress(
+          "glXMakeContextCurrent", true);
+  fn_glXQueryVersion =
+      (pfn_glXQueryVersion)core::GetGlesProcAddress("glXQueryVersion", true);
+  fn_glXDestroyContext = (pfn_glXDestroyContext)core::GetGlesProcAddress(
+      "glXDestroyContext", true);
+  fn_glXGetProcAddress = (pfn_glXGetProcAddress)core::GetGlesProcAddress(
+      "glXGetProcAddress", true);
 
-    fn_glXChooseFBConfig = (pfn_glXChooseFBConfig)core::GetGlesProcAddress("glXChooseFBConfig", true);
-    fn_glXCreateNewContext = (pfn_glXCreateNewContext)core::GetGlesProcAddress("glXCreateNewContext", true);
-    fn_glXCreatePbuffer = (pfn_glXCreatePbuffer)core::GetGlesProcAddress("glXCreatePbuffer", true);
-    fn_glXDestroyPbuffer = (pfn_glXDestroyPbuffer)core::GetGlesProcAddress("glXDestroyPbuffer", true);
-    fn_glXMakeContextCurrent = (pfn_glXMakeContextCurrent)core::GetGlesProcAddress("glXMakeContextCurrent", true);
-    fn_glXQueryVersion = (pfn_glXQueryVersion)core::GetGlesProcAddress("glXQueryVersion", true);
-    fn_glXDestroyContext = (pfn_glXDestroyContext)core::GetGlesProcAddress("glXDestroyContext", true);
-    fn_glXGetProcAddress = (pfn_glXGetProcAddress)core::GetGlesProcAddress("glXGetProcAddress", true);
-
-    if (shared_context != nullptr) {
-        // Ensure that shared contexts also share X-display.
-        // Drivers are know to misbehave/crash without this.
-        // NB: This relies on the shared_context to stay alive.
-        mDisplay = shared_context->mDisplay;
-        mOwnsDisplay = false;
-    } else {
-        mDisplay = fn_XOpenDisplay(nullptr);
-        if (mDisplay == nullptr) {
-            // Default display was not found. This may be because we're executing in
-            // the bazel sandbox. Attempt to connect to the 0'th display instead.
-            mDisplay = fn_XOpenDisplay(":0");
-        }
-        if (mDisplay == nullptr) {
-            GAPID_FATAL("Unable to to open X display");
-        }
-        mOwnsDisplay = true;
+  if (shared_context != nullptr) {
+    // Ensure that shared contexts also share X-display.
+    // Drivers are know to misbehave/crash without this.
+    // NB: This relies on the shared_context to stay alive.
+    mDisplay = shared_context->mDisplay;
+    mOwnsDisplay = false;
+  } else {
+    mDisplay = fn_XOpenDisplay(nullptr);
+    if (mDisplay == nullptr) {
+      // Default display was not found. This may be because we're executing in
+      // the bazel sandbox. Attempt to connect to the 0'th display instead.
+      mDisplay = fn_XOpenDisplay(":0");
     }
-
-    int major;
-    int minor;
-    if (!fn_glXQueryVersion(mDisplay, &major, &minor) || (major == 1 && minor < 3)) {
-        GAPID_FATAL("GLX 1.3+ unsupported by X server (was %d.%d)", major, minor);
+    if (mDisplay == nullptr) {
+      GAPID_FATAL("Unable to to open X display");
     }
+    mOwnsDisplay = true;
+  }
 
-    // Initialize with a default target.
-    setBackbuffer(Backbuffer(
-          8, 8,
-          core::gl::GL_RGBA8,
-          core::gl::GL_DEPTH24_STENCIL8,
-          core::gl::GL_DEPTH24_STENCIL8));
+  int major;
+  int minor;
+  if (!fn_glXQueryVersion(mDisplay, &major, &minor) ||
+      (major == 1 && minor < 3)) {
+    GAPID_FATAL("GLX 1.3+ unsupported by X server (was %d.%d)", major, minor);
+  }
+
+  // Initialize with a default target.
+  setBackbuffer(Backbuffer(8, 8, core::gl::GL_RGBA8,
+                           core::gl::GL_DEPTH24_STENCIL8,
+                           core::gl::GL_DEPTH24_STENCIL8));
 }
 
 GlesRendererImpl::~GlesRendererImpl() {
-    reset();
+  reset();
 
-    if (mOwnsDisplay && mDisplay != nullptr) {
-        fn_XCloseDisplay(mDisplay);
-    }
+  if (mOwnsDisplay && mDisplay != nullptr) {
+    fn_XCloseDisplay(mDisplay);
+  }
 }
 
-Api* GlesRendererImpl::api() {
-  return &mApi;
-}
+Api* GlesRendererImpl::api() { return &mApi; }
 
 void GlesRendererImpl::reset() {
-    unbind();
+  unbind();
 
-    if (mContext != nullptr) {
-        fn_glXDestroyContext(mDisplay, mContext);
-        GAPID_DEBUG("Destroyed context %p", mContext);
-        mContext = nullptr;
-    }
+  if (mContext != nullptr) {
+    fn_glXDestroyContext(mDisplay, mContext);
+    GAPID_DEBUG("Destroyed context %p", mContext);
+    mContext = nullptr;
+  }
 
-    if (mPbuffer != 0) {
-        fn_glXDestroyPbuffer(mDisplay, mPbuffer);
-        mPbuffer = 0;
-    }
+  if (mPbuffer != 0) {
+    fn_glXDestroyPbuffer(mDisplay, mPbuffer);
+    mPbuffer = 0;
+  }
 
-    mBackbuffer = Backbuffer();
+  mBackbuffer = Backbuffer();
 }
 
 void GlesRendererImpl::createPbuffer(int width, int height) {
-    if (mPbuffer != 0) {
-        fn_glXDestroyPbuffer(mDisplay, mPbuffer);
-        mPbuffer = 0;
-    }
-    const int pbufferAttribs[] = {
-        GLX_PBUFFER_WIDTH, width,
-        GLX_PBUFFER_HEIGHT, height,
-        None
-    };
-    mPbuffer = fn_glXCreatePbuffer(mDisplay, mFBConfig, pbufferAttribs);
+  if (mPbuffer != 0) {
+    fn_glXDestroyPbuffer(mDisplay, mPbuffer);
+    mPbuffer = 0;
+  }
+  const int pbufferAttribs[] = {
+      // clang-format off
+      GLX_PBUFFER_WIDTH, width,
+      GLX_PBUFFER_HEIGHT, height,
+      None
+      // clang-format on
+  };
+  mPbuffer = fn_glXCreatePbuffer(mDisplay, mFBConfig, pbufferAttribs);
 }
 
-static void DebugCallback(uint32_t source, uint32_t type, Gles::GLuint id, uint32_t severity,
-                           Gles::GLsizei length, const Gles::GLchar* message, const void* user_param) {
-    auto renderer = reinterpret_cast<const GlesRendererImpl*>(user_param);
-    auto listener = renderer->getListener();
-    if (listener != nullptr) {
-        if (type == Gles::GLenum::GL_DEBUG_TYPE_ERROR || severity == Gles::GLenum::GL_DEBUG_SEVERITY_HIGH) {
-            listener->onDebugMessage(LOG_LEVEL_ERROR, Gles::INDEX, message);
-        } else {
-            listener->onDebugMessage(LOG_LEVEL_DEBUG, Gles::INDEX, message);
-        }
+static void DebugCallback(uint32_t source, uint32_t type, Gles::GLuint id,
+                          uint32_t severity, Gles::GLsizei length,
+                          const Gles::GLchar* message, const void* user_param) {
+  auto renderer = reinterpret_cast<const GlesRendererImpl*>(user_param);
+  auto listener = renderer->getListener();
+  if (listener != nullptr) {
+    if (type == Gles::GLenum::GL_DEBUG_TYPE_ERROR ||
+        severity == Gles::GLenum::GL_DEBUG_SEVERITY_HIGH) {
+      listener->onDebugMessage(LOG_LEVEL_ERROR, Gles::INDEX, message);
+    } else {
+      listener->onDebugMessage(LOG_LEVEL_DEBUG, Gles::INDEX, message);
     }
+  }
 }
 
 void GlesRendererImpl::setBackbuffer(Backbuffer backbuffer) {
-    if (mBackbuffer == backbuffer) {
-        return; // No change
+  if (mBackbuffer == backbuffer) {
+    return;  // No change
+  }
+
+  // Some exotic extensions let you create contexts without a backbuffer.
+  // In these cases the backbuffer is zero size - just create a small one.
+  int safe_width = (backbuffer.width > 0) ? backbuffer.width : 8;
+  int safe_height = (backbuffer.height > 0) ? backbuffer.height : 8;
+
+  if (mContext != nullptr) {
+    if (mBackbuffer.format == backbuffer.format) {
+      // Only a resize is necessary
+      GAPID_INFO("Resizing renderer: %dx%d -> %dx%d", mBackbuffer.width,
+                 mBackbuffer.height, backbuffer.width, backbuffer.height);
+      createPbuffer(safe_width, safe_height);
+      fn_glXMakeContextCurrent(mDisplay, mPbuffer, mPbuffer, mContext);
+      mBackbuffer = backbuffer;
+      return;
     }
 
-    // Some exotic extensions let you create contexts without a backbuffer.
-    // In these cases the backbuffer is zero size - just create a small one.
-    int safe_width = (backbuffer.width > 0) ? backbuffer.width : 8;
-    int safe_height = (backbuffer.height > 0) ? backbuffer.height : 8;
+    GAPID_WARNING(
+        "Recreating renderer: [0x%x, 0x%x, 0x%x] -> [0x%x, 0x%x, 0x%x]",
+        mBackbuffer.format.color, mBackbuffer.format.depth,
+        mBackbuffer.format.stencil, backbuffer.format.color,
+        backbuffer.format.depth, backbuffer.format.stencil);
+  }
 
-    if (mContext != nullptr) {
-        if (mBackbuffer.format == backbuffer.format) {
-            // Only a resize is necessary
-            GAPID_INFO("Resizing renderer: %dx%d -> %dx%d",
-                    mBackbuffer.width, mBackbuffer.height, backbuffer.width, backbuffer.height);
-            createPbuffer(safe_width, safe_height);
-            fn_glXMakeContextCurrent(mDisplay, mPbuffer, mPbuffer, mContext);
-            mBackbuffer = backbuffer;
-            return;
-        }
+  auto wasBound = tlsBound == this;
 
-        GAPID_WARNING("Recreating renderer: [0x%x, 0x%x, 0x%x] -> [0x%x, 0x%x, 0x%x]",
-                mBackbuffer.format.color, mBackbuffer.format.depth, mBackbuffer.format.stencil,
-                backbuffer.format.color, backbuffer.format.depth, backbuffer.format.stencil);
-    }
+  reset();
 
-    auto wasBound = tlsBound == this;
+  int r = 8, g = 8, b = 8, a = 8, d = 24, s = 8;
+  core::gl::getColorBits(backbuffer.format.color, r, g, b, a);
+  core::gl::getDepthBits(backbuffer.format.depth, d);
+  core::gl::getStencilBits(backbuffer.format.stencil, s);
 
-    reset();
+  const int visualAttribs[] = {
+      // clang-format off
+      GLX_RED_SIZE, r,
+      GLX_GREEN_SIZE, g,
+      GLX_BLUE_SIZE, b,
+      GLX_ALPHA_SIZE, a,
+      GLX_DEPTH_SIZE, d,
+      GLX_STENCIL_SIZE, s,
+      GLX_RENDER_TYPE, GLX_RGBA_BIT,
+      GLX_DRAWABLE_TYPE, GLX_PBUFFER_BIT,
+      None
+      // clang-format on
+  };
+  int fbConfigsCount;
+  GLXFBConfig* fbConfigs = fn_glXChooseFBConfig(
+      mDisplay, DefaultScreen(mDisplay), visualAttribs, &fbConfigsCount);
+  if (fbConfigs == nullptr) {
+    GAPID_FATAL("Unable to find a suitable X framebuffer config");
+  }
+  mFBConfig = fbConfigs[0];
+  fn_XFree(fbConfigs);
 
-    int r = 8, g = 8, b = 8, a = 8, d = 24, s = 8;
-    core::gl::getColorBits(backbuffer.format.color, r, g, b, a);
-    core::gl::getDepthBits(backbuffer.format.depth, d);
-    core::gl::getStencilBits(backbuffer.format.stencil, s);
-
-    const int visualAttribs[] = {
-        GLX_RED_SIZE, r,
-        GLX_GREEN_SIZE, g,
-        GLX_BLUE_SIZE, b,
-        GLX_ALPHA_SIZE, a,
-        GLX_DEPTH_SIZE, d,
-        GLX_STENCIL_SIZE, s,
-        GLX_RENDER_TYPE, GLX_RGBA_BIT,
-        GLX_DRAWABLE_TYPE, GLX_PBUFFER_BIT,
-        None
+  glXCreateContextAttribsARBProc glXCreateContextAttribsARB =
+      (glXCreateContextAttribsARBProc)fn_glXGetProcAddress(
+          "glXCreateContextAttribsARB");
+  if (glXCreateContextAttribsARB == nullptr) {
+    GAPID_FATAL("Unable to get address of glXCreateContextAttribsARB");
+  }
+  // Prevent X from taking down the process if the GL version is not supported.
+  auto oldHandler =
+      fn_XSetErrorHandler([](Display*, XErrorEvent*) -> int { return 0; });
+  for (auto gl_version : core::gl::sVersionSearchOrder) {
+    // List of name-value pairs.
+    const int contextAttribs[] = {
+        // clang-format off
+        GLX_RENDER_TYPE, GLX_RGBA_TYPE,
+        GLX_CONTEXT_MAJOR_VERSION_ARB, gl_version.major,
+        GLX_CONTEXT_MINOR_VERSION_ARB, gl_version.minor,
+        GLX_CONTEXT_FLAGS_ARB, GLX_CONTEXT_DEBUG_BIT_ARB,
+        GLX_CONTEXT_PROFILE_MASK_ARB, GLX_CONTEXT_CORE_PROFILE_BIT_ARB,
+        None,
+        // clang-format on
     };
-    int fbConfigsCount;
-    GLXFBConfig *fbConfigs = fn_glXChooseFBConfig(
-            mDisplay, DefaultScreen(mDisplay), visualAttribs, &fbConfigsCount);
-    if (fbConfigs == nullptr) {
-        GAPID_FATAL("Unable to find a suitable X framebuffer config");
+    mContext = glXCreateContextAttribsARB(mDisplay, mFBConfig, mSharedContext,
+                                          /* direct */ True, contextAttribs);
+    if (mContext != nullptr) {
+      GAPID_DEBUG("Created GL %i.%i context %p (shaded with context %p)",
+                  gl_version.major, gl_version.minor, mContext, mSharedContext);
+      break;
     }
-    mFBConfig = fbConfigs[0];
-    fn_XFree(fbConfigs);
+  }
+  fn_XSetErrorHandler(oldHandler);
+  if (mContext == nullptr) {
+    GAPID_FATAL("Failed to create glX context");
+  }
+  fn_XSync(mDisplay, False);
 
-    glXCreateContextAttribsARBProc glXCreateContextAttribsARB =
-        (glXCreateContextAttribsARBProc)fn_glXGetProcAddress("glXCreateContextAttribsARB");
-    if (glXCreateContextAttribsARB == nullptr) {
-        GAPID_FATAL("Unable to get address of glXCreateContextAttribsARB");
-    }
-    // Prevent X from taking down the process if the GL version is not supported.
-    auto oldHandler = fn_XSetErrorHandler([](Display*, XErrorEvent*)->int{ return 0; });
-    for (auto gl_version : core::gl::sVersionSearchOrder) {
-        // List of name-value pairs.
-        const int contextAttribs[] = {
-            GLX_RENDER_TYPE, GLX_RGBA_TYPE,
-            GLX_CONTEXT_MAJOR_VERSION_ARB, gl_version.major,
-            GLX_CONTEXT_MINOR_VERSION_ARB, gl_version.minor,
-            GLX_CONTEXT_FLAGS_ARB, GLX_CONTEXT_DEBUG_BIT_ARB,
-            GLX_CONTEXT_PROFILE_MASK_ARB, GLX_CONTEXT_CORE_PROFILE_BIT_ARB,
-            None,
-        };
-        mContext = glXCreateContextAttribsARB(
-            mDisplay, mFBConfig, mSharedContext, /* direct */ True, contextAttribs);
-        if (mContext != nullptr) {
-            GAPID_DEBUG("Created GL %i.%i context %p (shaded with context %p)",
-                        gl_version.major, gl_version.minor, mContext, mSharedContext);
-            break;
-        }
-    }
-    fn_XSetErrorHandler(oldHandler);
-    if (mContext == nullptr) {
-        GAPID_FATAL("Failed to create glX context");
-    }
-    fn_XSync(mDisplay, False);
+  createPbuffer(safe_width, safe_height);
 
-    createPbuffer(safe_width, safe_height);
+  mBackbuffer = backbuffer;
+  mNeedsResolve = true;
 
-    mBackbuffer = backbuffer;
-    mNeedsResolve = true;
-
-    if (wasBound) {
-        bind();
-    }
+  if (wasBound) {
+    bind();
+  }
 }
 
 void GlesRendererImpl::bind() {
-    auto bound = tlsBound;
-    if (bound == this) {
-        return;
-    }
+  auto bound = tlsBound;
+  if (bound == this) {
+    return;
+  }
 
-    if (bound != nullptr) {
-        bound->unbind();
-    }
+  if (bound != nullptr) {
+    bound->unbind();
+  }
 
-    if (!fn_glXMakeContextCurrent(mDisplay, mPbuffer, mPbuffer, mContext)) {
-        GAPID_FATAL("Unable to make GLX context current");
-    }
-    tlsBound = this;
+  if (!fn_glXMakeContextCurrent(mDisplay, mPbuffer, mPbuffer, mContext)) {
+    GAPID_FATAL("Unable to make GLX context current");
+  }
+  tlsBound = this;
 
-    if (mNeedsResolve) {
-        mNeedsResolve = false;
-        mApi.resolve();
-    }
+  if (mNeedsResolve) {
+    mNeedsResolve = false;
+    mApi.resolve();
+  }
 
-    if (mApi.mFunctionStubs.glDebugMessageCallback != nullptr) {
-        mApi.mFunctionStubs.glDebugMessageCallback(reinterpret_cast<void*>(&DebugCallback), this);
-        mApi.mFunctionStubs.glEnable(Gles::GLenum::GL_DEBUG_OUTPUT);
-        mApi.mFunctionStubs.glEnable(Gles::GLenum::GL_DEBUG_OUTPUT_SYNCHRONOUS);
-        GAPID_DEBUG("Enabled KHR_debug extension");
-    }
+  if (mApi.mFunctionStubs.glDebugMessageCallback != nullptr) {
+    mApi.mFunctionStubs.glDebugMessageCallback(
+        reinterpret_cast<void*>(&DebugCallback), this);
+    mApi.mFunctionStubs.glEnable(Gles::GLenum::GL_DEBUG_OUTPUT);
+    mApi.mFunctionStubs.glEnable(Gles::GLenum::GL_DEBUG_OUTPUT_SYNCHRONOUS);
+    GAPID_DEBUG("Enabled KHR_debug extension");
+  }
 }
 
 void GlesRendererImpl::unbind() {
-    if (tlsBound == this) {
-        fn_glXMakeContextCurrent(mDisplay, None, None, nullptr);
-        tlsBound = nullptr;
-    }
+  if (tlsBound == this) {
+    fn_glXMakeContextCurrent(mDisplay, None, None, nullptr);
+    tlsBound = nullptr;
+  }
 }
 
 const char* GlesRendererImpl::name() {
-    return reinterpret_cast<const char*>(
-        mApi.mFunctionStubs.glGetString(Gles::GLenum::GL_RENDERER));
+  return reinterpret_cast<const char*>(
+      mApi.mFunctionStubs.glGetString(Gles::GLenum::GL_RENDERER));
 }
 
 const char* GlesRendererImpl::extensions() {
-    if (!mQueriedExtensions) {
-        mQueriedExtensions = true;
-        int32_t n, i;
-        mApi.mFunctionStubs.glGetIntegerv(Gles::GLenum::GL_NUM_EXTENSIONS, &n);
-        for (i = 0; i < n; i++) {
-            if (i > 0) {
-              mExtensions += " ";
-            }
-            mExtensions += reinterpret_cast<const char*>(
-                mApi.mFunctionStubs.glGetStringi(Gles::GLenum::GL_EXTENSIONS, i));
-        }
+  if (!mQueriedExtensions) {
+    mQueriedExtensions = true;
+    int32_t n, i;
+    mApi.mFunctionStubs.glGetIntegerv(Gles::GLenum::GL_NUM_EXTENSIONS, &n);
+    for (i = 0; i < n; i++) {
+      if (i > 0) {
+        mExtensions += " ";
+      }
+      mExtensions += reinterpret_cast<const char*>(
+          mApi.mFunctionStubs.glGetStringi(Gles::GLenum::GL_EXTENSIONS, i));
     }
-    return &mExtensions[0];
+  }
+  return &mExtensions[0];
 }
 
 const char* GlesRendererImpl::vendor() {
-    return reinterpret_cast<const char*>(
-        mApi.mFunctionStubs.glGetString(Gles::GLenum::GL_VENDOR));
+  return reinterpret_cast<const char*>(
+      mApi.mFunctionStubs.glGetString(Gles::GLenum::GL_VENDOR));
 }
 
 const char* GlesRendererImpl::version() {
-    return reinterpret_cast<const char*>(
-        mApi.mFunctionStubs.glGetString(Gles::GLenum::GL_VERSION));
+  return reinterpret_cast<const char*>(
+      mApi.mFunctionStubs.glGetString(Gles::GLenum::GL_VERSION));
 }
 
-} // anonymous namespace
+}  // anonymous namespace
 
 GlesRenderer* GlesRenderer::create(GlesRenderer* shared_context) {
-    if (core::hasGLorGLES() && core::DlLoader::can_load("libX11.so")) {
-        return new GlesRendererImpl(reinterpret_cast<GlesRendererImpl*>(shared_context));
-    } else {
-        return nullptr;
-    }
+  if (core::hasGLorGLES() && core::DlLoader::can_load("libX11.so")) {
+    return new GlesRendererImpl(
+        reinterpret_cast<GlesRendererImpl*>(shared_context));
+  } else {
+    return nullptr;
+  }
 }
 
 }  // namespace gapir

--- a/gapir/cc/linux/vulkan_renderer.cpp
+++ b/gapir/cc/linux/vulkan_renderer.cpp
@@ -14,59 +14,53 @@
  * limitations under the License.
  */
 
-#include "gapir/cc/vulkan_gfx_api.h"
 #include "gapir/cc/vulkan_renderer.h"
+#include "gapir/cc/vulkan_gfx_api.h"
 
 namespace gapir {
 namespace {
 
 class VulkanRendererImpl : public VulkanRenderer {
-public:
-    VulkanRendererImpl();
-    virtual ~VulkanRendererImpl() override;
+ public:
+  VulkanRendererImpl();
+  virtual ~VulkanRendererImpl() override;
 
-    virtual Api* api() override;
+  virtual Api* api() override;
 
-    virtual bool isValid() override;
-private:
-    Vulkan mApi;
+  virtual bool isValid() override;
+
+ private:
+  Vulkan mApi;
 };
 
 VulkanRendererImpl::VulkanRendererImpl() {
-    mApi.resolve();
-    // Create a dummy instance renderer that never gets cleaned up.
-    // This works around some driver bugs.
-    // See https://github.com/google/gapid/issues/1899
-    auto create_info = Vulkan::VkInstanceCreateInfo{
-        Vulkan::VkStructureType::VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO,
-        nullptr,
-        0,
-        nullptr,
-        0,
-        nullptr,
-        0,
-        nullptr
-    };
-    Vulkan::VkInstance inst;
-    mApi.mFunctionStubs.vkCreateInstance(&create_info, nullptr, &inst);
+  mApi.resolve();
+  // Create a dummy instance renderer that never gets cleaned up.
+  // This works around some driver bugs.
+  // See https://github.com/google/gapid/issues/1899
+  auto create_info = Vulkan::VkInstanceCreateInfo{
+      Vulkan::VkStructureType::VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO,
+      nullptr,
+      0,
+      nullptr,
+      0,
+      nullptr,
+      0,
+      nullptr};
+  Vulkan::VkInstance inst;
+  mApi.mFunctionStubs.vkCreateInstance(&create_info, nullptr, &inst);
 }
 
-VulkanRendererImpl::~VulkanRendererImpl() {
-}
+VulkanRendererImpl::~VulkanRendererImpl() {}
 
-Api* VulkanRendererImpl::api() {
-  return &mApi;
-}
+Api* VulkanRendererImpl::api() { return &mApi; }
 
 bool VulkanRendererImpl::isValid() {
- return mApi.mFunctionStubs.vkCreateInstance != nullptr;
+  return mApi.mFunctionStubs.vkCreateInstance != nullptr;
 }
 
-} // anonymous namespace
+}  // anonymous namespace
 
-VulkanRenderer* VulkanRenderer::create() {
-    return new VulkanRendererImpl();
-}
-
+VulkanRenderer* VulkanRenderer::create() { return new VulkanRendererImpl(); }
 
 }  // namespace gapir

--- a/gapir/cc/memory_manager.h
+++ b/gapir/cc/memory_manager.h
@@ -26,165 +26,174 @@
 
 namespace gapir {
 
-// Memory manager class for managing the memory used by the replay system. Outside of this class
-// there shouldn't be any significant heap allocation in the replay daemon itself (small allocations
-// are possible for bookkeeping)
+// Memory manager class for managing the memory used by the replay system.
+// Outside of this class there shouldn't be any significant heap allocation in
+// the replay daemon itself (small allocations are possible for bookkeeping)
 //
-// The layout of the memory managed by the memory manager (extra paddings are possible between the
-// different memory regions):
-// | In memory resource cache | Volatile Memory | Replay data |
+// The layout of the memory managed by the memory manager (extra paddings are
+// possible between the different memory regions): | In memory resource cache |
+// Volatile Memory | Replay data |
 class MemoryManager {
-public:
-    // Creating a memory manager will try to allocate memory based on the size list provided, while
-    // keeping at least size * kOverheadFactor free bytes for possible driver overhead allocations.
-    // Stopping after the first successful allocation and cause a fatal error if none of the sizes
-    // could be allocated.
-    explicit MemoryManager(const std::vector<uint32_t>& sizeList);
+ public:
+  // Creating a memory manager will try to allocate memory based on the size
+  // list provided, while keeping at least size * kOverheadFactor free bytes for
+  // possible driver overhead allocations. Stopping after the first successful
+  // allocation and cause a fatal error if none of the sizes could be allocated.
+  explicit MemoryManager(const std::vector<uint32_t>& sizeList);
 
-    // Sets the size of the replay data. Returns true if the given size fits in the memory and false
-    // otherwise
-    bool setReplayDataSize(uint32_t constantMemorySize, uint32_t opcodeMemorySize);
+  // Sets the size of the replay data. Returns true if the given size fits in
+  // the memory and false otherwise
+  bool setReplayDataSize(uint32_t constantMemorySize,
+                         uint32_t opcodeMemorySize);
 
-    // Sets the size of the volatile memory. Returns true if the given size fits in the memory and
-    // false otherwise
-    bool setVolatileMemory(uint32_t size);
+  // Sets the size of the volatile memory. Returns true if the given size fits
+  // in the memory and false otherwise
+  bool setVolatileMemory(uint32_t size);
 
-    // Returns the size and the base address of the different memory regions managed by the memory
-    // manager
-    void* getBaseAddress() const { return mMemory.get(); }
-    void* getReplayAddress() const { return mReplayData.base; }
-    void* getOpcodeAddress() const { return mOpcodeMemory.base; }
-    void* getConstantAddress() const {return mConstantMemory.base;}
-    void* getVolatileAddress() const { return mVolatileMemory.base; }
-    uint32_t getSize() const { return mSize; }
-    uint32_t getOpcodeSize()   const { return mOpcodeMemory.size; }
-    uint32_t getConstantSize() const { return mConstantMemory.size; }
-    uint32_t getVolatileSize() const { return mVolatileMemory.size; }
+  // Returns the size and the base address of the different memory regions
+  // managed by the memory manager
+  void* getBaseAddress() const { return mMemory.get(); }
+  void* getReplayAddress() const { return mReplayData.base; }
+  void* getOpcodeAddress() const { return mOpcodeMemory.base; }
+  void* getConstantAddress() const { return mConstantMemory.base; }
+  void* getVolatileAddress() const { return mVolatileMemory.base; }
+  uint32_t getSize() const { return mSize; }
+  uint32_t getOpcodeSize() const { return mOpcodeMemory.size; }
+  uint32_t getConstantSize() const { return mConstantMemory.size; }
+  uint32_t getVolatileSize() const { return mVolatileMemory.size; }
 
-    // Converts a given relative (constant or volatile) pointer to an absolute pointer without
-    // checking if the given offset is inside the range of that memory
-    const void* constantToAbsolute(uint32_t offset) const;
-    void* volatileToAbsolute(uint32_t offset) const;
+  // Converts a given relative (constant or volatile) pointer to an absolute
+  // pointer without checking if the given offset is inside the range of that
+  // memory
+  const void* constantToAbsolute(uint32_t offset) const;
+  void* volatileToAbsolute(uint32_t offset) const;
 
-    // Converts an absolute pointer to a relative (constant or volatile) pointer without checking if
-    // the address is inside the range
-    uint32_t absoluteToConstant(const void* address) const;
-    uint32_t absoluteToVolatile(const void* address) const;
+  // Converts an absolute pointer to a relative (constant or volatile) pointer
+  // without checking if the address is inside the range
+  uint32_t absoluteToConstant(const void* address) const;
+  uint32_t absoluteToVolatile(const void* address) const;
 
-    // Checks if the given absolute pointer points inside the constant or inside the volatile
-    // memory
-    bool isConstantAddress(const void* address) const;
-    bool isVolatileAddress(const void* address) const;
+  // Checks if the given absolute pointer points inside the constant or inside
+  // the volatile memory
+  bool isConstantAddress(const void* address) const;
+  bool isVolatileAddress(const void* address) const;
 
-    // Checks if the given absolute pointer points inside the constant or inside
-    // the volatile memory. Check that address+size is also in the same range.
-    bool isConstantAddressWithSize(const void* address, size_t size) const;
-    bool isVolatileAddressWithSize(const void* address, size_t size) const;
+  // Checks if the given absolute pointer points inside the constant or inside
+  // the volatile memory. Check that address+size is also in the same range.
+  bool isConstantAddressWithSize(const void* address, size_t size) const;
+  bool isVolatileAddressWithSize(const void* address, size_t size) const;
 
-    // Returns true if address is marker absolute address value which is used
-    // to indicate a value which should not be observed.
-    bool isNotObservedAbsoluteAddress(const void* address) const;
-private:
-    // Struct to represent a memory interval inside the memory manager with its base address and its
-    // size
-    struct MemoryRange {
-        MemoryRange();
-        MemoryRange(uint8_t* base, uint32_t size);
-        uint8_t* end() const { return base + size; }
+  // Returns true if address is marker absolute address value which is used
+  // to indicate a value which should not be observed.
+  bool isNotObservedAbsoluteAddress(const void* address) const;
 
-        void* toAbsolute(uint32_t offset) const {
-            return base + offset;
-        }
+ private:
+  // Struct to represent a memory interval inside the memory manager with its
+  // base address and its size
+  struct MemoryRange {
+    MemoryRange();
+    MemoryRange(uint8_t* base, uint32_t size);
+    uint8_t* end() const { return base + size; }
 
-        bool isInRange(const void* address) const {
-            return address >= base && address < base + size;
-        }
+    void* toAbsolute(uint32_t offset) const { return base + offset; }
 
-        bool isInRangeWithSize(const void* address, size_t s) const {
-            const uint8_t* addr = static_cast<const uint8_t*>(address);
-            return address >= base && addr + s <= base + size;
-        }
+    bool isInRange(const void* address) const {
+      return address >= base && address < base + size;
+    }
 
-        uint32_t toOffset(const void* address) const {
-            const uint8_t* addr = static_cast<const uint8_t*>(address);
-            return static_cast<uint32_t>(addr - base);
-        }
+    bool isInRangeWithSize(const void* address, size_t s) const {
+      const uint8_t* addr = static_cast<const uint8_t*>(address);
+      return address >= base && addr + s <= base + size;
+    }
 
-        uint8_t* base;
-        uint32_t size;
-    };
+    uint32_t toOffset(const void* address) const {
+      const uint8_t* addr = static_cast<const uint8_t*>(address);
+      return static_cast<uint32_t>(addr - base);
+    }
 
-    // Alignment used for each memory region in bytes
-    static const uint32_t kAlignment = std::alignment_of<double>::value;
+    uint8_t* base;
+    uint32_t size;
+  };
 
-    // Align a given pointer based on the 'kAlignment' value. The return address is always smaller
-    // or equal to the given address what is required by the memory layout used
-    uint8_t* align(uint8_t* addr) const;
+  // Alignment used for each memory region in bytes
+  static const uint32_t kAlignment = std::alignment_of<double>::value;
 
-    // The size and the base address of the memory block managed by the memory manager. This pointer
-    // owns the allocated memory
-    uint32_t mSize;
-    std::unique_ptr<uint8_t[]> mMemory;
+  // Align a given pointer based on the 'kAlignment' value. The return address
+  // is always smaller or equal to the given address what is required by the
+  // memory layout used
+  uint8_t* align(uint8_t* addr) const;
 
-    // The size and base address of the replay data. The memory range specified by these values have
-    // to specify a subset of the memory managed by the memory manager.
-    MemoryRange mReplayData;
+  // The size and the base address of the memory block managed by the memory
+  // manager. This pointer owns the allocated memory
+  uint32_t mSize;
+  std::unique_ptr<uint8_t[]> mMemory;
 
-    // The size and base address of the opcode memory. The opcode memory is located in side the replay
-    // data, so the memory range specified by these values have to be the subset of the memory range
-    // specified by the replay data variables (size and pointer).
-    MemoryRange mOpcodeMemory;
+  // The size and base address of the replay data. The memory range specified by
+  // these values have to specify a subset of the memory managed by the memory
+  // manager.
+  MemoryRange mReplayData;
 
-    // The size and base address of the constant memory. The constant memory is located inside the
-    // replay data, so the memory range specified by these values have to be the subset of the
-    // memory range specified by the replay data variables (size and pointer)
-    MemoryRange mConstantMemory;
+  // The size and base address of the opcode memory. The opcode memory is
+  // located in side the replay data, so the memory range specified by these
+  // values have to be the subset of the memory range specified by the replay
+  // data variables (size and pointer).
+  MemoryRange mOpcodeMemory;
 
-    // The size and the base address of the volatile memory. The memory range specified by these
-    // values have to specify a subset of the memory managed by the memory manager.
-    MemoryRange mVolatileMemory;
+  // The size and base address of the constant memory. The constant memory is
+  // located inside the replay data, so the memory range specified by these
+  // values have to be the subset of the memory range specified by the replay
+  // data variables (size and pointer)
+  MemoryRange mConstantMemory;
+
+  // The size and the base address of the volatile memory. The memory range
+  // specified by these values have to specify a subset of the memory managed by
+  // the memory manager.
+  MemoryRange mVolatileMemory;
 };
 
 inline const void* MemoryManager::constantToAbsolute(uint32_t offset) const {
-    return mConstantMemory.toAbsolute(offset);
+  return mConstantMemory.toAbsolute(offset);
 }
 
 inline void* MemoryManager::volatileToAbsolute(uint32_t offset) const {
-    return mVolatileMemory.toAbsolute(offset);
+  return mVolatileMemory.toAbsolute(offset);
 }
 
 inline uint32_t MemoryManager::absoluteToConstant(const void* address) const {
-    return mConstantMemory.toOffset(address);
+  return mConstantMemory.toOffset(address);
 }
 
 inline uint32_t MemoryManager::absoluteToVolatile(const void* address) const {
-    return mVolatileMemory.toOffset(address);
+  return mVolatileMemory.toOffset(address);
 }
 
 inline bool MemoryManager::isConstantAddress(const void* address) const {
-    return mConstantMemory.isInRange(address);
+  return mConstantMemory.isInRange(address);
 }
 
 inline bool MemoryManager::isVolatileAddress(const void* address) const {
-    return mVolatileMemory.isInRange(address);
+  return mVolatileMemory.isInRange(address);
 }
 
-inline bool MemoryManager::isConstantAddressWithSize(const void* address, size_t size) const {
-    return mConstantMemory.isInRangeWithSize(address, size);
+inline bool MemoryManager::isConstantAddressWithSize(const void* address,
+                                                     size_t size) const {
+  return mConstantMemory.isInRangeWithSize(address, size);
 }
 
-inline bool MemoryManager::isVolatileAddressWithSize(const void* address, size_t size) const {
-    return mVolatileMemory.isInRangeWithSize(address, size);
+inline bool MemoryManager::isVolatileAddressWithSize(const void* address,
+                                                     size_t size) const {
+  return mVolatileMemory.isInRangeWithSize(address, size);
 }
 
-inline bool MemoryManager::isNotObservedAbsoluteAddress(const void* address) const {
-    // Pointer is not observed. This can be legal - for example
-    // glVertexAttribPointer may have been passed a pointer that was never
-    // observed. In this situation we pass a pointer that should cause an access
-    // violation if it is dereferenced. We opt to not use 0x00 as this is often
-    // overloaded to mean something else.
-    // Must match value used in replay/builder/builder.go
-    return address == reinterpret_cast<const void*>(uintptr_t(0xBADF00D));
+inline bool MemoryManager::isNotObservedAbsoluteAddress(
+    const void* address) const {
+  // Pointer is not observed. This can be legal - for example
+  // glVertexAttribPointer may have been passed a pointer that was never
+  // observed. In this situation we pass a pointer that should cause an access
+  // violation if it is dereferenced. We opt to not use 0x00 as this is often
+  // overloaded to mean something else.
+  // Must match value used in replay/builder/builder.go
+  return address == reinterpret_cast<const void*>(uintptr_t(0xBADF00D));
 }
 
 }  // namespace gapir

--- a/gapir/cc/memory_manager_test.cpp
+++ b/gapir/cc/memory_manager_test.cpp
@@ -28,106 +28,121 @@ namespace {
 const uint32_t MEMORY_SIZE = 4096;
 
 class MemoryManagerTest : public ::testing::Test {
-protected:
-    virtual void SetUp() {
-        std::vector<uint32_t> memorySizes = {MEMORY_SIZE};
-        mMemoryManager.reset(new MemoryManager(memorySizes));
-    }
+ protected:
+  virtual void SetUp() {
+    std::vector<uint32_t> memorySizes = {MEMORY_SIZE};
+    mMemoryManager.reset(new MemoryManager(memorySizes));
+  }
 
-    std::unique_ptr<MemoryManager> mMemoryManager;
+  std::unique_ptr<MemoryManager> mMemoryManager;
 };
 }  // anonymous namespace
 
 TEST_F(MemoryManagerTest, ConstantMemoryIsEmptyByDefault) {
-    EXPECT_EQ(0, mMemoryManager->getConstantSize());
+  EXPECT_EQ(0, mMemoryManager->getConstantSize());
 }
 
 TEST_F(MemoryManagerTest, ConstantSizeIsCorrect) {
-    // 64 bytes of opcodes, and 192 bytes of constants
-    mMemoryManager->setReplayDataSize(192, 64);
-    EXPECT_EQ(192, mMemoryManager->getConstantSize());
-    EXPECT_EQ(64, mMemoryManager->getOpcodeSize());
-    EXPECT_EQ((uint8_t*)mMemoryManager->getConstantAddress(),
-              (uint8_t*)mMemoryManager->getOpcodeAddress() - 192);
+  // 64 bytes of opcodes, and 192 bytes of constants
+  mMemoryManager->setReplayDataSize(192, 64);
+  EXPECT_EQ(192, mMemoryManager->getConstantSize());
+  EXPECT_EQ(64, mMemoryManager->getOpcodeSize());
+  EXPECT_EQ((uint8_t*)mMemoryManager->getConstantAddress(),
+            (uint8_t*)mMemoryManager->getOpcodeAddress() - 192);
 }
 
 TEST_F(MemoryManagerTest, DefaultVolatileSizeIsMemorySize) {
-    EXPECT_EQ(MEMORY_SIZE, mMemoryManager->getVolatileSize());
+  EXPECT_EQ(MEMORY_SIZE, mMemoryManager->getVolatileSize());
 }
 
 TEST_F(MemoryManagerTest, SetReplayDataSize) {
-    EXPECT_TRUE(mMemoryManager->setReplayDataSize(MEMORY_SIZE, 0));
-    EXPECT_FALSE(mMemoryManager->setReplayDataSize(MEMORY_SIZE + 1, 0));
-    EXPECT_TRUE(mMemoryManager->setReplayDataSize(MEMORY_SIZE, 0));
+  EXPECT_TRUE(mMemoryManager->setReplayDataSize(MEMORY_SIZE, 0));
+  EXPECT_FALSE(mMemoryManager->setReplayDataSize(MEMORY_SIZE + 1, 0));
+  EXPECT_TRUE(mMemoryManager->setReplayDataSize(MEMORY_SIZE, 0));
 
-    EXPECT_TRUE(mMemoryManager->setReplayDataSize(0, MEMORY_SIZE));
-    EXPECT_FALSE(mMemoryManager->setReplayDataSize(0, MEMORY_SIZE + 1));
-    EXPECT_TRUE(mMemoryManager->setReplayDataSize(0, MEMORY_SIZE));
+  EXPECT_TRUE(mMemoryManager->setReplayDataSize(0, MEMORY_SIZE));
+  EXPECT_FALSE(mMemoryManager->setReplayDataSize(0, MEMORY_SIZE + 1));
+  EXPECT_TRUE(mMemoryManager->setReplayDataSize(0, MEMORY_SIZE));
 }
 
 TEST_F(MemoryManagerTest, ExplicitVolatileSizeIsUpdated) {
-    const uint32_t volatileMemorySize = MEMORY_SIZE / 2;
-    mMemoryManager->setVolatileMemory(volatileMemorySize);
+  const uint32_t volatileMemorySize = MEMORY_SIZE / 2;
+  mMemoryManager->setVolatileMemory(volatileMemorySize);
 
-    EXPECT_NE(MEMORY_SIZE, mMemoryManager->getVolatileSize());
-    EXPECT_EQ(volatileMemorySize, mMemoryManager->getVolatileSize());
+  EXPECT_NE(MEMORY_SIZE, mMemoryManager->getVolatileSize());
+  EXPECT_EQ(volatileMemorySize, mMemoryManager->getVolatileSize());
 }
 
 TEST_F(MemoryManagerTest, OutOfBoundsVolatileSizeFails) {
-    EXPECT_TRUE(mMemoryManager->setReplayDataSize(MEMORY_SIZE / 2, 0));
+  EXPECT_TRUE(mMemoryManager->setReplayDataSize(MEMORY_SIZE / 2, 0));
 
-    EXPECT_TRUE(mMemoryManager->setVolatileMemory(MEMORY_SIZE / 2));
-    EXPECT_FALSE(mMemoryManager->setVolatileMemory(MEMORY_SIZE / 2 + 1));
-    EXPECT_TRUE(mMemoryManager->setVolatileMemory(MEMORY_SIZE / 2));
+  EXPECT_TRUE(mMemoryManager->setVolatileMemory(MEMORY_SIZE / 2));
+  EXPECT_FALSE(mMemoryManager->setVolatileMemory(MEMORY_SIZE / 2 + 1));
+  EXPECT_TRUE(mMemoryManager->setVolatileMemory(MEMORY_SIZE / 2));
 }
 
 TEST_F(MemoryManagerTest, IsConstantAddressWorks) {
-    uint32_t constantMemorySize = 1024;
+  uint32_t constantMemorySize = 1024;
 
-    std::vector<uint8_t> constantMemory(constantMemorySize, 0);
-    mMemoryManager->setReplayDataSize(constantMemorySize, 128);
-    uint8_t* constantBase = static_cast<uint8_t*>(mMemoryManager->getReplayAddress());
-    EXPECT_EQ(mMemoryManager->getReplayAddress(), mMemoryManager->getConstantAddress());
-    memcpy(constantBase, &constantMemory.front(), constantMemory.size());
+  std::vector<uint8_t> constantMemory(constantMemorySize, 0);
+  mMemoryManager->setReplayDataSize(constantMemorySize, 128);
+  uint8_t* constantBase =
+      static_cast<uint8_t*>(mMemoryManager->getReplayAddress());
+  EXPECT_EQ(mMemoryManager->getReplayAddress(),
+            mMemoryManager->getConstantAddress());
+  memcpy(constantBase, &constantMemory.front(), constantMemory.size());
 
-    EXPECT_TRUE(mMemoryManager->isConstantAddress(constantBase));
-    EXPECT_TRUE(mMemoryManager->isConstantAddress(constantBase + constantMemorySize / 2));
-    EXPECT_FALSE(mMemoryManager->isConstantAddress(constantBase + constantMemorySize));
-    EXPECT_FALSE(mMemoryManager->isConstantAddress(constantBase - 1));
-    EXPECT_FALSE(mMemoryManager->isConstantAddress(mMemoryManager->volatileToAbsolute(0)));
+  EXPECT_TRUE(mMemoryManager->isConstantAddress(constantBase));
+  EXPECT_TRUE(
+      mMemoryManager->isConstantAddress(constantBase + constantMemorySize / 2));
+  EXPECT_FALSE(
+      mMemoryManager->isConstantAddress(constantBase + constantMemorySize));
+  EXPECT_FALSE(mMemoryManager->isConstantAddress(constantBase - 1));
+  EXPECT_FALSE(
+      mMemoryManager->isConstantAddress(mMemoryManager->volatileToAbsolute(0)));
 }
 
 TEST_F(MemoryManagerTest, IsVolatileAddressWorks) {
-    uint32_t volatileSize = 1024;
+  uint32_t volatileSize = 1024;
 
-    mMemoryManager->setReplayDataSize(512, 0);
-    mMemoryManager->setVolatileMemory(volatileSize);
-    uint8_t* volatileBase = static_cast<uint8_t*>(mMemoryManager->volatileToAbsolute(0));
+  mMemoryManager->setReplayDataSize(512, 0);
+  mMemoryManager->setVolatileMemory(volatileSize);
+  uint8_t* volatileBase =
+      static_cast<uint8_t*>(mMemoryManager->volatileToAbsolute(0));
 
-    EXPECT_TRUE(mMemoryManager->isVolatileAddress(volatileBase));
-    EXPECT_TRUE(mMemoryManager->isVolatileAddress(volatileBase + volatileSize / 2));
-    EXPECT_FALSE(mMemoryManager->isVolatileAddress(volatileBase + volatileSize));
-    EXPECT_FALSE(mMemoryManager->isVolatileAddress(volatileBase - 1));
-    EXPECT_FALSE(mMemoryManager->isVolatileAddress(mMemoryManager->constantToAbsolute(0)));
+  EXPECT_TRUE(mMemoryManager->isVolatileAddress(volatileBase));
+  EXPECT_TRUE(
+      mMemoryManager->isVolatileAddress(volatileBase + volatileSize / 2));
+  EXPECT_FALSE(mMemoryManager->isVolatileAddress(volatileBase + volatileSize));
+  EXPECT_FALSE(mMemoryManager->isVolatileAddress(volatileBase - 1));
+  EXPECT_FALSE(
+      mMemoryManager->isVolatileAddress(mMemoryManager->constantToAbsolute(0)));
 }
 
 TEST_F(MemoryManagerTest, AbsoluteToVolatile) {
-    mMemoryManager->setVolatileMemory(MEMORY_SIZE / 2);
+  mMemoryManager->setVolatileMemory(MEMORY_SIZE / 2);
 
-    EXPECT_EQ(10, mMemoryManager->absoluteToVolatile(
-                          static_cast<uint8_t*>(mMemoryManager->getVolatileAddress()) + 10));
+  EXPECT_EQ(
+      10,
+      mMemoryManager->absoluteToVolatile(
+          static_cast<uint8_t*>(mMemoryManager->getVolatileAddress()) + 10));
 }
 
 TEST_F(MemoryManagerTest, AbsoluteToConstant) {
-    uint32_t constantMemorySize = 1024;
+  uint32_t constantMemorySize = 1024;
 
-    std::vector<uint8_t> constantMemory(constantMemorySize, 0);
-    mMemoryManager->setReplayDataSize(constantMemorySize, 128);
-    uint8_t* constantBase = static_cast<uint8_t*>(mMemoryManager->getReplayAddress());
-    EXPECT_EQ(mMemoryManager->getReplayAddress(), mMemoryManager->getConstantAddress());
-    memcpy(constantBase, &constantMemory.front(), constantMemory.size());
-    EXPECT_EQ(10, mMemoryManager->absoluteToConstant(
-                          static_cast<const uint8_t*>(mMemoryManager->constantToAbsolute(0)) + 10));
+  std::vector<uint8_t> constantMemory(constantMemorySize, 0);
+  mMemoryManager->setReplayDataSize(constantMemorySize, 128);
+  uint8_t* constantBase =
+      static_cast<uint8_t*>(mMemoryManager->getReplayAddress());
+  EXPECT_EQ(mMemoryManager->getReplayAddress(),
+            mMemoryManager->getConstantAddress());
+  memcpy(constantBase, &constantMemory.front(), constantMemory.size());
+  EXPECT_EQ(
+      10,
+      mMemoryManager->absoluteToConstant(
+          static_cast<const uint8_t*>(mMemoryManager->constantToAbsolute(0)) +
+          10));
 }
 
 }  // namespace test

--- a/gapir/cc/mock_resource_provider.h
+++ b/gapir/cc/mock_resource_provider.h
@@ -19,8 +19,8 @@
 
 #include "resource_provider.h"
 
-#include <vector>
 #include <gmock/gmock.h>
+#include <vector>
 
 #include "replay_connection.h"
 
@@ -28,48 +28,55 @@ namespace gapir {
 namespace test {
 
 class MockResourceProvider : public ResourceProvider {
-public:
-    MOCK_METHOD5(get, bool(const Resource* resources, size_t count, ReplayConnection* conn,
-                           void* target, size_t targetSize));
+ public:
+  MOCK_METHOD5(get,
+               bool(const Resource* resources, size_t count,
+                    ReplayConnection* conn, void* target, size_t targetSize));
 
-    MOCK_METHOD5(prefetch, void(const Resource* resources, size_t count,
-                                ReplayConnection* conn, void* temp, size_t tempSize));
+  MOCK_METHOD5(prefetch,
+               void(const Resource* resources, size_t count,
+                    ReplayConnection* conn, void* temp, size_t tempSize));
 };
 
-// PatternedResourceProvider is a ResourceProvider that writes a pattern to the pointer handed to
-// get, simulating the loading of a resource before calling the inner ResourceProvider.
-// The PatternedResourceProvider is expected to be placed between the ResourceProvider being
-// tested and the MockResourceProvider.
+// PatternedResourceProvider is a ResourceProvider that writes a pattern to the
+// pointer handed to get, simulating the loading of a resource before calling
+// the inner ResourceProvider. The PatternedResourceProvider is expected to be
+// placed between the ResourceProvider being tested and the
+// MockResourceProvider.
 class PatternedResourceProvider : public ResourceProvider {
-public:
-    inline PatternedResourceProvider(std::unique_ptr<ResourceProvider> inner)
-        : mInner(std::move(inner)) {}
+ public:
+  inline PatternedResourceProvider(std::unique_ptr<ResourceProvider> inner)
+      : mInner(std::move(inner)) {}
 
-    inline bool get(const Resource* resources, size_t count, ReplayConnection* conn,
-                    void* target, size_t targetSize) override {
-        auto pattern = patternFor(std::vector<Resource>(resources, resources + count));
-        memcpy(target, &pattern[0], pattern.size());
-        return mInner->get(resources, count, conn, target, targetSize);
+  inline bool get(const Resource* resources, size_t count,
+                  ReplayConnection* conn, void* target,
+                  size_t targetSize) override {
+    auto pattern =
+        patternFor(std::vector<Resource>(resources, resources + count));
+    memcpy(target, &pattern[0], pattern.size());
+    return mInner->get(resources, count, conn, target, targetSize);
+  }
+
+  inline void prefetch(const Resource* resources, size_t count,
+                       ReplayConnection* conn, void* temp,
+                       size_t tempSize) override {
+    mInner->prefetch(resources, count, conn, temp, tempSize);
+  }
+
+  // patternFor returns the memory pattern that will be written to the target
+  // pointer when calling get.
+  static std::vector<uint8_t> patternFor(
+      const std::vector<Resource>& resources) {
+    std::vector<uint8_t> v;
+    for (auto resource : resources) {
+      for (size_t i = 0; i < resource.size; i++) {
+        v.push_back(resource.id[i % resource.id.size()]);
+      }
     }
+    return v;
+  }
 
-    inline void prefetch(const Resource* resources, size_t count, ReplayConnection* conn,
-                         void* temp, size_t tempSize) override {
-        mInner->prefetch(resources, count, conn, temp, tempSize);
-    }
-
-    // patternFor returns the memory pattern that will be written to the target pointer when
-    // calling get.
-    static std::vector<uint8_t> patternFor(const std::vector<Resource>& resources) {
-        std::vector<uint8_t> v;
-        for (auto resource : resources) {
-            for (size_t i = 0; i < resource.size; i++) {
-                v.push_back(resource.id[i % resource.id.size()]);
-            }
-        }
-        return v;
-    }
-
-private:
+ private:
   std::unique_ptr<ResourceProvider> mInner;
 };
 

--- a/gapir/cc/osx/vulkan_renderer.mm
+++ b/gapir/cc/osx/vulkan_renderer.mm
@@ -14,43 +14,35 @@
  * limitations under the License.
  */
 
-#include "gapir/cc/vulkan_gfx_api.h"
 #include "gapir/cc/vulkan_renderer.h"
+#include "gapir/cc/vulkan_gfx_api.h"
 
 namespace gapir {
 namespace {
 
 class VulkanRendererImpl : public VulkanRenderer {
-public:
-    VulkanRendererImpl();
-    virtual ~VulkanRendererImpl() override;
+ public:
+  VulkanRendererImpl();
+  virtual ~VulkanRendererImpl() override;
 
-    virtual Api* api() override;
+  virtual Api* api() override;
 
-    virtual bool isValid() override;
-private:
-    Vulkan mApi;
+  virtual bool isValid() override;
+
+ private:
+  Vulkan mApi;
 };
 
-VulkanRendererImpl::VulkanRendererImpl() {
-}
+VulkanRendererImpl::VulkanRendererImpl() {}
 
-VulkanRendererImpl::~VulkanRendererImpl() {
-}
+VulkanRendererImpl::~VulkanRendererImpl() {}
 
-Api* VulkanRendererImpl::api() {
-  return &mApi;
-}
+Api* VulkanRendererImpl::api() { return &mApi; }
 
-bool VulkanRendererImpl::isValid() {
- return mApi.mFunctionStubs.vkCreateInstance != nullptr;
-}
+bool VulkanRendererImpl::isValid() { return mApi.mFunctionStubs.vkCreateInstance != nullptr; }
 
-} // anonymous namespace
+}  // anonymous namespace
 
-VulkanRenderer* VulkanRenderer::create() {
-    return new VulkanRendererImpl();
-}
-
+VulkanRenderer* VulkanRenderer::create() { return new VulkanRendererImpl(); }
 
 }  // namespace gapir

--- a/gapir/cc/post_buffer.h
+++ b/gapir/cc/post_buffer.h
@@ -26,41 +26,43 @@
 namespace gapir {
 
 // PostBuffer provides a delayed-send buffer for pushing data to the server.
-// This serves as an optimisation to batch many small postbacks into fewer, larger batches.
+// This serves as an optimisation to batch many small postbacks into fewer,
+// larger batches.
 class PostBuffer {
-public:
-    typedef std::function<bool(std::unique_ptr<ReplayConnection::Posts>)> PostBufferCallback;
+ public:
+  typedef std::function<bool(std::unique_ptr<ReplayConnection::Posts>)>
+      PostBufferCallback;
 
-    // Constructs a PostBuffer with the specified maximum capacity and function to invoke when
-    // the PostBuffer wants to flush the buffer to the server.
-    PostBuffer(uint32_t desiredCapacity, PostBufferCallback callback);
-    ~PostBuffer();
+  // Constructs a PostBuffer with the specified maximum capacity and function to
+  // invoke when the PostBuffer wants to flush the buffer to the server.
+  PostBuffer(uint32_t desiredCapacity, PostBufferCallback callback);
+  ~PostBuffer();
 
-    // Push data to the buffer. If the buffer does not have enough space to buffer the data, then
-    // the contents of the PushBuffer will be flushed.
-    bool push(const void* address, uint32_t count);
+  // Push data to the buffer. If the buffer does not have enough space to buffer
+  // the data, then the contents of the PushBuffer will be flushed.
+  bool push(const void* address, uint32_t count);
 
-    // Forcefully flush the PostBuffer. If the PostBuffer is empty then calling this function does
-    // nothing.
-    bool flush();
+  // Forcefully flush the PostBuffer. If the PostBuffer is empty then calling
+  // this function does nothing.
+  bool flush();
 
-private:
-    // The PostBuffer's internal buffer.
-    std::unique_ptr<ReplayConnection::Posts> mPosts;
+ private:
+  // The PostBuffer's internal buffer.
+  std::unique_ptr<ReplayConnection::Posts> mPosts;
 
-    // The total number of posts ever processed by this post buffer.
-    uint64_t mTotalPostCount;
+  // The total number of posts ever processed by this post buffer.
+  uint64_t mTotalPostCount;
 
-    // The maximum capacity of the internal buffer.
-    const uint32_t mCapacity;
+  // The maximum capacity of the internal buffer.
+  const uint32_t mCapacity;
 
-    // The flush callback function.
-    const PostBufferCallback mCallback;
+  // The flush callback function.
+  const PostBufferCallback mCallback;
 
-    // The offset in mBuffer for the next write.
-    uint32_t mOffset;
+  // The offset in mBuffer for the next write.
+  uint32_t mOffset;
 };
 
 }  // namespace gapir
 
-#endif // GAPIR_POSTBUFFER_H
+#endif  // GAPIR_POSTBUFFER_H

--- a/gapir/cc/renderer.h
+++ b/gapir/cc/renderer.h
@@ -21,45 +21,48 @@
 
 namespace gapir {
 
-// Renderer is an interface to an off-screen rendering context. Constructing a renderer will perform
-// any necessary hidden window construction and minimal event handling for the target platform.
+// Renderer is an interface to an off-screen rendering context. Constructing a
+// renderer will perform any necessary hidden window construction and minimal
+// event handling for the target platform.
 class Renderer {
-public:
-    class Listener {
-    public:
-     virtual void onDebugMessage(uint32_t severity, uint8_t api_index,
-                                 const char* msg) = 0;
-    };
+ public:
+  class Listener {
+   public:
+    virtual void onDebugMessage(uint32_t severity, uint8_t api_index,
+                                const char* msg) = 0;
+  };
 
-    inline Renderer();
+  inline Renderer();
 
-    // Destroys the renderer and any associated off-screen windows.
-    virtual ~Renderer() {}
+  // Destroys the renderer and any associated off-screen windows.
+  virtual ~Renderer() {}
 
-    // Returns the renderer's API.
-    virtual Api* api() = 0;
+  // Returns the renderer's API.
+  virtual Api* api() = 0;
 
-    template <typename T> inline T* getApi();
+  template <typename T>
+  inline T* getApi();
 
-    inline void setListener(Listener* listener);
-    inline Listener* getListener() const;
+  inline void setListener(Listener* listener);
+  inline Listener* getListener() const;
 
-    virtual bool isValid() = 0;
-private:
-    Listener* mListener;
+  virtual bool isValid() = 0;
+
+ private:
+  Listener* mListener;
 };
 
 inline Renderer::Renderer() : mListener(nullptr) {}
 
 template <typename T>
 inline T* Renderer::getApi() {
-    if (Api* api = this->api()) {
-        // Raw-pointer comparison is safe as the ID is static.
-        if (api->id() == T::ID) {
-            return static_cast<T*>(api);
-        }
+  if (Api* api = this->api()) {
+    // Raw-pointer comparison is safe as the ID is static.
+    if (api->id() == T::ID) {
+      return static_cast<T*>(api);
     }
-    return nullptr;
+  }
+  return nullptr;
 }
 
 inline void Renderer::setListener(Listener* listener) { mListener = listener; }
@@ -68,4 +71,3 @@ inline Renderer::Listener* Renderer::getListener() const { return mListener; }
 }  // namespace gapir
 
 #endif  // GAPIR_RENDERER_H
-

--- a/gapir/cc/replay_connection.cpp
+++ b/gapir/cc/replay_connection.cpp
@@ -19,9 +19,9 @@
 #include <grpc++/grpc++.h>
 #include <memory>
 
-#include "gapis/service/severity/severity.pb.h"
-#include "gapir/replay_service/service.grpc.pb.h"
 #include "core/cc/log.h"
+#include "gapir/replay_service/service.grpc.pb.h"
+#include "gapis/service/severity/severity.pb.h"
 
 namespace gapir {
 
@@ -87,13 +87,15 @@ uint64_t ReplayConnection::Posts::piece_id(int index) const {
   return mProtoPostData->post_data_pieces(index).id();
 }
 
-ReplayConnection::Posts::Posts() : mProtoPostData(new replay_service::PostData()) {}
+ReplayConnection::Posts::Posts()
+    : mProtoPostData(new replay_service::PostData()) {}
 
 // Payload member methods
 
 std::unique_ptr<ReplayConnection::Payload> ReplayConnection::Payload::get(
     ReplayGrpcStream* stream) {
-  std::unique_ptr<replay_service::ReplayRequest> req(new replay_service::ReplayRequest());
+  std::unique_ptr<replay_service::ReplayRequest> req(
+      new replay_service::ReplayRequest());
   if (!stream->Read(req.get())) {
     return nullptr;
   }
@@ -147,14 +149,16 @@ const void* ReplayConnection::Payload::opcodes_data() const {
   return mProtoReplayRequest->payload().opcodes().data();
 }
 
-ReplayConnection::Payload::Payload(std::unique_ptr<replay_service::ReplayRequest> req)
+ReplayConnection::Payload::Payload(
+    std::unique_ptr<replay_service::ReplayRequest> req)
     : mProtoReplayRequest(std::move(req)) {}
 
 // Resources member methods
 
 std::unique_ptr<ReplayConnection::Resources> ReplayConnection::Resources::get(
     ReplayGrpcStream* stream) {
-  std::unique_ptr<replay_service::ReplayRequest> req(new replay_service::ReplayRequest());
+  std::unique_ptr<replay_service::ReplayRequest> req(
+      new replay_service::ReplayRequest());
   if (!stream->Read(req.get())) {
     return nullptr;
   }
@@ -236,12 +240,8 @@ bool ReplayConnection::sendNotification(uint64_t id, uint32_t severity,
                                         const void* data, uint32_t data_size) {
   using severity::Severity;
   const Severity log_levels[] = {
-    Severity::FatalLevel,
-    Severity::ErrorLevel,
-    Severity::WarningLevel,
-    Severity::InfoLevel,
-    Severity::DebugLevel,
-    Severity::VerboseLevel,
+      Severity::FatalLevel, Severity::ErrorLevel, Severity::WarningLevel,
+      Severity::InfoLevel,  Severity::DebugLevel, Severity::VerboseLevel,
   };
   Severity sev = Severity::DebugLevel;
   if (severity <= LOG_LEVEL_DEBUG) {

--- a/gapir/cc/replay_connection.h
+++ b/gapir/cc/replay_connection.h
@@ -24,24 +24,26 @@
 #include <vector>
 
 namespace grpc {
-  template<typename RES, typename REQ> class ServerReaderWriter;
+template <typename RES, typename REQ>
+class ServerReaderWriter;
 }
 
 namespace replay_service {
-  class Payload;
-  class Resources;
-  class ReplayRequest;
-  class PayloadRequest;
-  class ResourceRequest;
-  class PostData;
-  class ReplayResponse;
-  class Notification;
-}
+class Payload;
+class Resources;
+class ReplayRequest;
+class PayloadRequest;
+class ResourceRequest;
+class PostData;
+class ReplayResponse;
+class Notification;
+}  // namespace replay_service
 
 namespace gapir {
 
 using ReplayGrpcStream =
-    grpc::ServerReaderWriter<replay_service::ReplayResponse, replay_service::ReplayRequest>;
+    grpc::ServerReaderWriter<replay_service::ReplayResponse,
+                             replay_service::ReplayRequest>;
 using PayloadHandler = std::function<bool(const replay_service::Payload&)>;
 using ResourcesHandler = std::function<bool(const replay_service::Resources&)>;
 
@@ -50,8 +52,8 @@ using ResourcesHandler = std::function<bool(const replay_service::Resources&)>;
 // detailed code.
 class ReplayConnection {
  public:
-  // ResourceRequest is a wraper class of replay_service::ResourceRequest, it hides the
-  // new/delete operations of the proto object from the outer code.
+  // ResourceRequest is a wraper class of replay_service::ResourceRequest, it
+  // hides the new/delete operations of the proto object from the outer code.
   class ResourceRequest {
    public:
     // Returns a new created empty ResourceRequest.
@@ -79,8 +81,8 @@ class ReplayConnection {
     std::unique_ptr<replay_service::ResourceRequest> mProtoResourceRequest;
   };
 
-  // Posts is a wraper class of replay_service::PostData, it hides the new/delete
-  // operations of the proto object from the outer code.
+  // Posts is a wraper class of replay_service::PostData, it hides the
+  // new/delete operations of the proto object from the outer code.
   class Posts {
    public:
     // Returns a new created empty Posts
@@ -118,8 +120,8 @@ class ReplayConnection {
     std::unique_ptr<replay_service::PostData> mProtoPostData;
   };
 
-  // Payload is a wraper class of replay_service::Payload, it hides the new/delete
-  // operations of the proto object from outer code.
+  // Payload is a wraper class of replay_service::Payload, it hides the
+  // new/delete operations of the proto object from outer code.
   class Payload {
    public:
     // Gets a Payload from replay connection stream. Takes the ownership of
@@ -164,8 +166,8 @@ class ReplayConnection {
     std::unique_ptr<replay_service::ReplayRequest> mProtoReplayRequest;
   };
 
-  // Resources is a wraper class of replay_service::Resources, it hides the new/delete
-  // operations of the proto object from outer code.
+  // Resources is a wraper class of replay_service::Resources, it hides the
+  // new/delete operations of the proto object from outer code.
   class Resources {
    public:
     // Gets a Resources from the replay connection stream, takes the ownership
@@ -226,9 +228,10 @@ class ReplayConnection {
   // Sends post data. Returns true if succeeded, otherwise returns false.
   virtual bool sendPostData(std::unique_ptr<Posts> posts);
   // Sends notification. Returns true if succeeded, otherwise returns false.
-  virtual bool sendNotification(uint64_t id, uint32_t severity, uint32_t api_index,
-                                uint64_t label, const std::string& msg,
-                                const void* data, uint32_t data_size);
+  virtual bool sendNotification(uint64_t id, uint32_t severity,
+                                uint32_t api_index, uint64_t label,
+                                const std::string& msg, const void* data,
+                                uint32_t data_size);
 
  protected:
   ReplayConnection(ReplayGrpcStream* stream) : mGrpcStream(stream) {}

--- a/gapir/cc/replay_request.cpp
+++ b/gapir/cc/replay_request.cpp
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#include "memory_manager.h"
 #include "replay_request.h"
+#include "memory_manager.h"
 #include "resource_provider.h"
 
 #include "core/cc/log.h"
@@ -31,8 +31,8 @@
 
 namespace gapir {
 
-std::unique_ptr<ReplayRequest> ReplayRequest::create(ReplayConnection* conn,
-                                                     MemoryManager* memoryManager) {
+std::unique_ptr<ReplayRequest> ReplayRequest::create(
+    ReplayConnection* conn, MemoryManager* memoryManager) {
   // Request the replay data from the server.
   if (conn == nullptr) {
     GAPID_ERROR("Failed to create ReplayRequest: null ReplayConnection");
@@ -40,13 +40,15 @@ std::unique_ptr<ReplayRequest> ReplayRequest::create(ReplayConnection* conn,
   }
   std::unique_ptr<ReplayConnection::Payload> payload = conn->getPayload();
   if (payload == nullptr) {
-      GAPID_ERROR("Failed to create ReplayRequest: null Payload")
+    GAPID_ERROR("Failed to create ReplayRequest: null Payload")
     return nullptr;  // failed at getting payload.
   }
-    // Reserve Replay data segments and load data into the memory manager.
-    if (!memoryManager->setReplayDataSize(payload->constants_size(),
-                                       payload->opcodes_size())) {
-    GAPID_ERROR("Failed to create ReplayRequest: failed to set replay data size (constant memory size or opcode memory size)")
+  // Reserve Replay data segments and load data into the memory manager.
+  if (!memoryManager->setReplayDataSize(payload->constants_size(),
+                                        payload->opcodes_size())) {
+    GAPID_ERROR(
+        "Failed to create ReplayRequest: failed to set replay data size "
+        "(constant memory size or opcode memory size)")
     return nullptr;
   }
   memcpy(memoryManager->getConstantAddress(), payload->constants_data(),
@@ -76,24 +78,24 @@ std::unique_ptr<ReplayRequest> ReplayRequest::create(ReplayConnection* conn,
   return req;
 }
 
-uint32_t ReplayRequest::getStackSize() const {
-    return mStackSize;
-}
+uint32_t ReplayRequest::getStackSize() const { return mStackSize; }
 
 uint32_t ReplayRequest::getVolatileMemorySize() const {
-    return mVolatileMemorySize;
+  return mVolatileMemorySize;
 }
 
 const std::vector<Resource>& ReplayRequest::getResources() const {
-    return mResources;
+  return mResources;
 }
 
-const std::pair<const void*, uint32_t>& ReplayRequest::getConstantMemory() const {
-    return mConstantMemory;
+const std::pair<const void*, uint32_t>& ReplayRequest::getConstantMemory()
+    const {
+  return mConstantMemory;
 }
 
-const std::pair<const uint32_t*, uint32_t>& ReplayRequest::getInstructionList() const {
-    return mInstructionList;
+const std::pair<const uint32_t*, uint32_t>& ReplayRequest::getInstructionList()
+    const {
+  return mInstructionList;
 }
 
 }  // namespace gapir

--- a/gapir/cc/replay_request.h
+++ b/gapir/cc/replay_request.h
@@ -31,47 +31,50 @@
 
 namespace gapir {
 
-// Class for storing the information about a replay request that came from the server
+// Class for storing the information about a replay request that came from the
+// server
 class ReplayRequest {
-public:
-    // Creates a new replay request and loads it content from the given replay connection. Returns
-    // the new replay request if loading it was successful or nullptr otherwise. The memory manager
-    // is used to store the content of the replay request
-    static std::unique_ptr<ReplayRequest> create(ReplayConnection* conn,
-                                                 MemoryManager* memoryManager);
+ public:
+  // Creates a new replay request and loads it content from the given replay
+  // connection. Returns the new replay request if loading it was successful or
+  // nullptr otherwise. The memory manager is used to store the content of the
+  // replay request
+  static std::unique_ptr<ReplayRequest> create(ReplayConnection* conn,
+                                               MemoryManager* memoryManager);
 
-    // Get the stack size required by the replay
-    uint32_t getStackSize() const;
+  // Get the stack size required by the replay
+  uint32_t getStackSize() const;
 
-    // Get the volatile memory size required by the replay
-    uint32_t getVolatileMemorySize() const;
+  // Get the volatile memory size required by the replay
+  uint32_t getVolatileMemorySize() const;
 
-    // Get the base address and the size of the constant memory
-    const std::pair<const void*, uint32_t>& getConstantMemory() const;
+  // Get the base address and the size of the constant memory
+  const std::pair<const void*, uint32_t>& getConstantMemory() const;
 
-    // Get the list of the resources with their size required by this replay
-    const std::vector<Resource>& getResources() const;
+  // Get the list of the resources with their size required by this replay
+  const std::vector<Resource>& getResources() const;
 
-    // Get the base address and the size (count of instructions) of the instruction list
-    const std::pair<const uint32_t*, uint32_t>& getInstructionList() const;
+  // Get the base address and the size (count of instructions) of the
+  // instruction list
+  const std::pair<const uint32_t*, uint32_t>& getInstructionList() const;
 
-private:
-    ReplayRequest() = default;
+ private:
+  ReplayRequest() = default;
 
-    // The size of the stack required by the replay
-    uint32_t mStackSize;
+  // The size of the stack required by the replay
+  uint32_t mStackSize;
 
-    // The size of the volatile memory required by the replay
-    uint32_t mVolatileMemorySize;
+  // The size of the volatile memory required by the replay
+  uint32_t mVolatileMemorySize;
 
-    // The base address and the size in bytes of the constant memory
-    std::pair<const void*, uint32_t> mConstantMemory;
+  // The base address and the size in bytes of the constant memory
+  std::pair<const void*, uint32_t> mConstantMemory;
 
-    // The base address and the number of the instructions
-    std::pair<const uint32_t*, uint32_t> mInstructionList;
+  // The base address and the number of the instructions
+  std::pair<const uint32_t*, uint32_t> mInstructionList;
 
-    // The list of resources (resource id, resource size) used by the replay
-    std::vector<Resource> mResources;
+  // The list of resources (resource id, resource size) used by the replay
+  std::vector<Resource> mResources;
 };
 
 }  // namespace gapir

--- a/gapir/cc/replay_request_test.cpp
+++ b/gapir/cc/replay_request_test.cpp
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-#include "memory_manager.h"
-#include "mock_resource_provider.h"
 #include "replay_request.h"
-#include "test_utilities.h"
+#include "memory_manager.h"
 #include "mock_replay_connection.h"
+#include "mock_resource_provider.h"
 #include "replay_connection.h"
+#include "test_utilities.h"
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
@@ -40,48 +40,54 @@ const std::string replayId = "ABCDE";
 }  // anonymous namespace
 
 TEST(ReplayRequestTestStatic, Create) {
-    uint32_t stackSize = 128;
-    uint32_t volatileMemorySize = 1024;
-    std::vector<uint8_t> constantMemory =
-        {'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H'};
-    std::vector<Resource> resources{{"ZYX", 16}, {"1234", 32}};
-    std::vector<uint32_t> instructionList{0, 1, 2};
+  uint32_t stackSize = 128;
+  uint32_t volatileMemorySize = 1024;
+  std::vector<uint8_t> constantMemory = {'A', 'B', 'C', 'D',
+                                         'E', 'F', 'G', 'H'};
+  std::vector<Resource> resources{{"ZYX", 16}, {"1234", 32}};
+  std::vector<uint32_t> instructionList{0, 1, 2};
 
-    auto payload = createPayload(stackSize, volatileMemorySize, constantMemory,
-                                 resources, instructionList);
+  auto payload = createPayload(stackSize, volatileMemorySize, constantMemory,
+                               resources, instructionList);
 
-    auto mock_conn = std::unique_ptr<MockReplayConnection>(new MockReplayConnection());
+  auto mock_conn =
+      std::unique_ptr<MockReplayConnection>(new MockReplayConnection());
 
-    EXPECT_CALL(*mock_conn, getPayload()).WillOnce(Return(ByMove(std::move(payload))));
+  EXPECT_CALL(*mock_conn, getPayload())
+      .WillOnce(Return(ByMove(std::move(payload))));
 
-    std::vector<uint32_t> memorySizes = {MEMORY_SIZE};
-    std::unique_ptr<MemoryManager> memoryManager(new MemoryManager(memorySizes));
+  std::vector<uint32_t> memorySizes = {MEMORY_SIZE};
+  std::unique_ptr<MemoryManager> memoryManager(new MemoryManager(memorySizes));
 
-    auto replayRequest =
-            ReplayRequest::create(mock_conn.get(), memoryManager.get());
+  auto replayRequest =
+      ReplayRequest::create(mock_conn.get(), memoryManager.get());
 
-    EXPECT_THAT(replayRequest, NotNull());
+  EXPECT_THAT(replayRequest, NotNull());
 
-    EXPECT_EQ(stackSize, replayRequest->getStackSize());
-    EXPECT_EQ(volatileMemorySize, replayRequest->getVolatileMemorySize());
-    EXPECT_EQ(resources, replayRequest->getResources());
-    EXPECT_THAT(constantMemory,
-        ElementsAreArray((uint8_t*)(replayRequest->getConstantMemory().first), replayRequest->getConstantMemory().second));
-    EXPECT_THAT(instructionList,
-        ElementsAreArray(replayRequest->getInstructionList().first, replayRequest->getInstructionList().second));
+  EXPECT_EQ(stackSize, replayRequest->getStackSize());
+  EXPECT_EQ(volatileMemorySize, replayRequest->getVolatileMemorySize());
+  EXPECT_EQ(resources, replayRequest->getResources());
+  EXPECT_THAT(
+      constantMemory,
+      ElementsAreArray((uint8_t*)(replayRequest->getConstantMemory().first),
+                       replayRequest->getConstantMemory().second));
+  EXPECT_THAT(instructionList,
+              ElementsAreArray(replayRequest->getInstructionList().first,
+                               replayRequest->getInstructionList().second));
 }
 
 TEST(ReplayRequestTestStatic, CreateErrorGet) {
-    auto mock_conn = std::unique_ptr<MockReplayConnection>(new MockReplayConnection());
-    EXPECT_CALL(*mock_conn, getPayload()).WillOnce(Return(ByMove(nullptr)));
+  auto mock_conn =
+      std::unique_ptr<MockReplayConnection>(new MockReplayConnection());
+  EXPECT_CALL(*mock_conn, getPayload()).WillOnce(Return(ByMove(nullptr)));
 
-    std::vector<uint32_t> memorySizes = {MEMORY_SIZE};
-    std::unique_ptr<MemoryManager> memoryManager(new MemoryManager(memorySizes));
+  std::vector<uint32_t> memorySizes = {MEMORY_SIZE};
+  std::unique_ptr<MemoryManager> memoryManager(new MemoryManager(memorySizes));
 
-    auto replayRequest =
-            ReplayRequest::create(mock_conn.get(), memoryManager.get());
+  auto replayRequest =
+      ReplayRequest::create(mock_conn.get(), memoryManager.get());
 
-    EXPECT_EQ(nullptr, replayRequest);
+  EXPECT_EQ(nullptr, replayRequest);
 }
 
 }  // namespace test

--- a/gapir/cc/resource.h
+++ b/gapir/cc/resource.h
@@ -27,20 +27,22 @@ typedef std::string ResourceId;
 
 // Resource represent a requestable blob of data from the server.
 class Resource {
-public:
-    inline Resource();
-    inline Resource(const Resource& other);
-    inline Resource(ResourceId id, uint32_t size);
-    inline bool operator == (const Resource& other) const;
+ public:
+  inline Resource();
+  inline Resource(const Resource& other);
+  inline Resource(ResourceId id, uint32_t size);
+  inline bool operator==(const Resource& other) const;
 
-    ResourceId id; // The resource identifier.
-    uint32_t size; // The resource size in bytes.
+  ResourceId id;  // The resource identifier.
+  uint32_t size;  // The resource size in bytes.
 };
 
 inline Resource::Resource() {}
-inline Resource::Resource(const Resource& other) : id(other.id), size(other.size) {}
-inline Resource::Resource(ResourceId id_, uint32_t size_) : id(id_), size(size_) {}
-inline bool Resource::operator == (const Resource& other) const {
+inline Resource::Resource(const Resource& other)
+    : id(other.id), size(other.size) {}
+inline Resource::Resource(ResourceId id_, uint32_t size_)
+    : id(id_), size(size_) {}
+inline bool Resource::operator==(const Resource& other) const {
   return id == other.id && size == other.size;
 }
 

--- a/gapir/cc/resource_cache.cpp
+++ b/gapir/cc/resource_cache.cpp
@@ -23,85 +23,80 @@
 
 namespace gapir {
 
-ResourceCache::ResourceCache(std::unique_ptr<ResourceProvider> fallbackProvider) :
-        mFallbackProvider(std::move(fallbackProvider)) {}
+ResourceCache::ResourceCache(std::unique_ptr<ResourceProvider> fallbackProvider)
+    : mFallbackProvider(std::move(fallbackProvider)) {}
 
-bool ResourceCache::get(const Resource*         resources,
-                        size_t                  count,
-                        ReplayConnection*       conn,
-                        void*                   target,
-                        size_t                  size) {
-    uint8_t* dst = reinterpret_cast<uint8_t*>(target);
-    Batch batch(dst, size);
-    for (size_t i = 0; i < count; i++) {
-        const Resource& resource = resources[i];
-        if (size < resource.size) {
-            return false;  // Not enough space
-        }
-        // Try fetching the resource from the cache.
-        if (getCache(resource, dst)) {
-            // In cache. Flush the pending requests.
-            // Note: This implementation can result in many round trips to the
-            // GAPIS, because whenever a cache hit happens, all the pending
-            // resources accumulated before this resource must be fetched and
-            // loaded prior to the cached resource to be loaded. The original
-            // design was based around the idea that we could load the resource
-            // directly into the destination buffer without temporary copies.
-            // As gRPC forces us to have temporary copies, this implementation
-            // should be changed to have a single fetch.
-            // TODO: Update this batching logic to reduce the number of resource
-            // fetching calls.
-            if (!batch.flush(*this, conn)) {
-                return false;  // Failed to get resources from fallback provider.
-            }
-            batch = Batch(dst, size);
-        } else {
-            // Not in cache.
-            // Add this to the batch we need to request from the fallback provider.
-            batch.append(resource);
-        }
-        dst += resource.size;
-        size -= resource.size;
+bool ResourceCache::get(const Resource* resources, size_t count,
+                        ReplayConnection* conn, void* target, size_t size) {
+  uint8_t* dst = reinterpret_cast<uint8_t*>(target);
+  Batch batch(dst, size);
+  for (size_t i = 0; i < count; i++) {
+    const Resource& resource = resources[i];
+    if (size < resource.size) {
+      return false;  // Not enough space
     }
-    return batch.flush(*this, conn);
+    // Try fetching the resource from the cache.
+    if (getCache(resource, dst)) {
+      // In cache. Flush the pending requests.
+      // Note: This implementation can result in many round trips to the
+      // GAPIS, because whenever a cache hit happens, all the pending
+      // resources accumulated before this resource must be fetched and
+      // loaded prior to the cached resource to be loaded. The original
+      // design was based around the idea that we could load the resource
+      // directly into the destination buffer without temporary copies.
+      // As gRPC forces us to have temporary copies, this implementation
+      // should be changed to have a single fetch.
+      // TODO: Update this batching logic to reduce the number of resource
+      // fetching calls.
+      if (!batch.flush(*this, conn)) {
+        return false;  // Failed to get resources from fallback provider.
+      }
+      batch = Batch(dst, size);
+    } else {
+      // Not in cache.
+      // Add this to the batch we need to request from the fallback provider.
+      batch.append(resource);
+    }
+    dst += resource.size;
+    size -= resource.size;
+  }
+  return batch.flush(*this, conn);
 }
 
 ResourceCache::Batch::Batch(void* target, size_t size)
-    : mTarget(reinterpret_cast<uint8_t*>(target))
-    , mSize(0)
-    , mSpace(size) {
-
-    GAPID_ASSERT(target != nullptr);
+    : mTarget(reinterpret_cast<uint8_t*>(target)), mSize(0), mSpace(size) {
+  GAPID_ASSERT(target != nullptr);
 }
 
 bool ResourceCache::Batch::append(const Resource& resource) {
-    if (mTarget == nullptr) {
-        GAPID_FATAL("Cannot append after flush.");
-    }
-    if (mSpace < resource.size) {
-        return false;
-    }
-    mResources.push_back(resource);
-    mSize += resource.size;
-    mSpace -= resource.size;
-    return true;
+  if (mTarget == nullptr) {
+    GAPID_FATAL("Cannot append after flush.");
+  }
+  if (mSpace < resource.size) {
+    return false;
+  }
+  mResources.push_back(resource);
+  mSize += resource.size;
+  mSpace -= resource.size;
+  return true;
 }
 
 bool ResourceCache::Batch::flush(ResourceCache& cache, ReplayConnection* conn) {
-    uint8_t* ptr = mTarget;
-    mTarget = nullptr; // nullptr is used for detecting append-after-flush.
-    size_t count = mResources.size();
-    if (count == 0) {
-        return true;
-    }
-    if (!cache.mFallbackProvider->get(mResources.data(), count, conn, ptr, mSize)) {
-        return false;
-    }
-    for (auto resource : mResources) {
-        cache.putCache(resource, ptr);
-        ptr += resource.size;
-    }
+  uint8_t* ptr = mTarget;
+  mTarget = nullptr;  // nullptr is used for detecting append-after-flush.
+  size_t count = mResources.size();
+  if (count == 0) {
     return true;
+  }
+  if (!cache.mFallbackProvider->get(mResources.data(), count, conn, ptr,
+                                    mSize)) {
+    return false;
+  }
+  for (auto resource : mResources) {
+    cache.putCache(resource, ptr);
+    ptr += resource.size;
+  }
+  return true;
 }
 
-} // namespace gapir
+}  // namespace gapir

--- a/gapir/cc/resource_cache.h
+++ b/gapir/cc/resource_cache.h
@@ -29,46 +29,51 @@ namespace gapir {
 // ResourceCache is an abstract base class for caching resource providers.
 // TODO: simplify the caching logic as we adopted gRPC.
 class ResourceCache : public ResourceProvider {
-public:
-    ResourceCache(std::unique_ptr<ResourceProvider> fallbackProvider);
+ public:
+  ResourceCache(std::unique_ptr<ResourceProvider> fallbackProvider);
 
-    // Loads count resources from the provider and writes them, in-order, to target.
-    // If the net size of all the resources exceeds size, then false is returned.
-    bool get(const Resource* resources, size_t count, ReplayConnection* conn,
-             void* target, size_t size) override;
+  // Loads count resources from the provider and writes them, in-order, to
+  // target. If the net size of all the resources exceeds size, then false is
+  // returned.
+  bool get(const Resource* resources, size_t count, ReplayConnection* conn,
+           void* target, size_t size) override;
 
-protected:
-    virtual void putCache(const Resource& resource, const void* data) = 0;
-    virtual bool getCache(const Resource& resource, void* data) = 0;
+ protected:
+  virtual void putCache(const Resource& resource, const void* data) = 0;
+  virtual bool getCache(const Resource& resource, void* data) = 0;
 
-    // Fall back resource provider for the cases when the requested resource is not in the cache.
-    std::unique_ptr<ResourceProvider> mFallbackProvider;
+  // Fall back resource provider for the cases when the requested resource is
+  // not in the cache.
+  std::unique_ptr<ResourceProvider> mFallbackProvider;
 
-    // Batch is a helper class for accumulating resources to request on the fallback provider.
-    class Batch {
-    public:
-        // Constructor.
-        // target is the pointer to the memory to hold the fetched resources on calling flush.
-        // size is the size in bytes of the buffer at target.
-        Batch(void* target, size_t size);
+  // Batch is a helper class for accumulating resources to request on the
+  // fallback provider.
+  class Batch {
+   public:
+    // Constructor.
+    // target is the pointer to the memory to hold the fetched resources on
+    // calling flush. size is the size in bytes of the buffer at target.
+    Batch(void* target, size_t size);
 
-        // append adds the resource to the batch.
-        // Returns true if the resource fits in the remaining buffer space, otherwise false.
-        bool append(const Resource& resource);
+    // append adds the resource to the batch.
+    // Returns true if the resource fits in the remaining buffer space,
+    // otherwise false.
+    bool append(const Resource& resource);
 
-        // flush requests the resources appended to the Batch from the fallback provider.
-        // The requested resources are added to the cache using putCache.
-        // Once called, the batch must not be used again.
-        // Returns true if all resources were fetched, otherwise false.
-        bool flush(ResourceCache& cache, ReplayConnection* conn);
-    private:
-        std::vector<Resource> mResources; // Batch of resources to request.
-        uint8_t* mTarget;                 // Target address of resource data.
-        size_t mSize;                     // Target buffer size.
-        size_t mSpace;                    // mSize - size of all resources in batch.
-    };
+    // flush requests the resources appended to the Batch from the fallback
+    // provider. The requested resources are added to the cache using putCache.
+    // Once called, the batch must not be used again.
+    // Returns true if all resources were fetched, otherwise false.
+    bool flush(ResourceCache& cache, ReplayConnection* conn);
+
+   private:
+    std::vector<Resource> mResources;  // Batch of resources to request.
+    uint8_t* mTarget;                  // Target address of resource data.
+    size_t mSize;                      // Target buffer size.
+    size_t mSpace;  // mSize - size of all resources in batch.
+  };
 };
 
-} // namespace gapir
+}  // namespace gapir
 
 #endif  // GAPIR_RESOURCE_CACHE_H

--- a/gapir/cc/resource_disk_cache.h
+++ b/gapir/cc/resource_disk_cache.h
@@ -17,8 +17,8 @@
 #ifndef GAPIR_RESOURCE_DISK_CACHE_H
 #define GAPIR_RESOURCE_DISK_CACHE_H
 
-#include "resource_cache.h"
 #include "replay_connection.h"
+#include "resource_cache.h"
 
 #include "core/cc/archive.h"
 
@@ -29,25 +29,27 @@ namespace gapir {
 
 // Unlimited size disk cache for resources
 class ResourceDiskCache : public ResourceCache {
-public:
-    // Creates new disk cache with the specified base path. If the base path is not readable or it
-    // can't be created then returns the fall back provider.
-    static std::unique_ptr<ResourceProvider> create(
-            std::unique_ptr<ResourceProvider> fallbackProvider, const std::string& path);
+ public:
+  // Creates new disk cache with the specified base path. If the base path is
+  // not readable or it can't be created then returns the fall back provider.
+  static std::unique_ptr<ResourceProvider> create(
+      std::unique_ptr<ResourceProvider> fallbackProvider,
+      const std::string& path);
 
   // Prefetches the specified resources, caching them to disk.
   void prefetch(const Resource* resources, size_t count, ReplayConnection* conn,
                 void* temp, size_t tempSize) override;
 
-protected:
-    void putCache(const Resource& resource, const void* data) override;
-    bool getCache(const Resource& resource, void* data) override;
+ protected:
+  void putCache(const Resource& resource, const void* data) override;
+  bool getCache(const Resource& resource, void* data) override;
 
-private:
-    ResourceDiskCache(std::unique_ptr<ResourceProvider> fallbackProvider, const std::string& path);
+ private:
+  ResourceDiskCache(std::unique_ptr<ResourceProvider> fallbackProvider,
+                    const std::string& path);
 
-    // Disk-backed archive holding the cached resources.
-    core::Archive mArchive;
+  // Disk-backed archive holding the cached resources.
+  core::Archive mArchive;
 };
 
 }  // namespace gapir

--- a/gapir/cc/resource_in_memory_cache.cpp
+++ b/gapir/cc/resource_in_memory_cache.cpp
@@ -29,183 +29,194 @@
 namespace gapir {
 
 std::unique_ptr<ResourceInMemoryCache> ResourceInMemoryCache::create(
-        std::unique_ptr<ResourceProvider> fallbackProvider, void* buffer) {
-    return std::unique_ptr<ResourceInMemoryCache>(
-            new ResourceInMemoryCache(std::move(fallbackProvider), buffer));
+    std::unique_ptr<ResourceProvider> fallbackProvider, void* buffer) {
+  return std::unique_ptr<ResourceInMemoryCache>(
+      new ResourceInMemoryCache(std::move(fallbackProvider), buffer));
 }
 
-ResourceInMemoryCache::ResourceInMemoryCache(std::unique_ptr<ResourceProvider> fallbackProvider,
-                                             void* buffer)
-        : ResourceCache(std::move(fallbackProvider))
-        , mHead(new Block(0, 0))
-        , mBuffer(static_cast<uint8_t*>(buffer))
-        , mBufferSize(0) {
-}
+ResourceInMemoryCache::ResourceInMemoryCache(
+    std::unique_ptr<ResourceProvider> fallbackProvider, void* buffer)
+    : ResourceCache(std::move(fallbackProvider)),
+      mHead(new Block(0, 0)),
+      mBuffer(static_cast<uint8_t*>(buffer)),
+      mBufferSize(0) {}
 
 ResourceInMemoryCache::~ResourceInMemoryCache() {
-    while (mHead->next != mHead) {
-        destroy(mHead->next);
-    }
-    delete mHead;
+  while (mHead->next != mHead) {
+    destroy(mHead->next);
+  }
+  delete mHead;
 }
 
-void ResourceInMemoryCache::prefetch(const Resource*         resources,
-                                     size_t                  count,
-                                     ReplayConnection*       conn,
-                                     void*                   temp,
-                                     size_t                  tempSize) {
-    if (temp == nullptr) {
-        return;
+void ResourceInMemoryCache::prefetch(const Resource* resources, size_t count,
+                                     ReplayConnection* conn, void* temp,
+                                     size_t tempSize) {
+  if (temp == nullptr) {
+    return;
+  }
+  GAPID_DEBUG(
+      "ResourceInMemoryCache::prefetch(count: %zu, mBufferSize: %zu, tempSize: "
+      "%zu)",
+      count, mBufferSize, tempSize);
+  Batch batch(temp, tempSize);
+  size_t space = mBufferSize;
+  for (size_t i = 0; i < count; i++) {
+    const Resource& resource = resources[i];
+    if (space < resource.size) {
+      break;
     }
-    GAPID_DEBUG("ResourceInMemoryCache::prefetch(count: %zu, mBufferSize: %zu, tempSize: %zu)", count, mBufferSize, tempSize);
-    Batch batch(temp, tempSize);
-    size_t space = mBufferSize;
-    for (size_t i = 0; i < count; i++) {
-        const Resource& resource = resources[i];
-        if (space < resource.size) {
-            break;
-        }
-        space -= resource.size;
-        if (mCache.find(resource.id) != mCache.end()) {
-            continue;
-        }
-        if (!batch.append(resource)) {
-            batch.flush(*this, conn);
-            batch = Batch(temp, tempSize);
-        }
+    space -= resource.size;
+    if (mCache.find(resource.id) != mCache.end()) {
+      continue;
     }
-    batch.flush(*this, conn);
+    if (!batch.append(resource)) {
+      batch.flush(*this, conn);
+      batch = Batch(temp, tempSize);
+    }
+  }
+  batch.flush(*this, conn);
 }
 
 void ResourceInMemoryCache::clear() {
-    mCache.clear();
-    while (mHead->next != mHead) {
-        mHead = destroy(mHead);
-    }
-    *mHead = Block(0, mBufferSize);
-    mHead->next = mHead->prev = mHead;
+  mCache.clear();
+  while (mHead->next != mHead) {
+    mHead = destroy(mHead);
+  }
+  *mHead = Block(0, mBufferSize);
+  mHead->next = mHead->prev = mHead;
 }
 
 void ResourceInMemoryCache::resize(size_t newSize) {
-    GAPID_DEBUG("Cache resizing: %zu -> %zu", mBufferSize, newSize);
-    if (newSize == mBufferSize) {
-        return; // No change.
+  GAPID_DEBUG("Cache resizing: %zu -> %zu", mBufferSize, newSize);
+  if (newSize == mBufferSize) {
+    return;  // No change.
+  }
+
+  Block* first = this->first();
+  Block* last = this->last();
+
+  // Remove all the blocks that are completely beyond the end of the new size.
+  while (last != first && last->offset > newSize) {
+    last = last->prev;
+    destroy(last->next);
+  }
+
+  if (!last->isFree()) {
+    if (last->end() > newSize) {
+      // The last block wraps the buffer. We need to evict this as we've
+      // changed the wrapping point.
+      free(last);
+    } else {
+      // Buffer has grown. Add new space block.
+      last = new Block(last->end(), 0);
+      last->linkBefore(first);
     }
+  }
+  // Whether we've grown or shrunk, the last block will always be free.
+  // Re-adjust the size so that it touches the first block.
+  last->size = (newSize - last->offset) + first->offset;
 
-    Block* first = this->first();
-    Block* last = this->last();
+  // If there's only one block remaining, it's free. Make sure it starts at 0.
+  if (last == first) {
+    last->offset = 0;
+  }
 
-    // Remove all the blocks that are completely beyond the end of the new size.
-    while (last != first && last->offset > newSize) {
-        last = last->prev;
-        destroy(last->next);
-    }
-
-    if (!last->isFree()) {
-        if (last->end() > newSize) {
-            // The last block wraps the buffer. We need to evict this as we've
-            // changed the wrapping point.
-            free(last);
-        } else {
-            // Buffer has grown. Add new space block.
-            last = new Block(last->end(), 0);
-            last->linkBefore(first);
-        }
-    }
-    // Whether we've grown or shrunk, the last block will always be free.
-    // Re-adjust the size so that it touches the first block.
-    last->size = (newSize - last->offset) + first->offset;
-
-    // If there's only one block remaining, it's free. Make sure it starts at 0.
-    if (last == first) {
-        last->offset = 0;
-    }
-
-    mHead = last; // Move head to the space.
-    mBufferSize = newSize;
+  mHead = last;  // Move head to the space.
+  mBufferSize = newSize;
 }
 
 void ResourceInMemoryCache::dump(FILE* out) {
-    Block* first = last()->next;
-    foreach_block(first, [&](Block* block) { fprintf(out, (block == first) ? "┏━━━━━━━━━━━━━━━━" : "┳━━━━━━━━━━━━━━━━"); });
-    fprintf(out, "┓\n");
-    foreach_block(first, [&](Block* block) { fprintf(out, "┃ offset: %6zu ", block->offset); });
-    fprintf(out, "┃\n");
-    foreach_block(first, [&](Block* block) { fprintf(out, "┃ size:   %6zu ", block->size); });
-    fprintf(out, "┃\n");
-    foreach_block(first, [&](Block* block) {
-        if (block->isFree()) {
-            fprintf(out, "┃ free           ");
-        } else {
-            fprintf(out, "┃ id: %10.10s ", block->id.c_str());
-        }
-    });
-    fprintf(out, "┃\n");
-    foreach_block(first, [&](Block* block) { fprintf(out, (block == mHead) ? "┃ head           " : "┃                "); });
-    fprintf(out, "┃\n");
-    foreach_block(first, [&](Block* block) { fprintf(out, (block == first) ? "┗━━━━━━━━━━━━━━━━" : "┻━━━━━━━━━━━━━━━━"); });
-    fprintf(out, "┛\n");
+  Block* first = last()->next;
+  foreach_block(first, [&](Block* block) {
+    fprintf(out, (block == first) ? "┏━━━━━━━━━━━━━━━━" : "┳━━━━━━━━━━━━━━━━");
+  });
+  fprintf(out, "┓\n");
+  foreach_block(first, [&](Block* block) {
+    fprintf(out, "┃ offset: %6zu ", block->offset);
+  });
+  fprintf(out, "┃\n");
+  foreach_block(first, [&](Block* block) {
+    fprintf(out, "┃ size:   %6zu ", block->size);
+  });
+  fprintf(out, "┃\n");
+  foreach_block(first, [&](Block* block) {
+    if (block->isFree()) {
+      fprintf(out, "┃ free           ");
+    } else {
+      fprintf(out, "┃ id: %10.10s ", block->id.c_str());
+    }
+  });
+  fprintf(out, "┃\n");
+  foreach_block(first, [&](Block* block) {
+    fprintf(out, (block == mHead) ? "┃ head           " : "┃                ");
+  });
+  fprintf(out, "┃\n");
+  foreach_block(first, [&](Block* block) {
+    fprintf(out, (block == first) ? "┗━━━━━━━━━━━━━━━━" : "┻━━━━━━━━━━━━━━━━");
+  });
+  fprintf(out, "┛\n");
 }
 
-void ResourceInMemoryCache::putCache(const Resource& resource, const void* data) {
-    if (resource.size > mBufferSize) {
-        return; // Wouldn't fit even if everything was evicted.
-    }
+void ResourceInMemoryCache::putCache(const Resource& resource,
+                                     const void* data) {
+  if (resource.size > mBufferSize) {
+    return;  // Wouldn't fit even if everything was evicted.
+  }
 
-    // Merge mHead into next block(s) until it is big enough to hold our resource.
-    while (mHead->size < resource.size) {
-        mHead->size += mHead->next->size;
-        destroy(mHead->next);
-    }
+  // Merge mHead into next block(s) until it is big enough to hold our resource.
+  while (mHead->size < resource.size) {
+    mHead->size += mHead->next->size;
+    destroy(mHead->next);
+  }
 
-    if (mHead->size > resource.size) {
-        // We've got some left-over space in this block. Split it.
-        size_t space = mHead->size - resource.size;
-        size_t offset = (mHead->offset + resource.size) % mBufferSize;
-        auto next = new Block(offset, space);
-        next->linkAfter(mHead);
-        mHead->size = resource.size;
-    }
+  if (mHead->size > resource.size) {
+    // We've got some left-over space in this block. Split it.
+    size_t space = mHead->size - resource.size;
+    size_t offset = (mHead->offset + resource.size) % mBufferSize;
+    auto next = new Block(offset, space);
+    next->linkAfter(mHead);
+    mHead->size = resource.size;
+  }
 
-    // Update mCache.
-    mCache.erase(mHead->id);
-    mCache.emplace(resource.id, mHead->offset);
-    mHead->id = resource.id;
+  // Update mCache.
+  mCache.erase(mHead->id);
+  mCache.emplace(resource.id, mHead->offset);
+  mHead->id = resource.id;
 
-    // Copy data.
-    if (mHead->offset + resource.size <= mBufferSize) {
-        memcpy(mBuffer + mHead->offset, data, resource.size);
-    } else {
-        // Wraps the end of the buffer
-        const uint8_t* dst = reinterpret_cast<const uint8_t*>(data);
-        size_t a = mBufferSize - mHead->offset;
-        size_t b = resource.size - a;
-        memcpy(mBuffer + mHead->offset, dst, a);
-        memcpy(mBuffer, dst + a, b);
-    }
+  // Copy data.
+  if (mHead->offset + resource.size <= mBufferSize) {
+    memcpy(mBuffer + mHead->offset, data, resource.size);
+  } else {
+    // Wraps the end of the buffer
+    const uint8_t* dst = reinterpret_cast<const uint8_t*>(data);
+    size_t a = mBufferSize - mHead->offset;
+    size_t b = resource.size - a;
+    memcpy(mBuffer + mHead->offset, dst, a);
+    memcpy(mBuffer, dst + a, b);
+  }
 
-    // Move head on to the next block.
-    mHead = mHead->next;
+  // Move head on to the next block.
+  mHead = mHead->next;
 }
 
 bool ResourceInMemoryCache::getCache(const Resource& resource, void* data) {
-    auto iter = mCache.find(resource.id);
-    if (iter == mCache.end()) {
-        return false;
-    }
-    // Cached resource found. Copy data.
-    size_t offset = iter->second;
-    if (offset + resource.size <= mBufferSize) {
-        memcpy(data, mBuffer + offset, resource.size);
-    } else {
-        // Wraps the end of the buffer
-        uint8_t* dst = reinterpret_cast<uint8_t*>(data);
-        size_t a = mBufferSize - offset;
-        size_t b = resource.size - a;
-        memcpy(dst, mBuffer + offset, a);
-        memcpy(dst + a, mBuffer, b);
-    }
-    return true;
+  auto iter = mCache.find(resource.id);
+  if (iter == mCache.end()) {
+    return false;
+  }
+  // Cached resource found. Copy data.
+  size_t offset = iter->second;
+  if (offset + resource.size <= mBufferSize) {
+    memcpy(data, mBuffer + offset, resource.size);
+  } else {
+    // Wraps the end of the buffer
+    uint8_t* dst = reinterpret_cast<uint8_t*>(data);
+    size_t a = mBufferSize - offset;
+    size_t b = resource.size - a;
+    memcpy(dst, mBuffer + offset, a);
+    memcpy(dst + a, mBuffer, b);
+  }
+  return true;
 }
 
 }  // namespace gapir

--- a/gapir/cc/resource_in_memory_cache.h
+++ b/gapir/cc/resource_in_memory_cache.h
@@ -17,8 +17,8 @@
 #ifndef GAPIR_RESOURCE_IN_MEMORY_CACHE_H
 #define GAPIR_RESOURCE_IN_MEMORY_CACHE_H
 
-#include "resource_cache.h"
 #include "replay_connection.h"
+#include "resource_cache.h"
 
 #include "core/cc/assert.h"
 
@@ -28,173 +28,181 @@
 
 namespace gapir {
 
-// Fixed size in-memory resource cache. It uses a ring buffer to store the cache and
-// starts invalidating cache entries from the oldest to the newest when more space
-// is required.
+// Fixed size in-memory resource cache. It uses a ring buffer to store the cache
+// and starts invalidating cache entries from the oldest to the newest when more
+// space is required.
 class ResourceInMemoryCache : public ResourceCache {
-public:
-    // Creates a new in-memory cache with the given fallback provider and base address. The initial
-    // cache size is 0 byte.
-    static std::unique_ptr<ResourceInMemoryCache> create(
-            std::unique_ptr<ResourceProvider> fallbackProvider, void* buffer);
+ public:
+  // Creates a new in-memory cache with the given fallback provider and base
+  // address. The initial cache size is 0 byte.
+  static std::unique_ptr<ResourceInMemoryCache> create(
+      std::unique_ptr<ResourceProvider> fallbackProvider, void* buffer);
 
-    // destructor
-    ~ResourceInMemoryCache();
+  // destructor
+  ~ResourceInMemoryCache();
 
-    // Prefetches the specified resources, caching as many that fit in memory as possible.
-    void prefetch(const Resource* resources, size_t count, ReplayConnection* conn,
-                  void* temp, size_t tempSize) override;
+  // Prefetches the specified resources, caching as many that fit in memory as
+  // possible.
+  void prefetch(const Resource* resources, size_t count, ReplayConnection* conn,
+                void* temp, size_t tempSize) override;
 
-    // clears the cache.
-    void clear();
+  // clears the cache.
+  void clear();
 
-    // resets the size of the buffer used for caching.
-    void resize(size_t newSize);
+  // resets the size of the buffer used for caching.
+  void resize(size_t newSize);
 
-    // debug print the internal state.
-    void dump(FILE*);
+  // debug print the internal state.
+  void dump(FILE*);
 
-protected:
-    // A doubly-linked list data structure representing a chunk of memory in the cache.
-    struct Block {
-        inline Block();
-        inline Block(size_t offset, size_t size);
-        inline Block(size_t offset, size_t size, const ResourceId& id);
+ protected:
+  // A doubly-linked list data structure representing a chunk of memory in the
+  // cache.
+  struct Block {
+    inline Block();
+    inline Block(size_t offset, size_t size);
+    inline Block(size_t offset, size_t size, const ResourceId& id);
 
-        inline ~Block();
+    inline ~Block();
 
-        inline void linkAfter(Block* other);
-        inline void linkBefore(Block* other);
-        inline void unlink();
-        inline bool isFree() const;
-        inline size_t end() const;
+    inline void linkAfter(Block* other);
+    inline void linkBefore(Block* other);
+    inline void unlink();
+    inline bool isFree() const;
+    inline size_t end() const;
 
-        size_t offset; // offset in bytes from mBuffer.
-        size_t size;   // size in bytes. May wrap-around the cache buffer.
-        ResourceId id;
-        Block* next;
-        Block* prev;
-    };
+    size_t offset;  // offset in bytes from mBuffer.
+    size_t size;    // size in bytes. May wrap-around the cache buffer.
+    ResourceId id;
+    Block* next;
+    Block* prev;
+  };
 
-    void putCache(const Resource& resource, const void* data) override;
-    bool getCache(const Resource& resource, void* data) override;
+  void putCache(const Resource& resource, const void* data) override;
+  bool getCache(const Resource& resource, void* data) override;
 
-    // free evicts the cache entry for block, transforming it into a free block.
-    void free(Block* block);
+  // free evicts the cache entry for block, transforming it into a free block.
+  void free(Block* block);
 
-    // foreach_block calls cb for each block, starting with first.
-    void foreach_block(Block* first, const std::function<void(Block*)>& cb);
+  // foreach_block calls cb for each block, starting with first.
+  void foreach_block(Block* first, const std::function<void(Block*)>& cb);
 
-    // destroy frees, unlinks and deletes the block, returning the next block.
-    Block* destroy(Block* block);
+  // destroy frees, unlinks and deletes the block, returning the next block.
+  Block* destroy(Block* block);
 
-    // first returns the block with the lowest offset.
-    Block* first();
+  // first returns the block with the lowest offset.
+  Block* first();
 
-    // last returns the block with the highest offset.
-    Block* last();
-private:
-    // constructor
-    ResourceInMemoryCache(std::unique_ptr<ResourceProvider> fallbackProvider, void* buffer);
+  // last returns the block with the highest offset.
+  Block* last();
 
-    // put adds the the resource to the cache.
-    // size must be less or equal to mBufferSize.
-    void put(const ResourceId& id, size_t size, const uint8_t* data);
+ private:
+  // constructor
+  ResourceInMemoryCache(std::unique_ptr<ResourceProvider> fallbackProvider,
+                        void* buffer);
 
-    // A pointer to the next block to be used for a resource allocation.
-    // While filling the cache, mHead will point to the first free block. Once
-    // the cache is full it will point to an existing cache entry that will be
-    // next to be evicted.
-    Block* mHead;
+  // put adds the the resource to the cache.
+  // size must be less or equal to mBufferSize.
+  void put(const ResourceId& id, size_t size, const uint8_t* data);
 
-    // A map of cached resource identifiers to offsets on mBuffer.
-    std::unordered_map<ResourceId, size_t> mCache;
+  // A pointer to the next block to be used for a resource allocation.
+  // While filling the cache, mHead will point to the first free block. Once
+  // the cache is full it will point to an existing cache entry that will be
+  // next to be evicted.
+  Block* mHead;
 
-    // The base address and the size of the memory used for caching.
-    // This memory region is owned by the memory manager class, not by the cache itself.
-    uint8_t* mBuffer;
-    size_t mBufferSize;
+  // A map of cached resource identifiers to offsets on mBuffer.
+  std::unordered_map<ResourceId, size_t> mCache;
+
+  // The base address and the size of the memory used for caching.
+  // This memory region is owned by the memory manager class, not by the cache
+  // itself.
+  uint8_t* mBuffer;
+  size_t mBufferSize;
 };
 
 inline ResourceInMemoryCache::Block::Block()
-        : offset(0), size(0), next(this), prev(this) {}
+    : offset(0), size(0), next(this), prev(this) {}
 inline ResourceInMemoryCache::Block::Block(size_t offset_, size_t size_)
-        : offset(offset_), size(size_), next(this), prev(this) {}
-inline ResourceInMemoryCache::Block::Block(size_t offset_, size_t size_, const ResourceId& id_)
-        : offset(offset_), size(size_), id(id_), next(this), prev(this) {}
+    : offset(offset_), size(size_), next(this), prev(this) {}
+inline ResourceInMemoryCache::Block::Block(size_t offset_, size_t size_,
+                                           const ResourceId& id_)
+    : offset(offset_), size(size_), id(id_), next(this), prev(this) {}
 
 inline ResourceInMemoryCache::Block::~Block() {
-    GAPID_ASSERT(next == this && prev == this);
+  GAPID_ASSERT(next == this && prev == this);
 }
 
 inline void ResourceInMemoryCache::Block::linkAfter(Block* other) {
-    GAPID_ASSERT(next == this && prev == this);
-    next = other->next;
-    prev = other;
-    next->prev = this;
-    prev->next = this;
+  GAPID_ASSERT(next == this && prev == this);
+  next = other->next;
+  prev = other;
+  next->prev = this;
+  prev->next = this;
 }
 
 inline void ResourceInMemoryCache::Block::linkBefore(Block* other) {
-    GAPID_ASSERT(next == this && prev == this);
-    next = other;
-    prev = other->prev;
-    next->prev = this;
-    prev->next = this;
+  GAPID_ASSERT(next == this && prev == this);
+  next = other;
+  prev = other->prev;
+  next->prev = this;
+  prev->next = this;
 }
 
 inline void ResourceInMemoryCache::Block::unlink() {
-    GAPID_ASSERT(next != this && prev != this);
-    next->prev = prev;
-    prev->next = next;
-    next = this;
-    prev = this;
+  GAPID_ASSERT(next != this && prev != this);
+  next->prev = prev;
+  prev->next = next;
+  next = this;
+  prev = this;
 }
 
 inline bool ResourceInMemoryCache::Block::isFree() const {
-    return id.size() == 0;
+  return id.size() == 0;
 }
 
 inline size_t ResourceInMemoryCache::Block::end() const {
-    return offset + size;
+  return offset + size;
 }
 
 inline void ResourceInMemoryCache::free(Block* block) {
-    mCache.erase(block->id);
-    block->id = ResourceId();
+  mCache.erase(block->id);
+  block->id = ResourceId();
 }
 
-inline void ResourceInMemoryCache::foreach_block(Block* first, const std::function<void(Block*)>& cb) {
-    std::vector<Block*> blocks;
-    blocks.push_back(first);
-    for (Block* block = first->next; block != first; block = block->next) {
-        blocks.push_back(block);
-    }
-    for (Block* block : blocks) {
-        cb(block);
-    }
+inline void ResourceInMemoryCache::foreach_block(
+    Block* first, const std::function<void(Block*)>& cb) {
+  std::vector<Block*> blocks;
+  blocks.push_back(first);
+  for (Block* block = first->next; block != first; block = block->next) {
+    blocks.push_back(block);
+  }
+  for (Block* block : blocks) {
+    cb(block);
+  }
 }
 
-inline ResourceInMemoryCache::Block* ResourceInMemoryCache::destroy(Block* block) {
-    Block* next = block->next;
-    if (mHead == block) {
-        mHead = next;
-    }
-    free(block);
-    block->unlink();
-    delete block;
-    return next;
+inline ResourceInMemoryCache::Block* ResourceInMemoryCache::destroy(
+    Block* block) {
+  Block* next = block->next;
+  if (mHead == block) {
+    mHead = next;
+  }
+  free(block);
+  block->unlink();
+  delete block;
+  return next;
 }
 
 inline ResourceInMemoryCache::Block* ResourceInMemoryCache::first() {
-    return last()->next;
+  return last()->next;
 }
 
 inline ResourceInMemoryCache::Block* ResourceInMemoryCache::last() {
-    Block* block = mHead;
-    for (; block->next->offset > block->offset; block = block->next) {
-    }
-    return block;
+  Block* block = mHead;
+  for (; block->next->offset > block->offset; block = block->next) {
+  }
+  return block;
 }
 
 }  // namespace gapir

--- a/gapir/cc/resource_in_memory_cache_test.cpp
+++ b/gapir/cc/resource_in_memory_cache_test.cpp
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
+#include "resource_in_memory_cache.h"
 #include "memory_manager.h"
 #include "mock_resource_provider.h"
-#include "resource_in_memory_cache.h"
 #include "resource_provider.h"
 #include "test_utilities.h"
 
@@ -43,375 +43,389 @@ const Resource E("E", 2048);
 const Resource Z("Z", 1);
 
 class ResourceInMemoryCacheTest : public Test {
-protected:
-    virtual void SetUp() {
-        std::vector<uint32_t> memorySizes = {MEMORY_SIZE};
-        mMemoryManager.reset(new MemoryManager(memorySizes));
-        mMemoryManager->setVolatileMemory(MEMORY_SIZE - CACHE_SIZE);
+ protected:
+  virtual void SetUp() {
+    std::vector<uint32_t> memorySizes = {MEMORY_SIZE};
+    mMemoryManager.reset(new MemoryManager(memorySizes));
+    mMemoryManager->setVolatileMemory(MEMORY_SIZE - CACHE_SIZE);
 
-        // ResourceInMemoryCache -> PatternedResourceProvider -> MockResourceProvider
-        mFallbackProvider = new StrictMock<MockResourceProvider>();
+    // ResourceInMemoryCache -> PatternedResourceProvider ->
+    // MockResourceProvider
+    mFallbackProvider = new StrictMock<MockResourceProvider>();
 
-        auto patternedResourceProvider = new PatternedResourceProvider(
-                std::unique_ptr<StrictMock<MockResourceProvider>>(mFallbackProvider));
+    auto patternedResourceProvider = new PatternedResourceProvider(
+        std::unique_ptr<StrictMock<MockResourceProvider>>(mFallbackProvider));
 
-        mResourceInMemoryCache = ResourceInMemoryCache::create(
-                std::unique_ptr<PatternedResourceProvider>(patternedResourceProvider),
-                mMemoryManager->getBaseAddress());
+    mResourceInMemoryCache = ResourceInMemoryCache::create(
+        std::unique_ptr<PatternedResourceProvider>(patternedResourceProvider),
+        mMemoryManager->getBaseAddress());
 
-        mResourceInMemoryCache->resize(CACHE_SIZE);
+    mResourceInMemoryCache->resize(CACHE_SIZE);
+  }
+
+  inline void expectCacheHit(std::vector<Resource> resources) {
+    SCOPED_TRACE("expectCacheHit");
+
+    auto pattern = PatternedResourceProvider::patternFor(resources);
+    size_t size = pattern.size();
+
+    std::vector<uint8_t> got(size);
+
+    // Test as a single request.
+    EXPECT_TRUE(mResourceInMemoryCache->get(resources.data(), resources.size(),
+                                            nullptr, got.data(), size));
+
+    EXPECT_EQ(got, pattern);
+
+    // Test individually
+    size_t offset = 0;
+    for (auto resource : resources) {
+      EXPECT_TRUE(mResourceInMemoryCache->get(&resource, 1, nullptr,
+                                              &got[offset], resource.size));
+      offset += resource.size;
     }
 
-    inline void expectCacheHit(std::vector<Resource> resources) {
-        SCOPED_TRACE("expectCacheHit");
+    EXPECT_EQ(got, pattern);
 
-        auto pattern = PatternedResourceProvider::patternFor(resources);
-        size_t size = pattern.size();
-
-        std::vector<uint8_t> got(size);
-
-        // Test as a single request.
-        EXPECT_TRUE(mResourceInMemoryCache->get(
-            resources.data(), resources.size(), nullptr, got.data(), size));
-
-        EXPECT_EQ(got, pattern);
-
-        // Test individually
-        size_t offset = 0;
-        for (auto resource : resources) {
-            EXPECT_TRUE(mResourceInMemoryCache->get(&resource, 1, nullptr, &got[offset], resource.size));
-            offset += resource.size;
-        }
-
-        EXPECT_EQ(got, pattern);
-
-        if (HasFailure()) {
-            mResourceInMemoryCache->dump(stdout);
-        }
+    if (HasFailure()) {
+      mResourceInMemoryCache->dump(stdout);
     }
+  }
 
-    inline void expectCacheMiss(std::vector<Resource> resources) {
-        SCOPED_TRACE("expectCacheMiss");
+  inline void expectCacheMiss(std::vector<Resource> resources) {
+    SCOPED_TRACE("expectCacheMiss");
 
-        size_t size = 0;
-        for (auto resource : resources) {
-            size += resource.size;
-        }
-        std::vector<uint8_t> got(size);
-        EXPECT_CALL(*mFallbackProvider, get(_, _, _, got.data(), size))
-            .With(Args<0, 1>(ElementsAreArray(resources)))
-            .WillOnce(Return(true))
-            .RetiresOnSaturation();
-        EXPECT_TRUE(mResourceInMemoryCache->get(
-            resources.data(), resources.size(), nullptr, got.data(), size));
-
-        auto pattern = PatternedResourceProvider::patternFor(resources);
-        EXPECT_EQ(got, pattern);
+    size_t size = 0;
+    for (auto resource : resources) {
+      size += resource.size;
     }
+    std::vector<uint8_t> got(size);
+    EXPECT_CALL(*mFallbackProvider, get(_, _, _, got.data(), size))
+        .With(Args<0, 1>(ElementsAreArray(resources)))
+        .WillOnce(Return(true))
+        .RetiresOnSaturation();
+    EXPECT_TRUE(mResourceInMemoryCache->get(resources.data(), resources.size(),
+                                            nullptr, got.data(), size));
 
-    static const size_t TEMP_SIZE = 2048;
+    auto pattern = PatternedResourceProvider::patternFor(resources);
+    EXPECT_EQ(got, pattern);
+  }
 
-    StrictMock<MockResourceProvider>* mFallbackProvider;
+  static const size_t TEMP_SIZE = 2048;
 
-    std::unique_ptr<MemoryManager> mMemoryManager;
-    std::unique_ptr<ResourceInMemoryCache> mResourceInMemoryCache;
-    uint8_t mTemp[TEMP_SIZE];
+  StrictMock<MockResourceProvider>* mFallbackProvider;
+
+  std::unique_ptr<MemoryManager> mMemoryManager;
+  std::unique_ptr<ResourceInMemoryCache> mResourceInMemoryCache;
+  uint8_t mTemp[TEMP_SIZE];
 };
 
 }  // anonymous namespace
 
 // Test that get() calls with uncached data propagages to the fallback provider.
 TEST_F(ResourceInMemoryCacheTest, PopulateNoFill) {
-    InSequence x;
+  InSequence x;
 
-    expectCacheMiss({A});
-    expectCacheMiss({B});
-    expectCacheMiss({C, D});
+  expectCacheMiss({A});
+  expectCacheMiss({B});
+  expectCacheMiss({C, D});
 }
 
 // Test that get() calls with cached data propagages to the fallback provider.
 TEST_F(ResourceInMemoryCacheTest, CacheHit) {
-    InSequence x;
+  InSequence x;
 
-    expectCacheMiss({A});
-    expectCacheMiss({B});
-    expectCacheHit({A, B});
+  expectCacheMiss({A});
+  expectCacheMiss({B});
+  expectCacheHit({A, B});
 }
 
 TEST_F(ResourceInMemoryCacheTest, Prefetch) {
-    InSequence x;
+  InSequence x;
 
-    mResourceInMemoryCache->resize(A.size + B.size + C.size + D.size);
-    EXPECT_CALL(*mFallbackProvider, get(_, _, _, mTemp, A.size + B.size + C.size + D.size))
-        .With(Args<0, 1>(ElementsAre(A, B, C, D)))
-        .WillOnce(Return(true));
+  mResourceInMemoryCache->resize(A.size + B.size + C.size + D.size);
+  EXPECT_CALL(*mFallbackProvider,
+              get(_, _, _, mTemp, A.size + B.size + C.size + D.size))
+      .With(Args<0, 1>(ElementsAre(A, B, C, D)))
+      .WillOnce(Return(true));
 
-    Resource resources[] = {A, B, C, D, E};
-    mResourceInMemoryCache->prefetch(resources, 5, nullptr, mTemp, TEMP_SIZE);
+  Resource resources[] = {A, B, C, D, E};
+  mResourceInMemoryCache->prefetch(resources, 5, nullptr, mTemp, TEMP_SIZE);
 
-    // These should be cached.
-    expectCacheHit({C, B});
+  // These should be cached.
+  expectCacheHit({C, B});
 
-    // This shouldn't.
-    expectCacheMiss({Z});
+  // This shouldn't.
+  expectCacheMiss({Z});
 }
 
 TEST_F(ResourceInMemoryCacheTest, PrefetchCacheHit) {
-    mResourceInMemoryCache->resize(A.size + B.size + C.size + D.size);
-    expectCacheMiss({A, B, C, D});
-// ┏━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━┓
-// ┃ offset:      0 ┃ offset:     64 ┃ offset:    320 ┃ offset:    832 ┃
-// ┃ size:       64 ┃ size:      256 ┃ size:      512 ┃ size:     1024 ┃
-// ┃ id:          A ┃ id:          B ┃ id:          C ┃ id:          D ┃
-// ┃ head           ┃                ┃                ┃                ┃
-// ┗━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━━┛
-    Resource resources[] = {A, B, C, D};
-    mResourceInMemoryCache->prefetch(resources, 4, nullptr, mTemp, TEMP_SIZE);
-// ┏━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━┓
-// ┃ offset:      0 ┃ offset:     64 ┃ offset:    320 ┃ offset:    832 ┃
-// ┃ size:       64 ┃ size:      256 ┃ size:      512 ┃ size:     1024 ┃
-// ┃ id:          A ┃ id:          B ┃ id:          C ┃ id:          D ┃
-// ┃ head           ┃                ┃                ┃                ┃
-// ┗━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━━┛
-    expectCacheHit({A, B, C, D});
+  mResourceInMemoryCache->resize(A.size + B.size + C.size + D.size);
+  expectCacheMiss({A, B, C, D});
+  // ┏━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━┓
+  // ┃ offset:      0 ┃ offset:     64 ┃ offset:    320 ┃ offset:    832 ┃
+  // ┃ size:       64 ┃ size:      256 ┃ size:      512 ┃ size:     1024 ┃
+  // ┃ id:          A ┃ id:          B ┃ id:          C ┃ id:          D ┃
+  // ┃ head           ┃                ┃                ┃                ┃
+  // ┗━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━━┛
+  Resource resources[] = {A, B, C, D};
+  mResourceInMemoryCache->prefetch(resources, 4, nullptr, mTemp, TEMP_SIZE);
+  // ┏━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━┓
+  // ┃ offset:      0 ┃ offset:     64 ┃ offset:    320 ┃ offset:    832 ┃
+  // ┃ size:       64 ┃ size:      256 ┃ size:      512 ┃ size:     1024 ┃
+  // ┃ id:          A ┃ id:          B ┃ id:          C ┃ id:          D ┃
+  // ┃ head           ┃                ┃                ┃                ┃
+  // ┗━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━━┛
+  expectCacheHit({A, B, C, D});
 }
 
 TEST_F(ResourceInMemoryCacheTest, PrefetchPartialCacheHit) {
-    InSequence x;
+  InSequence x;
 
-    mResourceInMemoryCache->resize(A.size + B.size + C.size + D.size);
-    expectCacheMiss({A, C});
-// ┏━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━┓
-// ┃ offset:      0 ┃ offset:     64 ┃ offset:    320 ┃ offset:    832 ┃
-// ┃ size:       64 ┃ size:      256 ┃ size:      512 ┃ size:     1024 ┃
-// ┃ id:          A ┃ id:          B ┃ id:          C ┃ id:          D ┃
-// ┃ head           ┃                ┃                ┃                ┃
-// ┗━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━━┛
-    Resource resources[] = {A, B, C, D};
-    EXPECT_CALL(*mFallbackProvider, get(_, _, _, mTemp, B.size + D.size))
-        .With(Args<0, 1>(ElementsAre(B, D)))
-        .WillOnce(Return(true));
-    mResourceInMemoryCache->prefetch(resources, 4, nullptr, mTemp, TEMP_SIZE);
-// ┏━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━┓
-// ┃ offset:      0 ┃ offset:     64 ┃ offset:    320 ┃ offset:    832 ┃
-// ┃ size:       64 ┃ size:      256 ┃ size:      512 ┃ size:     1024 ┃
-// ┃ id:          A ┃ id:          B ┃ id:          C ┃ id:          D ┃
-// ┃ head           ┃                ┃                ┃                ┃
-// ┗━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━━┛
-    expectCacheHit({A, B, C, D});
+  mResourceInMemoryCache->resize(A.size + B.size + C.size + D.size);
+  expectCacheMiss({A, C});
+  // ┏━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━┓
+  // ┃ offset:      0 ┃ offset:     64 ┃ offset:    320 ┃ offset:    832 ┃
+  // ┃ size:       64 ┃ size:      256 ┃ size:      512 ┃ size:     1024 ┃
+  // ┃ id:          A ┃ id:          B ┃ id:          C ┃ id:          D ┃
+  // ┃ head           ┃                ┃                ┃                ┃
+  // ┗━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━━┛
+  Resource resources[] = {A, B, C, D};
+  EXPECT_CALL(*mFallbackProvider, get(_, _, _, mTemp, B.size + D.size))
+      .With(Args<0, 1>(ElementsAre(B, D)))
+      .WillOnce(Return(true));
+  mResourceInMemoryCache->prefetch(resources, 4, nullptr, mTemp, TEMP_SIZE);
+  // ┏━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━┓
+  // ┃ offset:      0 ┃ offset:     64 ┃ offset:    320 ┃ offset:    832 ┃
+  // ┃ size:       64 ┃ size:      256 ┃ size:      512 ┃ size:     1024 ┃
+  // ┃ id:          A ┃ id:          B ┃ id:          C ┃ id:          D ┃
+  // ┃ head           ┃                ┃                ┃                ┃
+  // ┗━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━━┛
+  expectCacheHit({A, B, C, D});
 }
 
 TEST_F(ResourceInMemoryCacheTest, PrefetchPartialCacheHitWithWrapped) {
-    InSequence x;
+  InSequence x;
 
-    mResourceInMemoryCache->resize(B.size + C.size + D.size);
-    expectCacheMiss({C, B, A, D});
-// ┏━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━┓
-// ┃ offset:     64 ┃ offset:    512 ┃ offset:    768 ┃ offset:    832 ┃
-// ┃ size:      448 ┃ size:      256 ┃ size:       64 ┃ size:     1024 ┃
-// ┃ free           ┃ id:          B ┃ id:          A ┃ id:          D ┃
-// ┃ head           ┃                ┃                ┃                ┃
-// ┗━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━━┛
-    Resource resources[] = {B, C, D};
-    EXPECT_CALL(*mFallbackProvider, get(_, _, _, mTemp, C.size))
-        .With(Args<0, 1>(ElementsAre(C)))
-        .WillOnce(Return(true));
-    mResourceInMemoryCache->prefetch(resources, 3, nullptr, mTemp, TEMP_SIZE);
-// ┏━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┓
-// ┃ offset:  64 ┃ offset: 576 ┃ offset: 768 ┃ offset:  832 ┃
-// ┃ size:   512 ┃ size:   192 ┃ size:    64 ┃ size:   1024 ┃
-// ┃ id:       C ┃ free        ┃ id:       A ┃ id:        D ┃
-// ┃             ┃ head        ┃             ┃              ┃
-// ┗━━━━━━━━━━━━━┻━━━━━━━━━━━━━┻━━━━━━━━━━━━━┻━━━━━━━━━━━━━━┛
-    expectCacheHit({C, A, D});
+  mResourceInMemoryCache->resize(B.size + C.size + D.size);
+  expectCacheMiss({C, B, A, D});
+  // ┏━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━┓
+  // ┃ offset:     64 ┃ offset:    512 ┃ offset:    768 ┃ offset:    832 ┃
+  // ┃ size:      448 ┃ size:      256 ┃ size:       64 ┃ size:     1024 ┃
+  // ┃ free           ┃ id:          B ┃ id:          A ┃ id:          D ┃
+  // ┃ head           ┃                ┃                ┃                ┃
+  // ┗━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━━┛
+  Resource resources[] = {B, C, D};
+  EXPECT_CALL(*mFallbackProvider, get(_, _, _, mTemp, C.size))
+      .With(Args<0, 1>(ElementsAre(C)))
+      .WillOnce(Return(true));
+  mResourceInMemoryCache->prefetch(resources, 3, nullptr, mTemp, TEMP_SIZE);
+  // ┏━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┓
+  // ┃ offset:  64 ┃ offset: 576 ┃ offset: 768 ┃ offset:  832 ┃
+  // ┃ size:   512 ┃ size:   192 ┃ size:    64 ┃ size:   1024 ┃
+  // ┃ id:       C ┃ free        ┃ id:       A ┃ id:        D ┃
+  // ┃             ┃ head        ┃             ┃              ┃
+  // ┗━━━━━━━━━━━━━┻━━━━━━━━━━━━━┻━━━━━━━━━━━━━┻━━━━━━━━━━━━━━┛
+  expectCacheHit({C, A, D});
 }
 
 TEST_F(ResourceInMemoryCacheTest, Resize) {
-    InSequence x;
+  InSequence x;
 
-    mResourceInMemoryCache->resize(D.size / 2);
+  mResourceInMemoryCache->resize(D.size / 2);
 
-    // D is too big to fit in the cache.
-    expectCacheMiss({D});
-    expectCacheMiss({D});
+  // D is too big to fit in the cache.
+  expectCacheMiss({D});
+  expectCacheMiss({D});
 
-    mResourceInMemoryCache->resize(D.size);
-    expectCacheMiss({D});
-    expectCacheHit({D}); // Now should be big enough to hold D.
+  mResourceInMemoryCache->resize(D.size);
+  expectCacheMiss({D});
+  expectCacheHit({D});  // Now should be big enough to hold D.
 
-    // Same size. Should be an effective no-op.
-    mResourceInMemoryCache->resize(D.size);
-    expectCacheHit({D});
+  // Same size. Should be an effective no-op.
+  mResourceInMemoryCache->resize(D.size);
+  expectCacheHit({D});
 
-    // Expand the buffer to also include space for C.
-    mResourceInMemoryCache->resize(D.size + C.size);
-    expectCacheHit({D});
-    expectCacheMiss({C});
-    expectCacheHit({D, C});
+  // Expand the buffer to also include space for C.
+  mResourceInMemoryCache->resize(D.size + C.size);
+  expectCacheHit({D});
+  expectCacheMiss({C});
+  expectCacheHit({D, C});
 
-    // Reduce the buffer so that it can no longer fit C.
-    mResourceInMemoryCache->resize(D.size + B.size);
-    expectCacheHit({D});
-    expectCacheMiss({C});
+  // Reduce the buffer so that it can no longer fit C.
+  mResourceInMemoryCache->resize(D.size + B.size);
+  expectCacheHit({D});
+  expectCacheMiss({C});
 
-    // Reduce the buffer so that it is empty.
-    mResourceInMemoryCache->resize(0);
-    expectCacheMiss({D, C});
+  // Reduce the buffer so that it is empty.
+  mResourceInMemoryCache->resize(0);
+  expectCacheMiss({D, C});
 
-    // Grow the buffer to hold A, B, C, D, E and a bit of space.
-    mResourceInMemoryCache->resize(A.size + B.size + C.size + D.size + E.size + 10);
-    expectCacheMiss({A, B, C, D, E});
-    expectCacheHit({A, B, C, D, E});
+  // Grow the buffer to hold A, B, C, D, E and a bit of space.
+  mResourceInMemoryCache->resize(A.size + B.size + C.size + D.size + E.size +
+                                 10);
+  expectCacheMiss({A, B, C, D, E});
+  expectCacheHit({A, B, C, D, E});
 
-    // Reduce the buffer so that it can fit A, B and a bit of space.
-    mResourceInMemoryCache->resize(A.size + B.size + 10);
-    expectCacheHit({A, B});
-    expectCacheMiss({C, D, E});
+  // Reduce the buffer so that it can fit A, B and a bit of space.
+  mResourceInMemoryCache->resize(A.size + B.size + 10);
+  expectCacheHit({A, B});
+  expectCacheMiss({C, D, E});
 }
 
 TEST_F(ResourceInMemoryCacheTest, CachingLogic) {
-    InSequence x;
+  InSequence x;
 
-    Resource A1("A1", 1), B1("B1", 1), C1("C1", 1), D1("D1", 1);
-    Resource E1("E1", 1), F1("F1", 1), G1("G1", 1), H1("H1", 1);
-    Resource A2("A2", 2), B2("B2", 2), C2("C2", 2), D2("D2", 2);
-    mResourceInMemoryCache->resize(8);
-// ┏━━━━━━━━━━━━━━━━┓
-// ┃ offset:      0 ┃
-// ┃ size:        8 ┃
-// ┃ free           ┃
-// ┃ head           ┃
-// ┗━━━━━━━━━━━━━━━━┛
-    {
-        SCOPED_TRACE(".1");
-        expectCacheMiss({A1, B1, C1, D1, E1, F1, G1, H1});
-        expectCacheHit({A1, B1, C1, D1, E1, F1, G1, H1});
-    }
-// ┏━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━┓
-// ┃ offset:  0 ┃ offset:  1 ┃ offset:  2 ┃ offset:  3 ┃ offset:  4 ┃ offset:  5 ┃ offset:  6 ┃ offset:  7 ┃
-// ┃ size:    1 ┃ size:    1 ┃ size:    1 ┃ size:    1 ┃ size:    1 ┃ size:    1 ┃ size:    1 ┃ size:    1 ┃
-// ┃ id:     A1 ┃ id:     B1 ┃ id:     C1 ┃ id:     D1 ┃ id:     E1 ┃ id:     F1 ┃ id:     G1 ┃ id:     H1 ┃
-// ┃ head       ┃            ┃            ┃            ┃            ┃            ┃            ┃            ┃
-// ┗━━━━━━━━━━━━┻━━━━━━━━━━━━┻━━━━━━━━━━━━┻━━━━━━━━━━━━┻━━━━━━━━━━━━┻━━━━━━━━━━━━┻━━━━━━━━━━━━┻━━━━━━━━━━━━┛
-    {
-        SCOPED_TRACE(".2");
-        expectCacheMiss({A2, B2});
-        expectCacheHit({A2, B2, E1, F1, G1, H1});
-    }
-// ┏━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━┓
-// ┃ offset:  0 ┃ offset:  2 ┃ offset:  4 ┃ offset:  5 ┃ offset:  6 ┃ offset:  7 ┃
-// ┃ size:    2 ┃ size:    2 ┃ size:    1 ┃ size:    1 ┃ size:    1 ┃ size:    1 ┃
-// ┃ id:     A2 ┃ id:     B2 ┃ id:     E1 ┃ id:     F1 ┃ id:     G1 ┃ id:     H1 ┃
-// ┃            ┃            ┃ head       ┃            ┃            ┃            ┃
-// ┗━━━━━━━━━━━━┻━━━━━━━━━━━━┻━━━━━━━━━━━━┻━━━━━━━━━━━━┻━━━━━━━━━━━━┻━━━━━━━━━━━━┛
-    {
-        SCOPED_TRACE(".3");
-        expectCacheMiss({A1, B1, C1});
-        expectCacheHit({A1, B1, C1, A2, B2, H1});
-    }
-// ┏━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━┓
-// ┃ offset:  0 ┃ offset:  2 ┃ offset:  4 ┃ offset:  5 ┃ offset:  6 ┃ offset:  7 ┃
-// ┃ size:    2 ┃ size:    2 ┃ size:    1 ┃ size:    1 ┃ size:    1 ┃ size:    1 ┃
-// ┃ id:     A2 ┃ id:     B2 ┃ id:     A1 ┃ id:     B1 ┃ id:     C1 ┃ id:     H1 ┃
-// ┃            ┃            ┃            ┃            ┃            ┃ head       ┃
-// ┗━━━━━━━━━━━━┻━━━━━━━━━━━━┻━━━━━━━━━━━━┻━━━━━━━━━━━━┻━━━━━━━━━━━━┻━━━━━━━━━━━━┛
-    {
-        SCOPED_TRACE(".4");
-        expectCacheMiss({C2});
-        expectCacheHit({A1, B1, C1, B2, C2});
-    }
-// ┏━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━┓
-// ┃ offset: 1 ┃ offset:  2 ┃ offset:  4 ┃ offset:  5 ┃ offset:  6 ┃ offset:  7 ┃
-// ┃ size:   1 ┃ size:    2 ┃ size:    1 ┃ size:    1 ┃ size:    1 ┃ size:    2 ┃
-// ┃ free      ┃ id:     B2 ┃ id:     A1 ┃ id:     B1 ┃ id:     C1 ┃ id:     C2 ┃
-// ┃ head      ┃            ┃            ┃            ┃            ┃            ┃
-// ┗━━━━━━━━━━━┻━━━━━━━━━━━━┻━━━━━━━━━━━━┻━━━━━━━━━━━━┻━━━━━━━━━━━━┻━━━━━━━━━━━━┛
-    {
-        SCOPED_TRACE(".5");
-        expectCacheMiss({D1});
-        expectCacheHit({B2, A1, B1, C1, C2, D1});
-    }
-// ┏━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━┓
-// ┃ offset:  1 ┃ offset:  2 ┃ offset:  4 ┃ offset:  5 ┃ offset:  6 ┃ offset:  7 ┃
-// ┃ size:    1 ┃ size:    2 ┃ size:    1 ┃ size:    1 ┃ size:    1 ┃ size:    2 ┃
-// ┃ id:     D1 ┃ id:     B2 ┃ id:     A1 ┃ id:     B1 ┃ id:     C1 ┃ id:     C2 ┃
-// ┃            ┃ head       ┃            ┃            ┃            ┃            ┃
-// ┗━━━━━━━━━━━━┻━━━━━━━━━━━━┻━━━━━━━━━━━━┻━━━━━━━━━━━━┻━━━━━━━━━━━━┻━━━━━━━━━━━━┛
-    {
-        SCOPED_TRACE(".6");
-        Resource resources[] = {A1, B1, C1, D1, E1};
-        EXPECT_CALL(*mFallbackProvider, get(_, _, _, mTemp, 1))
-            .With(Args<0, 1>(ElementsAre(E1)))
-            .WillOnce(Return(true));
-        mResourceInMemoryCache->prefetch(resources, 5, nullptr, mTemp, TEMP_SIZE);
-        expectCacheHit({A1, B1, C1, D1, E1});
-    }
-// ┏━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━┓
-// ┃ offset:  1 ┃ offset:  2 ┃ offset: 3 ┃ offset:  4 ┃ offset:  5 ┃ offset:  6 ┃ offset:  7 ┃
-// ┃ size:    1 ┃ size:    1 ┃ size:   1 ┃ size:    1 ┃ size:    1 ┃ size:    1 ┃ size:    2 ┃
-// ┃ id:     D1 ┃ id:     E1 ┃ free      ┃ id:     A1 ┃ id:     B1 ┃ id:     C1 ┃ id:     C2 ┃
-// ┃            ┃            ┃ head      ┃            ┃            ┃            ┃            ┃
-// ┗━━━━━━━━━━━━┻━━━━━━━━━━━━┻━━━━━━━━━━━┻━━━━━━━━━━━━┻━━━━━━━━━━━━┻━━━━━━━━━━━━┻━━━━━━━━━━━━┛
-    {
-        SCOPED_TRACE(".7");
-        expectCacheMiss({A2, B2});
-        expectCacheHit({D1, E1, A2, B2, C2});
-    }
-// ┏━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━┓
-// ┃ offset:  1 ┃ offset:  2 ┃ offset:  3 ┃ offset:  5 ┃ offset:  7 ┃
-// ┃ size:    1 ┃ size:    1 ┃ size:    2 ┃ size:    2 ┃ size:    2 ┃
-// ┃ id:     D1 ┃ id:     E1 ┃ id:     A2 ┃ id:     B2 ┃ id:     C2 ┃
-// ┃ head       ┃            ┃            ┃            ┃ head       ┃
-// ┗━━━━━━━━━━━━┻━━━━━━━━━━━━┻━━━━━━━━━━━━┻━━━━━━━━━━━━┻━━━━━━━━━━━━┛
-    {
-        Resource resources[] = {A1, C2, D2};
-        EXPECT_CALL(*mFallbackProvider, get(_, _, _, mTemp, A1.size + D2.size))
-            .With(Args<0, 1>(ElementsAre(A1, D2)))
-            .WillOnce(Return(true));
-        mResourceInMemoryCache->prefetch(resources, 3, nullptr, mTemp, TEMP_SIZE);
-    }
-// ┏━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━┓
-// ┃ offset:  0 ┃ offset:  2 ┃ offset:  3 ┃ offset:  5 ┃ offset:  7 ┃
-// ┃ size:    2 ┃ size:    1 ┃ size:    2 ┃ size:    2 ┃ size:    1 ┃
-// ┃ id:     D2 ┃ id:     E1 ┃ id:     A2 ┃ id:     B2 ┃ id:     A1 ┃
-// ┃            ┃ head       ┃            ┃            ┃            ┃
-// ┗━━━━━━━━━━━━┻━━━━━━━━━━━━┻━━━━━━━━━━━━┻━━━━━━━━━━━━┻━━━━━━━━━━━━┛
-    {
-        SCOPED_TRACE(".8");
-        expectCacheHit({D2, E1, A2, B2, A1});
-    }
+  Resource A1("A1", 1), B1("B1", 1), C1("C1", 1), D1("D1", 1);
+  Resource E1("E1", 1), F1("F1", 1), G1("G1", 1), H1("H1", 1);
+  Resource A2("A2", 2), B2("B2", 2), C2("C2", 2), D2("D2", 2);
+  mResourceInMemoryCache->resize(8);
+  // ┏━━━━━━━━━━━━━━━━┓
+  // ┃ offset:      0 ┃
+  // ┃ size:        8 ┃
+  // ┃ free           ┃
+  // ┃ head           ┃
+  // ┗━━━━━━━━━━━━━━━━┛
+  {
+    SCOPED_TRACE(".1");
+    expectCacheMiss({A1, B1, C1, D1, E1, F1, G1, H1});
+    expectCacheHit({A1, B1, C1, D1, E1, F1, G1, H1});
+  }
+  // clang-format off
+  // ┏━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━┓
+  // ┃ offset:  0 ┃ offset:  1 ┃ offset:  2 ┃ offset:  3 ┃ offset:  4 ┃ offset:  5 ┃ offset:  6 ┃ offset:  7 ┃
+  // ┃ size:    1 ┃ size:    1 ┃ size:    1 ┃ size:    1 ┃ size:    1 ┃ size:    1 ┃ size:    1 ┃ size:    1 ┃
+  // ┃ id:     A1 ┃ id:     B1 ┃ id:     C1 ┃ id:     D1 ┃ id:     E1 ┃ id:     F1 ┃ id:     G1 ┃ id:     H1 ┃
+  // ┃ head       ┃            ┃            ┃            ┃            ┃            ┃            ┃            ┃
+  // ┗━━━━━━━━━━━━┻━━━━━━━━━━━━┻━━━━━━━━━━━━┻━━━━━━━━━━━━┻━━━━━━━━━━━━┻━━━━━━━━━━━━┻━━━━━━━━━━━━┻━━━━━━━━━━━━┛
+  // clang-format on
+  {
+    SCOPED_TRACE(".2");
+    expectCacheMiss({A2, B2});
+    expectCacheHit({A2, B2, E1, F1, G1, H1});
+  }
+  // clang-format off
+  // ┏━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━┓
+  // ┃ offset:  0 ┃ offset:  2 ┃ offset:  4 ┃ offset:  5 ┃ offset:  6 ┃ offset:  7 ┃
+  // ┃ size:    2 ┃ size:    2 ┃ size:    1 ┃ size:    1 ┃ size:    1 ┃ size:    1 ┃
+  // ┃ id:     A2 ┃ id:     B2 ┃ id:     E1 ┃ id:     F1 ┃ id:     G1 ┃ id:     H1 ┃
+  // ┃            ┃            ┃ head       ┃            ┃            ┃            ┃
+  // ┗━━━━━━━━━━━━┻━━━━━━━━━━━━┻━━━━━━━━━━━━┻━━━━━━━━━━━━┻━━━━━━━━━━━━┻━━━━━━━━━━━━┛
+  // clang-format on
+  {
+    SCOPED_TRACE(".3");
+    expectCacheMiss({A1, B1, C1});
+    expectCacheHit({A1, B1, C1, A2, B2, H1});
+  }
+  // clang-format off
+  // ┏━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━┓
+  // ┃ offset:  0 ┃ offset:  2 ┃ offset:  4 ┃ offset:  5 ┃ offset:  6 ┃ offset:  7 ┃
+  // ┃ size:    2 ┃ size:    2 ┃ size:    1 ┃ size:    1 ┃ size:    1 ┃ size:    1 ┃
+  // ┃ id:     A2 ┃ id:     B2 ┃ id:     A1 ┃ id:     B1 ┃ id:     C1 ┃ id:     H1 ┃
+  // ┃            ┃            ┃            ┃            ┃            ┃ head       ┃
+  // ┗━━━━━━━━━━━━┻━━━━━━━━━━━━┻━━━━━━━━━━━━┻━━━━━━━━━━━━┻━━━━━━━━━━━━┻━━━━━━━━━━━━┛
+  // clang-format on
+  {
+    SCOPED_TRACE(".4");
+    expectCacheMiss({C2});
+    expectCacheHit({A1, B1, C1, B2, C2});
+  }
+  // clang-format off
+  // ┏━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━┓
+  // ┃ offset: 1 ┃ offset:  2 ┃ offset:  4 ┃ offset:  5 ┃ offset:  6 ┃ offset:  7 ┃
+  // ┃ size:   1 ┃ size:    2 ┃ size:    1 ┃ size:    1 ┃ size:    1 ┃ size:    2 ┃
+  // ┃ free      ┃ id:     B2 ┃ id:     A1 ┃ id:     B1 ┃ id:     C1 ┃ id:     C2 ┃
+  // ┃ head      ┃            ┃            ┃            ┃            ┃            ┃
+  // ┗━━━━━━━━━━━┻━━━━━━━━━━━━┻━━━━━━━━━━━━┻━━━━━━━━━━━━┻━━━━━━━━━━━━┻━━━━━━━━━━━━┛
+  // clang-format on
+  {
+    SCOPED_TRACE(".5");
+    expectCacheMiss({D1});
+    expectCacheHit({B2, A1, B1, C1, C2, D1});
+  }
+  // clang-format off
+  // ┏━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━┓
+  // ┃ offset:  1 ┃ offset:  2 ┃ offset:  4 ┃ offset:  5 ┃ offset:  6 ┃ offset:  7 ┃
+  // ┃ size:    1 ┃ size:    2 ┃ size:    1 ┃ size:    1 ┃ size:    1 ┃ size:    2 ┃
+  // ┃ id:     D1 ┃ id:     B2 ┃ id:     A1 ┃ id:     B1 ┃ id:     C1 ┃ id:     C2 ┃
+  // ┃            ┃ head       ┃            ┃            ┃            ┃            ┃
+  // ┗━━━━━━━━━━━━┻━━━━━━━━━━━━┻━━━━━━━━━━━━┻━━━━━━━━━━━━┻━━━━━━━━━━━━┻━━━━━━━━━━━━┛
+  // clang-format on
+  {
+    SCOPED_TRACE(".6");
+    Resource resources[] = {A1, B1, C1, D1, E1};
+    EXPECT_CALL(*mFallbackProvider, get(_, _, _, mTemp, 1))
+        .With(Args<0, 1>(ElementsAre(E1)))
+        .WillOnce(Return(true));
+    mResourceInMemoryCache->prefetch(resources, 5, nullptr, mTemp, TEMP_SIZE);
+    expectCacheHit({A1, B1, C1, D1, E1});
+  }
+  // clang-format off
+  // ┏━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━┓
+  // ┃ offset:  1 ┃ offset:  2 ┃ offset: 3 ┃ offset:  4 ┃ offset:  5 ┃ offset:  6 ┃ offset:  7 ┃
+  // ┃ size:    1 ┃ size:    1 ┃ size:   1 ┃ size:    1 ┃ size:    1 ┃ size:    1 ┃ size:    2 ┃
+  // ┃ id:     D1 ┃ id:     E1 ┃ free      ┃ id:     A1 ┃ id:     B1 ┃ id:     C1 ┃ id:     C2 ┃
+  // ┃            ┃            ┃ head      ┃            ┃            ┃            ┃            ┃
+  // ┗━━━━━━━━━━━━┻━━━━━━━━━━━━┻━━━━━━━━━━━┻━━━━━━━━━━━━┻━━━━━━━━━━━━┻━━━━━━━━━━━━┻━━━━━━━━━━━━┛
+  // clang-format on
+  {
+    SCOPED_TRACE(".7");
+    expectCacheMiss({A2, B2});
+    expectCacheHit({D1, E1, A2, B2, C2});
+  }
+  // ┏━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━┓
+  // ┃ offset:  1 ┃ offset:  2 ┃ offset:  3 ┃ offset:  5 ┃ offset:  7 ┃
+  // ┃ size:    1 ┃ size:    1 ┃ size:    2 ┃ size:    2 ┃ size:    2 ┃
+  // ┃ id:     D1 ┃ id:     E1 ┃ id:     A2 ┃ id:     B2 ┃ id:     C2 ┃
+  // ┃ head       ┃            ┃            ┃            ┃ head       ┃
+  // ┗━━━━━━━━━━━━┻━━━━━━━━━━━━┻━━━━━━━━━━━━┻━━━━━━━━━━━━┻━━━━━━━━━━━━┛
+  {
+    Resource resources[] = {A1, C2, D2};
+    EXPECT_CALL(*mFallbackProvider, get(_, _, _, mTemp, A1.size + D2.size))
+        .With(Args<0, 1>(ElementsAre(A1, D2)))
+        .WillOnce(Return(true));
+    mResourceInMemoryCache->prefetch(resources, 3, nullptr, mTemp, TEMP_SIZE);
+  }
+  // ┏━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━┓
+  // ┃ offset:  0 ┃ offset:  2 ┃ offset:  3 ┃ offset:  5 ┃ offset:  7 ┃
+  // ┃ size:    2 ┃ size:    1 ┃ size:    2 ┃ size:    2 ┃ size:    1 ┃
+  // ┃ id:     D2 ┃ id:     E1 ┃ id:     A2 ┃ id:     B2 ┃ id:     A1 ┃
+  // ┃            ┃ head       ┃            ┃            ┃            ┃
+  // ┗━━━━━━━━━━━━┻━━━━━━━━━━━━┻━━━━━━━━━━━━┻━━━━━━━━━━━━┻━━━━━━━━━━━━┛
+  {
+    SCOPED_TRACE(".8");
+    expectCacheHit({D2, E1, A2, B2, A1});
+  }
 }
-
 
 TEST_F(ResourceInMemoryCacheTest, PrefecthOverrun) {
-    InSequence x;
+  InSequence x;
 
-    Resource A1("A1", 1), B1("B1", 1), C1("C1", 1), D1("D1", 1);
-    Resource E1("E1", 1), F1("F1", 1), G1("G1", 1), H1("H1", 1);
-    Resource A2("A2", 2), B2("B2", 2), C2("C2", 2), D2("D2", 2);
-    mResourceInMemoryCache->resize(8);
+  Resource A1("A1", 1), B1("B1", 1), C1("C1", 1), D1("D1", 1);
+  Resource E1("E1", 1), F1("F1", 1), G1("G1", 1), H1("H1", 1);
+  Resource A2("A2", 2), B2("B2", 2), C2("C2", 2), D2("D2", 2);
+  mResourceInMemoryCache->resize(8);
 
-    Resource resources1[] = {A1, B1, C1, D1, E1};
-    EXPECT_CALL(*mFallbackProvider, get(_, _, _, mTemp, 5))
-        .With(Args<0, 1>(ElementsAre(A1, B1, C1, D1, E1)))
-        .WillOnce(Return(true));
-    mResourceInMemoryCache->prefetch(resources1, 5, nullptr, mTemp, TEMP_SIZE);
+  Resource resources1[] = {A1, B1, C1, D1, E1};
+  EXPECT_CALL(*mFallbackProvider, get(_, _, _, mTemp, 5))
+      .With(Args<0, 1>(ElementsAre(A1, B1, C1, D1, E1)))
+      .WillOnce(Return(true));
+  mResourceInMemoryCache->prefetch(resources1, 5, nullptr, mTemp, TEMP_SIZE);
 
-    // ┏━━━━━━┳━━━━━━┳━━━━━━┳━━━━━━┳━━━━━━┳━━━━━━┳━━━━━━┳━━━━━━┓
-    // ┃  A1  ┃  B1  ┃  C1  ┃  D1  ┃  E1  ┃      ┃      ┃      ┃
-    // ┗━━━━━━┻━━━━━━┻━━━━━━┻━━━━━━┻━━━━━━┻━━━━━━┻━━━━━━┻━━━━━━┛
+  // ┏━━━━━━┳━━━━━━┳━━━━━━┳━━━━━━┳━━━━━━┳━━━━━━┳━━━━━━┳━━━━━━┓
+  // ┃  A1  ┃  B1  ┃  C1  ┃  D1  ┃  E1  ┃      ┃      ┃      ┃
+  // ┗━━━━━━┻━━━━━━┻━━━━━━┻━━━━━━┻━━━━━━┻━━━━━━┻━━━━━━┻━━━━━━┛
 
-    expectCacheHit({A1, B1, C1, D1, E1});
-    expectCacheMiss({A2, B2});
+  expectCacheHit({A1, B1, C1, D1, E1});
+  expectCacheMiss({A2, B2});
 
-    // ┏━━━━━━┳━━━━━━┳━━━━━━┳━━━━━━┳━━━━━━┳━━━━━━┳━━━━━━┳━━━━━━┓
-    // ┃  B2  ┃  B1  ┃  C1  ┃  D1  ┃  E1  ┃     A2      ┃  B2  ┃
-    // ┗━━━━━━┻━━━━━━┻━━━━━━┻━━━━━━┻━━━━━━┻━━━━━━┻━━━━━━┻━━━━━━┛
+  // ┏━━━━━━┳━━━━━━┳━━━━━━┳━━━━━━┳━━━━━━┳━━━━━━┳━━━━━━┳━━━━━━┓
+  // ┃  B2  ┃  B1  ┃  C1  ┃  D1  ┃  E1  ┃     A2      ┃  B2  ┃
+  // ┗━━━━━━┻━━━━━━┻━━━━━━┻━━━━━━┻━━━━━━┻━━━━━━┻━━━━━━┻━━━━━━┛
 
-    expectCacheHit({B2, B1, C1, D1, E1, A2});
-    expectCacheMiss({A1});
+  expectCacheHit({B2, B1, C1, D1, E1, A2});
+  expectCacheMiss({A1});
 }
-
 
 }  // namespace test
 }  // namespace gapir

--- a/gapir/cc/resource_provider.h
+++ b/gapir/cc/resource_provider.h
@@ -26,18 +26,21 @@ namespace gapir {
 class ReplayConnection;
 
 class ResourceProvider {
-public:
-    virtual ~ResourceProvider() {}
+ public:
+  virtual ~ResourceProvider() {}
 
-    // Loads count resources from the provider and writes them, in-order, to target.
-    // If the net size of all the resources exceeds size, then false is returned.
-    virtual bool get(const Resource* resources, size_t count, ReplayConnection* conn,
-                     void* target, size_t targetSize) = 0;
+  // Loads count resources from the provider and writes them, in-order, to
+  // target. If the net size of all the resources exceeds size, then false is
+  // returned.
+  virtual bool get(const Resource* resources, size_t count,
+                   ReplayConnection* conn, void* target, size_t targetSize) = 0;
 
-    // Prefetches the resources for resource providers where prefetching is available.
-    // temp is a temporary buffer of size tempSize that can be used by prefetch.
-    virtual void prefetch(const Resource* resources, size_t count, ReplayConnection* conn, 
-    											void* temp, size_t tempSize) = 0;
+  // Prefetches the resources for resource providers where prefetching is
+  // available. temp is a temporary buffer of size tempSize that can be used by
+  // prefetch.
+  virtual void prefetch(const Resource* resources, size_t count,
+                        ReplayConnection* conn, void* temp,
+                        size_t tempSize) = 0;
 };
 
 }  // namespace gapir

--- a/gapir/cc/resource_requester.cpp
+++ b/gapir/cc/resource_requester.cpp
@@ -24,14 +24,11 @@
 namespace gapir {
 
 std::unique_ptr<ResourceRequester> ResourceRequester::create() {
-    return std::unique_ptr<ResourceRequester>(new ResourceRequester());
+  return std::unique_ptr<ResourceRequester>(new ResourceRequester());
 }
 
-bool ResourceRequester::get(const Resource*         resources,
-                            size_t                  count,
-                            ReplayConnection*       conn,
-                            void*                   target,
-                            size_t                  size) {
+bool ResourceRequester::get(const Resource* resources, size_t count,
+                            ReplayConnection* conn, void* target, size_t size) {
   if (count == 0) {
     return true;
   }
@@ -61,10 +58,8 @@ bool ResourceRequester::get(const Resource*         resources,
   return true;
 }
 
-void ResourceRequester::prefetch(const Resource*         resources,
-                                 size_t                  count,
-                                 ReplayConnection*       conn,
-                                 void*                   temp,
-                                 size_t                  tempSize) {}
+void ResourceRequester::prefetch(const Resource* resources, size_t count,
+                                 ReplayConnection* conn, void* temp,
+                                 size_t tempSize) {}
 
 }  // namespace gapir

--- a/gapir/cc/resource_requester.h
+++ b/gapir/cc/resource_requester.h
@@ -17,28 +17,31 @@
 #ifndef GAPIR_RESOURCE_REQUESTER_H
 #define GAPIR_RESOURCE_REQUESTER_H
 
-#include "resource_provider.h"
 #include "replay_connection.h"
+#include "resource_provider.h"
 
-#include <memory> // std::unique_ptr
+#include <memory>  // std::unique_ptr
 
 namespace gapir {
 
-// Resource provider which use the ServerConnection to fetch the resources from the server
+// Resource provider which use the ServerConnection to fetch the resources from
+// the server
 class ResourceRequester : public ResourceProvider {
-public:
-    static std::unique_ptr<ResourceRequester> create();
+ public:
+  static std::unique_ptr<ResourceRequester> create();
 
-    // Request all of the requested resources from the ServerConnection with a single GET request.
-    bool get(const Resource* resources, size_t count, ReplayConnection* conn,
-             void* target, size_t size) override;
+  // Request all of the requested resources from the ServerConnection with a
+  // single GET request.
+  bool get(const Resource* resources, size_t count, ReplayConnection* conn,
+           void* target, size_t size) override;
 
-    // No prefetching is supported because there is no storage layer in this resource provider.
-    void prefetch(const Resource* resources, size_t count, ReplayConnection* conn,
-                  void* temp, size_t tempSize) override;
+  // No prefetching is supported because there is no storage layer in this
+  // resource provider.
+  void prefetch(const Resource* resources, size_t count, ReplayConnection* conn,
+                void* temp, size_t tempSize) override;
 
-private:
-    ResourceRequester() = default;
+ private:
+  ResourceRequester() = default;
 };
 
 }  // namespace gapir

--- a/gapir/cc/resource_requester_test.cpp
+++ b/gapir/cc/resource_requester_test.cpp
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-#include "resource_provider.h"
 #include "resource_requester.h"
-#include "test_utilities.h"
-#include "replay_connection.h"
 #include "mock_replay_connection.h"
+#include "replay_connection.h"
+#include "resource_provider.h"
+#include "test_utilities.h"
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
@@ -39,59 +39,59 @@ const Resource A("A", 3);
 const Resource B("B", 5);
 
 class ResourceRequesterTest : public Test {
-protected:
-    virtual void SetUp() {
-        mResourceProvider = ResourceRequester::create();
-        mConn.reset(new MockReplayConnection());
-    }
+ protected:
+  virtual void SetUp() {
+    mResourceProvider = ResourceRequester::create();
+    mConn.reset(new MockReplayConnection());
+  }
 
-    std::unique_ptr<MockReplayConnection> mConn;
-    std::unique_ptr<ResourceProvider> mResourceProvider;
-    std::vector<uint8_t> mBuffer;
+  std::unique_ptr<MockReplayConnection> mConn;
+  std::unique_ptr<ResourceProvider> mResourceProvider;
+  std::vector<uint8_t> mBuffer;
 };
 
 }  // anonymous namespace
 
 TEST_F(ResourceRequesterTest, SingleGet) {
-    std::vector<uint8_t> payload = {'X', 'Y', 'Z'};
-    mBuffer.resize(payload.size());
+  std::vector<uint8_t> payload = {'X', 'Y', 'Z'};
+  mBuffer.resize(payload.size());
 
-    auto res = createResources(payload);
-    EXPECT_CALL(*mConn, mockedGetResources(NotNull()))
-        .WillOnce(Invoke([&res](ReplayConnection::ResourceRequest* req)
-                             -> std::unique_ptr<ReplayConnection::Resources> {
-          auto p = std::unique_ptr<replay_service::ResourceRequest>(
-              req->release_to_proto());
-          EXPECT_EQ(p->expected_total_size(), A.size);
-          EXPECT_EQ(p->ids_size(), 1);
-          EXPECT_EQ(p->ids(0), A.id);
-          return std::move(res);
-        }));
-    EXPECT_TRUE(mResourceProvider->get(&A, 1, mConn.get(), mBuffer.data(), 3));
-    EXPECT_THAT(mBuffer, ElementsAreArray(payload));
-
+  auto res = createResources(payload);
+  EXPECT_CALL(*mConn, mockedGetResources(NotNull()))
+      .WillOnce(Invoke([&res](ReplayConnection::ResourceRequest* req)
+                           -> std::unique_ptr<ReplayConnection::Resources> {
+        auto p = std::unique_ptr<replay_service::ResourceRequest>(
+            req->release_to_proto());
+        EXPECT_EQ(p->expected_total_size(), A.size);
+        EXPECT_EQ(p->ids_size(), 1);
+        EXPECT_EQ(p->ids(0), A.id);
+        return std::move(res);
+      }));
+  EXPECT_TRUE(mResourceProvider->get(&A, 1, mConn.get(), mBuffer.data(), 3));
+  EXPECT_THAT(mBuffer, ElementsAreArray(payload));
 }
 
 TEST_F(ResourceRequesterTest, MultiGet) {
-    std::vector<uint8_t> payload = {'X', 'Y', 'Z', '1', '2', '3', '4', '5'};
-    mBuffer.resize(payload.size());
+  std::vector<uint8_t> payload = {'X', 'Y', 'Z', '1', '2', '3', '4', '5'};
+  mBuffer.resize(payload.size());
 
-    auto res = createResources(payload);
-    EXPECT_CALL(*mConn, mockedGetResources(NotNull()))
-        .WillOnce(Invoke([&res](ReplayConnection::ResourceRequest* req)
-                             -> std::unique_ptr<ReplayConnection::Resources> {
-          auto p = std::unique_ptr<replay_service::ResourceRequest>(
-              req->release_to_proto());
-          EXPECT_EQ(p->expected_total_size(), A.size + B.size);
-          EXPECT_EQ(p->ids_size(), 2);
-          EXPECT_EQ(p->ids(0), A.id);
-          EXPECT_EQ(p->ids(1), B.id);
-          return std::move(res);
-        }));
+  auto res = createResources(payload);
+  EXPECT_CALL(*mConn, mockedGetResources(NotNull()))
+      .WillOnce(Invoke([&res](ReplayConnection::ResourceRequest* req)
+                           -> std::unique_ptr<ReplayConnection::Resources> {
+        auto p = std::unique_ptr<replay_service::ResourceRequest>(
+            req->release_to_proto());
+        EXPECT_EQ(p->expected_total_size(), A.size + B.size);
+        EXPECT_EQ(p->ids_size(), 2);
+        EXPECT_EQ(p->ids(0), A.id);
+        EXPECT_EQ(p->ids(1), B.id);
+        return std::move(res);
+      }));
 
-    Resource resReq[] = {A, B};
-    EXPECT_TRUE(mResourceProvider->get(resReq, 2, mConn.get(), mBuffer.data(), mBuffer.size()));
-    EXPECT_THAT(mBuffer, ElementsAreArray(payload));
+  Resource resReq[] = {A, B};
+  EXPECT_TRUE(mResourceProvider->get(resReq, 2, mConn.get(), mBuffer.data(),
+                                     mBuffer.size()));
+  EXPECT_THAT(mBuffer, ElementsAreArray(payload));
 }
-}  // namespace gapir
 }  // namespace test
+}  // namespace gapir

--- a/gapir/cc/server.cpp
+++ b/gapir/cc/server.cpp
@@ -32,8 +32,8 @@ using grpc::ServerBuilder;
 using grpc::ServerContext;
 using grpc::ServerReaderWriter;
 using grpc::Status;
-using ReplayStream =
-    grpc::ServerReaderWriter<replay_service::ReplayResponse, replay_service::ReplayRequest>;
+using ReplayStream = grpc::ServerReaderWriter<replay_service::ReplayResponse,
+                                              replay_service::ReplayRequest>;
 
 // The key of the metadata value that contains authentication token. This is
 // common knowledge shared between GAPIR client (which is GAPIS) and GAPIR
@@ -104,9 +104,8 @@ Server::Server(const char* authToken, int idleTimeoutSec,
     : mSecCounter(0),
       mShuttingDown(false),
       mGrpcServer(nullptr),
-      mServiceImpl(
-          new GapirServiceImpl(authToken, handle_replay,
-                               [this]() { this->mSecCounter.store(0); })),
+      mServiceImpl(new GapirServiceImpl(
+          authToken, handle_replay, [this]() { this->mSecCounter.store(0); })),
       mIdleTimeoutCloser(
           idleTimeoutSec > 0 ? new std::thread([idleTimeoutSec, this] {
             while (idleTimeoutSec > this->mSecCounter.fetch_add(1) &&
@@ -121,7 +120,8 @@ std::unique_ptr<Server> Server::createAndStart(const char* uri,
                                                const char* authToken,
                                                int idleTimeoutSec,
                                                ReplayHandler handle_replay) {
-  std::unique_ptr<Server> server(new Server(authToken, idleTimeoutSec, handle_replay));
+  std::unique_ptr<Server> server(
+      new Server(authToken, idleTimeoutSec, handle_replay));
   ServerBuilder builder;
   builder.SetMaxSendMessageSize(std::numeric_limits<int>::max());
   builder.SetMaxReceiveMessageSize(std::numeric_limits<int>::max());

--- a/gapir/cc/server.h
+++ b/gapir/cc/server.h
@@ -17,12 +17,12 @@
 #ifndef GAPID_SERVER_CONNECTION_H
 #define GAPID_SERVER_CONNECTION_H
 
+#include <grpc++/grpc++.h>
 #include <atomic>
 #include <functional>
 #include <memory>
 #include <string>
 #include <thread>
-#include <grpc++/grpc++.h>
 
 #include "core/cc/log.h"
 #include "gapir/replay_service/service.grpc.pb.h"
@@ -52,9 +52,10 @@ class GapirServiceImpl final : public replay_service::Gapir::Service {
 
   grpc::Status Replay(
       grpc::ServerContext* context,
-      grpc::ServerReaderWriter<replay_service::ReplayResponse, replay_service::ReplayRequest>*
-          stream) override;
-  grpc::Status Ping(grpc::ServerContext* context, const replay_service::PingRequest*,
+      grpc::ServerReaderWriter<replay_service::ReplayResponse,
+                               replay_service::ReplayRequest>* stream) override;
+  grpc::Status Ping(grpc::ServerContext* context,
+                    const replay_service::PingRequest*,
                     replay_service::PingResponse* res) override;
   grpc::Status Shutdown(grpc::ServerContext* context,
                         const replay_service::ShutdownRequest*,
@@ -114,7 +115,10 @@ class Server {
   void wait() { mGrpcServer->Wait(); }
 
   // Shuts down the server, it waits for all RPC processing to finish.
-  void shutdown() { mShuttingDown.store(true); mGrpcServer->Shutdown(); }
+  void shutdown() {
+    mShuttingDown.store(true);
+    mGrpcServer->Shutdown();
+  }
 
  private:
   Server(const char* authToken, int idleTimeoutSec,

--- a/gapir/cc/server_connection_test.cpp
+++ b/gapir/cc/server_connection_test.cpp
@@ -39,112 +39,119 @@ const ResourceId AB[] = {A, B};
 const std::string replayId = "ABCDE";
 
 class ServerConnectionTest : public ::testing::Test {
-protected:
-    virtual void SetUp() {
-        mConnection = new core::test::MockConnection();
-        mServerConnection = createServerConnection(mConnection, replayId, 0);
-    }
+ protected:
+  virtual void SetUp() {
+    mConnection = new core::test::MockConnection();
+    mServerConnection = createServerConnection(mConnection, replayId, 0);
+  }
 
-    core::test::MockConnection* mConnection;
-    std::unique_ptr<ServerConnection> mServerConnection;
-    std::vector<uint8_t> mBuffer;
+  core::test::MockConnection* mConnection;
+  std::unique_ptr<ServerConnection> mServerConnection;
+  std::vector<uint8_t> mBuffer;
 };
 }  // anonymous namespace
 
 TEST(ServerConnectionTestStatic, Create) {
-    auto connection = new core::test::MockConnection();
-    uint32_t replayLength = 0x56003412;
-    pushString(&connection->in, replayId);
-    pushUint32(&connection->in, replayLength);
+  auto connection = new core::test::MockConnection();
+  uint32_t replayLength = 0x56003412;
+  pushString(&connection->in, replayId);
+  pushUint32(&connection->in, replayLength);
 
-    auto svrConnection = ServerConnection::create(std::unique_ptr<core::Connection>(connection));
+  auto svrConnection =
+      ServerConnection::create(std::unique_ptr<core::Connection>(connection));
 
-    EXPECT_THAT(svrConnection, NotNull());
-    EXPECT_EQ(replayId, svrConnection->replayId());
-    EXPECT_EQ(replayLength, svrConnection->replayLength());
+  EXPECT_THAT(svrConnection, NotNull());
+  EXPECT_EQ(replayId, svrConnection->replayId());
+  EXPECT_EQ(replayLength, svrConnection->replayLength());
 }
 
 TEST(ServerConnectionTestStatic, CreateErrorReadReplayId) {
-    auto connection = new core::test::MockConnection();
-    pushUint8(&connection->in, 'A');
-    // Replay id read failed
-    auto svrConnection = ServerConnection::create(std::unique_ptr<core::Connection>(connection));
+  auto connection = new core::test::MockConnection();
+  pushUint8(&connection->in, 'A');
+  // Replay id read failed
+  auto svrConnection =
+      ServerConnection::create(std::unique_ptr<core::Connection>(connection));
 
-    EXPECT_THAT(svrConnection, IsNull());
+  EXPECT_THAT(svrConnection, IsNull());
 }
 
 TEST_F(ServerConnectionTest, Get) {
-    std::vector<uint8_t> resourceContent{1, 2, 3};
-    mBuffer.resize(resourceContent.size());
+  std::vector<uint8_t> resourceContent{1, 2, 3};
+  mBuffer.resize(resourceContent.size());
 
-    std::vector<uint8_t> expected;
-    pushUint8(&expected, ServerConnection::MESSAGE_TYPE_GET);
-    pushUint32(&expected, 2);
-    pushUint32(&expected, 3);
-    pushUint32(&expected, 0);
-    pushString(&expected, "A");
-    pushString(&expected, "B");
+  std::vector<uint8_t> expected;
+  pushUint8(&expected, ServerConnection::MESSAGE_TYPE_GET);
+  pushUint32(&expected, 2);
+  pushUint32(&expected, 3);
+  pushUint32(&expected, 0);
+  pushString(&expected, "A");
+  pushString(&expected, "B");
 
-    pushBytes(&mConnection->in, resourceContent);
+  pushBytes(&mConnection->in, resourceContent);
 
-    EXPECT_TRUE(mServerConnection->getResources(AB, 2, mBuffer.data(), mBuffer.size()));
-    EXPECT_THAT(mBuffer, ElementsAreArray(resourceContent));
-    EXPECT_EQ(mConnection->out, expected);
+  EXPECT_TRUE(
+      mServerConnection->getResources(AB, 2, mBuffer.data(), mBuffer.size()));
+  EXPECT_THAT(mBuffer, ElementsAreArray(resourceContent));
+  EXPECT_EQ(mConnection->out, expected);
 }
 
 TEST_F(ServerConnectionTest, GetErrorMessageType) {
-    mBuffer.resize(3);
-    mConnection->out_limit = 0;
-    EXPECT_FALSE(mServerConnection->getResources(AB, 2, mBuffer.data(), mBuffer.size()));
+  mBuffer.resize(3);
+  mConnection->out_limit = 0;
+  EXPECT_FALSE(
+      mServerConnection->getResources(AB, 2, mBuffer.data(), mBuffer.size()));
 }
 
 TEST_F(ServerConnectionTest, GetErrorCount) {
-    mBuffer.resize(3);
-    mConnection->out_limit = 1;
-    EXPECT_FALSE(mServerConnection->getResources(AB, 2, mBuffer.data(), mBuffer.size()));
+  mBuffer.resize(3);
+  mConnection->out_limit = 1;
+  EXPECT_FALSE(
+      mServerConnection->getResources(AB, 2, mBuffer.data(), mBuffer.size()));
 }
 
 TEST_F(ServerConnectionTest, GetErrorId) {
-    mBuffer.resize(3);
-    mConnection->out_limit = 3;
-    EXPECT_FALSE(mServerConnection->getResources(AB, 2, mBuffer.data(), mBuffer.size()));
+  mBuffer.resize(3);
+  mConnection->out_limit = 3;
+  EXPECT_FALSE(
+      mServerConnection->getResources(AB, 2, mBuffer.data(), mBuffer.size()));
 }
 
 TEST_F(ServerConnectionTest, GetErrorContent) {
-    mBuffer.resize(3);
-    mConnection->out_limit = 6;
-    EXPECT_FALSE(mServerConnection->getResources(AB, 2, mBuffer.data(), mBuffer.size()));
+  mBuffer.resize(3);
+  mConnection->out_limit = 6;
+  EXPECT_FALSE(
+      mServerConnection->getResources(AB, 2, mBuffer.data(), mBuffer.size()));
 }
 
 TEST_F(ServerConnectionTest, Post) {
-    std::vector<uint8_t> postData{1, 2, 3};
+  std::vector<uint8_t> postData{1, 2, 3};
 
-    std::vector<uint8_t> expected;
-    pushUint8(&expected, ServerConnection::MESSAGE_TYPE_POST);
-    pushUint32(&expected, 3);
-    pushBytes(&expected, postData);
+  std::vector<uint8_t> expected;
+  pushUint8(&expected, ServerConnection::MESSAGE_TYPE_POST);
+  pushUint32(&expected, 3);
+  pushBytes(&expected, postData);
 
-    EXPECT_TRUE(mServerConnection->post(&postData.front(), postData.size()));
-    EXPECT_EQ(mConnection->out, expected);
+  EXPECT_TRUE(mServerConnection->post(&postData.front(), postData.size()));
+  EXPECT_EQ(mConnection->out, expected);
 }
 
 TEST_F(ServerConnectionTest, PostErrorMessageType) {
-    std::vector<uint8_t> postData{1, 2, 3};
-    mConnection->out_limit = 0;
-    EXPECT_FALSE(mServerConnection->post(&postData.front(), postData.size()));
+  std::vector<uint8_t> postData{1, 2, 3};
+  mConnection->out_limit = 0;
+  EXPECT_FALSE(mServerConnection->post(&postData.front(), postData.size()));
 }
 
 TEST_F(ServerConnectionTest, PostErrorSize) {
-    std::vector<uint8_t> postData{1, 2, 3};
-    mConnection->out_limit = 1;
-    EXPECT_FALSE(mServerConnection->post(&postData.front(), postData.size()));
+  std::vector<uint8_t> postData{1, 2, 3};
+  mConnection->out_limit = 1;
+  EXPECT_FALSE(mServerConnection->post(&postData.front(), postData.size()));
 }
 
 TEST_F(ServerConnectionTest, PostErrorData) {
-    std::vector<uint8_t> postData{1, 2, 3};
-    mConnection->out_limit = 4;
-    EXPECT_FALSE(mServerConnection->post(&postData.front(), postData.size()));
+  std::vector<uint8_t> postData{1, 2, 3};
+  mConnection->out_limit = 4;
+  EXPECT_FALSE(mServerConnection->post(&postData.front(), postData.size()));
 }
 
-}  // namespace gapir
 }  // namespace test
+}  // namespace gapir

--- a/gapir/cc/stack.cpp
+++ b/gapir/cc/stack.cpp
@@ -25,257 +25,265 @@
 
 namespace gapir {
 
-bool Stack::pushCheck(const char * what) {
-    if (!mValid) {
-        GAPID_WARNING("%s on invalid stack", what);
-        return false;
-    }
+bool Stack::pushCheck(const char* what) {
+  if (!mValid) {
+    GAPID_WARNING("%s on invalid stack", what);
+    return false;
+  }
 
-    if (mTop > mStack.size() - 1) {
-        mValid = false;
-        GAPID_WARNING("%s with invalid stack head, offset: %d", what, mTop);
-        return false;
-    }
-    return true;
+  if (mTop > mStack.size() - 1) {
+    mValid = false;
+    GAPID_WARNING("%s with invalid stack head, offset: %d", what, mTop);
+    return false;
+  }
+  return true;
 }
 
-bool Stack::popCheck(const char * what) {
-    if (!mValid) {
-        GAPID_WARNING("%s on invalid stack", what);
-        return false;
-    }
+bool Stack::popCheck(const char* what) {
+  if (!mValid) {
+    GAPID_WARNING("%s on invalid stack", what);
+    return false;
+  }
 
-    if (mTop == 0 || mTop > mStack.size()) {
-        mValid = false;
-        GAPID_WARNING("%s with invalid stack head, offset: %d", what, mTop);
-        return false;
-    }
-    return true;
+  if (mTop == 0 || mTop > mStack.size()) {
+    mValid = false;
+    GAPID_WARNING("%s with invalid stack head, offset: %d", what, mTop);
+    return false;
+  }
+  return true;
 }
 
 const char* Stack::Entry::debugInfo(const MemoryManager* memoryManager) const {
-    static const size_t size = 256;
-    static char buf[size];
-    switch (mType) {
+  static const size_t size = 256;
+  static char buf[size];
+  switch (mType) {
     case BaseType::Bool:
-        snprintf(buf, size, "bool<%d>", value<bool>());
-        break;
+      snprintf(buf, size, "bool<%d>", value<bool>());
+      break;
     case BaseType::Int8:
-        snprintf(buf, size, "int8<%" PRId8 ">", value<int8_t>());
-        break;
+      snprintf(buf, size, "int8<%" PRId8 ">", value<int8_t>());
+      break;
     case BaseType::Int16:
-        snprintf(buf, size, "int16<%" PRId16 ">", value<int16_t>());
-        break;
+      snprintf(buf, size, "int16<%" PRId16 ">", value<int16_t>());
+      break;
     case BaseType::Int32:
-        snprintf(buf, size, "int32<%" PRId32 ">", value<int32_t>());
-        break;
+      snprintf(buf, size, "int32<%" PRId32 ">", value<int32_t>());
+      break;
     case BaseType::Int64:
-        snprintf(buf, size, "int64<%" PRId64 ">", value<int64_t>());
-        break;
+      snprintf(buf, size, "int64<%" PRId64 ">", value<int64_t>());
+      break;
     case BaseType::Uint8:
-        snprintf(buf, size, "uint8<%" PRIu8 ">", value<uint8_t>());
-        break;
+      snprintf(buf, size, "uint8<%" PRIu8 ">", value<uint8_t>());
+      break;
     case BaseType::Uint16:
-        snprintf(buf, size, "uint16<%" PRIu16 ">", value<uint16_t>());
-        break;
+      snprintf(buf, size, "uint16<%" PRIu16 ">", value<uint16_t>());
+      break;
     case BaseType::Uint32:
-        snprintf(buf, size, "uint32<%" PRIu32 ">", value<uint32_t>());
-        break;
+      snprintf(buf, size, "uint32<%" PRIu32 ">", value<uint32_t>());
+      break;
     case BaseType::Uint64:
-        snprintf(buf, size, "uint64<%" PRIu64 ">", value<uint64_t>());
-        break;
+      snprintf(buf, size, "uint64<%" PRIu64 ">", value<uint64_t>());
+      break;
     case BaseType::Float:
-        snprintf(buf, size, "float<%f>", value<float>());
-        break;
+      snprintf(buf, size, "float<%f>", value<float>());
+      break;
     case BaseType::Double:
-        snprintf(buf, size, "double<%f>", value<double>());
-        break;
+      snprintf(buf, size, "double<%f>", value<double>());
+      break;
     case BaseType::AbsolutePointer: {
-        const void* pointer = value<void*>();
-        if (memoryManager->isNotObservedAbsoluteAddress(pointer)) {
-            snprintf(buf, size, "absolute-ptr<%p> SPECIAL", value<void*>());
-        } else {
-            snprintf(buf, size, "absolute-ptr<%p> valid", value<void*>());
-        }
-        break;
+      const void* pointer = value<void*>();
+      if (memoryManager->isNotObservedAbsoluteAddress(pointer)) {
+        snprintf(buf, size, "absolute-ptr<%p> SPECIAL", value<void*>());
+      } else {
+        snprintf(buf, size, "absolute-ptr<%p> valid", value<void*>());
+      }
+      break;
     }
     case BaseType::ConstantPointer: {
-        uint32_t offset = value<uint32_t>();
-        const void* pointer = memoryManager->constantToAbsolute(offset);
-        if (memoryManager->isConstantAddress(pointer)) {
-            snprintf(buf, size, "constant-ptr<0x%x> valid (%p)", offset, pointer);
-        } else {
-            snprintf(buf, size, "constant-ptr<0x%x> INVALID (%p)", offset, pointer);
-        }
-        break;
+      uint32_t offset = value<uint32_t>();
+      const void* pointer = memoryManager->constantToAbsolute(offset);
+      if (memoryManager->isConstantAddress(pointer)) {
+        snprintf(buf, size, "constant-ptr<0x%x> valid (%p)", offset, pointer);
+      } else {
+        snprintf(buf, size, "constant-ptr<0x%x> INVALID (%p)", offset, pointer);
+      }
+      break;
     }
     case BaseType::VolatilePointer: {
-        uint32_t offset = value<uint32_t>();
-        const void* pointer = memoryManager->volatileToAbsolute(offset);
-        if (memoryManager->isVolatileAddress(pointer)) {
-            snprintf(buf, size, "volatile-ptr<0x%x> valid (%p)", offset, pointer);
-        } else {
-            snprintf(buf, size, "volatile-ptr<0x%x> INVALID (%p)", offset, pointer);
-        }
-        break;
+      uint32_t offset = value<uint32_t>();
+      const void* pointer = memoryManager->volatileToAbsolute(offset);
+      if (memoryManager->isVolatileAddress(pointer)) {
+        snprintf(buf, size, "volatile-ptr<0x%x> valid (%p)", offset, pointer);
+      } else {
+        snprintf(buf, size, "volatile-ptr<0x%x> INVALID (%p)", offset, pointer);
+      }
+      break;
     }
     default:
-        snprintf(buf, size, "unknown type<%d>", int(mType));
-        break;
-    }
-    return buf;
+      snprintf(buf, size, "unknown type<%d>", int(mType));
+      break;
+  }
+  return buf;
 }
 
-Stack::Stack(uint32_t size, const MemoryManager* memoryManager) :
-        mValid(true), mTop(0), mStack(size), mMemoryManager(memoryManager) {
-}
+Stack::Stack(uint32_t size, const MemoryManager* memoryManager)
+    : mValid(true), mTop(0), mStack(size), mMemoryManager(memoryManager) {}
 
 void Stack::printStack() const {
-    GAPID_DEBUG("Stack size: %u", mTop);
-    for (uint32_t i = 0; i < mTop; ++i) {
-        GAPID_DEBUG("(%d) %s", i, mStack[i].debugInfo(mMemoryManager));
-    }
+  GAPID_DEBUG("Stack size: %u", mTop);
+  for (uint32_t i = 0; i < mTop; ++i) {
+    GAPID_DEBUG("(%d) %s", i, mStack[i].debugInfo(mMemoryManager));
+  }
 }
 
 BaseType Stack::getTopType() {
-    if (!mValid) {
-        GAPID_WARNING("GetTopType on invalid stack");
-        return BaseType::Bool;
-    }
+  if (!mValid) {
+    GAPID_WARNING("GetTopType on invalid stack");
+    return BaseType::Bool;
+  }
 
-    if (mTop == 0 || mTop > mStack.size()) {
-        mValid = false;
-        GAPID_WARNING("GetTopType with invalid stack head: %u (size: %" PRIsize ")", mTop, mStack.size());
-        return BaseType::Bool;
-    }
+  if (mTop == 0 || mTop > mStack.size()) {
+    mValid = false;
+    GAPID_WARNING("GetTopType with invalid stack head: %u (size: %" PRIsize ")",
+                  mTop, mStack.size());
+    return BaseType::Bool;
+  }
 
-    return mStack[mTop - 1].type();
+  return mStack[mTop - 1].type();
 }
 
 void Stack::pushFrom(BaseType type, const void* data) {
-    if (!pushCheck("pushFrom")) {
-        return;
-    }
+  if (!pushCheck("pushFrom")) {
+    return;
+  }
 
-    if (data == nullptr) {
-        GAPID_WARNING("pushFrom nullptr");
-        mValid = false;
-        return;
-    }
+  if (data == nullptr) {
+    GAPID_WARNING("pushFrom nullptr");
+    mValid = false;
+    return;
+  }
 
-    mStack[mTop].set(type, data);
-    DEBUG_STACK("+%s pushFrom(%p)\n", mStack[mTop].debugInfo(mMemoryManager), data);
-    mTop++;
+  mStack[mTop].set(type, data);
+  DEBUG_STACK("+%s pushFrom(%p)\n", mStack[mTop].debugInfo(mMemoryManager),
+              data);
+  mTop++;
 }
 
 void Stack::popTo(void* address) {
-    if (!popCheck("popTo")) {
-        return;
-    }
+  if (!popCheck("popTo")) {
+    return;
+  }
 
-    switch (getTopType()) {
-        case BaseType::ConstantPointer:
-        case BaseType::VolatilePointer: {
-            void* pointer = pop<void*>();
-            // Note we are copying the pointer not what is pointed to.
-            memcpy(address, &pointer, sizeof(pointer));
-            return;
-        }
-        default:
-            mTop--;
-            DEBUG_STACK("-%s popTo(%p)\n", mStack[mTop].debugInfo(mMemoryManager), address);
-            memcpy(address, mStack[mTop].valuePtr(), baseTypeSize(mStack[mTop].type()));
-            return;
+  switch (getTopType()) {
+    case BaseType::ConstantPointer:
+    case BaseType::VolatilePointer: {
+      void* pointer = pop<void*>();
+      // Note we are copying the pointer not what is pointed to.
+      memcpy(address, &pointer, sizeof(pointer));
+      return;
     }
+    default:
+      mTop--;
+      DEBUG_STACK("-%s popTo(%p)\n", mStack[mTop].debugInfo(mMemoryManager),
+                  address);
+      memcpy(address, mStack[mTop].valuePtr(),
+             baseTypeSize(mStack[mTop].type()));
+      return;
+  }
 }
 
 void Stack::discard(uint32_t count) {
-    if (!mValid) {
-        GAPID_WARNING("Discard on invalid stack");
-        return;
-    }
+  if (!mValid) {
+    GAPID_WARNING("Discard on invalid stack");
+    return;
+  }
 
-    if (count > mTop) {
-        mValid = false;
-        GAPID_WARNING("Discarding more element (%u) then in the stack (%u)", count, mTop);
-        return;
-    }
+  if (count > mTop) {
+    mValid = false;
+    GAPID_WARNING("Discarding more element (%u) then in the stack (%u)", count,
+                  mTop);
+    return;
+  }
 
-    for (uint32_t i = 0; i < count; i++) {
-        DEBUG_STACK("-%s discard()\n", mStack[mTop - i - 1].debugInfo(mMemoryManager));
-    }
+  for (uint32_t i = 0; i < count; i++) {
+    DEBUG_STACK("-%s discard()\n",
+                mStack[mTop - i - 1].debugInfo(mMemoryManager));
+  }
 
-    mTop -= count;
+  mTop -= count;
 }
 
 void Stack::clone(uint32_t n) {
-    if (!mValid) {
-        GAPID_WARNING("Clone on invalid stack");
-        return;
-    }
+  if (!mValid) {
+    GAPID_WARNING("Clone on invalid stack");
+    return;
+  }
 
-    if (mTop >= mStack.size()) {
-        mValid = false;
-        GAPID_WARNING("Cloning to full stack");
-        return;
-    }
+  if (mTop >= mStack.size()) {
+    mValid = false;
+    GAPID_WARNING("Cloning to full stack");
+    return;
+  }
 
-    if (mTop < n + 1) {
-        mValid = false;
-        GAPID_WARNING("Cloning from invalid index: %u (head: %u)", n, mTop);
-        return;
-    }
+  if (mTop < n + 1) {
+    mValid = false;
+    GAPID_WARNING("Cloning from invalid index: %u (head: %u)", n, mTop);
+    return;
+  }
 
-    mStack[mTop] = mStack[mTop - n - 1];
-    DEBUG_STACK("+%s clone(%d)\n", mStack[mTop].debugInfo(mMemoryManager), n);
-    mTop++;
+  mStack[mTop] = mStack[mTop - n - 1];
+  DEBUG_STACK("+%s clone(%d)\n", mStack[mTop].debugInfo(mMemoryManager), n);
+  mTop++;
 }
 
 const void* Stack::checkAndGetTopPointer(const char* what) {
-    auto type = mStack[mTop].type();
-    switch (type) {
-        case BaseType::AbsolutePointer: {
-            return mStack[mTop].value<const void*>();
-        }
-        case BaseType::ConstantPointer: {
-            uint32_t offset = mStack[mTop].value<uint32_t>();
-            const void* pointer = mMemoryManager->constantToAbsolute(offset);
-            if (!mMemoryManager->isConstantAddress(pointer)) {
-                GAPID_WARNING("%s: Invalid constant address %p offset 0x%x", what, pointer, offset);
-                mValid = false;
-                return nullptr;
-            }
-            return pointer;
-        }
-        case BaseType::VolatilePointer: {
-            uint32_t offset = mStack[mTop].value<uint32_t>();
-            void* pointer = mMemoryManager->volatileToAbsolute(offset);
-            if (!mMemoryManager->isVolatileAddress(pointer)) {
-                GAPID_WARNING("%s Invalid volatile address %p offset 0x%x", what, pointer, offset);
-                mValid = false;
-                return nullptr;
-            }
-            return pointer;
-        }
-        default:
-            GAPID_WARNING("%s top was not a pointer type: %s", what, baseTypeName(type));
-            mValid = false;
-            return nullptr;
+  auto type = mStack[mTop].type();
+  switch (type) {
+    case BaseType::AbsolutePointer: {
+      return mStack[mTop].value<const void*>();
     }
-    return nullptr;
+    case BaseType::ConstantPointer: {
+      uint32_t offset = mStack[mTop].value<uint32_t>();
+      const void* pointer = mMemoryManager->constantToAbsolute(offset);
+      if (!mMemoryManager->isConstantAddress(pointer)) {
+        GAPID_WARNING("%s: Invalid constant address %p offset 0x%x", what,
+                      pointer, offset);
+        mValid = false;
+        return nullptr;
+      }
+      return pointer;
+    }
+    case BaseType::VolatilePointer: {
+      uint32_t offset = mStack[mTop].value<uint32_t>();
+      void* pointer = mMemoryManager->volatileToAbsolute(offset);
+      if (!mMemoryManager->isVolatileAddress(pointer)) {
+        GAPID_WARNING("%s Invalid volatile address %p offset 0x%x", what,
+                      pointer, offset);
+        mValid = false;
+        return nullptr;
+      }
+      return pointer;
+    }
+    default:
+      GAPID_WARNING("%s top was not a pointer type: %s", what,
+                    baseTypeName(type));
+      mValid = false;
+      return nullptr;
+  }
+  return nullptr;
 }
 
 bool Stack::checkTopForInvalidPointer(const char* what) {
-    auto type = mStack[mTop].type();
-    switch (type) {
-        case BaseType::ConstantPointer:
-        case BaseType::VolatilePointer: {
-            checkAndGetTopPointer(what);
-            return isValid();
-        }
-        default:
-            return true;
+  auto type = mStack[mTop].type();
+  switch (type) {
+    case BaseType::ConstantPointer:
+    case BaseType::VolatilePointer: {
+      checkAndGetTopPointer(what);
+      return isValid();
     }
+    default:
+      return true;
+  }
 }
 
 }  // namespace gapir

--- a/gapir/cc/stack.h
+++ b/gapir/cc/stack.h
@@ -31,443 +31,447 @@
 
 namespace gapir {
 
-// Strongly typed, limited size stack for the stack based virtual machine. If an invalid operation
-// is called on the stack then the stack will go into an invalid state where each operation is no op
-// (except print stack). From an invalid state the stack can't go back to a valid state again.
+// Strongly typed, limited size stack for the stack based virtual machine. If an
+// invalid operation is called on the stack then the stack will go into an
+// invalid state where each operation is no op (except print stack). From an
+// invalid state the stack can't go back to a valid state again.
 class Stack {
-public:
-    // Representation of an unconverted value from the stack.
-    typedef uint64_t BaseValue;
+ public:
+  // Representation of an unconverted value from the stack.
+  typedef uint64_t BaseValue;
 
-    // Construct a new stack with the given size and memory manager
-    // The memory manager is needed to resolve constant and volatile pointers to absolute pointers
-    Stack(uint32_t size, const MemoryManager* memoryManager);
+  // Construct a new stack with the given size and memory manager
+  // The memory manager is needed to resolve constant and volatile pointers to
+  // absolute pointers
+  Stack(uint32_t size, const MemoryManager* memoryManager);
 
-    // Pop the element from the top of the stack as the given type if its type is matching with the
-    // given type. For pointer types convert the pointer to an absolute pointer before returning it.
-    // Puts the stack into an invalid state if called on an empty stack or if the requested type
-    // doesn't match with the type of the value at the top of the stack.
+  // Pop the element from the top of the stack as the given type if its type is
+  // matching with the given type. For pointer types convert the pointer to an
+  // absolute pointer before returning it. Puts the stack into an invalid state
+  // if called on an empty stack or if the requested type doesn't match with the
+  // type of the value at the top of the stack.
+  template <typename T>
+  T pop() {
+    if (!popCheck("pop")) {
+      return T();
+    }
+    GAPID_VERBOSE("-%s pop()", mStack[mTop - 1].debugInfo(mMemoryManager));
+    return PopImpl<T>::pop(this);
+  }
+
+  // Pop the static array (stored as a pointer) from the top of the stack.
+  template <typename T, int N>
+  core::StaticArray<T, N> pop() {
+    T* ptr = pop<T*>();
+    core::StaticArray<T, N> out;
+    for (int i = 0; i < N; i++) {
+      out[i] = ptr[i];
+    }
+    return out;
+  }
+
+  // Pop the volatile pointer from the top of the stack. If the top element
+  // is not a volatile pointer puts the stack into and invalid state. Also,
+  // puts the stack into an invalid state if called on an empty stack.
+  // Use with care, this template casts a pointer to a T* with no way of
+  // knowing if that is safe.
+  template <typename T>
+  T* popVolatile() {
+    if (!popCheck("popVolatile")) {
+      return nullptr;
+    }
+    BaseType type = getTopType();
+    if (type != BaseType::VolatilePointer) {
+      GAPID_WARNING("popVolatile called for type %s", baseTypeName(type));
+      mValid = false;
+      return nullptr;
+    }
+    return pop<T*>();
+  }
+
+  // Pop the constant pointer from the top of the stack. If the top element
+  // is not a constant pointer puts the stack into and invalid state. Also,
+  // puts the stack into an invalid state if called on an empty stack.
+  // Use with care, this template casts a pointer to a const T* with no way of
+  // knowing if that is safe.
+  template <typename T>
+  const T* popConstant() {
+    if (!popCheck("popConstant")) {
+      return nullptr;
+    }
+    BaseType type = getTopType();
+    if (type != BaseType::ConstantPointer) {
+      GAPID_WARNING("popConstant called for type %s", baseTypeName(type));
+      mValid = false;
+      return nullptr;
+    }
+    return pop<const T*>();
+  }
+
+  // Pop the element from the top of the stack and return its unconverted typed
+  // value. Puts the stack into an invalid state if called on an empty stack.
+  BaseValue popBaseValue() {
+    if (!popCheck("popBaseValue")) {
+      return 0;
+    }
+    mTop--;
+    return mStack[mTop].getBaseValue();
+  }
+
+  // Push the given type and base value to the top of the stack. Put the
+  // stack into invalid state if called on a full stack.
+  void pushValue(BaseType type, BaseValue value) {
+    if (!pushCheck("pushValue")) {
+      return;
+    }
+    pushFrom(type, &value);
+    checkTopForInvalidPointer("pushValue");
+  }
+
+  // Push the given value to the top of the stack with a type determined by the
+  // type of the value given. Put the stack into invalid state if called on a
+  // full stack.
+  template <typename T>
+  void push(T value) {
+    if (!pushCheck("push")) {
+      return;
+    }
+
+    mStack[mTop].set(value);
+    if (!checkTopForInvalidPointer("push")) {
+      return;
+    }
+    GAPID_VERBOSE("+%s push()", mStack[mTop].debugInfo(mMemoryManager));
+    mTop++;
+  }
+
+  // Returns the type of the element at the top of the stack. Put the stack into
+  // invalid state if called on an empty stack.
+  BaseType getTopType();
+
+  // Discards count amount of elements from the top of the stack. Put the stack
+  // into invalid state if the stack contains fewer element then the given
+  // count.
+  void discard(uint32_t count);
+
+  // Clone the n-th element from the top of the stack to the top of the stack.
+  // The currently top most element is the 0th and the index is increasing with
+  // going down in the stack. Put the stack into invalid state if called on a
+  // full stacked or if the given index points out from the stack (greater then
+  // current size minus one).
+  void clone(uint32_t n);
+
+  // Print the content of the stack to the log output. The output is only
+  // written to the log output if the debug level is at least DEBUG. This
+  // function will work even if the stack is not in a valid state.
+  void printStack() const;
+
+  // Returns if the stack is in a valid state or not.
+  bool isValid() const { return mValid; }
+
+  // Pop the item from the top of the stack to the given memory address. The
+  // number of bytes written to the address is determined by the type of the
+  // element at the top of the stack. Pointers are converted to absolute
+  // pointers before writing to the address. The stack will enter an invalid
+  // state if called on an empty stack. Take care if using an address on the
+  // program stack. Use getTopType() to check the type of the object you will
+  // pop and/or make sure the receiver is sizeof(BaseValue).
+  void popTo(void* address);
+
+  // Push a new item to the stack with the given type from the given memory
+  // address. Put the stack into invalid state if it is already full before the
+  // call.
+  void pushFrom(BaseType type, const void* data);
+
+ private:
+  // Check that the stack is valid and a pop is allowed (non-empty).
+  bool popCheck(const char* what);
+  // Check that the stack is valid and a push is allowed (non-full).
+  bool pushCheck(const char* what);
+  // Check that if top is a pointer type that it is valid.
+  bool checkTopForInvalidPointer(const char* what);
+  // Check that top is a pointer type, that it is valid and return it.
+  const void* checkAndGetTopPointer(const char* what);
+
+  // Implementation of the pop method for non pointer types.
+  template <typename T>
+  struct PopImpl {
+    static T pop(Stack* stack) {
+      stack->mTop--;
+      BaseType baseType =
+          TypeToBaseType<typename std::remove_cv<T>::type>::type;
+      if (stack->mStack[stack->mTop].type() != baseType) {
+        stack->mValid = false;
+        GAPID_WARNING(
+            "Pop type (%s) doesn't match with the type at the top of the stack "
+            "(%s)",
+            baseTypeName(baseType),
+            baseTypeName(stack->mStack[stack->mTop].type()));
+        return T();
+      }
+      return stack->mStack[stack->mTop].value<T>();
+    }
+  };
+
+  // Implementation of the pop method for pointer types.
+  // Use with care, this template casts a pointer to a T* with no
+  // way of knowing if that is safe.
+  template <typename T>
+  struct PopImpl<T*> {
+    static T* pop(Stack* stack) {
+      stack->mTop--;
+      const void* pointer = stack->checkAndGetTopPointer("pop");
+      return const_cast<T*>(static_cast<const T*>(pointer));
+    }
+  };
+
+  class Entry {
+   public:
+    const void* valuePtr() const { return &mValue; }
+
     template <typename T>
-    T pop() {
-        if (!popCheck("pop")) {
-            return T();
-        }
-        GAPID_VERBOSE("-%s pop()", mStack[mTop-1].debugInfo(mMemoryManager));
-        return PopImpl<T>::pop(this);
+    const T value() const {
+      static_assert(sizeof(mValue) >= sizeof(T),
+                    "T is too large to be used as value");
+      T t;
+      if (!getTo(&t)) {
+        GAPID_WARNING("Error: read stack value inappropriate type %s wanted %s",
+                      baseTypeName(mType),
+                      baseTypeName(TypeToBaseType<T>::type));
+        return T();
+      }
+      return t;
     }
 
-    // Pop the static array (stored as a pointer) from the top of the stack.
-    template <typename T, int N>
-    core::StaticArray<T, N> pop() {
-        T* ptr = pop<T*>();
-        core::StaticArray<T, N> out;
-        for (int i = 0; i < N; i++) {
-          out[i] = ptr[i];
-        }
-        return out;
+    const BaseType& type() const { return mType; }
+
+    void set(bool b) {
+      mType = TypeToBaseType<bool>::type;
+      mValue.b = b;
+    }
+    void set(int8_t i8) {
+      mType = TypeToBaseType<int8_t>::type;
+      mValue.i8 = i8;
+    }
+    void set(int16_t i16) {
+      mType = TypeToBaseType<int16_t>::type;
+      mValue.i16 = i16;
+    }
+    void set(int32_t i32) {
+      mType = TypeToBaseType<int32_t>::type;
+      mValue.i32 = i32;
+    }
+    void set(int64_t i64) {
+      mType = TypeToBaseType<int64_t>::type;
+      mValue.i64 = i64;
+    }
+    void set(uint8_t u8) {
+      mType = TypeToBaseType<uint8_t>::type;
+      mValue.u8 = u8;
+    }
+    void set(uint16_t u16) {
+      mType = TypeToBaseType<uint16_t>::type;
+      mValue.u16 = u16;
+    }
+    void set(uint32_t u32) {
+      mType = TypeToBaseType<uint32_t>::type;
+      mValue.u32 = u32;
+    }
+    void set(uint64_t u64) {
+      mType = TypeToBaseType<uint64_t>::type;
+      mValue.u64 = u64;
+    }
+    void set(float f) {
+      mType = TypeToBaseType<float>::type;
+      mValue.f = f;
+    }
+    void set(double d) {
+      mType = TypeToBaseType<double>::type;
+      mValue.d = d;
     }
 
-    // Pop the volatile pointer from the top of the stack. If the top element
-    // is not a volatile pointer puts the stack into and invalid state. Also,
-    // puts the stack into an invalid state if called on an empty stack.
-    // Use with care, this template casts a pointer to a T* with no way of
-    // knowing if that is safe.
     template <typename T>
-    T* popVolatile() {
-        if (!popCheck("popVolatile")) {
-            return nullptr;
-        }
-        BaseType type = getTopType();
-        if (type != BaseType::VolatilePointer) {
-            GAPID_WARNING("popVolatile called for type %s", baseTypeName(type));
-            mValid = false;
-            return nullptr;
-        }
-        return pop<T*>();
+    void set(T* p) {
+      mType = BaseType::AbsolutePointer;
+      mValue.p = const_cast<typename std::remove_const<T>::type*>(p);
     }
 
-    // Pop the constant pointer from the top of the stack. If the top element
-    // is not a constant pointer puts the stack into and invalid state. Also,
-    // puts the stack into an invalid state if called on an empty stack.
-    // Use with care, this template casts a pointer to a const T* with no way of
-    // knowing if that is safe.
     template <typename T>
-    const T* popConstant() {
-        if (!popCheck("popConstant")) {
-            return nullptr;
-        }
-        BaseType type = getTopType();
-        if (type != BaseType::ConstantPointer) {
-            GAPID_WARNING("popConstant called for type %s", baseTypeName(type));
-            mValid = false;
-            return nullptr;
-        }
-        return pop<const T*>();
+    void set(T val) {
+      static_assert(sizeof(T) == sizeof(mValue.u32),
+                    "Enum base type is not uint32_t");
+      mType = BaseType::Uint32;
+      mValue.u32 = uint32_t(val);
     }
 
-    // Pop the element from the top of the stack and return its unconverted typed value.
-    // Puts the stack into an invalid state if called on an empty stack.
-    BaseValue popBaseValue() {
-        if (!popCheck("popBaseValue")) {
-            return 0;
-        }
-        mTop--;
-        return mStack[mTop].getBaseValue();
+    void set(BaseType type, const void* data) {
+      // Little endian assumption
+      memcpy(&mValue, data, baseTypeSize(type));
+      mType = type;
     }
 
-    // Push the given type and base value to the top of the stack. Put the
-    // stack into invalid state if called on a full stack.
-    void pushValue(BaseType type, BaseValue value) {
-        if (!pushCheck("pushValue")) {
-            return;
-        }
-        pushFrom(type, &value);
-        checkTopForInvalidPointer("pushValue");
+    bool getTo(bool* b) const {
+      if (mType != TypeToBaseType<bool>::type) {
+        return false;
+      }
+      *b = mValue.b;
+      return true;
+    }
+    bool getTo(int8_t* i8) const {
+      if (mType != TypeToBaseType<int8_t>::type) {
+        return false;
+      }
+      *i8 = mValue.i8;
+      return true;
+    }
+    bool getTo(int16_t* i16) const {
+      if (mType != TypeToBaseType<int16_t>::type) {
+        return false;
+      }
+      *i16 = mValue.i16;
+      return true;
+    }
+    bool getTo(int32_t* i32) const {
+      if (mType != TypeToBaseType<int32_t>::type) {
+        return false;
+      }
+      *i32 = mValue.i32;
+      return true;
+    }
+    bool getTo(int64_t* i64) const {
+      if (mType != TypeToBaseType<int64_t>::type) {
+        return false;
+      }
+      *i64 = mValue.i64;
+      return true;
+    }
+    bool getTo(uint8_t* u8) const {
+      if (mType != TypeToBaseType<uint8_t>::type) {
+        return false;
+      }
+      *u8 = mValue.u8;
+      return true;
+    }
+    bool getTo(uint16_t* u16) const {
+      if (mType != TypeToBaseType<uint16_t>::type) {
+        return false;
+      }
+      *u16 = mValue.u16;
+      return true;
+    }
+    bool getTo(uint32_t* u32) const {
+      if (mType != TypeToBaseType<uint32_t>::type &&
+          mType != BaseType::VolatilePointer &&
+          mType != BaseType::ConstantPointer) {
+        return false;
+      }
+      *u32 = mValue.u32;
+      return true;
+    }
+    bool getTo(uint64_t* u64) const {
+      if (mType != TypeToBaseType<uint64_t>::type) {
+        return false;
+      }
+      *u64 = mValue.u64;
+      return true;
+    }
+    bool getTo(float* f) const {
+      if (mType != TypeToBaseType<float>::type) {
+        return false;
+      }
+      *f = mValue.f;
+      return true;
+    }
+    bool getTo(double* d) const {
+      if (mType != TypeToBaseType<double>::type) {
+        return false;
+      }
+      *d = mValue.d;
+      return true;
     }
 
-    // Push the given value to the top of the stack with a type determined by the type of the value
-    // given. Put the stack into invalid state if called on a full stack.
     template <typename T>
-    void push(T value) {
-        if (!pushCheck("push")) {
-            return;
-        }
-
-        mStack[mTop].set(value);
-        if (!checkTopForInvalidPointer("push")) {
-            return;
-        }
-        GAPID_VERBOSE("+%s push()", mStack[mTop].debugInfo(mMemoryManager));
-        mTop++;
+    bool getTo(T* val) const {
+      static_assert(sizeof(T) == sizeof(mValue.u32),
+                    "Enum base type is not uint32_t");
+      if (mType != BaseType::Uint32) {
+        return false;
+      }
+      *val = T(mValue.u32);
+      return true;
     }
 
-    // Returns the type of the element at the top of the stack. Put the stack into invalid state if
-    // called on an empty stack.
-    BaseType getTopType();
-
-    // Discards count amount of elements from the top of the stack. Put the stack into invalid state
-    // if the stack contains fewer element then the given count.
-    void discard(uint32_t count);
-
-    // Clone the n-th element from the top of the stack to the top of the stack. The currently top
-    // most element is the 0th and the index is increasing with going down in the stack. Put the
-    // stack into invalid state if called on a full stacked or if the given index points out from
-    // the stack (greater then current size minus one).
-    void clone(uint32_t n);
-
-    // Print the content of the stack to the log output. The output is only written to the log
-    // output if the debug level is at least DEBUG. This function will work even if the stack is not
-    // in a valid state.
-    void printStack() const;
-
-    // Returns if the stack is in a valid state or not.
-    bool isValid() const {
-        return mValid;
+    bool getTo(const void** p) const {
+      if (mType != BaseType::AbsolutePointer) {
+        return false;
+      }
+      *p = mValue.p;
+      return true;
     }
 
-    // Pop the item from the top of the stack to the given memory address. The number of bytes
-    // written to the address is determined by the type of the element at the top of the stack.
-    // Pointers are converted to absolute pointers before writing to the address.
-    // The stack will enter an invalid state if called on an empty stack.
-    // Take care if using an address on the program stack. Use getTopType()
-    // to check the type of the object you will pop and/or
-    // make sure the receiver is sizeof(BaseValue).
-    void popTo(void* address);
+    bool getTo(void** p) const {
+      if (mType != BaseType::AbsolutePointer) {
+        return false;
+      }
+      *p = mValue.p;
+      return true;
+    }
 
-    // Push a new item to the stack with the given type from the given memory address. Put the stack
-    // into invalid state if it is already full before the call.
-    void pushFrom(BaseType type, const void* data);
-private:
-    // Check that the stack is valid and a pop is allowed (non-empty).
-    bool popCheck(const char * what);
-    // Check that the stack is valid and a push is allowed (non-full).
-    bool pushCheck(const char * what);
-    // Check that if top is a pointer type that it is valid.
-    bool checkTopForInvalidPointer(const char *what);
-    // Check that top is a pointer type, that it is valid and return it.
-    const void* checkAndGetTopPointer(const char *what);
+    BaseValue getBaseValue() const { return mValue.bv; }
 
-    // Implementation of the pop method for non pointer types.
-    template <typename T>
-    struct PopImpl {
-        static T pop(Stack* stack) {
-            stack->mTop--;
-            BaseType baseType = TypeToBaseType<typename std::remove_cv<T>::type>::type;
-            if (stack->mStack[stack->mTop].type() != baseType) {
-                stack->mValid = false;
-                GAPID_WARNING(
-                        "Pop type (%s) doesn't match with the type at the top of the stack (%s)",
-                        baseTypeName(baseType),
-                        baseTypeName(stack->mStack[stack->mTop].type()));
-                return T();
-            }
-            return stack->mStack[stack->mTop].value<T>();
-        }
+    // Return a string describing the stack entry.
+    // The pointer returned is only valid until the next call to debugInfo,
+    // regardless of the Entry instance. This function is not thread safe.
+    const char* debugInfo(const MemoryManager* memoryManager) const;
+
+   private:
+    // Type of the element stored by this entry
+    BaseType mType;
+
+    // Union of all possible types stored on the stack for creating a unified
+    // value type with getter function to access the value as a specific type
+    union ValueType {
+      bool b;
+      int8_t i8;
+      int16_t i16;
+      int32_t i32;
+      int64_t i64;
+      uint8_t u8;
+      uint16_t u16;
+      uint32_t u32;
+      uint64_t u64;
+      float f;
+      double d;
+      void* p;
+      BaseValue bv;
     };
 
-    // Implementation of the pop method for pointer types.
-    // Use with care, this template casts a pointer to a T* with no
-    // way of knowing if that is safe.
-    template <typename T>
-    struct PopImpl<T*> {
-        static T* pop(Stack* stack) {
-            stack->mTop--;
-            const void* pointer = stack->checkAndGetTopPointer("pop");
-            return const_cast<T*>(static_cast<const T*>(pointer));
-        }
-    };
+    ValueType mValue;
 
-    class Entry {
-    public:
-        const void* valuePtr() const {
-            return &mValue;
-        }
+    static_assert(sizeof(BaseValue) >= sizeof(ValueType),
+                  "Stack::BaseValue is not large enough");
+  };
 
-        template <typename T>
-        const T value() const {
-            static_assert(sizeof(mValue) >= sizeof(T),
-                          "T is too large to be used as value");
-            T t;
-            if (!getTo(&t)) {
-                GAPID_WARNING(
-                    "Error: read stack value inappropriate type %s wanted %s",
-                    baseTypeName(mType), baseTypeName(TypeToBaseType<T>::type));
-                return T();
-            }
-            return t;
-        }
+  // Indicates if the stack is in a consistent state (true value) or not (false
+  // value). The stack go into an inconsistent state after an invalid operation.
+  // When mValid is false then all of the operation on the stack (expect
+  // printing the stack) produce a warning message and falls back to no op (with
+  // zero initialized return value where necessary). The stack can't go back
+  // from an invalid state to a valid state again.
+  bool mValid;
 
-        const BaseType& type() const {
-            return mType;
-        }
+  // Contains the offset of the first empty slot in the stack from the bottom of
+  // the stack. The value of it indicates the number of elements currently in
+  // the stack.
+  uint32_t mTop;
 
-        void set(bool b) {
-            mType = TypeToBaseType<bool>::type;
-            mValue.b = b;
-        }
-        void set(int8_t i8) {
-            mType = TypeToBaseType<int8_t>::type;
-            mValue.i8 = i8;
-        }
-        void set(int16_t i16) {
-            mType = TypeToBaseType<int16_t>::type;
-            mValue.i16 = i16;
-        }
-        void set(int32_t i32) {
-            mType = TypeToBaseType<int32_t>::type;
-            mValue.i32 = i32;
-        }
-        void set(int64_t i64) {
-            mType = TypeToBaseType<int64_t>::type;
-            mValue.i64 = i64;
-        }
-        void set(uint8_t u8) {
-            mType = TypeToBaseType<uint8_t>::type;
-            mValue.u8 = u8;
-        }
-        void set(uint16_t u16) {
-            mType = TypeToBaseType<uint16_t>::type;
-            mValue.u16 = u16;
-        }
-        void set(uint32_t u32) {
-            mType = TypeToBaseType<uint32_t>::type;
-            mValue.u32 = u32;
-        }
-        void set(uint64_t u64) {
-            mType = TypeToBaseType<uint64_t>::type;
-            mValue.u64 = u64;
-        }
-        void set(float f) {
-            mType = TypeToBaseType<float>::type;
-            mValue.f = f;
-        }
-        void set(double d) {
-            mType = TypeToBaseType<double>::type;
-            mValue.d = d;
-        }
+  // mStack stores the entries currently in the stack. The 0th element
+  // corresponds to the bottom of the stack.
+  std::vector<Entry> mStack;
 
-        template <typename T>
-        void set(T* p) {
-            mType = BaseType::AbsolutePointer;
-            mValue.p = const_cast<typename std::remove_const<T>::type*>(p);
-        }
-
-        template <typename T>
-        void set(T val) {
-            static_assert(sizeof(T) == sizeof(mValue.u32),
-                          "Enum base type is not uint32_t");
-            mType = BaseType::Uint32;
-            mValue.u32 = uint32_t(val);
-        }
-
-        void set(BaseType type, const void* data) {
-            // Little endian assumption
-            memcpy(&mValue, data, baseTypeSize(type));
-            mType = type;
-        }
-
-        bool getTo(bool* b) const {
-            if (mType != TypeToBaseType<bool>::type) {
-                return false;
-            }
-            *b = mValue.b;
-            return true;
-        }
-        bool getTo(int8_t* i8) const {
-            if (mType != TypeToBaseType<int8_t>::type) {
-                return false;
-            }
-            *i8 = mValue.i8;
-            return true;
-        }
-        bool getTo(int16_t* i16) const {
-            if (mType != TypeToBaseType<int16_t>::type) {
-                return false;
-            }
-            *i16 = mValue.i16;
-            return true;
-        }
-        bool getTo(int32_t* i32) const {
-            if (mType != TypeToBaseType<int32_t>::type) {
-                return false;
-            }
-            *i32 = mValue.i32;
-            return true;
-        }
-        bool getTo(int64_t* i64) const {
-            if (mType != TypeToBaseType<int64_t>::type) {
-                return false;
-            }
-            *i64 = mValue.i64;
-            return true;
-        }
-        bool getTo(uint8_t* u8) const {
-            if (mType != TypeToBaseType<uint8_t>::type) {
-                return false;
-            }
-            *u8 = mValue.u8;
-            return true;
-        }
-        bool getTo(uint16_t* u16) const {
-            if (mType != TypeToBaseType<uint16_t>::type) {
-                return false;
-            }
-            *u16 = mValue.u16;
-            return true;
-        }
-        bool getTo(uint32_t* u32) const {
-            if (mType != TypeToBaseType<uint32_t>::type &&
-                mType != BaseType::VolatilePointer &&
-                mType != BaseType::ConstantPointer) {
-                return false;
-            }
-            *u32 = mValue.u32;
-            return true;
-        }
-        bool getTo(uint64_t* u64) const {
-            if (mType != TypeToBaseType<uint64_t>::type) {
-                return false;
-            }
-            *u64 = mValue.u64;
-            return true;
-        }
-        bool getTo(float* f) const {
-            if (mType != TypeToBaseType<float>::type) {
-                return false;
-            }
-            *f = mValue.f;
-            return true;
-        }
-        bool getTo(double* d) const {
-            if (mType != TypeToBaseType<double>::type) {
-                return false;
-            }
-            *d = mValue.d;
-            return true;
-        }
-
-        template <typename T>
-        bool getTo(T* val) const {
-            static_assert(sizeof(T) == sizeof(mValue.u32),
-                          "Enum base type is not uint32_t");
-            if (mType != BaseType::Uint32) {
-                return false;
-            }
-            *val = T(mValue.u32);
-            return true;
-        }
-
-        bool getTo(const void** p) const {
-            if (mType != BaseType::AbsolutePointer) {
-                return false;
-            }
-            *p = mValue.p;
-            return true;
-        }
-
-        bool getTo(void** p) const {
-            if (mType != BaseType::AbsolutePointer) {
-                return false;
-            }
-            *p = mValue.p;
-            return true;
-        }
-
-        BaseValue getBaseValue() const {
-            return mValue.bv;
-        }
-
-        // Return a string describing the stack entry.
-        // The pointer returned is only valid until the next call to debugInfo, regardless of the
-        // Entry instance.
-        // This function is not thread safe.
-        const char* debugInfo(const MemoryManager* memoryManager) const;
-    private:
-        // Type of the element stored by this entry
-        BaseType mType;
-
-        // Union of all possible types stored on the stack for creating a unified value type with
-        // getter function to access the value as a specific type
-        union ValueType {
-            bool     b;
-            int8_t   i8;
-            int16_t  i16;
-            int32_t  i32;
-            int64_t  i64;
-            uint8_t  u8;
-            uint16_t u16;
-            uint32_t u32;
-            uint64_t u64;
-            float    f;
-            double   d;
-            void*    p;
-            BaseValue bv;
-        };
-
-        ValueType mValue;
-
-        static_assert(sizeof(BaseValue) >= sizeof(ValueType),
-                      "Stack::BaseValue is not large enough");
-    };
-
-    // Indicates if the stack is in a consistent state (true value) or not (false value). The stack
-    // go into an inconsistent state after an invalid operation. When mValid is false then all of
-    // the operation on the stack (expect printing the stack) produce a warning message and falls
-    // back to no op (with zero initialized return value where necessary). The stack can't go back
-    // from an invalid state to a valid state again.
-    bool mValid;
-
-    // Contains the offset of the first empty slot in the stack from the bottom of the stack. The
-    // value of it indicates the number of elements currently in the stack.
-    uint32_t mTop;
-
-    // mStack stores the entries currently in the stack. The 0th element corresponds to the bottom
-    // of the stack.
-    std::vector<Entry> mStack;
-
-    // Reference to the memory manager used to resolve constant and volatile pointers to absolute
-    // pointers when thy are popped from the stack.
-    const MemoryManager* mMemoryManager;
+  // Reference to the memory manager used to resolve constant and volatile
+  // pointers to absolute pointers when thy are popped from the stack.
+  const MemoryManager* mMemoryManager;
 };
 
 }  // namespace gapir

--- a/gapir/cc/stack_test.cpp
+++ b/gapir/cc/stack_test.cpp
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#include "memory_manager.h"
 #include "stack.h"
+#include "memory_manager.h"
 #include "test_utilities.h"
 
 #include <gtest/gtest.h>
@@ -31,267 +31,265 @@ const uint32_t STACK_CAPACITY = 128;
 const uint32_t CONSTANT_SIZE = 128;
 
 class StackTest : public ::testing::Test {
-protected:
-    virtual void SetUp() {
-        std::vector<uint32_t> memorySizes = {MEMORY_SIZE};
-        mMemoryManager.reset(new MemoryManager(memorySizes));
-        mStack.reset(new Stack(STACK_CAPACITY, mMemoryManager.get()));
-        mMemoryManager->setReplayDataSize(CONSTANT_SIZE, 0);
-    }
+ protected:
+  virtual void SetUp() {
+    std::vector<uint32_t> memorySizes = {MEMORY_SIZE};
+    mMemoryManager.reset(new MemoryManager(memorySizes));
+    mStack.reset(new Stack(STACK_CAPACITY, mMemoryManager.get()));
+    mMemoryManager->setReplayDataSize(CONSTANT_SIZE, 0);
+  }
 
-    std::unique_ptr<MemoryManager> mMemoryManager;
-    std::unique_ptr<Stack> mStack;
+  std::unique_ptr<MemoryManager> mMemoryManager;
+  std::unique_ptr<Stack> mStack;
 };
 
 void fillStack(Stack* stack, uint32_t n) {
-    for (unsigned i = 0; i < n; ++i) {
-        stack->push<uint32_t>(0);
-    }
+  for (unsigned i = 0; i < n; ++i) {
+    stack->push<uint32_t>(0);
+  }
 }
 }  // anonymous namespace
 
-TEST_F(StackTest, IsValid) {
-    EXPECT_TRUE(mStack->isValid());
-}
+TEST_F(StackTest, IsValid) { EXPECT_TRUE(mStack->isValid()); }
 
 TEST_F(StackTest, GetType) {
-    mStack->push<uint32_t>(123);
-    EXPECT_EQ(BaseType::Uint32, mStack->getTopType());
-    EXPECT_TRUE(mStack->isValid());
-    mStack->discard(1);
-    EXPECT_TRUE(mStack->isValid());
+  mStack->push<uint32_t>(123);
+  EXPECT_EQ(BaseType::Uint32, mStack->getTopType());
+  EXPECT_TRUE(mStack->isValid());
+  mStack->discard(1);
+  EXPECT_TRUE(mStack->isValid());
 
-    mStack->push<void*>(nullptr);
-    EXPECT_EQ(BaseType::AbsolutePointer, mStack->getTopType());
-    EXPECT_TRUE(mStack->isValid());
-    mStack->discard(1);
-    EXPECT_TRUE(mStack->isValid());
+  mStack->push<void*>(nullptr);
+  EXPECT_EQ(BaseType::AbsolutePointer, mStack->getTopType());
+  EXPECT_TRUE(mStack->isValid());
+  mStack->discard(1);
+  EXPECT_TRUE(mStack->isValid());
 }
 
 TEST_F(StackTest, GetTypeErrorEmptyStack) {
-    mStack->getTopType();
-    EXPECT_FALSE(mStack->isValid());
+  mStack->getTopType();
+  EXPECT_FALSE(mStack->isValid());
 
-    mStack->getTopType();
-    EXPECT_FALSE(mStack->isValid());
+  mStack->getTopType();
+  EXPECT_FALSE(mStack->isValid());
 }
 
 TEST_F(StackTest, PushValue) {
-    uint32_t x = 123456789;
-    mStack->pushValue(BaseType::Uint32, x);
-    EXPECT_EQ(123456789, mStack->pop<uint32_t>());
-    EXPECT_TRUE(mStack->isValid());
+  uint32_t x = 123456789;
+  mStack->pushValue(BaseType::Uint32, x);
+  EXPECT_EQ(123456789, mStack->pop<uint32_t>());
+  EXPECT_TRUE(mStack->isValid());
 }
 
 TEST_F(StackTest, PushValueErrorStackOverflow) {
-    fillStack(mStack.get(), STACK_CAPACITY);
-    EXPECT_TRUE(mStack->isValid());
+  fillStack(mStack.get(), STACK_CAPACITY);
+  EXPECT_TRUE(mStack->isValid());
 
-    uint32_t x = 123456789;
-    mStack->pushValue(BaseType::Uint32, x);
-    EXPECT_FALSE(mStack->isValid());
+  uint32_t x = 123456789;
+  mStack->pushValue(BaseType::Uint32, x);
+  EXPECT_FALSE(mStack->isValid());
 
-    mStack->pushValue(BaseType::Uint32, x);
-    EXPECT_FALSE(mStack->isValid());
+  mStack->pushValue(BaseType::Uint32, x);
+  EXPECT_FALSE(mStack->isValid());
 }
 
 TEST_F(StackTest, PopVolatilePtrWithoutConvert) {
-    uint32_t offset = 0x123;
-    mStack->pushValue(BaseType::VolatilePointer, offset);
+  uint32_t offset = 0x123;
+  mStack->pushValue(BaseType::VolatilePointer, offset);
 
-    uint32_t pointer = mStack->popBaseValue();
-    EXPECT_TRUE(mStack->isValid());
+  uint32_t pointer = mStack->popBaseValue();
+  EXPECT_TRUE(mStack->isValid());
 
-    EXPECT_EQ(offset, pointer);
+  EXPECT_EQ(offset, pointer);
 }
 
 TEST_F(StackTest, PopVolatilePtrWithConvert) {
-    uint32_t offset = 0x123;
-    mStack->pushValue(BaseType::VolatilePointer, offset);
+  uint32_t offset = 0x123;
+  mStack->pushValue(BaseType::VolatilePointer, offset);
 
-    const void* pointer = mStack->popVolatile<const void*>();
-    EXPECT_TRUE(mStack->isValid());
+  const void* pointer = mStack->popVolatile<const void*>();
+  EXPECT_TRUE(mStack->isValid());
 
-    EXPECT_EQ(mMemoryManager->volatileToAbsolute(offset), pointer);
+  EXPECT_EQ(mMemoryManager->volatileToAbsolute(offset), pointer);
 }
 
 TEST_F(StackTest, PopConstantPtrWithoutConvert) {
-    uint32_t offset = 0x12;
-    mStack->pushValue(BaseType::ConstantPointer, offset);
+  uint32_t offset = 0x12;
+  mStack->pushValue(BaseType::ConstantPointer, offset);
 
-    uint32_t pointer = mStack->popBaseValue();
-    EXPECT_TRUE(mStack->isValid());
+  uint32_t pointer = mStack->popBaseValue();
+  EXPECT_TRUE(mStack->isValid());
 
-    EXPECT_EQ(offset, pointer);
+  EXPECT_EQ(offset, pointer);
 }
 
 TEST_F(StackTest, PopConstantPtrWithConvert) {
-    uint32_t offset = 0x12;
-    mStack->pushValue(BaseType::ConstantPointer, offset);
+  uint32_t offset = 0x12;
+  mStack->pushValue(BaseType::ConstantPointer, offset);
 
-    const void* pointer = mStack->popConstant<const void*>();
-    EXPECT_TRUE(mStack->isValid());
+  const void* pointer = mStack->popConstant<const void*>();
+  EXPECT_TRUE(mStack->isValid());
 
-    EXPECT_EQ(mMemoryManager->constantToAbsolute(offset), pointer);
+  EXPECT_EQ(mMemoryManager->constantToAbsolute(offset), pointer);
 }
 
 TEST_F(StackTest, PopErrorEmptyStack) {
-    mStack->pop<uint32_t>();
-    EXPECT_FALSE(mStack->isValid());
+  mStack->pop<uint32_t>();
+  EXPECT_FALSE(mStack->isValid());
 }
 
 TEST_F(StackTest, PopConstantErrorEmptyStack) {
-    mStack->popConstant<const void*>();
-    EXPECT_FALSE(mStack->isValid());
+  mStack->popConstant<const void*>();
+  EXPECT_FALSE(mStack->isValid());
 }
 
 TEST_F(StackTest, PopVolatileErrorEmptyStack) {
-    mStack->popVolatile<void*>();
-    EXPECT_FALSE(mStack->isValid());
+  mStack->popVolatile<void*>();
+  EXPECT_FALSE(mStack->isValid());
 }
 
 TEST_F(StackTest, PopBaseValueErrorEmptyStack) {
-    mStack->popBaseValue();
-    EXPECT_FALSE(mStack->isValid());
+  mStack->popBaseValue();
+  EXPECT_FALSE(mStack->isValid());
 }
 
 TEST_F(StackTest, Discard) {
-    mStack->push<uint32_t>(1234);
-    mStack->push<uint32_t>(2345);
-    mStack->push<uint32_t>(3356);
-    EXPECT_TRUE(mStack->isValid());
+  mStack->push<uint32_t>(1234);
+  mStack->push<uint32_t>(2345);
+  mStack->push<uint32_t>(3356);
+  EXPECT_TRUE(mStack->isValid());
 
-    mStack->discard(2);
-    EXPECT_TRUE(mStack->isValid());
-    EXPECT_EQ(1234, mStack->pop<uint32_t>());
+  mStack->discard(2);
+  EXPECT_TRUE(mStack->isValid());
+  EXPECT_EQ(1234, mStack->pop<uint32_t>());
 }
 
 TEST_F(StackTest, SequentialDiscard) {
-    mStack->push<uint32_t>(12);
-    mStack->push<uint32_t>(123);
-    mStack->push<uint32_t>(234);
-    mStack->discard(1);
-    mStack->push<uint32_t>(345);
-    mStack->discard(1);
+  mStack->push<uint32_t>(12);
+  mStack->push<uint32_t>(123);
+  mStack->push<uint32_t>(234);
+  mStack->discard(1);
+  mStack->push<uint32_t>(345);
+  mStack->discard(1);
 
-    EXPECT_TRUE(mStack->isValid());
-    EXPECT_EQ(123, mStack->pop<uint32_t>());
+  EXPECT_TRUE(mStack->isValid());
+  EXPECT_EQ(123, mStack->pop<uint32_t>());
 }
 
 TEST_F(StackTest, DiscardErrorStackUnderflow) {
-    mStack->push<uint32_t>(1234);
-    EXPECT_TRUE(mStack->isValid());
+  mStack->push<uint32_t>(1234);
+  EXPECT_TRUE(mStack->isValid());
 
-    mStack->discard(2);
-    EXPECT_FALSE(mStack->isValid());
+  mStack->discard(2);
+  EXPECT_FALSE(mStack->isValid());
 
-    mStack->discard(1);
-    EXPECT_FALSE(mStack->isValid());
+  mStack->discard(1);
+  EXPECT_FALSE(mStack->isValid());
 }
 
 TEST_F(StackTest, Clone) {
-    mStack->push<uint32_t>(1234);
-    mStack->push<uint32_t>(2345);
-    EXPECT_TRUE(mStack->isValid());
+  mStack->push<uint32_t>(1234);
+  mStack->push<uint32_t>(2345);
+  EXPECT_TRUE(mStack->isValid());
 
-    mStack->clone(1);
-    EXPECT_TRUE(mStack->isValid());
+  mStack->clone(1);
+  EXPECT_TRUE(mStack->isValid());
 
-    EXPECT_EQ(1234, mStack->pop<uint32_t>());
-    EXPECT_EQ(2345, mStack->pop<uint32_t>());
-    EXPECT_EQ(1234, mStack->pop<uint32_t>());
-    EXPECT_TRUE(mStack->isValid());
+  EXPECT_EQ(1234, mStack->pop<uint32_t>());
+  EXPECT_EQ(2345, mStack->pop<uint32_t>());
+  EXPECT_EQ(1234, mStack->pop<uint32_t>());
+  EXPECT_TRUE(mStack->isValid());
 }
 
 TEST_F(StackTest, CloneErrorNonExistantIndex) {
-    mStack->clone(1);
-    EXPECT_FALSE(mStack->isValid());
+  mStack->clone(1);
+  EXPECT_FALSE(mStack->isValid());
 
-    mStack->clone(1);
-    EXPECT_FALSE(mStack->isValid());
+  mStack->clone(1);
+  EXPECT_FALSE(mStack->isValid());
 }
 
 TEST_F(StackTest, CloneErrorOutsideOfCapacity) {
-    mStack->push<uint32_t>(1234);
-    mStack->push<uint32_t>(2345);
-    EXPECT_TRUE(mStack->isValid());
+  mStack->push<uint32_t>(1234);
+  mStack->push<uint32_t>(2345);
+  EXPECT_TRUE(mStack->isValid());
 
-    mStack->clone(3);
-    EXPECT_FALSE(mStack->isValid());
+  mStack->clone(3);
+  EXPECT_FALSE(mStack->isValid());
 }
 
 TEST_F(StackTest, CloneErrorStackOverflow) {
-    fillStack(mStack.get(), STACK_CAPACITY);
-    EXPECT_TRUE(mStack->isValid());
+  fillStack(mStack.get(), STACK_CAPACITY);
+  EXPECT_TRUE(mStack->isValid());
 
-    mStack->clone(1);
-    EXPECT_FALSE(mStack->isValid());
+  mStack->clone(1);
+  EXPECT_FALSE(mStack->isValid());
 
-    mStack->clone(1);
-    EXPECT_FALSE(mStack->isValid());
+  mStack->clone(1);
+  EXPECT_FALSE(mStack->isValid());
 }
 
 TEST_F(StackTest, PushPop) {
-    mStack->push<uint32_t>(123);
-    EXPECT_TRUE(mStack->isValid());
+  mStack->push<uint32_t>(123);
+  EXPECT_TRUE(mStack->isValid());
 
-    ASSERT_EQ(123, mStack->pop<uint32_t>());
-    EXPECT_TRUE(mStack->isValid());
+  ASSERT_EQ(123, mStack->pop<uint32_t>());
+  EXPECT_TRUE(mStack->isValid());
 }
 
 TEST_F(StackTest, PopVolatilePointer) {
-    uint32_t a = 0;
-    mStack->pushValue(BaseType::VolatilePointer, a);
-    EXPECT_TRUE(mStack->isValid());
-    EXPECT_EQ(mMemoryManager->volatileToAbsolute(0), mStack->pop<void*>());
+  uint32_t a = 0;
+  mStack->pushValue(BaseType::VolatilePointer, a);
+  EXPECT_TRUE(mStack->isValid());
+  EXPECT_EQ(mMemoryManager->volatileToAbsolute(0), mStack->pop<void*>());
 }
 
 TEST_F(StackTest, PopConstantPointer) {
-    uint32_t a = 0;
-    mStack->pushValue(BaseType::ConstantPointer, a);
-    EXPECT_TRUE(mStack->isValid());
-    EXPECT_EQ(mMemoryManager->constantToAbsolute(0), mStack->pop<const void*>());
+  uint32_t a = 0;
+  mStack->pushValue(BaseType::ConstantPointer, a);
+  EXPECT_TRUE(mStack->isValid());
+  EXPECT_EQ(mMemoryManager->constantToAbsolute(0), mStack->pop<const void*>());
 }
 
 TEST_F(StackTest, PopAbsolutePointer) {
-    mStack->push<void*>(nullptr);
-    EXPECT_TRUE(mStack->isValid());
-    EXPECT_EQ(nullptr, mStack->pop<void*>());
+  mStack->push<void*>(nullptr);
+  EXPECT_TRUE(mStack->isValid());
+  EXPECT_EQ(nullptr, mStack->pop<void*>());
 }
 
 TEST_F(StackTest, PopErrorStackUnderflow) {
-    mStack->pop<uint32_t>();
-    EXPECT_FALSE(mStack->isValid());
+  mStack->pop<uint32_t>();
+  EXPECT_FALSE(mStack->isValid());
 
-    mStack->pop<uint32_t>();
-    EXPECT_FALSE(mStack->isValid());
+  mStack->pop<uint32_t>();
+  EXPECT_FALSE(mStack->isValid());
 }
 
 TEST_F(StackTest, PopErrorTypeMissmatch) {
-    mStack->push<uint16_t>(123);
-    EXPECT_TRUE(mStack->isValid());
+  mStack->push<uint16_t>(123);
+  EXPECT_TRUE(mStack->isValid());
 
-    mStack->pop<uint32_t>();
-    EXPECT_FALSE(mStack->isValid());
+  mStack->pop<uint32_t>();
+  EXPECT_FALSE(mStack->isValid());
 }
 
 TEST_F(StackTest, PopErrorMismatchingPointerType) {
-    mStack->push<uint32_t>(123);
-    EXPECT_TRUE(mStack->isValid());
+  mStack->push<uint32_t>(123);
+  EXPECT_TRUE(mStack->isValid());
 
-    mStack->pop<void*>();
-    EXPECT_FALSE(mStack->isValid());
+  mStack->pop<void*>();
+  EXPECT_FALSE(mStack->isValid());
 }
 
 TEST_F(StackTest, PushErrorOverCapacity) {
-    fillStack(mStack.get(), STACK_CAPACITY);
-    EXPECT_TRUE(mStack->isValid());
+  fillStack(mStack.get(), STACK_CAPACITY);
+  EXPECT_TRUE(mStack->isValid());
 
-    mStack->push<uint32_t>(1);
-    EXPECT_FALSE(mStack->isValid());
+  mStack->push<uint32_t>(1);
+  EXPECT_FALSE(mStack->isValid());
 
-    mStack->push<uint32_t>(1);
-    EXPECT_FALSE(mStack->isValid());
+  mStack->push<uint32_t>(1);
+  EXPECT_FALSE(mStack->isValid());
 }
 
 }  // namespace test

--- a/gapir/cc/test_utilities.h
+++ b/gapir/cc/test_utilities.h
@@ -19,8 +19,8 @@
 
 #include "base_type.h"
 #include "interpreter.h"
-#include "resource_provider.h"
 #include "replay_connection.h"
+#include "resource_provider.h"
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
@@ -36,22 +36,23 @@ class ServerConnection;
 
 namespace test {
 
-
-// Action for setting the values pointed by a void pointer (arg0). Data should be an iterable
-// collection of uint8_t types and arg should be a void pointer.
+// Action for setting the values pointed by a void pointer (arg0). Data should
+// be an iterable collection of uint8_t types and arg should be a void pointer.
 ACTION_P(SetVoidPointee, data) {
-    uint32_t i = 0;
-    uint8_t* typedArg = static_cast<uint8_t*>(arg0);
-    for (uint8_t it : data) {
-        typedArg[i] = it;
-        ++i;
-    }
+  uint32_t i = 0;
+  uint8_t* typedArg = static_cast<uint8_t*>(arg0);
+  for (uint8_t it : data) {
+    typedArg[i] = it;
+    ++i;
+  }
 }
 
-// Create an instruction code from the given details that can be interpreted by the interpreter
+// Create an instruction code from the given details that can be interpreted by
+// the interpreter
 uint32_t instruction(Interpreter::InstructionCode code);
 uint32_t instruction(Interpreter::InstructionCode code, uint32_t data);
-uint32_t instruction(Interpreter::InstructionCode code, BaseType type, uint32_t data);
+uint32_t instruction(Interpreter::InstructionCode code, BaseType type,
+                     uint32_t data);
 
 void pushBytes(std::vector<uint8_t>* buf, const std::vector<uint8_t>& v);
 void pushUint8(std::vector<uint8_t>* buf, uint8_t v);

--- a/gapir/cc/test_utilities_test.cpp
+++ b/gapir/cc/test_utilities_test.cpp
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
+#include "test_utilities.h"
 #include "base_type.h"
 #include "interpreter.h"
-#include "test_utilities.h"
 #include "replay_connection.h"
 
 #include "gapir/replay_service/service.pb.h"
@@ -27,50 +27,49 @@
 #include <string>
 #include <vector>
 
-using ::testing::_;
 using ::testing::DoAll;
 using ::testing::NotNull;
 using ::testing::Return;
 using ::testing::ReturnArg;
 using ::testing::StrictMock;
 using ::testing::WithArg;
+using ::testing::_;
 
 namespace gapir {
 namespace test {
 
 uint32_t instruction(Interpreter::InstructionCode code) {
-    return static_cast<uint32_t>(code) << 26;
+  return static_cast<uint32_t>(code) << 26;
 }
 
 uint32_t instruction(Interpreter::InstructionCode code, uint32_t data) {
-    return (static_cast<uint32_t>(code) << 26) | (data & 0x03ffffffU);
+  return (static_cast<uint32_t>(code) << 26) | (data & 0x03ffffffU);
 }
 
-uint32_t instruction(Interpreter::InstructionCode code, BaseType type, uint32_t data) {
-    return (static_cast<uint32_t>(code) << 26) | (static_cast<uint32_t>(type) << 20) |
-           (data & 0x000fffff);
+uint32_t instruction(Interpreter::InstructionCode code, BaseType type,
+                     uint32_t data) {
+  return (static_cast<uint32_t>(code) << 26) |
+         (static_cast<uint32_t>(type) << 20) | (data & 0x000fffff);
 }
 
 void pushBytes(std::vector<uint8_t>* buf, const std::vector<uint8_t>& v) {
   buf->insert(buf->end(), v.begin(), v.end());
 }
-void pushUint8(std::vector<uint8_t>* buf, uint8_t v) {
-  buf->push_back(v);
-}
+void pushUint8(std::vector<uint8_t>* buf, uint8_t v) { buf->push_back(v); }
 void pushUint32(std::vector<uint8_t>* buf, uint32_t v) {
-    for (uint8_t i = 0; i < 32; i += 8) {
-      buf->push_back((v >> i) & 0xff);
+  for (uint8_t i = 0; i < 32; i += 8) {
+    buf->push_back((v >> i) & 0xff);
   }
 }
 void pushString(std::vector<uint8_t>* buf, const std::string& str) {
-  for(char c : str) {
-      buf->push_back(c);
+  for (char c : str) {
+    buf->push_back(c);
   }
   buf->push_back(0);
 }
 void pushString(std::vector<uint8_t>* buf, const char* str) {
-  for(char c = *str; c != 0; str++, c = *str) {
-      buf->push_back(c);
+  for (char c = *str; c != 0; str++, c = *str) {
+    buf->push_back(c);
   }
   buf->push_back(0);
 }
@@ -80,7 +79,8 @@ std::unique_ptr<ReplayConnection::Payload> createPayload(
     const std::vector<uint8_t>& constantMemory,
     const std::vector<Resource>& resources,
     const std::vector<uint32_t>& instructions) {
-  auto p = std::unique_ptr<replay_service::Payload>(new replay_service::Payload);
+  auto p =
+      std::unique_ptr<replay_service::Payload>(new replay_service::Payload);
   p->set_stack_size(stackSize);
   p->set_volatile_memory_size(volatileMemorySize);
   p->set_constants(constantMemory.data(), constantMemory.size());
@@ -96,7 +96,8 @@ std::unique_ptr<ReplayConnection::Payload> createPayload(
 
 std::unique_ptr<ReplayConnection::Resources> createResources(
     const std::vector<uint8_t>& data) {
-  auto p = std::unique_ptr<replay_service::Resources>(new replay_service::Resources);
+  auto p =
+      std::unique_ptr<replay_service::Resources>(new replay_service::Resources);
   p->set_data(data.data(), data.size());
   return std::unique_ptr<ReplayConnection::Resources>(
       new ReplayConnection::Resources(std::move(p)));

--- a/gapir/cc/thread_pool.h
+++ b/gapir/cc/thread_pool.h
@@ -19,10 +19,10 @@
 
 #include "core/cc/semaphore.h"
 
-#include <mutex>
 #include <functional>
-#include <thread>
+#include <mutex>
 #include <queue>
+#include <thread>
 #include <unordered_map>
 
 namespace gapir {
@@ -31,42 +31,43 @@ typedef uint64_t ThreadID;
 
 // ThreadPool holds a number of threads that can have work assigned to them.
 class ThreadPool {
-public:
-    typedef std::function<void()> F;
+ public:
+  typedef std::function<void()> F;
 
-    ThreadPool();
+  ThreadPool();
 
-    // Destructor. Waits for all threads to finish their work before returning.
-    ~ThreadPool();
+  // Destructor. Waits for all threads to finish their work before returning.
+  ~ThreadPool();
 
-    // Appends F to the queue of work for the thread with the given ID.
-    // If this is the first time enqueue has been called with the given thread
-    // ID then it is created.
-    void enqueue(ThreadID, const F&);
+  // Appends F to the queue of work for the thread with the given ID.
+  // If this is the first time enqueue has been called with the given thread
+  // ID then it is created.
+  void enqueue(ThreadID, const F&);
 
-private:
-    class Thread {
-    public:
-        Thread();
-        ~Thread();
-        void enqueue(const F&);
-    private:
-        Thread(const Thread&) = delete;
-        Thread& operator = (const Thread&) = delete;
+ private:
+  class Thread {
+   public:
+    Thread();
+    ~Thread();
+    void enqueue(const F&);
 
-        static void worker(Thread*);
+   private:
+    Thread(const Thread&) = delete;
+    Thread& operator=(const Thread&) = delete;
 
-        std::thread* mThread; // The thread.
-        std::queue<F> mWork;  // The queue of pending work.
-        std::mutex mMutex;    // Guards mWork.
-        core::Semaphore mSemaphore; // Number of work items.
-    };
+    static void worker(Thread*);
 
-    ThreadPool(const ThreadPool&) = delete;
-    ThreadPool& operator = (const ThreadPool&) = delete;
+    std::thread* mThread;        // The thread.
+    std::queue<F> mWork;         // The queue of pending work.
+    std::mutex mMutex;           // Guards mWork.
+    core::Semaphore mSemaphore;  // Number of work items.
+  };
 
-    std::mutex mMutex; // Guards mThreads
-    std::unordered_map<ThreadID, Thread*> mThreads;
+  ThreadPool(const ThreadPool&) = delete;
+  ThreadPool& operator=(const ThreadPool&) = delete;
+
+  std::mutex mMutex;  // Guards mThreads
+  std::unordered_map<ThreadID, Thread*> mThreads;
 };
 
 }  // namespace gapir

--- a/gapir/cc/vulkan_renderer.h
+++ b/gapir/cc/vulkan_renderer.h
@@ -24,15 +24,15 @@ namespace gapir {
 // The Vulkan renderer implementation.
 // TODO(antiagainst): Right now this is just a skeleton. Flesh out it.
 class VulkanRenderer : public Renderer {
-public:
-    // Construct and return an offscreen renderer.
-    static VulkanRenderer* create();
+ public:
+  // Construct and return an offscreen renderer.
+  static VulkanRenderer* create();
 
-    // Returns the renderer's API.
-    virtual Api* api() = 0;
+  // Returns the renderer's API.
+  virtual Api* api() = 0;
 
-    // Return true if this is a valid api for this system.
-    virtual bool isValid() = 0;
+  // Return true if this is a valid api for this system.
+  virtual bool isValid() = 0;
 };
 
 }  // namespace gapir

--- a/gapir/cc/windows/gles_renderer.cpp
+++ b/gapir/cc/windows/gles_renderer.cpp
@@ -14,17 +14,17 @@
  * limitations under the License.
  */
 
-#include "gapir/cc/gles_gfx_api.h"
 #include "gapir/cc/gles_renderer.h"
+#include "gapir/cc/gles_gfx_api.h"
 
-#include "core/cc/thread.h"
 #include "core/cc/gl/formats.h"
 #include "core/cc/gl/versions.h"
 #include "core/cc/log.h"
+#include "core/cc/thread.h"
 
-#include <memory>
 #include <windows.h>
 #include <winuser.h>
+#include <memory>
 #include <string>
 
 namespace gapir {
@@ -32,13 +32,20 @@ namespace {
 
 DECLARE_HANDLE(HPBUFFERARB);
 
-typedef BOOL(*PFNWGLCHOOSEPIXELFORMATARB)(HDC hdc, const int *piAttribIList, const FLOAT *pfAttribFList, UINT nMaxFormats, int *piFormats, UINT *nNumFormats);
-typedef HGLRC(*PFNWGLCREATECONTEXTATTRIBSARBPROC)(HDC hDC, HGLRC hShareContext, const int *attribList);
-typedef HPBUFFERARB(*PFNWGLCREATEPBUFFERARB)(HDC hDC, int iPixelFormat, int iWidth, int iHeight, const int *piAttribList);
-typedef HDC(*PFNWGLGETPBUFFERDCARB)(HPBUFFERARB hPbuffer);
-typedef int(*PFNWGLRELEASEPBUFFERDCARB)(HPBUFFERARB hPbuffer, HDC hDC);
-typedef BOOL(*PFNWGLDESTROYPBUFFERARB)(HPBUFFERARB hPbuffer);
-typedef BOOL(*PFNWGLQUERYPBUFFERARB)(HPBUFFERARB hPbuffer, int iAttribute, int *piValue);
+typedef BOOL (*PFNWGLCHOOSEPIXELFORMATARB)(HDC hdc, const int* piAttribIList,
+                                           const FLOAT* pfAttribFList,
+                                           UINT nMaxFormats, int* piFormats,
+                                           UINT* nNumFormats);
+typedef HGLRC (*PFNWGLCREATECONTEXTATTRIBSARBPROC)(HDC hDC, HGLRC hShareContext,
+                                                   const int* attribList);
+typedef HPBUFFERARB (*PFNWGLCREATEPBUFFERARB)(HDC hDC, int iPixelFormat,
+                                              int iWidth, int iHeight,
+                                              const int* piAttribList);
+typedef HDC (*PFNWGLGETPBUFFERDCARB)(HPBUFFERARB hPbuffer);
+typedef int (*PFNWGLRELEASEPBUFFERDCARB)(HPBUFFERARB hPbuffer, HDC hDC);
+typedef BOOL (*PFNWGLDESTROYPBUFFERARB)(HPBUFFERARB hPbuffer);
+typedef BOOL (*PFNWGLQUERYPBUFFERARB)(HPBUFFERARB hPbuffer, int iAttribute,
+                                      int* piValue);
 
 const int WGL_CONTEXT_RELEASE_BEHAVIOR_ARB = 0x2097;
 const int WGL_CONTEXT_MAJOR_VERSION_ARB = 0x2091;
@@ -58,434 +65,451 @@ const int WGL_STENCIL_BITS_ARB = 0x2023;
 const TCHAR* wndClassName = TEXT("gapir");
 
 class WGL {
-public:
-    class PBuffer {
-    public:
-        ~PBuffer();
+ public:
+  class PBuffer {
+   public:
+    ~PBuffer();
 
-        static std::shared_ptr<PBuffer> create(const GlesRenderer::Backbuffer& backbuffer, PBuffer* shared_ctx);
+    static std::shared_ptr<PBuffer> create(
+        const GlesRenderer::Backbuffer& backbuffer, PBuffer* shared_ctx);
 
-        void bind();
-        void unbind();
-        void set_backbuffer(const GlesRenderer::Backbuffer& backbuffer);
+    void bind();
+    void unbind();
+    void set_backbuffer(const GlesRenderer::Backbuffer& backbuffer);
 
-    private:
-        PBuffer(const GlesRenderer::Backbuffer& backbuffer, PBuffer* shared_ctx);
+   private:
+    PBuffer(const GlesRenderer::Backbuffer& backbuffer, PBuffer* shared_ctx);
 
-        void create_buffer(const GlesRenderer::Backbuffer& backbuffer);
-        void release_buffer();
+    void create_buffer(const GlesRenderer::Backbuffer& backbuffer);
+    void release_buffer();
 
-        HPBUFFERARB mPBuf;
-        HGLRC mCtx;
-        HDC  mHDC;
-    };
-
-    WGL();
-
-    static const WGL& get();
-
-private:
-    HWND mWindow;
+    HPBUFFERARB mPBuf;
+    HGLRC mCtx;
     HDC mHDC;
+  };
 
-    PFNWGLCHOOSEPIXELFORMATARB ChoosePixelFormatARB;
-    PFNWGLCREATECONTEXTATTRIBSARBPROC CreateContextAttribsARB;
-    PFNWGLCREATEPBUFFERARB CreatePbufferARB;
-    PFNWGLGETPBUFFERDCARB GetPbufferDCARB;
-    PFNWGLRELEASEPBUFFERDCARB ReleasePbufferDCARB;
-    PFNWGLDESTROYPBUFFERARB DestroyPbufferARB;
-    PFNWGLQUERYPBUFFERARB QueryPbufferARB;
+  WGL();
+
+  static const WGL& get();
+
+ private:
+  HWND mWindow;
+  HDC mHDC;
+
+  PFNWGLCHOOSEPIXELFORMATARB ChoosePixelFormatARB;
+  PFNWGLCREATECONTEXTATTRIBSARBPROC CreateContextAttribsARB;
+  PFNWGLCREATEPBUFFERARB CreatePbufferARB;
+  PFNWGLGETPBUFFERDCARB GetPbufferDCARB;
+  PFNWGLRELEASEPBUFFERDCARB ReleasePbufferDCARB;
+  PFNWGLDESTROYPBUFFERARB DestroyPbufferARB;
+  PFNWGLQUERYPBUFFERARB QueryPbufferARB;
 };
 
-WGL::PBuffer::PBuffer(const GlesRenderer::Backbuffer& backbuffer, PBuffer* shared_ctx)
-        : mPBuf(nullptr)
-        , mCtx(nullptr)
-        , mHDC(nullptr) {
+WGL::PBuffer::PBuffer(const GlesRenderer::Backbuffer& backbuffer,
+                      PBuffer* shared_ctx)
+    : mPBuf(nullptr), mCtx(nullptr), mHDC(nullptr) {
+  create_buffer(backbuffer);
 
-    create_buffer(backbuffer);
-
-    auto wgl = WGL::get();
-    for (auto gl_version : core::gl::sVersionSearchOrder) {
-        std::vector<int> attribs;
-        attribs.push_back(WGL_CONTEXT_MAJOR_VERSION_ARB);
-        attribs.push_back(gl_version.major);
-        attribs.push_back(WGL_CONTEXT_MINOR_VERSION_ARB);
-        attribs.push_back(gl_version.minor);
-        // https://www.khronos.org/registry/OpenGL/extensions/KHR/KHR_context_flush_control.txt
-        // These are disabled as they don't seem to improve performance.
-        // attribs.push_back(WGL_CONTEXT_RELEASE_BEHAVIOR_ARB);
-        // attribs.push_back(WGL_CONTEXT_RELEASE_BEHAVIOR_NONE_ARB);
-        attribs.push_back(0);
-        auto ctx = wgl.CreateContextAttribsARB(mHDC, (shared_ctx != nullptr) ? shared_ctx->mCtx : nullptr, attribs.data());
-        if (ctx != nullptr) {
-            mCtx = ctx;
-            return;
-        }
+  auto wgl = WGL::get();
+  for (auto gl_version : core::gl::sVersionSearchOrder) {
+    std::vector<int> attribs;
+    attribs.push_back(WGL_CONTEXT_MAJOR_VERSION_ARB);
+    attribs.push_back(gl_version.major);
+    attribs.push_back(WGL_CONTEXT_MINOR_VERSION_ARB);
+    attribs.push_back(gl_version.minor);
+    // https://www.khronos.org/registry/OpenGL/extensions/KHR/KHR_context_flush_control.txt
+    // These are disabled as they don't seem to improve performance.
+    // attribs.push_back(WGL_CONTEXT_RELEASE_BEHAVIOR_ARB);
+    // attribs.push_back(WGL_CONTEXT_RELEASE_BEHAVIOR_NONE_ARB);
+    attribs.push_back(0);
+    auto ctx = wgl.CreateContextAttribsARB(
+        mHDC, (shared_ctx != nullptr) ? shared_ctx->mCtx : nullptr,
+        attribs.data());
+    if (ctx != nullptr) {
+      mCtx = ctx;
+      return;
     }
-    GAPID_FATAL("Failed to create GL context using wglCreateContextAttribsARB. Error: 0x%x", GetLastError());
+  }
+  GAPID_FATAL(
+      "Failed to create GL context using wglCreateContextAttribsARB. Error: "
+      "0x%x",
+      GetLastError());
 }
 
 WGL::PBuffer::~PBuffer() {
-    release_buffer();
-    if (!wglDeleteContext(mCtx)) {
-        GAPID_ERROR("Failed to delete GL context. Error: 0x%x", GetLastError());
-    }
+  release_buffer();
+  if (!wglDeleteContext(mCtx)) {
+    GAPID_ERROR("Failed to delete GL context. Error: 0x%x", GetLastError());
+  }
 }
 
 void WGL::PBuffer::create_buffer(const GlesRenderer::Backbuffer& backbuffer) {
-    release_buffer();
+  release_buffer();
 
-    int r = 8, g = 8, b = 8, a = 8, d = 24, s = 8;
-    core::gl::getColorBits(backbuffer.format.color, r, g, b, a);
-    core::gl::getDepthBits(backbuffer.format.depth, d);
-    core::gl::getStencilBits(backbuffer.format.stencil, s);
+  int r = 8, g = 8, b = 8, a = 8, d = 24, s = 8;
+  core::gl::getColorBits(backbuffer.format.color, r, g, b, a);
+  core::gl::getDepthBits(backbuffer.format.depth, d);
+  core::gl::getStencilBits(backbuffer.format.stencil, s);
 
-    // Some exotic extensions let you create contexts without a backbuffer.
-    // In these cases the backbuffer is zero size - just create a small one.
-    int safe_width = (backbuffer.width > 0) ? backbuffer.width : 8;
-    int safe_height = (backbuffer.height > 0) ? backbuffer.height : 8;
+  // Some exotic extensions let you create contexts without a backbuffer.
+  // In these cases the backbuffer is zero size - just create a small one.
+  int safe_width = (backbuffer.width > 0) ? backbuffer.width : 8;
+  int safe_height = (backbuffer.height > 0) ? backbuffer.height : 8;
 
-    const unsigned int MAX_FORMATS = 32;
+  const unsigned int MAX_FORMATS = 32;
 
-    int formats[MAX_FORMATS];
-    unsigned int num_formats;
-    const int fmt_attribs[] = {
-        WGL_DRAW_TO_PBUFFER_ARB, 1,
-        WGL_SUPPORT_OPENGL_ARB, 1,
-        WGL_DEPTH_BITS_ARB, d,
-        WGL_STENCIL_BITS_ARB, s,
-        WGL_RED_BITS_ARB, r,
-        WGL_GREEN_BITS_ARB, g,
-        WGL_BLUE_BITS_ARB, b,
-        WGL_ALPHA_BITS_ARB, a,
-        0, // terminator
-    };
+  int formats[MAX_FORMATS];
+  unsigned int num_formats;
+  const int fmt_attribs[] = {
+      // clang-format off
+      WGL_DRAW_TO_PBUFFER_ARB, 1,
+      WGL_SUPPORT_OPENGL_ARB, 1,
+      WGL_DEPTH_BITS_ARB, d,
+      WGL_STENCIL_BITS_ARB, s,
+      WGL_RED_BITS_ARB, r,
+      WGL_GREEN_BITS_ARB, g,
+      WGL_BLUE_BITS_ARB, b,
+      WGL_ALPHA_BITS_ARB, a,
+      0, // terminator
+      // clang-format on
+  };
 
-    auto wgl = WGL::get();
+  auto wgl = WGL::get();
 
-    if (!wgl.ChoosePixelFormatARB(wgl.mHDC, fmt_attribs, nullptr, MAX_FORMATS, formats, &num_formats)) {
-        GAPID_FATAL("wglChoosePixelFormatARB failed. Error: 0x%x", GetLastError());
-    }
-    if (num_formats == 0) {
-        GAPID_FATAL("wglChoosePixelFormatARB returned no compatibile formats");
-    }
-    auto format = formats[0]; // TODO: Examine returned formats?
-    const int create_attribs[] = { 0 };
-    mPBuf = wgl.CreatePbufferARB(wgl.mHDC, format, safe_width, safe_height, create_attribs);
-    if (mPBuf == nullptr) {
-        GAPID_FATAL("wglCreatePbufferARB(%p, %d, %d, %d, %p) failed. Error: 0x%x",
-            wgl.mHDC, format, safe_width, safe_height, create_attribs, GetLastError());
-    }
+  if (!wgl.ChoosePixelFormatARB(wgl.mHDC, fmt_attribs, nullptr, MAX_FORMATS,
+                                formats, &num_formats)) {
+    GAPID_FATAL("wglChoosePixelFormatARB failed. Error: 0x%x", GetLastError());
+  }
+  if (num_formats == 0) {
+    GAPID_FATAL("wglChoosePixelFormatARB returned no compatibile formats");
+  }
+  auto format = formats[0];  // TODO: Examine returned formats?
+  const int create_attribs[] = {0};
+  mPBuf = wgl.CreatePbufferARB(wgl.mHDC, format, safe_width, safe_height,
+                               create_attribs);
+  if (mPBuf == nullptr) {
+    GAPID_FATAL("wglCreatePbufferARB(%p, %d, %d, %d, %p) failed. Error: 0x%x",
+                wgl.mHDC, format, safe_width, safe_height, create_attribs,
+                GetLastError());
+  }
 
-    mHDC = wgl.GetPbufferDCARB(mPBuf);
-    if (mHDC == nullptr) {
-        GAPID_FATAL("wglGetPbufferDCARB(%p) failed. Error: 0x%x", mPBuf, GetLastError());
-    }
+  mHDC = wgl.GetPbufferDCARB(mPBuf);
+  if (mHDC == nullptr) {
+    GAPID_FATAL("wglGetPbufferDCARB(%p) failed. Error: 0x%x", mPBuf,
+                GetLastError());
+  }
 }
 
 void WGL::PBuffer::release_buffer() {
-    auto wgl = WGL::get();
-    if (mHDC != nullptr) {
-        if (!wgl.ReleasePbufferDCARB(mPBuf, mHDC)) {
-            GAPID_ERROR("Failed to release HDC. Error: 0x%x", GetLastError());
-        }
-        mHDC = nullptr;
+  auto wgl = WGL::get();
+  if (mHDC != nullptr) {
+    if (!wgl.ReleasePbufferDCARB(mPBuf, mHDC)) {
+      GAPID_ERROR("Failed to release HDC. Error: 0x%x", GetLastError());
     }
-    if (mPBuf != nullptr) {
-        if (!wgl.DestroyPbufferARB(mPBuf)) {
-            GAPID_ERROR("Failed to destroy pbuffer. Error: 0x%x", GetLastError());
-        }
-        mPBuf = nullptr;
+    mHDC = nullptr;
+  }
+  if (mPBuf != nullptr) {
+    if (!wgl.DestroyPbufferARB(mPBuf)) {
+      GAPID_ERROR("Failed to destroy pbuffer. Error: 0x%x", GetLastError());
     }
+    mPBuf = nullptr;
+  }
 }
 
 void WGL::PBuffer::bind() {
-    if (!wglMakeCurrent(mHDC, mCtx)) {
-        GAPID_FATAL("Failed to bind GL context. Error: 0x%x", GetLastError());
-    }
+  if (!wglMakeCurrent(mHDC, mCtx)) {
+    GAPID_FATAL("Failed to bind GL context. Error: 0x%x", GetLastError());
+  }
 }
 
 void WGL::PBuffer::unbind() {
-    if (!wglMakeCurrent(mHDC, nullptr)) {
-        GAPID_FATAL("Failed to unbind GL context. Error: 0x%x", GetLastError());
-    }
+  if (!wglMakeCurrent(mHDC, nullptr)) {
+    GAPID_FATAL("Failed to unbind GL context. Error: 0x%x", GetLastError());
+  }
 }
 
 void WGL::PBuffer::set_backbuffer(const GlesRenderer::Backbuffer& backbuffer) {
-    // Kill the pbuffer, and create a new one with the new backbuffer settings.
-    //
-    // Note - according to the MSDN documentation of wglMakeCurrent:
-    // "It need not be the same hdc that was passed to wglCreateContext when
-    // hglrc was created, but it must be on the same device and have the same
-    // pixel format."
-    //
-    // This means pixel format changes should error. If this happens, we're
-    // going to have to come up with a different approach.
-    create_buffer(backbuffer);
+  // Kill the pbuffer, and create a new one with the new backbuffer settings.
+  //
+  // Note - according to the MSDN documentation of wglMakeCurrent:
+  // "It need not be the same hdc that was passed to wglCreateContext when
+  // hglrc was created, but it must be on the same device and have the same
+  // pixel format."
+  //
+  // This means pixel format changes should error. If this happens, we're
+  // going to have to come up with a different approach.
+  create_buffer(backbuffer);
 }
 
-std::shared_ptr<WGL::PBuffer> WGL::PBuffer::create(const GlesRenderer::Backbuffer& backbuffer, PBuffer* shared_ctx) {
-    return std::shared_ptr<PBuffer>(new PBuffer(backbuffer, shared_ctx));
+std::shared_ptr<WGL::PBuffer> WGL::PBuffer::create(
+    const GlesRenderer::Backbuffer& backbuffer, PBuffer* shared_ctx) {
+  return std::shared_ptr<PBuffer>(new PBuffer(backbuffer, shared_ctx));
 }
 
 WGL::WGL() {
-    class registerWindowClass {
-    public:
-        registerWindowClass() {
-            WNDCLASS wc;
-            memset(&wc, 0, sizeof(wc));
+  class registerWindowClass {
+   public:
+    registerWindowClass() {
+      WNDCLASS wc;
+      memset(&wc, 0, sizeof(wc));
 
-            auto hInstance = GetModuleHandle(nullptr);
-            if (hInstance == nullptr) {
-                GAPID_FATAL("Failed to get module handle. Error: 0x%x", GetLastError());
-            }
+      auto hInstance = GetModuleHandle(nullptr);
+      if (hInstance == nullptr) {
+        GAPID_FATAL("Failed to get module handle. Error: 0x%x", GetLastError());
+      }
 
-            wc.style = 0;
-            wc.lpfnWndProc = DefWindowProc;
-            wc.hInstance = hInstance;
-            wc.hCursor = LoadCursor(0, IDC_ARROW); // TODO: Needed?
-            wc.hbrBackground = HBRUSH(COLOR_WINDOW + 1);
-            wc.lpszMenuName = TEXT("");
-            wc.lpszClassName = wndClassName;
+      wc.style = 0;
+      wc.lpfnWndProc = DefWindowProc;
+      wc.hInstance = hInstance;
+      wc.hCursor = LoadCursor(0, IDC_ARROW);  // TODO: Needed?
+      wc.hbrBackground = HBRUSH(COLOR_WINDOW + 1);
+      wc.lpszMenuName = TEXT("");
+      wc.lpszClassName = wndClassName;
 
-            if (RegisterClass(&wc) == 0) {
-                GAPID_FATAL("Failed to register window class. Error: 0x%x", GetLastError());
-            }
-        }
-    };
-
-    static registerWindowClass rwc;
-
-    mWindow = CreateWindow(wndClassName, TEXT(""), WS_POPUP, 0, 0, 8, 8, 0, 0, GetModuleHandle(0), 0);
-    if (mWindow == 0) {
-        GAPID_FATAL("Failed to create window. Error: 0x%x", GetLastError());
+      if (RegisterClass(&wc) == 0) {
+        GAPID_FATAL("Failed to register window class. Error: 0x%x",
+                    GetLastError());
+      }
     }
+  };
 
-    mHDC = GetDC(mWindow);
-    if (mHDC == nullptr) {
-        GAPID_FATAL("GetDC failed. Error: 0x%x", GetLastError());
-    }
+  static registerWindowClass rwc;
 
-    PIXELFORMATDESCRIPTOR pfd;
-    memset(&pfd, 0, sizeof(pfd));
-    pfd.nSize = sizeof(PIXELFORMATDESCRIPTOR);
-    pfd.nVersion = 1;
-    pfd.dwFlags = PFD_DRAW_TO_WINDOW | PFD_SUPPORT_OPENGL;
-    pfd.iPixelType = PFD_TYPE_RGBA;
-    pfd.cRedBits = 8;
-    pfd.cGreenBits = 8;
-    pfd.cBlueBits = 8;
-    pfd.cAlphaBits = 8;
-    pfd.cDepthBits = 24;
-    pfd.cStencilBits = 8;
-    pfd.cColorBits = 32;
-    pfd.iLayerType = PFD_MAIN_PLANE;
-    int pixel_fmt = ChoosePixelFormat(mHDC, &pfd);
-    SetPixelFormat(mHDC, pixel_fmt, &pfd);
+  mWindow = CreateWindow(wndClassName, TEXT(""), WS_POPUP, 0, 0, 8, 8, 0, 0,
+                         GetModuleHandle(0), 0);
+  if (mWindow == 0) {
+    GAPID_FATAL("Failed to create window. Error: 0x%x", GetLastError());
+  }
 
-    // Resolve extension functions.
-    CreateContextAttribsARB = nullptr;
-    auto temp_context = wglCreateContext(mHDC);
-    if (temp_context == nullptr) {
-        GAPID_FATAL("Couldn't create temporary WGL context. Error: 0x%x", GetLastError());
-    }
+  mHDC = GetDC(mWindow);
+  if (mHDC == nullptr) {
+    GAPID_FATAL("GetDC failed. Error: 0x%x", GetLastError());
+  }
 
-    wglMakeCurrent(mHDC, temp_context);
+  PIXELFORMATDESCRIPTOR pfd;
+  memset(&pfd, 0, sizeof(pfd));
+  pfd.nSize = sizeof(PIXELFORMATDESCRIPTOR);
+  pfd.nVersion = 1;
+  pfd.dwFlags = PFD_DRAW_TO_WINDOW | PFD_SUPPORT_OPENGL;
+  pfd.iPixelType = PFD_TYPE_RGBA;
+  pfd.cRedBits = 8;
+  pfd.cGreenBits = 8;
+  pfd.cBlueBits = 8;
+  pfd.cAlphaBits = 8;
+  pfd.cDepthBits = 24;
+  pfd.cStencilBits = 8;
+  pfd.cColorBits = 32;
+  pfd.iLayerType = PFD_MAIN_PLANE;
+  int pixel_fmt = ChoosePixelFormat(mHDC, &pfd);
+  SetPixelFormat(mHDC, pixel_fmt, &pfd);
 
-#define RESOLVE(name) \
-    name = reinterpret_cast< decltype(name) >(wglGetProcAddress("wgl"#name)); \
-    if (name == nullptr) { GAPID_FATAL("Couldn't resolve function 'wgl" #name "'"); }
+  // Resolve extension functions.
+  CreateContextAttribsARB = nullptr;
+  auto temp_context = wglCreateContext(mHDC);
+  if (temp_context == nullptr) {
+    GAPID_FATAL("Couldn't create temporary WGL context. Error: 0x%x",
+                GetLastError());
+  }
 
-    RESOLVE(CreateContextAttribsARB);
-    RESOLVE(ChoosePixelFormatARB);
-    RESOLVE(CreateContextAttribsARB);
-    RESOLVE(CreatePbufferARB);
-    RESOLVE(GetPbufferDCARB);
-    RESOLVE(ReleasePbufferDCARB);
-    RESOLVE(DestroyPbufferARB);
-    RESOLVE(QueryPbufferARB);
+  wglMakeCurrent(mHDC, temp_context);
+
+#define RESOLVE(name)                                                      \
+  name = reinterpret_cast<decltype(name)>(wglGetProcAddress("wgl" #name)); \
+  if (name == nullptr) {                                                   \
+    GAPID_FATAL("Couldn't resolve function 'wgl" #name "'");               \
+  }
+
+  RESOLVE(CreateContextAttribsARB);
+  RESOLVE(ChoosePixelFormatARB);
+  RESOLVE(CreateContextAttribsARB);
+  RESOLVE(CreatePbufferARB);
+  RESOLVE(GetPbufferDCARB);
+  RESOLVE(ReleasePbufferDCARB);
+  RESOLVE(DestroyPbufferARB);
+  RESOLVE(QueryPbufferARB);
 
 #undef RESOLVE
 
-    wglMakeCurrent(mHDC, nullptr);
-    wglDeleteContext(temp_context);
+  wglMakeCurrent(mHDC, nullptr);
+  wglDeleteContext(temp_context);
 }
 
 const WGL& WGL::get() {
-    // This is thread-local as anything touching a HDC is pretty much
-    // non-thread safe.
-    static thread_local WGL instance;
-    return instance;
+  // This is thread-local as anything touching a HDC is pretty much
+  // non-thread safe.
+  static thread_local WGL instance;
+  return instance;
 }
 
 class GlesRendererImpl : public GlesRenderer {
-public:
-    GlesRendererImpl(GlesRendererImpl* shared_context);
-    virtual ~GlesRendererImpl() override;
+ public:
+  GlesRendererImpl(GlesRendererImpl* shared_context);
+  virtual ~GlesRendererImpl() override;
 
-    virtual Api* api() override;
-    virtual void setBackbuffer(Backbuffer backbuffer) override;
-    virtual void bind() override;
-    virtual void unbind() override;
-    virtual const char* name() override;
-    virtual const char* extensions() override;
-    virtual const char* vendor() override;
-    virtual const char* version() override;
+  virtual Api* api() override;
+  virtual void setBackbuffer(Backbuffer backbuffer) override;
+  virtual void bind() override;
+  virtual void unbind() override;
+  virtual const char* name() override;
+  virtual const char* extensions() override;
+  virtual const char* vendor() override;
+  virtual const char* version() override;
 
-private:
-    void reset();
+ private:
+  void reset();
 
-    Gles mApi;
-    Backbuffer mBackbuffer;
+  Gles mApi;
+  Backbuffer mBackbuffer;
 
-    bool mNeedsResolve;
-    bool mQueriedExtensions;
-    std::string mExtensions;
-    std::shared_ptr<WGL::PBuffer> mContext;
-    std::shared_ptr<WGL::PBuffer> mSharedContext;
+  bool mNeedsResolve;
+  bool mQueriedExtensions;
+  std::string mExtensions;
+  std::shared_ptr<WGL::PBuffer> mContext;
+  std::shared_ptr<WGL::PBuffer> mSharedContext;
 
-    static thread_local GlesRendererImpl* tlsBound;
+  static thread_local GlesRendererImpl* tlsBound;
 };
 
 thread_local GlesRendererImpl* GlesRendererImpl::tlsBound = nullptr;
 
 GlesRendererImpl::GlesRendererImpl(GlesRendererImpl* shared_context)
-        : mNeedsResolve(true)
-        , mQueriedExtensions(false)
-        , mSharedContext(shared_context != nullptr ? shared_context->mContext : nullptr) {
-}
+    : mNeedsResolve(true),
+      mQueriedExtensions(false),
+      mSharedContext(shared_context != nullptr ? shared_context->mContext
+                                               : nullptr) {}
 
-GlesRendererImpl::~GlesRendererImpl() {
-    reset();
-}
+GlesRendererImpl::~GlesRendererImpl() { reset(); }
 
-Api* GlesRendererImpl::api() {
-  return &mApi;
-}
+Api* GlesRendererImpl::api() { return &mApi; }
 
 void GlesRendererImpl::reset() {
-    unbind();
-    mContext = nullptr;
-    mBackbuffer = Backbuffer();
+  unbind();
+  mContext = nullptr;
+  mBackbuffer = Backbuffer();
 }
 
-static void DebugCallback(uint32_t source, uint32_t type, Gles::GLuint id, uint32_t severity,
-                           Gles::GLsizei length, const Gles::GLchar* message, const void* user_param) {
-    auto renderer = reinterpret_cast<const GlesRendererImpl*>(user_param);
-    auto listener = renderer->getListener();
-    if (listener != nullptr) {
-        if (type == Gles::GLenum::GL_DEBUG_TYPE_ERROR || severity == Gles::GLenum::GL_DEBUG_SEVERITY_HIGH) {
-            listener->onDebugMessage(LOG_LEVEL_ERROR, Gles::INDEX, message);
-        } else {
-            listener->onDebugMessage(LOG_LEVEL_DEBUG, Gles::INDEX, message);
-        }
+static void DebugCallback(uint32_t source, uint32_t type, Gles::GLuint id,
+                          uint32_t severity, Gles::GLsizei length,
+                          const Gles::GLchar* message, const void* user_param) {
+  auto renderer = reinterpret_cast<const GlesRendererImpl*>(user_param);
+  auto listener = renderer->getListener();
+  if (listener != nullptr) {
+    if (type == Gles::GLenum::GL_DEBUG_TYPE_ERROR ||
+        severity == Gles::GLenum::GL_DEBUG_SEVERITY_HIGH) {
+      listener->onDebugMessage(LOG_LEVEL_ERROR, Gles::INDEX, message);
+    } else {
+      listener->onDebugMessage(LOG_LEVEL_DEBUG, Gles::INDEX, message);
     }
+  }
 }
 
 void GlesRendererImpl::setBackbuffer(Backbuffer backbuffer) {
-    auto wasBound = tlsBound == this;
-    GAPID_ASSERT(wasBound /* The renderer has to be bound when changing the backbuffer */);
+  auto wasBound = tlsBound == this;
+  GAPID_ASSERT(
+      wasBound /* The renderer has to be bound when changing the backbuffer */);
 
-    if (mBackbuffer == backbuffer) {
-        return; // No change
+  if (mBackbuffer == backbuffer) {
+    return;  // No change
+  }
+
+  if (mContext == nullptr) {
+    mContext = WGL::PBuffer::create(backbuffer, mSharedContext.get());
+    mContext->bind();
+    mApi.resolve();
+    mNeedsResolve = false;
+    if (mApi.mFunctionStubs.glDebugMessageCallback != nullptr) {
+      mApi.mFunctionStubs.glDebugMessageCallback(
+          reinterpret_cast<void*>(&DebugCallback), this);
+      mApi.mFunctionStubs.glEnable(Gles::GLenum::GL_DEBUG_OUTPUT);
+      mApi.mFunctionStubs.glEnable(Gles::GLenum::GL_DEBUG_OUTPUT_SYNCHRONOUS);
+      GAPID_DEBUG("Enabled KHR_debug extension");
     }
+  } else {
+    unbind();
+    mContext->set_backbuffer(backbuffer);
+    mNeedsResolve = true;
+    bind();
+  }
 
-    if (mContext == nullptr) {
-        mContext = WGL::PBuffer::create(backbuffer, mSharedContext.get());
-        mContext->bind();
-        mApi.resolve();
-        mNeedsResolve = false;
-        if (mApi.mFunctionStubs.glDebugMessageCallback != nullptr) {
-            mApi.mFunctionStubs.glDebugMessageCallback(reinterpret_cast<void*>(&DebugCallback), this);
-            mApi.mFunctionStubs.glEnable(Gles::GLenum::GL_DEBUG_OUTPUT);
-            mApi.mFunctionStubs.glEnable(Gles::GLenum::GL_DEBUG_OUTPUT_SYNCHRONOUS);
-            GAPID_DEBUG("Enabled KHR_debug extension");
-        }
-    } else {
-        unbind();
-        mContext->set_backbuffer(backbuffer);
-        mNeedsResolve = true;
-        bind();
-    }
-
-    mBackbuffer = backbuffer;
+  mBackbuffer = backbuffer;
 }
 
 void GlesRendererImpl::bind() {
-    auto bound = tlsBound;
-    if (bound == this) {
-        return;
-    }
+  auto bound = tlsBound;
+  if (bound == this) {
+    return;
+  }
 
-    if (bound != nullptr) {
-        bound->unbind();
-    }
+  if (bound != nullptr) {
+    bound->unbind();
+  }
 
-    tlsBound = this;
+  tlsBound = this;
 
-    if (mContext == nullptr) {
-        return;
-    }
+  if (mContext == nullptr) {
+    return;
+  }
 
-    mContext->bind();
+  mContext->bind();
 
-    if (mNeedsResolve) {
-        mNeedsResolve = false;
-        mApi.resolve();
-    }
+  if (mNeedsResolve) {
+    mNeedsResolve = false;
+    mApi.resolve();
+  }
 }
 
 void GlesRendererImpl::unbind() {
-    if (tlsBound == this) {
-        if (mContext != nullptr) {
-            mContext->unbind();
-        }
-        tlsBound = nullptr;
+  if (tlsBound == this) {
+    if (mContext != nullptr) {
+      mContext->unbind();
     }
+    tlsBound = nullptr;
+  }
 }
 
 const char* GlesRendererImpl::name() {
-    return reinterpret_cast<const char*>(
-        mApi.mFunctionStubs.glGetString(Gles::GLenum::GL_RENDERER));
+  return reinterpret_cast<const char*>(
+      mApi.mFunctionStubs.glGetString(Gles::GLenum::GL_RENDERER));
 }
 
 const char* GlesRendererImpl::extensions() {
-    if (!mQueriedExtensions) {
-        mQueriedExtensions = true;
-        int32_t n, i;
-        mApi.mFunctionStubs.glGetIntegerv(Gles::GLenum::GL_NUM_EXTENSIONS, &n);
-        bool first = true;
-        for (i = 0; i < n; i++) {
-            const char* extension = reinterpret_cast<const char*>(
-                mApi.mFunctionStubs.glGetStringi(Gles::GLenum::GL_EXTENSIONS, i));
-            if (extension == nullptr) {
-                GAPID_WARNING("glGetStringi(GL_EXTENSIONS, %d) return nullptr", i);
-                continue;
-            }
-            if (!first) {
-              mExtensions += " ";
-            }
-            mExtensions += extension;
-            first = false;
-        }
+  if (!mQueriedExtensions) {
+    mQueriedExtensions = true;
+    int32_t n, i;
+    mApi.mFunctionStubs.glGetIntegerv(Gles::GLenum::GL_NUM_EXTENSIONS, &n);
+    bool first = true;
+    for (i = 0; i < n; i++) {
+      const char* extension = reinterpret_cast<const char*>(
+          mApi.mFunctionStubs.glGetStringi(Gles::GLenum::GL_EXTENSIONS, i));
+      if (extension == nullptr) {
+        GAPID_WARNING("glGetStringi(GL_EXTENSIONS, %d) return nullptr", i);
+        continue;
+      }
+      if (!first) {
+        mExtensions += " ";
+      }
+      mExtensions += extension;
+      first = false;
     }
-    return (mExtensions.size() > 0) ? &mExtensions[0] : nullptr;
+  }
+  return (mExtensions.size() > 0) ? &mExtensions[0] : nullptr;
 }
 
 const char* GlesRendererImpl::vendor() {
-    return reinterpret_cast<const char*>(
-        mApi.mFunctionStubs.glGetString(Gles::GLenum::GL_VENDOR));
+  return reinterpret_cast<const char*>(
+      mApi.mFunctionStubs.glGetString(Gles::GLenum::GL_VENDOR));
 }
 
 const char* GlesRendererImpl::version() {
-    return reinterpret_cast<const char*>(
-        mApi.mFunctionStubs.glGetString(Gles::GLenum::GL_VERSION));
+  return reinterpret_cast<const char*>(
+      mApi.mFunctionStubs.glGetString(Gles::GLenum::GL_VERSION));
 }
 
-} // anonymous namespace
+}  // anonymous namespace
 
 GlesRenderer* GlesRenderer::create(GlesRenderer* shared_context) {
-    return new GlesRendererImpl(reinterpret_cast<GlesRendererImpl*>(shared_context));
+  return new GlesRendererImpl(
+      reinterpret_cast<GlesRendererImpl*>(shared_context));
 }
 
 }  // namespace gapir

--- a/gapir/cc/windows/vulkan_renderer.cpp
+++ b/gapir/cc/windows/vulkan_renderer.cpp
@@ -14,43 +14,37 @@
  * limitations under the License.
  */
 
-#include "gapir/cc/vulkan_gfx_api.h"
 #include "gapir/cc/vulkan_renderer.h"
+#include "gapir/cc/vulkan_gfx_api.h"
 
 namespace gapir {
 namespace {
 
 class VulkanRendererImpl : public VulkanRenderer {
-public:
-    VulkanRendererImpl();
-    virtual ~VulkanRendererImpl() override;
+ public:
+  VulkanRendererImpl();
+  virtual ~VulkanRendererImpl() override;
 
-    virtual Api* api() override;
+  virtual Api* api() override;
 
-    virtual bool isValid() override;
-private:
-    Vulkan mApi;
+  virtual bool isValid() override;
+
+ private:
+  Vulkan mApi;
 };
 
-VulkanRendererImpl::VulkanRendererImpl() {
-    mApi.resolve();
-}
+VulkanRendererImpl::VulkanRendererImpl() { mApi.resolve(); }
 
-VulkanRendererImpl::~VulkanRendererImpl() {
-}
+VulkanRendererImpl::~VulkanRendererImpl() {}
 
-Api* VulkanRendererImpl::api() {
-  return &mApi;
-}
+Api* VulkanRendererImpl::api() { return &mApi; }
 
 bool VulkanRendererImpl::isValid() {
- return mApi.mFunctionStubs.vkCreateInstance != nullptr;
+  return mApi.mFunctionStubs.vkCreateInstance != nullptr;
 }
 
-} // anonymous namespace
+}  // anonymous namespace
 
-VulkanRenderer* VulkanRenderer::create() {
-    return new VulkanRendererImpl();
-}
+VulkanRenderer* VulkanRenderer::create() { return new VulkanRendererImpl(); }
 
 }  // namespace gapir

--- a/gapis/shadertools/cc/common.cpp
+++ b/gapis/shadertools/cc/common.cpp
@@ -72,6 +72,8 @@ std::string extractString(const std::vector<uint32_t>& words) {
       ret += c;
     }
   }
-  assert(false && "extractString: expected the vector to represent a null-terminated string");
+  assert(false &&
+         "extractString: expected the vector to represent a null-terminated "
+         "string");
   return ret;
 }

--- a/gapis/shadertools/cc/disassemble_test.cpp
+++ b/gapis/shadertools/cc/disassemble_test.cpp
@@ -21,7 +21,6 @@
 #include <vector>
 
 int main(int argc, char* argv[]) {
-
   const char* filename = argv[1];
 
   std::vector<uint32_t> spirv_binary;
@@ -48,10 +47,11 @@ int main(int argc, char* argv[]) {
     return 1;
   }
 
-  const char* dis_text = getDisassembleText(spirv_binary.data(), spirv_binary.size());
+  const char* dis_text =
+      getDisassembleText(spirv_binary.data(), spirv_binary.size());
 
   if (dis_text) {
-  	printf("%s\n", dis_text);
+    printf("%s\n", dis_text);
   } else {
     printf("Disassemble error.\n");
     return 2;

--- a/gapis/shadertools/cc/libmanager.h
+++ b/gapis/shadertools/cc/libmanager.h
@@ -76,7 +76,7 @@ typedef struct convert_options_t {
   bool disassemble;
   bool relaxed;
   bool strip_optimizations;
-  int  target_glsl_version;
+  int target_glsl_version;
 } convert_options_t;
 
 typedef struct compile_options_t {
@@ -86,8 +86,8 @@ typedef struct compile_options_t {
 } compile_options_t;
 
 typedef struct spirv_binary_t {
-    uint32_t* words;
-    size_t words_num;
+  uint32_t* words;
+  size_t words_num;
 } spirv_binary_t;
 
 typedef struct glsl_compile_result_t {
@@ -96,7 +96,8 @@ typedef struct glsl_compile_result_t {
   spirv_binary_t binary;
 } glsl_compile_result_t;
 
-code_with_debug_info_t* convertGlsl(const char*, size_t, const convert_options_t*);
+code_with_debug_info_t* convertGlsl(const char*, size_t,
+                                    const convert_options_t*);
 
 void deleteGlslCodeWithDebug(code_with_debug_info_t*);
 

--- a/gapis/shadertools/cc/name_manager.cpp
+++ b/gapis/shadertools/cc/name_manager.cpp
@@ -26,7 +26,9 @@ namespace namemanager {
 /**
  * Returns string of the variable with a given id and without offset
  **/
-std::string NameManager::getStrName(uint32_t id) { return getStrName(id_offset(id, NONMEMBER_OFFSET)); }
+std::string NameManager::getStrName(uint32_t id) {
+  return getStrName(id_offset(id, NONMEMBER_OFFSET));
+}
 
 /**
  * Returns string of the variable with a given id and offset
@@ -35,9 +37,11 @@ std::string NameManager::getStrName(id_offset id) {
   name_map::iterator it = id_to_inst.find(id);
   std::string res;
 
-  assert(it != id_to_inst.end() && "getStrName: not recognized instruction id with given offset.");
+  assert(it != id_to_inst.end() &&
+         "getStrName: not recognized instruction id with given offset.");
   if (it != id_to_inst.end())
-    res = extractString(it->second->GetOperand(getStringPosition(it->second->opcode())).words);
+    res = extractString(
+        it->second->GetOperand(getStringPosition(it->second->opcode())).words);
   return res;
 }
 
@@ -46,7 +50,8 @@ void NameManager::addName(Instruction* inst) {
       (inst->opcode() == SpvOpMemberName && inst->NumOperands() >= 3)) {
     uint32_t id = inst->GetSingleWordOperand(0);
     uint32_t offset = getNameOffset(inst);
-    id_to_inst.insert(std::pair<id_offset, Instruction*>(id_offset(id, offset), inst));
+    id_to_inst.insert(
+        std::pair<id_offset, Instruction*>(id_offset(id, offset), inst));
     names_ids.insert(id);
   }
 }
@@ -108,4 +113,4 @@ uint32_t NameManager::getNameOffset(Instruction* inst) {
   }
   return res;
 }
-}
+}  // namespace namemanager

--- a/gapis/shadertools/cc/name_manager.h
+++ b/gapis/shadertools/cc/name_manager.h
@@ -18,16 +18,16 @@
 #define NAME_MANAGER_H_
 
 #include "third_party/SPIRV-Tools/include/spirv-tools/libspirv.h"
+#include "third_party/SPIRV-Tools/include/spirv-tools/libspirv.hpp"
+#include "third_party/SPIRV-Tools/source/opt/instruction.h"
 #include "third_party/SPIRV-Tools/source/opt/iterator.h"
 #include "third_party/SPIRV-Tools/source/opt/module.h"
-#include "third_party/SPIRV-Tools/source/opt/instruction.h"
-#include "third_party/SPIRV-Tools/include/spirv-tools/libspirv.hpp"
 
 #include <map>
 #include <unordered_set>
 
-using spvtools::ir::Module;
 using spvtools::ir::Instruction;
+using spvtools::ir::Module;
 
 namespace namemanager {
 

--- a/gapis/shadertools/cc/spirv2glsl.cpp
+++ b/gapis/shadertools/cc/spirv2glsl.cpp
@@ -21,7 +21,8 @@
 // so it is important we never include both at the same time.
 #include "third_party/SPIRV-Cross/spirv_glsl.hpp"
 
-std::string spirv2glsl(std::vector<uint32_t> spirv, int glsl_version, bool strip_optimizations) {
+std::string spirv2glsl(std::vector<uint32_t> spirv, int glsl_version,
+                       bool strip_optimizations) {
   spirv_cross::CompilerGLSL glsl(std::move(spirv));
   spirv_cross::CompilerGLSL::Options cross_options;
   cross_options.version = glsl_version == 0 ? 330 : glsl_version;

--- a/gapis/shadertools/cc/spirv2glsl.h
+++ b/gapis/shadertools/cc/spirv2glsl.h
@@ -17,4 +17,5 @@
 #include <string>
 #include <vector>
 
-std::string spirv2glsl(std::vector<uint32_t> spirv, int glsl_version, bool strip_optimizations);
+std::string spirv2glsl(std::vector<uint32_t> spirv, int glsl_version,
+                       bool strip_optimizations);

--- a/gapis/shadertools/cc/spv_manager.h
+++ b/gapis/shadertools/cc/spv_manager.h
@@ -19,42 +19,42 @@
 
 #include "third_party/SPIRV-Headers/include/spirv/unified1/spirv.hpp"
 #include "third_party/SPIRV-Tools/include/spirv-tools/libspirv.h"
+#include "third_party/SPIRV-Tools/include/spirv-tools/libspirv.hpp"
 #include "third_party/SPIRV-Tools/source/assembly_grammar.h"
 #include "third_party/SPIRV-Tools/source/opcode.h"
 #include "third_party/SPIRV-Tools/source/operand.h"
-#include "third_party/SPIRV-Tools/source/opt/def_use_manager.h"
-#include "third_party/SPIRV-Tools/include/spirv-tools/libspirv.hpp"
 #include "third_party/SPIRV-Tools/source/opt/build_module.h"
+#include "third_party/SPIRV-Tools/source/opt/def_use_manager.h"
 #include "third_party/SPIRV-Tools/source/opt/ir_context.h"
 #include "third_party/SPIRV-Tools/source/opt/make_unique.h"
 #include "third_party/SPIRV-Tools/source/opt/reflect.h"
 #include "third_party/SPIRV-Tools/source/opt/type_manager.h"
 #include "third_party/SPIRV-Tools/source/opt/types.h"
 
-#include "name_manager.h"
 #include "common.h"
+#include "name_manager.h"
 
 #include "libmanager.h"
 
+#include <stdint.h>
 #include <cstring>
 #include <iostream>
 #include <map>
 #include <set>
-#include <stdint.h>
 #include <string>
 #include <utility>  // std::pair, std::make_pair
 #include <vector>
 
 namespace spvmanager {
 
-using spvtools::ir::IRContext;
-using spvtools::ir::Module;
-using spvtools::ir::Instruction;
 using spvtools::ir::BasicBlock;
 using spvtools::ir::Function;
-using spvtools::opt::analysis::TypeManager;
-using spvtools::opt::analysis::Type;
+using spvtools::ir::IRContext;
+using spvtools::ir::Instruction;
+using spvtools::ir::Module;
 using spvtools::opt::analysis::DefUseManager;
+using spvtools::opt::analysis::Type;
+using spvtools::opt::analysis::TypeManager;
 
 #define MANAGER_SPV_ENV SPV_ENV_UNIVERSAL_1_1  // from spirv-tools
 
@@ -73,14 +73,17 @@ class SpvManager {
     globals.void_id = 0;
     globals.label_print_id = 0;
 
-    auto print_msg_to_stderr = [](spv_message_level_t, const char*, const spv_position_t&, const char* m) {
+    auto print_msg_to_stderr = [](spv_message_level_t, const char*,
+                                  const spv_position_t&, const char* m) {
       std::cerr << "error: " << m << std::endl;
     };
 
-    std::unique_ptr<spv_context_t> spvContext(spvContextCreate(MANAGER_SPV_ENV));
+    std::unique_ptr<spv_context_t> spvContext(
+        spvContextCreate(MANAGER_SPV_ENV));
     grammar.reset(new libspirv::AssemblyGrammar(spvContext.get()));
     // init module
-    context = spvtools::BuildModule(MANAGER_SPV_ENV, print_msg_to_stderr, spv_binary.data(), spv_binary.size());
+    context = spvtools::BuildModule(MANAGER_SPV_ENV, print_msg_to_stderr,
+                                    spv_binary.data(), spv_binary.size());
     type_mgr.reset(new TypeManager(print_msg_to_stderr, context.get()));
     def_use_mgr.reset(new DefUseManager(context->module()));
     name_mgr.reset(new namemanager::NameManager(context->module()));
@@ -127,25 +130,32 @@ class SpvManager {
   map_uint consts;
 
   std::vector<spvtools::ir::Operand> makeOperands(
-      spv_opcode_desc&, std::initializer_list<std::initializer_list<uint32_t>>&, const char* = nullptr);
-  std::unique_ptr<Instruction> makeInstruction(SpvOp_, uint32_t, uint32_t,
-                                               std::initializer_list<std::initializer_list<uint32_t>>,
-                                               const char* = nullptr);
-  std::unique_ptr<BasicBlock> makeBasicBlock(uint32_t, Function*,
-                                             std::vector<std::unique_ptr<Instruction>>&&);
+      spv_opcode_desc&, std::initializer_list<std::initializer_list<uint32_t>>&,
+      const char* = nullptr);
+  std::unique_ptr<Instruction> makeInstruction(
+      SpvOp_, uint32_t, uint32_t,
+      std::initializer_list<std::initializer_list<uint32_t>>,
+      const char* = nullptr);
+  std::unique_ptr<BasicBlock> makeBasicBlock(
+      uint32_t, Function*, std::vector<std::unique_ptr<Instruction>>&&);
 
   uint32_t addName(const char*);
   uint32_t addConstant(uint32_t, std::initializer_list<uint32_t>);
-  uint32_t addTypeInst(SpvOp_, std::initializer_list<std::initializer_list<uint32_t>>, uint32_t = 0);
+  uint32_t addTypeInst(SpvOp_,
+                       std::initializer_list<std::initializer_list<uint32_t>>,
+                       uint32_t = 0);
   void addVariable(uint32_t, uint32_t, spv::StorageClass);
   void addGlobalVariable(spv::StorageClass, Variable*);
   uint32_t addFunction(const char*, uint32_t, uint32_t);
 
-  uint32_t collectInstWithResult(SpvOp_, std::initializer_list<std::initializer_list<uint32_t>> = {{}},
-                                 uint32_t = 0);
-  void collectInstWithoutResult(SpvOp_, std::initializer_list<std::initializer_list<uint32_t>> = {{}},
-                                uint32_t = 0);
-  uint32_t collectCompositeConstruct(std::initializer_list<std::initializer_list<uint32_t>>, uint32_t);
+  uint32_t collectInstWithResult(
+      SpvOp_, std::initializer_list<std::initializer_list<uint32_t>> = {{}},
+      uint32_t = 0);
+  void collectInstWithoutResult(
+      SpvOp_, std::initializer_list<std::initializer_list<uint32_t>> = {{}},
+      uint32_t = 0);
+  uint32_t collectCompositeConstruct(
+      std::initializer_list<std::initializer_list<uint32_t>>, uint32_t);
   void collectCondition(uint32_t, uint32_t);
   uint32_t collectTypeConversion(name_type, uint32_t);
   void collectPrintCall(name_type, uint32_t = 0);

--- a/tools/build/mingw_toolchain/file_collector.h
+++ b/tools/build/mingw_toolchain/file_collector.h
@@ -24,8 +24,9 @@ class FileCollector {
 
   // Type of params files expected.
   enum ParamsType {
-    GCC, // params files only contain inputs and support \\?\ paths.
-    AR,  // first file parameter is output and params file does not support \\?\ paths.
+    GCC,  // params files only contain inputs and support \\?\ paths.
+    AR,  // first file parameter is output and params file does not support \\?\
+         // paths.
   };
 
   // Processes the @ param file specified by path and returns the path
@@ -50,7 +51,8 @@ class FileCollector {
   // Handles a line/path read from a @ params file. p should contain the
   // index of the last '/' in path. If isOutput is true, the path is
   // processed as an output of the wrapped binary, otherwhise as an input.
-  std::string HandleParam(const std::string& path, std::string::size_type p, bool isOutput);
+  std::string HandleParam(const std::string& path, std::string::size_type p,
+                          bool isOutput);
 
   struct Output {
     std::string final_;
@@ -86,6 +88,6 @@ class ArgumentCollector {
   // only if the return code is 0.
   int Execute(const std::string exe, FileCollector* fc);
 
-private:
+ private:
   std::vector<std::string> arguments_;
 };

--- a/tools/build/third_party/SPIRV-Tools-Generated/DebugInfo.h
+++ b/tools/build/third_party/SPIRV-Tools-Generated/DebugInfo.h
@@ -1,19 +1,19 @@
 // Copyright (c) 2017 The Khronos Group Inc.
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and/or associated documentation files (the "Materials"),
 // to deal in the Materials without restriction, including without limitation
 // the rights to use, copy, modify, merge, publish, distribute, sublicense,
 // and/or sell copies of the Materials, and to permit persons to whom the
 // Materials are furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Materials.
-// 
+//
 // MODIFICATIONS TO THIS FILE MAY MEAN IT NO LONGER ACCURATELY REFLECTS KHRONOS
 // STANDARDS. THE UNMODIFIED, NORMATIVE VERSIONS OF KHRONOS SPECIFICATIONS AND
-// HEADER INFORMATION ARE LOCATED AT https://www.khronos.org/registry/ 
-// 
+// HEADER INFORMATION ARE LOCATED AT https://www.khronos.org/registry/
+//
 // THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
 // OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
@@ -21,6 +21,8 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 // FROM,OUT OF OR IN CONNECTION WITH THE MATERIALS OR THE USE OR OTHER DEALINGS
 // IN THE MATERIALS.
+
+// clang-format off
 
 #ifndef SPIRV_EXTINST_DebugInfo_H_
 #define SPIRV_EXTINST_DebugInfo_H_

--- a/tools/build/third_party/cityhash-byteswap.h
+++ b/tools/build/third_party/cityhash-byteswap.h
@@ -1,3 +1,4 @@
+// clang-format off
 #define bswap_16(x) (((x&0xff00)>>8) \
                   | ((x&0x00ff)))
 
@@ -14,3 +15,4 @@
                   | ((x&0x0000000000ff0000)>>16) \
                   | ((x&0x000000000000ff00)>>8) \
                   | ((x&0x00000000000000ff)))
+// clang-format on

--- a/tools/build/third_party/llvm/include/llvm/Config/abi-breaking.h
+++ b/tools/build/third_party/llvm/include/llvm/Config/abi-breaking.h
@@ -1,4 +1,5 @@
-/*===------- llvm/Config/abi-breaking.h - llvm configuration -------*- C -*-===*/
+/*===------- llvm/Config/abi-breaking.h - llvm configuration -------*- C
+ * -*-===*/
 /*                                                                            */
 /*                     The LLVM Compiler Infrastructure                       */
 /*                                                                            */
@@ -6,6 +7,8 @@
 /* License. See LICENSE.TXT for details.                                      */
 /*                                                                            */
 /*===----------------------------------------------------------------------===*/
+
+// clang-format off
 
 /* This file controls the C++ ABI break introduced in LLVM public header. */
 


### PR DESCRIPTION
`find -iname "*.h" -o -iname "*.cpp" -o -iname "*.mm" | xargs clang-format -i -style=Google`

I've done a spinkling of `clang-format off` statements around things it really messed up.