### PR TITLE
Vulkan: Fix missing fetches of physical device properties

### DIFF
--- a/gapis/api/vulkan/replay.go
+++ b/gapis/api/vulkan/replay.go
@@ -277,6 +277,9 @@ func (t *makeAttachementReadable) Transform(ctx context.Context, id api.CmdID, c
 			propList = append(propList, allProps.PhyDevToProperties().Get(dev).Clone(s.Arena, api.CloneContext{}))
 		}
 		newEnumerate := buildReplayEnumeratePhysicalDevices(ctx, s, cb, e.Instance(), numDev, devs, propList)
+		for _, e := range cmd.Extras().All() {
+			newEnumerate.Extras().Add(e)
+		}
 		out.MutateAndWrite(ctx, id, newEnumerate)
 		return
 	}

--- a/gapis/api/vulkan/synthetic.api
+++ b/gapis/api/vulkan/synthetic.api
@@ -133,6 +133,8 @@ cmd VkResult replayEnumeratePhysicalDevices(
     device := ?
     devices[i] = device
   }
+  props := fetchPhysicalDeviceProperties(instance, devices)
+  memProps := fetchPhysicalDeviceMemoryProperties(instance, devices)
   for i in (0 .. count) {
     object := switch (PhysicalDevices[devices[i]] == null) {
       case true:
@@ -143,6 +145,12 @@ cmd VkResult replayEnumeratePhysicalDevices(
     object.Instance = instance
     object.Index = i
     object.VulkanHandle = devices[i]
+    if memProps != null {
+      object.MemoryProperties = memProps.PhyDevToMemoryProperties[devices[i]]
+    }
+    if props != null {
+      object.PhysicalDeviceProperties = props.PhyDevToProperties[devices[i]]
+    }
     PhysicalDevices[devices[i]] = object
   }
   return ?


### PR DESCRIPTION
When mutating for replay, the new physical device enumeration commands
does not fetch the properties, this results into failure when using the
physical device object later