### PR TITLE
Fix a bug in current DCE

### DIFF
--- a/gapis/api/vulkan/footprint_builder.go
+++ b/gapis/api/vulkan/footprint_builder.go
@@ -1603,6 +1603,9 @@ func (vb *FootprintBuilder) recordBarriers(ctx context.Context,
 			modify(ctx, cbh, d)
 			ft.AddBehavior(ctx, cbh)
 		}
+		cbh := sc.cmd.newBehavior(ctx, sc, vb.machine, execInfo)
+		read(ctx, cbh, attachedReads...)
+		ft.AddBehavior(ctx, cbh)
 	}
 }
 


### PR DESCRIPTION
For vkCmdWaitForEvent, the 'read' to the event handle and signals should
be carried out no matter whether there are memory barriers.

Fix #2010 