### PR TITLE
Use proto.Equal instead of reflect.DeepEqual for device memory layout

### DIFF
--- a/core/os/device/device.go
+++ b/core/os/device/device.go
@@ -15,8 +15,6 @@
 package device
 
 import (
-	"reflect"
-
 	"github.com/golang/protobuf/proto"
 )
 
@@ -181,5 +179,5 @@ func (m *MemoryLayout) Clone() *MemoryLayout {
 
 // SameAs returns true if the MemoryLayouts are equal.
 func (m *MemoryLayout) SameAs(o *MemoryLayout) bool {
-	return reflect.DeepEqual(m, o)
+	return proto.Equal(m, o)
 }


### PR DESCRIPTION
As we updated the protobuf, this should be updated too.
reflect.DeepEqual() does not work correctly.