### PR TITLE
Fix gapidapk ABI/abi field name mismatch

### DIFF
--- a/gapidapk/android/app/src/main/java/com/google/android/gapid/PackageInfoService.java
+++ b/gapidapk/android/app/src/main/java/com/google/android/gapid/PackageInfoService.java
@@ -382,7 +382,7 @@ public class PackageInfoService extends IntentService {
         packageJson.put("debuggable", isDebuggable);
         packageJson.put("icon", iconIndex);
         if (primaryCpuAbi != null) {
-            packageJson.put("abi", primaryCpuAbi);
+            packageJson.put("ABI", primaryCpuAbi);
         }
         packageJson.put("activities", activitiesJson);
         return packageJson;


### PR DESCRIPTION
Fixes a bug from baeb540 where the proto field was updated but not one of the jsonpb users.