### PR TITLE
Change strip_include_prefix into copt to build gapid as a sub-repo

### DIFF
--- a/gapic/src/platform/BUILD.bazel
+++ b/gapic/src/platform/BUILD.bazel
@@ -43,16 +43,18 @@ cc_binary(
         ":jni.h",
         ":jni_md.h",
     ],
+    copts = [
+        "-Iexternal/local_jdk/include",
+        "-Iexternal/local_jdk/include/linux",
+    ],
 )
 
 cc_library(
     name = "jni.h",
     hdrs = ["@local_jdk//:jni_header"],
-    strip_include_prefix = "/external/local_jdk/include",
 )
 
 cc_library(
     name = "jni_md.h",
     hdrs = ["@local_jdk//:jni_md_header-linux"],
-    strip_include_prefix = "/external/local_jdk/include/linux",
 )


### PR DESCRIPTION
When building gapid as a child repo, bazel appends the "external/gapid" to strip_include_prefix. To avoid that, using the copts with "-I" instead.
