### PR TITLE
Fix type assertion breaking secondary command buffers

### DIFF
--- a/gapis/api/vulkan/vulkan_terminator.go
+++ b/gapis/api/vulkan/vulkan_terminator.go
@@ -257,7 +257,7 @@ func rebuildCommandBuffer(ctx context.Context,
 			NewU32ːVkCommandBufferᵐ(a), // CommandBuffers
 		)
 		pcmd := commandBuffer.CommandReferences().Get(uint32(idx[0]))
-		execCmdData, ok := GetCommandArgs(ctx, pcmd, GetState(s)).(VkCmdExecuteCommandsArgs)
+		execCmdData, ok := GetCommandArgs(ctx, pcmd, GetState(s)).(VkCmdExecuteCommandsArgsʳ)
 		if !ok {
 			panic("Rebuild command buffer including secondary commands at a primary " +
 				"command other than VkCmdExecuteCommands")


### PR DESCRIPTION
rebuildCommandBuffer was always failing because it was asserting the wrong type and then failing.

Patch tested with [vulkan_test_applications/execute_commands](https://github.com/google/vulkan_test_applications/tree/master/application_sandbox/execute_commands) by forcing a replay with the cut in the middle of a secondary command buffer execution (crashes before, succeeds now).