### PR TITLE
Vulkan: Fix crash at VkDestroyDebugReportCallbackEXT

### DIFF
--- a/gapis/api/vulkan/replay.go
+++ b/gapis/api/vulkan/replay.go
@@ -431,7 +431,7 @@ func (t *destroyResourcesAtEOS) Flush(ctx context.Context, out transform.Writer)
 
 	// Debug report callbacks
 	for handle, object := range so.DebugReportCallbacks().All() {
-		out.MutateAndWrite(ctx, id, cb.ReplayDestroyVkDebugReportCallback(object.Instance(), handle))
+		out.MutateAndWrite(ctx, id, cb.VkDestroyDebugReportCallbackEXT(object.Instance(), handle, p))
 	}
 
 	// Instances.

--- a/gapis/api/vulkan/synthetic.api
+++ b/gapis/api/vulkan/synthetic.api
@@ -209,16 +209,10 @@ cmd bool ReplayCreateVkDebugReportCallback(
   VkDebugReportCallbackEXT* pCallback) {
   if !(instance in Instances) { vkErrorInvalidInstance(instance) }
   if pCreateInfo == null { vkErrorNullPointer("VkDebugReportCallbackCreateInfoEXT") }
-  info := pCreateInfo[0]
+  read(pCreateInfo[0:1])
   handle := ?
   if pCallback == null { vkErrorNullPointer("VkDebugReportCallbackEXT") }
   pCallback[0] = handle
-  object := new!DebugReportCallbackObject(
-    Instance:     instance,
-    Flags:        info.flags,
-    VulkanHandle: handle,
-  )
-  DebugReportCallbacks[handle] = object
   return ?
 }
 
@@ -227,7 +221,4 @@ cmd void ReplayDestroyVkDebugReportCallback(
   VkInstance instance,
   VkDebugReportCallbackEXT callback) {
   if !(instance in Instances) { vkErrorInvalidInstance(instance) }
-  if (callback != as!VkDebugReportCallbackEXT(0)) {
-    delete(DebugReportCallbacks, callback)
-  }
 }


### PR DESCRIPTION
If the application uses debug report callback, we should not use our
synthetic commands to process their callback handles.