### PR TITLE
Use the system's DISPLAY env variable for tests.

### DIFF
--- a/tools/bazel.rc
+++ b/tools/bazel.rc
@@ -28,4 +28,4 @@ build:symbols --copt="-g" --strip=never
 build:nodroid --define NO_ANDROID=1
 
 # Tests requiring a GPU fail in the sandbox.
-test --strategy TestRunner=standalone
+test --strategy TestRunner=standalone --test_env DISPLAY


### PR DESCRIPTION
On linux the correct value for the `$DISPLAY` is required to open the X display to initialize the GL context. On systems, where the value is not `:0`, the tests currently fail.