### PR TITLE
Add footprint data for ReplayAllocateImageMemory

### DIFF
--- a/gapis/api/vulkan/footprint_builder.go
+++ b/gapis/api/vulkan/footprint_builder.go
@@ -1756,6 +1756,10 @@ func (vb *FootprintBuilder) BuildFootprint(ctx context.Context,
 		// representation of the cached data.
 		modify(ctx, bh, vkHandle(cmd.Image()))
 
+	case *ReplayAllocateImageMemory:
+		read(ctx, bh, vkHandle(cmd.Image()))
+		vkMem := cmd.PMemory().MustRead(ctx, cmd, s, nil)
+		write(ctx, bh, vkHandle(vkMem))
 	case *VkBindImageMemory:
 		read(ctx, bh, vkHandle(cmd.Image()))
 		read(ctx, bh, vkHandle(cmd.Memory()))


### PR DESCRIPTION
With #1984 it's possible for *ReplayAllocateImageMemory to occur in a capture.  Without an entry in the footprint_builder, it can be kept alive while the original vkCreateImage gets cut by dead code elimination, causing a crash on replay.  This fixes that.