### PR TITLE
Add color attachment option to screenshot

### DIFF
--- a/cmd/gapit/flags.go
+++ b/cmd/gapit/flags.go
@@ -238,14 +238,15 @@ type (
 		ADB         string         `help:"Path to the adb executable; leave empty to search the environment"`
 	}
 	ScreenshotFlags struct {
-		Gapis    GapisFlags
-		Gapir    GapirFlags
-		At       flags.U64Slice `help:"command/subcommand index for the screenshot"`
-		Frame    int64          `help:"frame index for the screenshot. Empty for last"`
-		Out      string         `help:"output image file (default 'screenshot.png')"`
-		NoOpt    bool           `help:"disables optimization of the replay stream"`
-		Overdraw bool           `help:"renders the overdraw instead of the colour framebuffer"`
-		Max      struct {
+		Gapis      GapisFlags
+		Gapir      GapirFlags
+		At         flags.U64Slice `help:"command/subcommand index for the screenshot"`
+		Frame      int64          `help:"frame index for the screenshot. Empty for last"`
+		Out        string         `help:"output image file (default 'screenshot.png')"`
+		NoOpt      bool           `help:"disables optimization of the replay stream"`
+		Attachment int            `help:"the color attachment to show (0-3)"`
+		Overdraw   bool           `help:"renders the overdraw instead of the colour framebuffer"`
+		Max        struct {
 			Overdraw int `help:"the amount of overdraw to map to white in the output"`
 		}
 		CommandFilterFlags

--- a/cmd/gapit/screenshot.go
+++ b/cmd/gapit/screenshot.go
@@ -113,12 +113,17 @@ func (verb *screenshotVerb) getSingleFrame(ctx context.Context, cmd *path.Comman
 	if verb.Overdraw {
 		settings.DrawMode = service.DrawMode_OVERDRAW
 	}
+
+	attachment, err := verb.getAttachment(ctx)
+	if err != nil {
+		return nil, log.Errf(ctx, err, "Get color attachment failed")
+	}
 	iip, err := client.GetFramebufferAttachment(ctx,
 		&service.ReplaySettings{
 			Device: device,
 			DisableReplayOptimization: verb.NoOpt,
 		},
-		cmd, api.FramebufferAttachment_Color0, settings, nil)
+		cmd, attachment, settings, nil)
 	if err != nil {
 		return nil, log.Errf(ctx, err, "GetFramebufferAttachment failed")
 	}
@@ -204,5 +209,20 @@ func rescaleBytes(ctx context.Context, data []byte, max int) {
 		} else {
 			data[i] = byte(int(data[i]) * 255 / max)
 		}
+	}
+}
+
+func (verb *screenshotVerb) getAttachment(ctx context.Context) (api.FramebufferAttachment, error) {
+	switch verb.Attachment {
+	case 0:
+		return api.FramebufferAttachment_Color0, nil
+	case 1:
+		return api.FramebufferAttachment_Color1, nil
+	case 2:
+		return api.FramebufferAttachment_Color2, nil
+	case 3:
+		return api.FramebufferAttachment_Color3, nil
+	default:
+		return 0, log.Errf(ctx, nil, "Invalid color attachment %v", verb.Attachment)
 	}
 }


### PR DESCRIPTION
Since screenshot can access the frame buffer at arbitrary points in a trace, it would be useful to be able to output the content of any of the color attachments.