### PR TITLE
Workaround #2027

### DIFF
--- a/gapidapk/android/app/src/main/java/com/google/android/gapid/PackageInfoService.java
+++ b/gapidapk/android/app/src/main/java/com/google/android/gapid/PackageInfoService.java
@@ -406,10 +406,14 @@ public class PackageInfoService extends IntentService {
                         public String filename(Pair<Resources, Integer> key) {
                             Resources resources = key.first;
                             int id = key.second;
-                            return resources.getResourcePackageName(id)
-                                    + "." + resources.getResourceTypeName(id)
-                                    + "." + resources.getResourceName(id)
-                                    + "." + iconDensity;
+                            try {
+                                return resources.getResourcePackageName(id)
+                                        + "." + resources.getResourceTypeName(id)
+                                        + "." + resources.getResourceName(id)
+                                        + "." + iconDensity;
+                            } catch (Resources.NotFoundException ex) {
+                                return null;
+                            }
                         }
 
                         @Override


### PR DESCRIPTION
If `getResourcePackageName` throws a `Resources.NotFoundException` in `filename()` return `null`.

Change the interface documentation of `FileCache.Builder` to allow for `null` return values, so that these are not cached.