### PR TITLE
Vulkan: State rebuilding optimization reduce the number of commands

### DIFF
--- a/gapii/cc/vulkan_extras.cpp
+++ b/gapii/cc/vulkan_extras.cpp
@@ -97,8 +97,8 @@ bool VulkanSpy::observeFramebuffer(CallObserver* observer, uint32_t* w,
   VkDevice device = image->mDevice;
   VkPhysicalDevice physical_device = mState.Devices[device]->mPhysicalDevice;
   VkInstance instance = mState.PhysicalDevices[physical_device]->mInstance;
-  VkQueue queue = image->mLastBoundQueue->mVulkanHandle;
-  uint32_t queue_family = image->mLastBoundQueue->mFamily;
+  VkQueue queue = mState.LastPresentInfo.mQueue;
+  uint32_t queue_family = mState.Queues[queue]->mFamily;
   auto& instance_fn = mImports.mVkInstanceFunctions[instance];
 
   VkPhysicalDeviceMemoryProperties memory_properties(arena());

--- a/gapis/api/vulkan/BUILD.bazel
+++ b/gapis/api/vulkan/BUILD.bazel
@@ -66,6 +66,7 @@ go_library(
         "read_framebuffer.go",
         "replay.go",
         "resources.go",
+        "scratch_resources.go",
         "state.go",
         "state_rebuilder.go",
         "vulkan.go",

--- a/gapis/api/vulkan/api/image.api
+++ b/gapis/api/vulkan/api/image.api
@@ -59,7 +59,6 @@
 @resource
 @internal class ImageObject {
   @unused VkDevice        Device
-  @unused ref!QueueObject LastBoundQueue
   ref!DeviceMemoryObject  BoundMemory
   VkDeviceSize            BoundMemoryOffset
   // mapping from the resource offsets to the sparse bindings in the unit of sparse blocks
@@ -93,7 +92,7 @@
   @hidden @nobox @internal u8[] Data
   VkImageLayout                 Layout
   ref!VkSubresourceLayout       LinearLayout
-  u32                           LastBoundQueueFamily
+  @unused ref!QueueObject       LastBoundQueue
 }
 
 @internal class SparseBoundImageAspectInfo {
@@ -231,8 +230,7 @@ cmd VkResult vkCreateImage(
           Width: width,
           Height:  height,
           Depth:  depth,
-          Layout:  info.initialLayout,
-          LastBoundQueueFamily: 0xFFFFFFFF)
+          Layout:  info.initialLayout)
         aspect.Layers[j].Levels[i] = level
       }
     }
@@ -583,6 +581,7 @@ sub void readImageSubresource(ref!ImageObject image, VkImageSubresourceRange rng
       for mipLevel in (rng.baseMipLevel .. rng.baseMipLevel + levelCount) {
         level := layer.Levels[mipLevel]
         read(level.Data)
+        level.LastBoundQueue = LastBoundQueue
       }
     }
   }
@@ -598,6 +597,7 @@ sub void writeImageSubresource(ref!ImageObject image, VkImageSubresourceRange rn
       for mipLevel in (rng.baseMipLevel .. rng.baseMipLevel + levelCount) {
         level := layer.Levels[mipLevel]
         write(level.Data)
+        level.LastBoundQueue = LastBoundQueue
       }
     }
   }
@@ -644,7 +644,7 @@ sub void transitionImageLayout(ref!ImageObject img, VkImageSubresourceRange rng,
             if (level in img.Aspects[aspectBit].Layers[layer].Levels) {
               imgLevel := img.Aspects[aspectBit].Layers[layer].Levels[level]
               imgLevel.Layout = newLayout
-              imgLevel.LastBoundQueueFamily = LastBoundQueue.Family
+              imgLevel.LastBoundQueue = LastBoundQueue
             }
           }
         }

--- a/gapis/api/vulkan/api/renderpass_framebuffer.api
+++ b/gapis/api/vulkan/api/renderpass_framebuffer.api
@@ -221,11 +221,7 @@ sub void dovkCmdBeginRenderPass(ref!vkCmdBeginRenderPassArgs args) {
   lastDrawInfo().InRenderPass = true
   attachments := lastDrawInfo().Framebuffer.ImageAttachments
   for i in (0 .. len(attachments)) {
-    v := attachments[as!u32(i)]
     loadImageAttachment(as!u32(i))
-    if (v.Image != null) {
-      v.Image.LastBoundQueue = LastBoundQueue
-    }
   }
   pushRenderPassMarker(args.RenderPass)
 }
@@ -339,12 +335,14 @@ sub void loadImageAttachment(u32 attachmentID) {
   if attachmentID != VK_ATTACHMENT_UNUSED {
     attachment := lastDrawInfo().Framebuffer.ImageAttachments[attachmentID]
     desc := lastDrawInfo().RenderPass.AttachmentDescriptions[attachmentID]
-    switch desc.loadOp {
-      case VK_ATTACHMENT_LOAD_OP_LOAD:
-        readImageSubresource(attachment.Image, attachment.SubresourceRange, desc.initialLayout)
-      default:
-        // write to the attachment image, to prevent any dependencies on previous writes
-        writeImageSubresource(attachment.Image, attachment.SubresourceRange, desc.initialLayout)
+    if attachment.Image != null {
+      switch desc.loadOp {
+        case VK_ATTACHMENT_LOAD_OP_LOAD:
+          readImageSubresource(attachment.Image, attachment.SubresourceRange, desc.initialLayout)
+        default:
+          // write to the attachment image, to prevent any dependencies on previous writes
+          writeImageSubresource(attachment.Image, attachment.SubresourceRange, desc.initialLayout)
+      }
     }
   }
 }
@@ -354,14 +352,16 @@ sub void storeImageAttachment(u32 attachmentID) {
   if attachmentID != VK_ATTACHMENT_UNUSED {
     attachment := lastDrawInfo().Framebuffer.ImageAttachments[attachmentID]
     desc := lastDrawInfo().RenderPass.AttachmentDescriptions[attachmentID]
-    if desc.initialLayout != desc.finalLayout {
-      transitionImageLayout(attachment.Image, attachment.SubresourceRange, VK_IMAGE_LAYOUT_UNDEFINED, desc.finalLayout)
-    }
-    switch desc.storeOp {
-      case VK_ATTACHMENT_STORE_OP_STORE:
-        writeImageSubresource(attachment.Image, attachment.SubresourceRange, desc.finalLayout)
-      default: {
-        // do nothing
+    if attachment.Image != null {
+      if desc.initialLayout != desc.finalLayout {
+        transitionImageLayout(attachment.Image, attachment.SubresourceRange, VK_IMAGE_LAYOUT_UNDEFINED, desc.finalLayout)
+      }
+      switch desc.storeOp {
+        case VK_ATTACHMENT_STORE_OP_STORE:
+          writeImageSubresource(attachment.Image, attachment.SubresourceRange, desc.finalLayout)
+        default: {
+          // do nothing
+        }
       }
     }
   }

--- a/gapis/api/vulkan/api/synchronization.api
+++ b/gapis/api/vulkan/api/synchronization.api
@@ -351,7 +351,6 @@ sub void dovkCmdWaitEvents(ref!vkCmdWaitEventsArgs args) {
       if !(b.image in Images) { vkErrorInvalidImage(b.image) }
       image := Images[b.image]
       transitionImageLayout(image, b.subresourceRange, b.oldLayout, b.newLayout)
-      image.LastBoundQueue = LastBoundQueue
     }
   }
 }
@@ -421,7 +420,6 @@ sub void dovkCmdPipelineBarrier(ref!vkCmdPipelineBarrierArgs args) {
     if v.oldLayout == VK_IMAGE_LAYOUT_UNDEFINED {
       writeImageSubresource(image, v.subresourceRange, v.newLayout)
     }
-    image.LastBoundQueue = LastBoundQueue
   }
 }
 

--- a/gapis/api/vulkan/extensions/khr_swapchain.api
+++ b/gapis/api/vulkan/extensions/khr_swapchain.api
@@ -258,6 +258,7 @@ cmd VkResult vkQueuePresentKHR(
     delete(LastPresentInfo.PresentImages, i)
   }
   LastPresentInfo.PresentImageCount = 0
+  LastPresentInfo.Queue = queue
 
 
   info := pPresentInfo[0]
@@ -289,7 +290,13 @@ cmd VkResult vkQueuePresentKHR(
     LastPresentInfo.PresentImages[LastPresentInfo.PresentImageCount] =
     image
     LastPresentInfo.PresentImageCount = LastPresentInfo.PresentImageCount + 1
-    image.LastBoundQueue = Queues[queue]
+    for _ , _ , aspect in image.Aspects {
+      for _ , _ , layer in aspect.Layers {
+        for _ , _ , level in layer.Levels {
+          level.LastBoundQueue = Queues[queue]
+        }
+      }
+    }
   }
   fence
   if (info.pResults != null) {

--- a/gapis/api/vulkan/image_primer.go
+++ b/gapis/api/vulkan/image_primer.go
@@ -49,7 +49,10 @@ const (
 
 // interfaces to interact with state rebuilder
 
-func (p *imagePrimer) primeByBufferCopy(img ImageObjectʳ, opaqueBoundRanges []VkImageSubresourceRange, queue QueueObjectʳ, sparseBindingQueue QueueObjectʳ) error {
+func (p *imagePrimer) primeByBufferCopy(img ImageObjectʳ, opaqueBoundRanges []VkImageSubresourceRange, queue QueueObjectʳ) error {
+	if queue.IsNil() {
+		return log.Errf(p.sb.ctx, nil, "[Priming image data by buffer->image copy] Nil queue")
+	}
 	job := newImagePrimerBufCopyJob(img, sameLayoutsOfImage(img))
 	for _, aspect := range p.sb.imageAspectFlagBits(img.ImageAspect()) {
 		job.addDst(p.sb.ctx, aspect, aspect, img)
@@ -61,28 +64,33 @@ func (p *imagePrimer) primeByBufferCopy(img ImageObjectʳ, opaqueBoundRanges []V
 	if sparseResidency(img) {
 		bcs.collectCopiesFromSparseImageBindings()
 	}
-	err := bcs.rolloutBufCopies(queue, sparseBindingQueue)
+	err := bcs.rolloutBufCopies(queue.VulkanHandle())
 	if err != nil {
-		return log.Errf(p.sb.ctx, err, "[Priming image data by buffer->image copy]")
+		return log.Errf(p.sb.ctx, err, "[Rolling out the buf->img copy commands for image: %v]", img.VulkanHandle())
 	}
 	return nil
 }
 
-func (p *imagePrimer) primeByRendering(img ImageObjectʳ, opaqueBoundRanges []VkImageSubresourceRange, queue, sparseBindingQueue QueueObjectʳ) error {
+func (p *imagePrimer) primeByRendering(img ImageObjectʳ, opaqueBoundRanges []VkImageSubresourceRange, queue QueueObjectʳ) error {
+	if queue.IsNil() {
+		return log.Err(p.sb.ctx, nil, "[Priming image data by rendering] Nil queue")
+	}
+	renderTsk := p.sb.newScratchTaskOnQueue(queue.VulkanHandle())
+
 	copyJob := newImagePrimerBufCopyJob(img, useSpecifiedLayout(VkImageLayout_VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL))
 	for _, aspect := range p.sb.imageAspectFlagBits(img.ImageAspect()) {
 		stagingImgs, stagingImgMems, err := p.allocStagingImages(img, aspect)
 		if err != nil {
-			return log.Errf(p.sb.ctx, err, "[Creating staging image for priming image data by rendering]")
+			return log.Errf(p.sb.ctx, err, "[Creating staging images for priming image data by rendering]")
 		}
-		defer func() {
+		renderTsk.deferUntilExecuted(func() {
 			for _, img := range stagingImgs {
 				p.sb.write(p.sb.cb.VkDestroyImage(img.Device(), img.VulkanHandle(), memory.Nullptr))
 			}
 			for _, mem := range stagingImgMems {
 				p.sb.write(p.sb.cb.VkFreeMemory(mem.Device(), mem.VulkanHandle(), memory.Nullptr))
 			}
-		}()
+		})
 		copyJob.addDst(p.sb.ctx, aspect, VkImageAspectFlagBits_VK_IMAGE_ASPECT_COLOR_BIT, stagingImgs...)
 	}
 	bcs := newImagePrimerBufferCopySession(p.sb, copyJob)
@@ -92,9 +100,9 @@ func (p *imagePrimer) primeByRendering(img ImageObjectʳ, opaqueBoundRanges []Vk
 	if sparseResidency(img) {
 		bcs.collectCopiesFromSparseImageBindings()
 	}
-	err := bcs.rolloutBufCopies(queue, sparseBindingQueue)
+	err := bcs.rolloutBufCopies(queue.VulkanHandle())
 	if err != nil {
-		return log.Errf(p.sb.ctx, err, "[Copying data to staging images for priming image: %v data by rendering]")
+		return log.Errf(p.sb.ctx, err, "[Rolling out the buf->img copy commands for staging images]")
 	}
 
 	renderJobs := []*ipRenderJob{}
@@ -113,17 +121,24 @@ func (p *imagePrimer) primeByRendering(img ImageObjectʳ, opaqueBoundRanges []Vk
 		}
 	}
 	for _, renderJob := range renderJobs {
-		err := p.rh.render(renderJob, queue)
+		err := p.rh.render(renderJob, renderTsk)
 		if err != nil {
 			log.E(p.sb.ctx, "[Priming image: %v, aspect: %v, layer: %v, level: %v data by rendering] %v",
 				renderJob.renderTarget.VulkanHandle(), renderJob.aspect, renderJob.layer, renderJob.level, err)
 		}
 	}
 
+	if err := renderTsk.commit(); err != nil {
+		return log.Errf(p.sb.ctx, err, "[Committing scratch task for priming image: %v data by rendering]", img.VulkanHandle())
+	}
+
 	return nil
 }
 
-func (p *imagePrimer) primeByImageStore(img ImageObjectʳ, opaqueBoundRanges []VkImageSubresourceRange, queue, sparseBindingQueue QueueObjectʳ) error {
+func (p *imagePrimer) primeByImageStore(img ImageObjectʳ, opaqueBoundRanges []VkImageSubresourceRange, queue QueueObjectʳ) error {
+	if queue.IsNil() {
+		return log.Err(p.sb.ctx, nil, "[Priming image data by imageStore] Nil queue")
+	}
 	storeJobs := []*ipStoreJob{}
 	for _, rng := range opaqueBoundRanges {
 		walkImageSubresourceRange(p.sb, img, rng,
@@ -158,25 +173,27 @@ func (p *imagePrimer) primeByImageStore(img ImageObjectʳ, opaqueBoundRanges []V
 	}
 
 	whole := p.sb.imageWholeSubresourceRange(img)
-	transitionInfo := []imgSubRngLayoutTransitionInfo{}
+	transitionInfo := []imageSubRangeInfo{}
 	oldLayouts := []VkImageLayout{}
 	walkImageSubresourceRange(p.sb, img, whole, func(aspect VkImageAspectFlagBits, layer, level uint32, unused byteSizeAndExtent) {
 		l := GetState(p.sb.newState).Images().Get(img.VulkanHandle()).Aspects().Get(aspect).Layers().Get(layer).Levels().Get(level)
-		transitionInfo = append(transitionInfo, imgSubRngLayoutTransitionInfo{
+		transitionInfo = append(transitionInfo, imageSubRangeInfo{
 			aspectMask:     VkImageAspectFlags(aspect),
 			baseMipLevel:   level,
 			levelCount:     1,
 			baseArrayLayer: layer,
 			layerCount:     1,
 			oldLayout:      l.Layout(),
-			newLayout:      VkImageLayout_VK_IMAGE_LAYOUT_UNDEFINED,
+			newLayout:      VkImageLayout_VK_IMAGE_LAYOUT_GENERAL,
+			oldQueue:       queue.VulkanHandle(),
+			newQueue:       queue.VulkanHandle(),
 		})
 		oldLayouts = append(oldLayouts, l.Layout())
 	})
-	p.sb.transitionImageLayout(img, transitionInfo, sparseBindingQueue, queue)
+	p.sb.changeImageSubRangeLayoutAndOwnership(img.VulkanHandle(), transitionInfo)
 
 	for _, job := range storeJobs {
-		err := p.sh.store(job, queue)
+		err := p.sh.store(job, queue.VulkanHandle())
 		if err != nil {
 			log.E(p.sb.ctx, "[Priming image: %v aspect: %v, layer: %v, level: %v, offset: %v, extent: %v data by imageStore] %v", job.storeTarget.VulkanHandle(), job.aspect, job.layer, job.level, job.opaqueBlockOffset, job.opaqueBlockExtent, err)
 		}
@@ -186,12 +203,15 @@ func (p *imagePrimer) primeByImageStore(img ImageObjectʳ, opaqueBoundRanges []V
 		transitionInfo[i].oldLayout = VkImageLayout_VK_IMAGE_LAYOUT_GENERAL
 		transitionInfo[i].newLayout = oldLayouts[i]
 	}
-	p.sb.transitionImageLayout(img, transitionInfo, sparseBindingQueue, queue)
+	p.sb.changeImageSubRangeLayoutAndOwnership(img.VulkanHandle(), transitionInfo)
 
 	return nil
 }
 
-func (p *imagePrimer) primeByPreinitialization(img ImageObjectʳ, opaqueBoundRanges []VkImageSubresourceRange, queue, sparseBindingQueue QueueObjectʳ) error {
+func (p *imagePrimer) primeByPreinitialization(img ImageObjectʳ, opaqueBoundRanges []VkImageSubresourceRange, queue QueueObjectʳ) error {
+	if queue.IsNil() {
+		return log.Err(p.sb.ctx, nil, "[Priming image data by pre-initialization] Nil queue")
+	}
 	newImg := GetState(p.sb.newState).Images().Get(img.VulkanHandle())
 	newMem := newImg.BoundMemory()
 	boundOffset := img.BoundMemoryOffset()
@@ -211,7 +231,7 @@ func (p *imagePrimer) primeByPreinitialization(img ImageObjectʳ, opaqueBoundRan
 	).AddRead(atdata.Data()).AddWrite(atdata.Data()))
 	atdata.Free()
 
-	transitionInfo := []imgSubRngLayoutTransitionInfo{}
+	transitionInfo := []imageSubRangeInfo{}
 	for _, rng := range opaqueBoundRanges {
 		walkImageSubresourceRange(p.sb, img, rng,
 			func(aspect VkImageAspectFlagBits, layer, level uint32, unused byteSizeAndExtent) {
@@ -221,7 +241,7 @@ func (p *imagePrimer) primeByPreinitialization(img ImageObjectʳ, opaqueBoundRan
 
 				p.sb.ReadDataAt(origDataSlice.ResourceID(p.sb.ctx, p.sb.oldState), uint64(linearLayout.Offset())+dat.Address(), origDataSlice.Size())
 
-				transitionInfo = append(transitionInfo, imgSubRngLayoutTransitionInfo{
+				transitionInfo = append(transitionInfo, imageSubRangeInfo{
 					aspectMask:     VkImageAspectFlags(aspect),
 					baseMipLevel:   level,
 					levelCount:     1,
@@ -229,6 +249,8 @@ func (p *imagePrimer) primeByPreinitialization(img ImageObjectʳ, opaqueBoundRan
 					layerCount:     1,
 					oldLayout:      VkImageLayout_VK_IMAGE_LAYOUT_PREINITIALIZED,
 					newLayout:      origLevel.Layout(),
+					oldQueue:       queue.VulkanHandle(),
+					newQueue:       queue.VulkanHandle(),
 				})
 			})
 	}
@@ -252,7 +274,7 @@ func (p *imagePrimer) primeByPreinitialization(img ImageObjectʳ, opaqueBoundRan
 		newMem.VulkanHandle(),
 	))
 
-	p.sb.transitionImageLayout(img, transitionInfo, sparseBindingQueue, queue)
+	p.sb.changeImageSubRangeLayoutAndOwnership(img.VulkanHandle(), transitionInfo)
 
 	return nil
 }
@@ -388,6 +410,8 @@ func useSpecifiedLayout(layout VkImageLayout) ipLayoutInfo {
 type ipStoreHandler struct {
 	sb              *stateBuilder
 	descSetLayouts  map[VkDevice]VkDescriptorSetLayout
+	descPools       map[VkDevice]VkDescriptorPool
+	descSets        map[VkDevice]VkDescriptorSet
 	pipelineLayouts map[VkDevice]VkPipelineLayout
 	pipelines       map[ipStoreShaderInfo]ComputePipelineObjectʳ
 	shaders         map[ipStoreShaderInfo]ShaderModuleObjectʳ
@@ -459,13 +483,15 @@ func newImagePrimerStoreHandler(sb *stateBuilder) *ipStoreHandler {
 	return &ipStoreHandler{
 		sb:              sb,
 		descSetLayouts:  map[VkDevice]VkDescriptorSetLayout{},
+		descPools:       map[VkDevice]VkDescriptorPool{},
+		descSets:        map[VkDevice]VkDescriptorSet{},
 		pipelineLayouts: map[VkDevice]VkPipelineLayout{},
 		pipelines:       map[ipStoreShaderInfo]ComputePipelineObjectʳ{},
 		shaders:         map[ipStoreShaderInfo]ShaderModuleObjectʳ{},
 	}
 }
 
-func (h *ipStoreHandler) store(job *ipStoreJob, queue QueueObjectʳ) error {
+func (h *ipStoreHandler) store(job *ipStoreJob, queue VkQueue) error {
 
 	var err error
 
@@ -478,30 +504,33 @@ func (h *ipStoreHandler) store(job *ipStoreJob, queue QueueObjectʳ) error {
 	}
 
 	// create descriptor pool
-	descPool := VkDescriptorPool(newUnusedID(true, func(x uint64) bool {
-		return GetState(h.sb.newState).DescriptorPools().Contains(VkDescriptorPool(x))
-	}))
-	descPoolSizes := []VkDescriptorPoolSize{
-		// for target image
-		NewVkDescriptorPoolSize(h.sb.ta,
-			VkDescriptorType_VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, // Type
-			1, // descriptorCount
-		),
-		// for image data
-		NewVkDescriptorPoolSize(h.sb.ta,
-			VkDescriptorType_VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER, // Type
-			1, // descriptorCount
-		),
-		// for image dimension info
-		NewVkDescriptorPoolSize(h.sb.ta,
-			VkDescriptorType_VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, // Type
-			1, // descriptorCount
-		),
+	if _, ok := h.descPools[dev]; !ok {
+		descPool := VkDescriptorPool(newUnusedID(true, func(x uint64) bool {
+			return GetState(h.sb.newState).DescriptorPools().Contains(VkDescriptorPool(x))
+		}))
+		descPoolSizes := []VkDescriptorPoolSize{
+			// for target image
+			NewVkDescriptorPoolSize(h.sb.ta,
+				VkDescriptorType_VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, // Type
+				1, // descriptorCount
+			),
+			// for image data
+			NewVkDescriptorPoolSize(h.sb.ta,
+				VkDescriptorType_VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER, // Type
+				1, // descriptorCount
+			),
+			// for image dimension info
+			NewVkDescriptorPoolSize(h.sb.ta,
+				VkDescriptorType_VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, // Type
+				1, // descriptorCount
+			),
+		}
+		vkCreateDescriptorPool(h.sb, dev, VkDescriptorPoolCreateFlags(
+			VkDescriptorPoolCreateFlagBits_VK_DESCRIPTOR_POOL_CREATE_FREE_DESCRIPTOR_SET_BIT),
+			1, descPoolSizes, descPool)
+		h.descPools[dev] = descPool
 	}
-	vkCreateDescriptorPool(h.sb, dev, VkDescriptorPoolCreateFlags(
-		VkDescriptorPoolCreateFlagBits_VK_DESCRIPTOR_POOL_CREATE_FREE_DESCRIPTOR_SET_BIT),
-		1, descPoolSizes, descPool)
-	defer h.sb.write(h.sb.cb.VkDestroyDescriptorPool(dev, descPool, memory.Nullptr))
+	descPool := h.descPools[dev]
 
 	// create descriptor set layout
 	if _, ok := h.descSetLayouts[dev]; !ok {
@@ -536,14 +565,14 @@ func (h *ipStoreHandler) store(job *ipStoreJob, queue QueueObjectʳ) error {
 	}
 
 	// allocate descriptor set
-	descSet := VkDescriptorSet(newUnusedID(true, func(x uint64) bool {
-		return GetState(h.sb.newState).DescriptorSets().Contains(VkDescriptorSet(x))
-	}))
-	vkAllocateDescriptorSet(h.sb, dev, descPool, h.descSetLayouts[dev], descSet)
-	defer func() {
-		h.sb.write(h.sb.cb.VkFreeDescriptorSets(dev, descPool, uint32(1),
-			NewVkDescriptorSetᶜᵖ(h.sb.MustAllocReadData(descSet).Ptr()), VkResult_VK_SUCCESS))
-	}()
+	if _, ok := h.descSets[dev]; !ok {
+		descSet := VkDescriptorSet(newUnusedID(true, func(x uint64) bool {
+			return GetState(h.sb.newState).DescriptorSets().Contains(VkDescriptorSet(x))
+		}))
+		vkAllocateDescriptorSet(h.sb, dev, descPool, h.descSetLayouts[dev], descSet)
+		h.descSets[dev] = descSet
+	}
+	descSet := h.descSets[dev]
 
 	// Create compute pipeline
 	if _, ok := h.pipelineLayouts[dev]; !ok {
@@ -623,23 +652,31 @@ func (h *ipStoreHandler) store(job *ipStoreJob, queue QueueObjectʳ) error {
 }
 
 func (h *ipStoreHandler) free() {
-	for _, p := range h.pipelines {
+	for dev, p := range h.pipelines {
 		h.sb.write(h.sb.cb.VkDestroyPipeline(p.Device(), p.VulkanHandle(), memory.Nullptr))
+		delete(h.pipelines, dev)
 	}
-	for _, m := range h.shaders {
+	for dev, m := range h.shaders {
 		h.sb.write(h.sb.cb.VkDestroyShaderModule(m.Device(), m.VulkanHandle(), memory.Nullptr))
+		delete(h.shaders, dev)
 	}
 	for dev, l := range h.pipelineLayouts {
 		h.sb.write(h.sb.cb.VkDestroyPipelineLayout(dev, l, memory.Nullptr))
+		delete(h.pipelineLayouts, dev)
+	}
+	for dev, p := range h.descPools {
+		h.sb.write(h.sb.cb.VkDestroyDescriptorPool(dev, p, memory.Nullptr))
+		delete(h.descPools, dev)
 	}
 	for dev, l := range h.descSetLayouts {
 		h.sb.write(h.sb.cb.VkDestroyDescriptorSetLayout(dev, l, memory.Nullptr))
+		delete(h.descSetLayouts, dev)
 	}
 }
 
 // Internal functions of image store handler
 
-func (h *ipStoreHandler) dispatchAndSubmit(info ipStoreDispatchInfo, queue QueueObjectʳ) error {
+func (h *ipStoreHandler) dispatch(info ipStoreDispatchInfo, tsk *scratchTask) error {
 
 	// check the number of texel
 	if uint32(len(info.data))%info.dataElementSize != 0 {
@@ -652,30 +689,41 @@ func (h *ipStoreHandler) dispatchAndSubmit(info ipStoreDispatchInfo, queue Queue
 	}
 
 	// data buffer and buffer view
-	dataBuf, dataMem := h.sb.allocAndFillScratchBuffer(
-		h.sb.s.Devices().Get(info.dev), []bufferSubRangeFillInfo{newBufferSubRangeFillInfoFromNewData(info.data, 0)},
+	dataBuf := tsk.newBuffer([]bufferSubRangeFillInfo{newBufferSubRangeFillInfoFromNewData(info.data, 0)},
 		VkBufferUsageFlagBits_VK_BUFFER_USAGE_UNIFORM_TEXEL_BUFFER_BIT)
-	defer h.sb.freeScratchBuffer(h.sb.s.Devices().Get(info.dev), dataBuf, dataMem)
-	dataBufView := VkBufferView(newUnusedID(true, func(x uint64) bool {
-		return GetState(h.sb.newState).BufferViews().Contains(VkBufferView(x))
-	}))
-	h.sb.write(h.sb.cb.VkCreateBufferView(
-		info.dev,
-		h.sb.MustAllocReadData(
-			NewVkBufferViewCreateInfo(h.sb.ta,
-				VkStructureType_VK_STRUCTURE_TYPE_BUFFER_VIEW_CREATE_INFO, // sType
-				0,                  // pNext
-				0,                  // flags
-				dataBuf,            // buffer
-				info.dataFormat,    // format
-				0,                  // offset
-				0xFFFFFFFFFFFFFFFF, // range
-			)).Ptr(),
-		memory.Nullptr,
-		h.sb.MustAllocWriteData(dataBufView).Ptr(),
-		VkResult_VK_SUCCESS,
-	))
-	defer h.sb.write(h.sb.cb.VkDestroyBufferView(info.dev, dataBufView, memory.Nullptr))
+	tsk.deferUntilExecuted(func() {
+		h.sb.write(h.sb.cb.VkDestroyBuffer(info.dev, dataBuf, memory.Nullptr))
+	})
+	tsk.deferUntilCommitted(func() {
+		dataBufView := VkBufferView(newUnusedID(true, func(x uint64) bool {
+			return GetState(h.sb.newState).BufferViews().Contains(VkBufferView(x))
+		}))
+		h.sb.write(h.sb.cb.VkCreateBufferView(
+			info.dev,
+			h.sb.MustAllocReadData(
+				NewVkBufferViewCreateInfo(h.sb.ta,
+					VkStructureType_VK_STRUCTURE_TYPE_BUFFER_VIEW_CREATE_INFO, // sType
+					0,                  // pNext
+					0,                  // flags
+					dataBuf,            // buffer
+					info.dataFormat,    // format
+					0,                  // offset
+					0xFFFFFFFFFFFFFFFF, // range
+				)).Ptr(),
+			memory.Nullptr,
+			h.sb.MustAllocWriteData(dataBufView).Ptr(),
+			VkResult_VK_SUCCESS,
+		))
+		tsk.deferUntilExecuted(func() {
+			h.sb.write(h.sb.cb.VkDestroyBufferView(info.dev, dataBufView, memory.Nullptr))
+		})
+		writeDescriptorSet(h.sb, info.dev, info.descSet, ipStoreUniformTexelBufferBinding, 0,
+			VkDescriptorType_VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER,
+			[]VkDescriptorImageInfo{},
+			[]VkDescriptorBufferInfo{},
+			[]VkBufferView{dataBufView},
+		)
+	})
 
 	// image view
 	imgView := VkImageView(newUnusedID(true, func(x uint64) bool {
@@ -718,7 +766,9 @@ func (h *ipStoreHandler) dispatchAndSubmit(info ipStoreDispatchInfo, queue Queue
 		h.sb.MustAllocWriteData(imgView).Ptr(),
 		VkResult_VK_SUCCESS,
 	))
-	defer h.sb.write(h.sb.cb.VkDestroyImageView(info.dev, imgView, memory.Nullptr))
+	tsk.deferUntilExecuted(func() {
+		h.sb.write(h.sb.cb.VkDestroyImageView(info.dev, imgView, memory.Nullptr))
+	})
 
 	// metadata buffer
 	// For an N dimensional image, metadata buffer contains:
@@ -753,63 +803,67 @@ func (h *ipStoreHandler) dispatchAndSubmit(info ipStoreDispatchInfo, queue Queue
 	metadata = append(metadata, uint32(info.offsetInOpaqueBlock), uint32(texelCount))
 	var db bytes.Buffer
 	binary.Write(&db, binary.LittleEndian, metadata)
-	metadataBuf, metadataMem := h.sb.allocAndFillScratchBuffer(
-		h.sb.s.Devices().Get(info.dev), []bufferSubRangeFillInfo{newBufferSubRangeFillInfoFromNewData(db.Bytes(), 0)},
+	metadataBuf := tsk.newBuffer(
+		[]bufferSubRangeFillInfo{newBufferSubRangeFillInfoFromNewData(db.Bytes(), 0)},
 		VkBufferUsageFlagBits_VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT)
-	defer h.sb.freeScratchBuffer(h.sb.s.Devices().Get(info.dev), metadataBuf, metadataMem)
+	tsk.deferUntilExecuted(func() {
+		h.sb.write(h.sb.cb.VkDestroyBuffer(info.dev, metadataBuf, memory.Nullptr))
+	})
 
-	writeDescriptorSet(h.sb, info.dev, info.descSet, ipStoreStorageImageBinding, 0, VkDescriptorType_VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, []VkDescriptorImageInfo{
-		NewVkDescriptorImageInfo(h.sb.ta,
-			0,       // Sampler
-			imgView, // ImageView
-			VkImageLayout_VK_IMAGE_LAYOUT_GENERAL, // ImageLayout
-		),
-	}, []VkDescriptorBufferInfo{}, []VkBufferView{})
-	writeDescriptorSet(h.sb, info.dev, info.descSet, ipStoreUniformBufferBinding, 0,
-		VkDescriptorType_VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
-		[]VkDescriptorImageInfo{},
-		[]VkDescriptorBufferInfo{
-			NewVkDescriptorBufferInfo(h.sb.ta,
-				metadataBuf,        // Buffer
-				0,                  // Offset
-				0xFFFFFFFFFFFFFFFF, // Range
+	tsk.deferUntilCommitted(func() {
+		writeDescriptorSet(h.sb, info.dev, info.descSet, ipStoreStorageImageBinding, 0, VkDescriptorType_VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, []VkDescriptorImageInfo{
+			NewVkDescriptorImageInfo(h.sb.ta,
+				0,       // Sampler
+				imgView, // ImageView
+				VkImageLayout_VK_IMAGE_LAYOUT_GENERAL, // ImageLayout
 			),
-		},
-		[]VkBufferView{},
-	)
-	writeDescriptorSet(h.sb, info.dev, info.descSet, ipStoreUniformTexelBufferBinding, 0,
-		VkDescriptorType_VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER,
-		[]VkDescriptorImageInfo{},
-		[]VkDescriptorBufferInfo{},
-		[]VkBufferView{dataBufView},
-	)
+		}, []VkDescriptorBufferInfo{}, []VkBufferView{})
+		writeDescriptorSet(h.sb, info.dev, info.descSet, ipStoreUniformBufferBinding, 0,
+			VkDescriptorType_VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
+			[]VkDescriptorImageInfo{},
+			[]VkDescriptorBufferInfo{
+				NewVkDescriptorBufferInfo(h.sb.ta,
+					metadataBuf,        // Buffer
+					0,                  // Offset
+					0xFFFFFFFFFFFFFFFF, // Range
+				),
+			},
+			[]VkBufferView{},
+		)
+	})
 
 	// commands
-	commandBuffer, commandPool := h.sb.getCommandBuffer(queue)
-	h.sb.write(h.sb.cb.VkCmdBindPipeline(
-		commandBuffer,
-		VkPipelineBindPoint_VK_PIPELINE_BIND_POINT_COMPUTE,
-		info.pipeline,
-	))
-	h.sb.write(h.sb.cb.VkCmdBindDescriptorSets(
-		commandBuffer,
-		VkPipelineBindPoint_VK_PIPELINE_BIND_POINT_COMPUTE,
-		info.pipelineLayout,
-		0, 1, h.sb.MustAllocReadData(info.descSet).Ptr(),
-		0, NewU32ᶜᵖ(memory.Nullptr),
-	))
-	groupCount := uint32(roundUp(uint64(texelCount), specMaxComputeLocalGroupSizeX))
-	h.sb.write(h.sb.cb.VkCmdDispatch(commandBuffer, groupCount, 1, 1))
-	h.sb.endSubmitAndDestroyCommandBuffer(queue, commandBuffer, commandPool)
+	tsk.recordCmdBufCommand(func(commandBuffer VkCommandBuffer) {
+		h.sb.write(h.sb.cb.VkCmdBindPipeline(
+			commandBuffer,
+			VkPipelineBindPoint_VK_PIPELINE_BIND_POINT_COMPUTE,
+			info.pipeline,
+		))
+		h.sb.write(h.sb.cb.VkCmdBindDescriptorSets(
+			commandBuffer,
+			VkPipelineBindPoint_VK_PIPELINE_BIND_POINT_COMPUTE,
+			info.pipelineLayout,
+			0, 1, h.sb.MustAllocReadData(info.descSet).Ptr(),
+			0, NewU32ᶜᵖ(memory.Nullptr),
+		))
+		groupCount := uint32(roundUp(uint64(texelCount), specMaxComputeLocalGroupSizeX))
+		h.sb.write(h.sb.cb.VkCmdDispatch(commandBuffer, groupCount, 1, 1))
+	})
 
 	return nil
 }
 
-func (h *ipStoreHandler) storeThroughTexelBuffer(info ipStoreTexelBufferStoreInfo, queue QueueObjectʳ) {
+func (h *ipStoreHandler) storeThroughTexelBuffer(info ipStoreTexelBufferStoreInfo, queue VkQueue) {
 	dispatchStart := uint32(0)
 	maxDispatchTexelCount := specMaxComputeGlobalGroupCountX * specMaxComputeLocalGroupSizeX
+	maxDispatchSize := uint32(maxDispatchTexelCount) * info.dataElementSize
+	// Need to reserve a buffer for metadata which can have at most 6 uint32.
+	maxScratchTexelBufferSize := scratchBufferSize - nextMultipleOf(6*4, 256)
+	if maxScratchTexelBufferSize < uint64(maxDispatchSize) {
+		maxDispatchSize = uint32(maxScratchTexelBufferSize) / info.dataElementSize * info.dataElementSize
+	}
 	for dispatchStart < uint32(len(info.data)) {
-		dispatchEnd := dispatchStart + uint32(maxDispatchTexelCount)*info.dataElementSize
+		dispatchEnd := dispatchStart + maxDispatchSize
 		if dispatchEnd > uint32(len(info.data)) {
 			dispatchEnd = uint32(len(info.data))
 		}
@@ -825,10 +879,15 @@ func (h *ipStoreHandler) storeThroughTexelBuffer(info ipStoreTexelBufferStoreInf
 			pipelineLayout:      info.pipeline.PipelineLayout().VulkanHandle(),
 			pipeline:            info.pipeline.VulkanHandle(),
 		}
-		err := h.dispatchAndSubmit(dispatchInfo, queue)
+		tsk := h.sb.newScratchTaskOnQueue(queue)
+		err := h.dispatch(dispatchInfo, tsk)
 		if err != nil {
-			log.E(h.sb.ctx, "[Priming storage image: %v by imageStore] %v", info.job.storeTarget.VulkanHandle())
+			log.E(h.sb.ctx, "[Priming storage image: %v by imageStore, data range: [%v-%v) ] %v", info.job.storeTarget.VulkanHandle(), dispatchStart, dispatchEnd, err)
 		}
+		if err := tsk.commit(); err != nil {
+			log.E(h.sb.ctx, "[Committing scratch task for priming storage image: %v by imageStore, data range: [%v-%v) ] %v", info.job.storeTarget.VulkanHandle(), dispatchStart, dispatchEnd, err)
+		}
+		h.sb.flushQueueFamilyScratchResources(tsk.queue)
 		dispatchStart = dispatchEnd
 	}
 }
@@ -988,8 +1047,7 @@ func (h *ipRenderHandler) free() {
 	}
 }
 
-func (h *ipRenderHandler) render(job *ipRenderJob, queue QueueObjectʳ) error {
-
+func (h *ipRenderHandler) render(job *ipRenderJob, tsk *scratchTask) error {
 	var outputBarrierAspect VkImageAspectFlags
 	switch job.aspect {
 	case VkImageAspectFlagBits_VK_IMAGE_ASPECT_COLOR_BIT:
@@ -1033,18 +1091,20 @@ func (h *ipRenderHandler) render(job *ipRenderJob, queue QueueObjectʳ) error {
 	}
 	descPool := h.createDescriptorPool(descSetInfo)
 	if !descPool.IsNil() {
-		defer h.sb.write(h.sb.cb.VkDestroyDescriptorPool(dev, descPool.VulkanHandle(), memory.Nullptr))
+		tsk.deferUntilExecuted(func() {
+			h.sb.write(h.sb.cb.VkDestroyDescriptorPool(dev, descPool.VulkanHandle(), memory.Nullptr))
+		})
 	} else {
 		return log.Errf(h.sb.ctx, nil, "failed to create descriptor pool for %v input attachments", len(job.inputAttachmentImages))
 	}
 	descSetLayout := h.getOrCreateDescriptorSetLayout(descSetInfo)
 	descSet := h.allocDescriptorSet(dev, descPool.VulkanHandle(), descSetLayout.VulkanHandle())
 	if !descSet.IsNil() {
-		defer func() {
+		tsk.deferUntilExecuted(func() {
 			h.sb.write(h.sb.cb.VkFreeDescriptorSets(
 				dev, descSet.DescriptorPool(), 1, NewVkDescriptorSetᶜᵖ(
 					h.sb.MustAllocReadData(descSet.VulkanHandle()).Ptr()), VkResult_VK_SUCCESS))
-		}()
+		})
 	} else {
 		return log.Errf(h.sb.ctx, nil, "failed to allocate descriptorset with %v input attachments", len(job.inputAttachmentImages))
 	}
@@ -1058,7 +1118,9 @@ func (h *ipRenderHandler) render(job *ipRenderJob, queue QueueObjectʳ) error {
 		view := h.createImageView(dev, input, VkImageAspectFlagBits_VK_IMAGE_ASPECT_COLOR_BIT, job.layer, job.level)
 		inputViews = append(inputViews, view)
 		if !view.IsNil() {
-			defer h.sb.write(h.sb.cb.VkDestroyImageView(dev, view.VulkanHandle(), memory.Nullptr))
+			tsk.deferUntilExecuted(func() {
+				h.sb.write(h.sb.cb.VkDestroyImageView(dev, view.VulkanHandle(), memory.Nullptr))
+			})
 		} else {
 			return log.Errf(h.sb.ctx, nil, "failed to create image view for input attachment image: %v", input.VulkanHandle())
 		}
@@ -1069,7 +1131,9 @@ func (h *ipRenderHandler) render(job *ipRenderJob, queue QueueObjectʳ) error {
 	}
 	outputView := h.createImageView(dev, job.renderTarget, job.aspect, job.layer, job.level)
 	if !outputView.IsNil() {
-		defer h.sb.write(h.sb.cb.VkDestroyImageView(dev, outputView.VulkanHandle(), memory.Nullptr))
+		tsk.deferUntilExecuted(func() {
+			h.sb.write(h.sb.cb.VkDestroyImageView(dev, outputView.VulkanHandle(), memory.Nullptr))
+		})
 	} else {
 		return log.Errf(h.sb.ctx, nil, "failed to create image view for rendering target image: %v", job.renderTarget.VulkanHandle())
 	}
@@ -1083,17 +1147,23 @@ func (h *ipRenderHandler) render(job *ipRenderJob, queue QueueObjectʳ) error {
 		))
 	}
 
-	writeDescriptorSet(h.sb, dev, descSet.VulkanHandle(), ipRenderInputAttachmentBinding, 0, VkDescriptorType_VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT, imgInfoList, []VkDescriptorBufferInfo{}, []VkBufferView{})
+	tsk.deferUntilCommitted(func() {
+		writeDescriptorSet(h.sb, dev, descSet.VulkanHandle(), ipRenderInputAttachmentBinding, 0, VkDescriptorType_VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT, imgInfoList, []VkDescriptorBufferInfo{}, []VkBufferView{})
+	})
 
 	var stencilIndexBuf VkBuffer
-	var stencilIndexMem VkDeviceMemory
 	if job.aspect == VkImageAspectFlagBits_VK_IMAGE_ASPECT_STENCIL_BIT {
 		// write the uniform buffer for rendering stencil value.
 		stencilBitIndices := []uint32{0}
 		var sbic bytes.Buffer
 		binary.Write(&sbic, binary.LittleEndian, stencilBitIndices)
-		stencilIndexBuf, stencilIndexMem = h.sb.allocAndFillScratchBuffer(h.sb.s.Devices().Get(dev), []bufferSubRangeFillInfo{newBufferSubRangeFillInfoFromNewData(sbic.Bytes(), 0)}, VkBufferUsageFlagBits_VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT|VkBufferUsageFlagBits_VK_BUFFER_USAGE_TRANSFER_DST_BIT)
-		defer h.sb.freeScratchBuffer(h.sb.s.Devices().Get(dev), stencilIndexBuf, stencilIndexMem)
+		stencilIndexBuf = tsk.newBuffer(
+			[]bufferSubRangeFillInfo{newBufferSubRangeFillInfoFromNewData(sbic.Bytes(), 0)},
+			VkBufferUsageFlagBits_VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT,
+			VkBufferUsageFlagBits_VK_BUFFER_USAGE_TRANSFER_DST_BIT)
+		tsk.deferUntilExecuted(func() {
+			h.sb.write(h.sb.cb.VkDestroyBuffer(dev, stencilIndexBuf, memory.Nullptr))
+		})
 
 		bufInfoList := []VkDescriptorBufferInfo{
 			NewVkDescriptorBufferInfo(h.sb.ta,
@@ -1103,7 +1173,9 @@ func (h *ipRenderHandler) render(job *ipRenderJob, queue QueueObjectʳ) error {
 			),
 		}
 
-		writeDescriptorSet(h.sb, dev, descSet.VulkanHandle(), ipRenderUniformBufferBinding, 0, VkDescriptorType_VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, []VkDescriptorImageInfo{}, bufInfoList, []VkBufferView{})
+		tsk.deferUntilCommitted(func() {
+			writeDescriptorSet(h.sb, dev, descSet.VulkanHandle(), ipRenderUniformBufferBinding, 0, VkDescriptorType_VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, []VkDescriptorImageInfo{}, bufInfoList, []VkBufferView{})
+		})
 	}
 
 	renderPassInfo := ipRenderPassInfo{
@@ -1117,7 +1189,9 @@ func (h *ipRenderHandler) render(job *ipRenderJob, queue QueueObjectʳ) error {
 	}
 	renderPass := h.createRenderPass(renderPassInfo, job.finalLayout)
 	if !renderPass.IsNil() {
-		defer h.sb.write(h.sb.cb.VkDestroyRenderPass(dev, renderPass.VulkanHandle(), memory.Nullptr))
+		tsk.deferUntilExecuted(func() {
+			h.sb.write(h.sb.cb.VkDestroyRenderPass(dev, renderPass.VulkanHandle(), memory.Nullptr))
+		})
 	} else {
 		return log.Errf(h.sb.ctx, nil, "failed to create renderpass for rendering")
 	}
@@ -1133,7 +1207,9 @@ func (h *ipRenderHandler) render(job *ipRenderJob, queue QueueObjectʳ) error {
 	framebuffer := h.createFramebuffer(dev, renderPass.VulkanHandle(), allViews,
 		uint32(targetLevelSize.width), uint32(targetLevelSize.height))
 	if !framebuffer.IsNil() {
-		defer h.sb.write(h.sb.cb.VkDestroyFramebuffer(dev, framebuffer.VulkanHandle(), memory.Nullptr))
+		tsk.deferUntilExecuted(func() {
+			h.sb.write(h.sb.cb.VkDestroyFramebuffer(dev, framebuffer.VulkanHandle(), memory.Nullptr))
+		})
 	} else {
 		return log.Errf(h.sb.ctx, nil, "failed to create framebuffer for rendering")
 	}
@@ -1168,8 +1244,10 @@ func (h *ipRenderHandler) render(job *ipRenderJob, queue QueueObjectʳ) error {
 		h.vertexBufferFillInfo = &i
 		h.vertexBufferFillInfo.storeNewData(h.sb)
 	}
-	vertexBuf, vertexBufMem := h.sb.allocAndFillScratchBuffer(h.sb.s.Devices().Get(dev), []bufferSubRangeFillInfo{*h.vertexBufferFillInfo}, VkBufferUsageFlagBits_VK_BUFFER_USAGE_VERTEX_BUFFER_BIT)
-	defer h.sb.freeScratchBuffer(h.sb.s.Devices().Get(dev), vertexBuf, vertexBufMem)
+	vertexBuf := tsk.newBuffer([]bufferSubRangeFillInfo{*h.vertexBufferFillInfo}, VkBufferUsageFlagBits_VK_BUFFER_USAGE_VERTEX_BUFFER_BIT)
+	tsk.deferUntilExecuted(func() {
+		h.sb.write(h.sb.cb.VkDestroyBuffer(dev, vertexBuf, memory.Nullptr))
+	})
 
 	if h.indexBufferFillInfo == nil {
 		var ic bytes.Buffer
@@ -1180,10 +1258,10 @@ func (h *ipRenderHandler) render(job *ipRenderJob, queue QueueObjectʳ) error {
 		h.indexBufferFillInfo = &i
 		h.indexBufferFillInfo.storeNewData(h.sb)
 	}
-	indexBuf, indexBufMem := h.sb.allocAndFillScratchBuffer(h.sb.s.Devices().Get(dev), []bufferSubRangeFillInfo{*h.indexBufferFillInfo}, VkBufferUsageFlagBits_VK_BUFFER_USAGE_INDEX_BUFFER_BIT)
-	defer h.sb.freeScratchBuffer(h.sb.s.Devices().Get(dev), indexBuf, indexBufMem)
-
-	commandBuffer, commandPool := h.sb.getCommandBuffer(queue)
+	indexBuf := tsk.newBuffer([]bufferSubRangeFillInfo{*h.indexBufferFillInfo}, VkBufferUsageFlagBits_VK_BUFFER_USAGE_INDEX_BUFFER_BIT)
+	tsk.deferUntilExecuted(func() {
+		h.sb.write(h.sb.cb.VkDestroyBuffer(dev, indexBuf, memory.Nullptr))
+	})
 
 	inputBarriers := []VkImageMemoryBarrier{}
 	for _, input := range job.inputAttachmentImages {
@@ -1196,8 +1274,8 @@ func (h *ipRenderHandler) render(job *ipRenderJob, queue QueueObjectʳ) error {
 				VkAccessFlags(VkAccessFlagBits_VK_ACCESS_INPUT_ATTACHMENT_READ_BIT),                                        // dstAccessMask
 				inputLevel.Layout(),                                                                                        // oldLayout
 				VkImageLayout_VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,                                                     // newLayout
-				queue.Family(),                                                                                             // srcQueueFamilyIndex
-				queue.Family(),                                                                                             // dstQueueFamilyIndex
+				queueFamilyIgnore,                                                                                          // srcQueueFamilyIndex
+				queueFamilyIgnore,                                                                                          // dstQueueFamilyIndex
 				input.VulkanHandle(),                                                                                       // image
 				NewVkImageSubresourceRange(h.sb.ta, // subresourceRange
 					VkImageAspectFlags(VkImageAspectFlagBits_VK_IMAGE_ASPECT_COLOR_BIT), // aspectMask
@@ -1216,8 +1294,8 @@ func (h *ipRenderHandler) render(job *ipRenderJob, queue QueueObjectʳ) error {
 		GetState(h.sb.newState).Images().Get(job.renderTarget.VulkanHandle()).Aspects().Get(
 			job.aspect).Layers().Get(job.layer).Levels().Get(job.level).Layout(), // oldLayout
 		outputPreRenderLayout,           // newLayout
-		queue.Family(),                  // srcQueueFamilyIndex
-		queue.Family(),                  // dstQueueFamilyIndex
+		queueFamilyIgnore,               // srcQueueFamilyIndex
+		queueFamilyIgnore,               // dstQueueFamilyIndex
 		job.renderTarget.VulkanHandle(), // image
 		NewVkImageSubresourceRange(h.sb.ta, // subresourceRange
 			outputBarrierAspect, // aspectMask
@@ -1232,8 +1310,8 @@ func (h *ipRenderHandler) render(job *ipRenderJob, queue QueueObjectʳ) error {
 			0, // pNext
 			VkAccessFlags((VkAccessFlagBits_VK_ACCESS_MEMORY_WRITE_BIT-1)|VkAccessFlagBits_VK_ACCESS_MEMORY_WRITE_BIT), // srcAccessMask
 			VkAccessFlags(VkAccessFlagBits_VK_ACCESS_VERTEX_ATTRIBUTE_READ_BIT),                                        // dstAccessMask
-			uint32(queue.Family()),                                                                                     // srcQueueFamilyIndex
-			uint32(queue.Family()),                                                                                     // dstQueueFamilyIndex
+			queueFamilyIgnore,                                                                                          // srcQueueFamilyIndex
+			queueFamilyIgnore,                                                                                          // dstQueueFamilyIndex
 			vertexBuf,                                                                                                  // buffer
 			0,                                                                                                          // offset
 			VkDeviceSize(h.vertexBufferFillInfo.size()), // size
@@ -1243,32 +1321,34 @@ func (h *ipRenderHandler) render(job *ipRenderJob, queue QueueObjectʳ) error {
 			0, // pNext
 			VkAccessFlags((VkAccessFlagBits_VK_ACCESS_MEMORY_WRITE_BIT-1)|VkAccessFlagBits_VK_ACCESS_MEMORY_WRITE_BIT), // srcAccessMask
 			VkAccessFlags(VkAccessFlagBits_VK_ACCESS_INDEX_READ_BIT),                                                   // dstAccessMask
-			uint32(queue.Family()),                                                                                     // srcQueueFamilyIndex
-			uint32(queue.Family()),                                                                                     // dstQueueFamilyIndex
+			queueFamilyIgnore,                                                                                          // srcQueueFamilyIndex
+			queueFamilyIgnore,                                                                                          // dstQueueFamilyIndex
 			indexBuf,                                                                                                   // buffer
 			0,                                                                                                          // offset
 			VkDeviceSize(h.indexBufferFillInfo.size()), // size
 		),
 	}
 
-	h.sb.write(h.sb.cb.VkCmdPipelineBarrier(
-		commandBuffer,
-		VkPipelineStageFlags(VkPipelineStageFlagBits_VK_PIPELINE_STAGE_ALL_COMMANDS_BIT),
-		VkPipelineStageFlags(VkPipelineStageFlagBits_VK_PIPELINE_STAGE_ALL_COMMANDS_BIT),
-		VkDependencyFlags(0),
-		uint32(0),
-		memory.Nullptr,
-		uint32(len(bufBarriers)),
-		h.sb.MustAllocReadData(bufBarriers).Ptr(),
-		uint32(len(append(inputBarriers, outputBarrier))),
-		h.sb.MustAllocReadData(append(inputBarriers, outputBarrier)).Ptr(),
-	))
+	tsk.recordCmdBufCommand(func(commandBuffer VkCommandBuffer) {
+		h.sb.write(h.sb.cb.VkCmdPipelineBarrier(
+			commandBuffer,
+			VkPipelineStageFlags(VkPipelineStageFlagBits_VK_PIPELINE_STAGE_ALL_COMMANDS_BIT),
+			VkPipelineStageFlags(VkPipelineStageFlagBits_VK_PIPELINE_STAGE_ALL_COMMANDS_BIT),
+			VkDependencyFlags(0),
+			uint32(0),
+			memory.Nullptr,
+			uint32(len(bufBarriers)),
+			h.sb.MustAllocReadData(bufBarriers).Ptr(),
+			uint32(len(append(inputBarriers, outputBarrier))),
+			h.sb.MustAllocReadData(append(inputBarriers, outputBarrier)).Ptr(),
+		))
+	})
 
 	switch job.aspect {
 	// render color or depth aspect
 	case VkImageAspectFlagBits_VK_IMAGE_ASPECT_COLOR_BIT, VkImageAspectFlagBits_VK_IMAGE_ASPECT_DEPTH_BIT:
 		drawInfo := ipRenderDrawInfo{
-			commandBuffer:    commandBuffer,
+			tsk:              tsk,
 			renderPass:       renderPass,
 			framebuffer:      framebuffer,
 			descSet:          descSet,
@@ -1289,77 +1369,79 @@ func (h *ipRenderHandler) render(job *ipRenderJob, queue QueueObjectʳ) error {
 	case VkImageAspectFlagBits_VK_IMAGE_ASPECT_STENCIL_BIT:
 		// render the i'th bit of all pixels.
 		for i := uint32(0); i < uint32(8); i++ {
-			h.sb.write(h.sb.cb.VkCmdPipelineBarrier(
-				commandBuffer,
-				VkPipelineStageFlags(VkPipelineStageFlagBits_VK_PIPELINE_STAGE_ALL_COMMANDS_BIT),
-				VkPipelineStageFlags(VkPipelineStageFlagBits_VK_PIPELINE_STAGE_ALL_COMMANDS_BIT),
-				VkDependencyFlags(0),
-				uint32(0),
-				memory.Nullptr,
-				uint32(1),
-				h.sb.MustAllocReadData([]VkBufferMemoryBarrier{
-					NewVkBufferMemoryBarrier(h.sb.ta,
-						VkStructureType_VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER, // sType
-						0, // pNext
-						VkAccessFlags((VkAccessFlagBits_VK_ACCESS_MEMORY_WRITE_BIT-1)|VkAccessFlagBits_VK_ACCESS_MEMORY_WRITE_BIT), // srcAccessMask
-						VkAccessFlags(VkAccessFlagBits_VK_ACCESS_TRANSFER_WRITE_BIT),                                               // dstAccessMask
-						uint32(queue.Family()),                                                                                     // srcQueueFamilyIndex
-						uint32(queue.Family()),                                                                                     // dstQueueFamilyIndex
-						stencilIndexBuf,                                                                                            // buffer
-						0,                                                                                                          // offset
-						VkDeviceSize(0xFFFFFFFFFFFFFFFF), // size
-					)}).Ptr(),
-				uint32(1),
-				h.sb.MustAllocReadData([]VkImageMemoryBarrier{
-					NewVkImageMemoryBarrier(h.sb.ta,
-						VkStructureType_VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER, // sType
-						0, // pNext
-						VkAccessFlags(VkAccessFlagBits_VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT), // srcAccessMask
-						VkAccessFlags(VkAccessFlagBits_VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT), // dstAccessMask
-						VkImageLayout_VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL,               // oldLayout
-						VkImageLayout_VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL,               // newLayout
-						queue.Family(),                  // srcQueueFamilyIndex
-						queue.Family(),                  // dstQueueFamilyIndex
-						job.renderTarget.VulkanHandle(), // image
-						NewVkImageSubresourceRange(h.sb.ta, // subresourceRange
-							outputBarrierAspect, // aspectMask
-							0,                   // baseMipLevel
-							job.renderTarget.Info().MipLevels(), // levelCount
-							0, // baseArrayLayer
-							job.renderTarget.Info().ArrayLayers(), // layerCount
-						),
-					)}).Ptr(),
-			))
-			h.sb.write(h.sb.cb.VkCmdUpdateBuffer(
-				commandBuffer,
-				stencilIndexBuf,
-				0, 4, NewVoidᶜᵖ(h.sb.MustAllocReadData([]uint32{i}).Ptr()),
-			))
-			h.sb.write(h.sb.cb.VkCmdPipelineBarrier(
-				commandBuffer,
-				VkPipelineStageFlags(VkPipelineStageFlagBits_VK_PIPELINE_STAGE_ALL_COMMANDS_BIT),
-				VkPipelineStageFlags(VkPipelineStageFlagBits_VK_PIPELINE_STAGE_ALL_COMMANDS_BIT),
-				VkDependencyFlags(0),
-				uint32(0),
-				memory.Nullptr,
-				uint32(1),
-				h.sb.MustAllocReadData([]VkBufferMemoryBarrier{
-					NewVkBufferMemoryBarrier(h.sb.ta,
-						VkStructureType_VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER, // sType
-						0, // pNext
-						VkAccessFlags(VkAccessFlagBits_VK_ACCESS_TRANSFER_WRITE_BIT), // srcAccessMask
-						VkAccessFlags(VkAccessFlagBits_VK_ACCESS_UNIFORM_READ_BIT),   // dstAccessMask
-						uint32(queue.Family()),                                       // srcQueueFamilyIndex
-						uint32(queue.Family()),                                       // dstQueueFamilyIndex
-						stencilIndexBuf,                                              // buffer
-						0,                                                            // offset
-						VkDeviceSize(0xFFFFFFFFFFFFFFFF), // size
-					)}).Ptr(),
-				uint32(0),
-				memory.Nullptr,
-			))
+			tsk.recordCmdBufCommand(func(commandBuffer VkCommandBuffer) {
+				h.sb.write(h.sb.cb.VkCmdPipelineBarrier(
+					commandBuffer,
+					VkPipelineStageFlags(VkPipelineStageFlagBits_VK_PIPELINE_STAGE_ALL_COMMANDS_BIT),
+					VkPipelineStageFlags(VkPipelineStageFlagBits_VK_PIPELINE_STAGE_ALL_COMMANDS_BIT),
+					VkDependencyFlags(0),
+					uint32(0),
+					memory.Nullptr,
+					uint32(1),
+					h.sb.MustAllocReadData([]VkBufferMemoryBarrier{
+						NewVkBufferMemoryBarrier(h.sb.ta,
+							VkStructureType_VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER, // sType
+							0, // pNext
+							VkAccessFlags((VkAccessFlagBits_VK_ACCESS_MEMORY_WRITE_BIT-1)|VkAccessFlagBits_VK_ACCESS_MEMORY_WRITE_BIT), // srcAccessMask
+							VkAccessFlags(VkAccessFlagBits_VK_ACCESS_TRANSFER_WRITE_BIT),                                               // dstAccessMask
+							queueFamilyIgnore,                                                                                          // srcQueueFamilyIndex
+							queueFamilyIgnore,                                                                                          // dstQueueFamilyIndex
+							stencilIndexBuf,                                                                                            // buffer
+							0,                                                                                                          // offset
+							VkDeviceSize(0xFFFFFFFFFFFFFFFF), // size
+						)}).Ptr(),
+					uint32(1),
+					h.sb.MustAllocReadData([]VkImageMemoryBarrier{
+						NewVkImageMemoryBarrier(h.sb.ta,
+							VkStructureType_VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER, // sType
+							0, // pNext
+							VkAccessFlags(VkAccessFlagBits_VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT), // srcAccessMask
+							VkAccessFlags(VkAccessFlagBits_VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT), // dstAccessMask
+							VkImageLayout_VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL,               // oldLayout
+							VkImageLayout_VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL,               // newLayout
+							queueFamilyIgnore,                                                            // srcQueueFamilyIndex
+							queueFamilyIgnore,                                                            // dstQueueFamilyIndex
+							job.renderTarget.VulkanHandle(),                                              // image
+							NewVkImageSubresourceRange(h.sb.ta, // subresourceRange
+								outputBarrierAspect, // aspectMask
+								0,                   // baseMipLevel
+								job.renderTarget.Info().MipLevels(), // levelCount
+								0, // baseArrayLayer
+								job.renderTarget.Info().ArrayLayers(), // layerCount
+							),
+						)}).Ptr(),
+				))
+				h.sb.write(h.sb.cb.VkCmdUpdateBuffer(
+					commandBuffer,
+					stencilIndexBuf,
+					0, 4, NewVoidᶜᵖ(h.sb.MustAllocReadData([]uint32{i}).Ptr()),
+				))
+				h.sb.write(h.sb.cb.VkCmdPipelineBarrier(
+					commandBuffer,
+					VkPipelineStageFlags(VkPipelineStageFlagBits_VK_PIPELINE_STAGE_ALL_COMMANDS_BIT),
+					VkPipelineStageFlags(VkPipelineStageFlagBits_VK_PIPELINE_STAGE_ALL_COMMANDS_BIT),
+					VkDependencyFlags(0),
+					uint32(0),
+					memory.Nullptr,
+					uint32(1),
+					h.sb.MustAllocReadData([]VkBufferMemoryBarrier{
+						NewVkBufferMemoryBarrier(h.sb.ta,
+							VkStructureType_VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER, // sType
+							0, // pNext
+							VkAccessFlags(VkAccessFlagBits_VK_ACCESS_TRANSFER_WRITE_BIT), // srcAccessMask
+							VkAccessFlags(VkAccessFlagBits_VK_ACCESS_UNIFORM_READ_BIT),   // dstAccessMask
+							queueFamilyIgnore,                                            // srcQueueFamilyIndex
+							queueFamilyIgnore,                                            // dstQueueFamilyIndex
+							stencilIndexBuf,                                              // buffer
+							0,                                                            // offset
+							VkDeviceSize(0xFFFFFFFFFFFFFFFF), // size
+						)}).Ptr(),
+					uint32(0),
+					memory.Nullptr,
+				))
+			})
 			drawInfo := ipRenderDrawInfo{
-				commandBuffer:    commandBuffer,
+				tsk:              tsk,
 				renderPass:       renderPass,
 				framebuffer:      framebuffer,
 				descSet:          descSet,
@@ -1379,48 +1461,49 @@ func (h *ipRenderHandler) render(job *ipRenderJob, queue QueueObjectʳ) error {
 			}
 			h.beginRenderPassAndDraw(drawInfo)
 		}
-		h.sb.write(h.sb.cb.VkCmdPipelineBarrier(
-			commandBuffer,
-			VkPipelineStageFlags(VkPipelineStageFlagBits_VK_PIPELINE_STAGE_ALL_COMMANDS_BIT),
-			VkPipelineStageFlags(VkPipelineStageFlagBits_VK_PIPELINE_STAGE_ALL_COMMANDS_BIT),
-			VkDependencyFlags(0),
-			0,
-			memory.Nullptr,
-			0,
-			memory.Nullptr,
-			1,
-			h.sb.MustAllocReadData([]VkImageMemoryBarrier{
-				NewVkImageMemoryBarrier(h.sb.ta,
-					VkStructureType_VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER, // sType
-					0, // pNext
-					VkAccessFlags(VkAccessFlagBits_VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT), // srcAccessMask
-					VkAccessFlags(VkAccessFlagBits_VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT), // dstAccessMask
-					VkImageLayout_VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL,               // oldLayout
-					job.finalLayout,                 // newLayout
-					queue.Family(),                  // srcQueueFamilyIndex
-					queue.Family(),                  // dstQueueFamilyIndex
-					job.renderTarget.VulkanHandle(), // image
-					NewVkImageSubresourceRange(h.sb.ta, // subresourceRange
-						outputBarrierAspect, // aspectMask
-						0,                   // baseMipLevel
-						job.renderTarget.Info().MipLevels(), // levelCount
-						0, // baseArrayLayer
-						job.renderTarget.Info().ArrayLayers(), // layerCount
-					),
-				)}).Ptr(),
-		))
+		tsk.recordCmdBufCommand(func(commandBuffer VkCommandBuffer) {
+			h.sb.write(h.sb.cb.VkCmdPipelineBarrier(
+				commandBuffer,
+				VkPipelineStageFlags(VkPipelineStageFlagBits_VK_PIPELINE_STAGE_ALL_COMMANDS_BIT),
+				VkPipelineStageFlags(VkPipelineStageFlagBits_VK_PIPELINE_STAGE_ALL_COMMANDS_BIT),
+				VkDependencyFlags(0),
+				0,
+				memory.Nullptr,
+				0,
+				memory.Nullptr,
+				1,
+				h.sb.MustAllocReadData([]VkImageMemoryBarrier{
+					NewVkImageMemoryBarrier(h.sb.ta,
+						VkStructureType_VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER, // sType
+						0, // pNext
+						VkAccessFlags(VkAccessFlagBits_VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT), // srcAccessMask
+						VkAccessFlags(VkAccessFlagBits_VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT), // dstAccessMask
+						VkImageLayout_VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL,               // oldLayout
+						job.finalLayout,                 // newLayout
+						queueFamilyIgnore,               // srcQueueFamilyIndex
+						queueFamilyIgnore,               // dstQueueFamilyIndex
+						job.renderTarget.VulkanHandle(), // image
+						NewVkImageSubresourceRange(h.sb.ta, // subresourceRange
+							outputBarrierAspect, // aspectMask
+							0,                   // baseMipLevel
+							job.renderTarget.Info().MipLevels(), // levelCount
+							0, // baseArrayLayer
+							job.renderTarget.Info().ArrayLayers(), // layerCount
+						),
+					)}).Ptr(),
+			))
+		})
 	default:
 		return log.Errf(h.sb.ctx, nil, "invalid aspect: %v to render", job.aspect)
 	}
 
-	h.sb.endSubmitAndDestroyCommandBuffer(queue, commandBuffer, commandPool)
 	return nil
 }
 
 // Internal functions for render handler
 
 type ipRenderDrawInfo struct {
-	commandBuffer    VkCommandBuffer
+	tsk              *scratchTask
 	renderPass       RenderPassObjectʳ
 	framebuffer      FramebufferObjectʳ
 	descSet          DescriptorSetObjectʳ
@@ -1437,115 +1520,116 @@ type ipRenderDrawInfo struct {
 }
 
 func (h *ipRenderHandler) beginRenderPassAndDraw(info ipRenderDrawInfo) {
-
-	h.sb.write(h.sb.cb.VkCmdBeginRenderPass(
-		info.commandBuffer,
-		h.sb.MustAllocReadData(
-			NewVkRenderPassBeginInfo(h.sb.ta,
-				VkStructureType_VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO, // sType
-				NewVoidᶜᵖ(memory.Nullptr),                                // pNext
-				info.renderPass.VulkanHandle(),                           // renderPass
-				info.framebuffer.VulkanHandle(),                          // framebuffer
-				NewVkRect2D(h.sb.ta, // renderArea
-					MakeVkOffset2D(h.sb.ta),
-					NewVkExtent2D(h.sb.ta, info.width, info.height),
-				),
-				0, // clearValueCount
-				0, // pClearValues
-			)).Ptr(),
-		VkSubpassContents(0),
-	))
-
-	if info.clearStencil {
-		h.sb.write(h.sb.cb.VkCmdClearAttachments(
-			info.commandBuffer,
-			uint32(1),
-			h.sb.MustAllocReadData([]VkClearAttachment{
-				NewVkClearAttachment(h.sb.ta,
-					VkImageAspectFlags(VkImageAspectFlagBits_VK_IMAGE_ASPECT_STENCIL_BIT), // aspectMask
-					0, // colorAttachment
-					MakeVkClearValue(h.sb.ta), // clearValue
-				),
-			}).Ptr(),
-			uint32(1),
-			h.sb.MustAllocReadData([]VkClearRect{
-				NewVkClearRect(h.sb.ta,
-					NewVkRect2D(h.sb.ta,
+	info.tsk.recordCmdBufCommand(func(commandBuffer VkCommandBuffer) {
+		h.sb.write(h.sb.cb.VkCmdBeginRenderPass(
+			commandBuffer,
+			h.sb.MustAllocReadData(
+				NewVkRenderPassBeginInfo(h.sb.ta,
+					VkStructureType_VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO, // sType
+					NewVoidᶜᵖ(memory.Nullptr),                                // pNext
+					info.renderPass.VulkanHandle(),                           // renderPass
+					info.framebuffer.VulkanHandle(),                          // framebuffer
+					NewVkRect2D(h.sb.ta, // renderArea
 						MakeVkOffset2D(h.sb.ta),
 						NewVkExtent2D(h.sb.ta, info.width, info.height),
-					), // rect
-					// the baseArrayLayer counts from the base layer of the
-					// attachment image view.
-					0, // baseArrayLayer
-					1, // layerCount
-				),
-			}).Ptr(),
+					),
+					0, // clearValueCount
+					0, // pClearValues
+				)).Ptr(),
+			VkSubpassContents(0),
 		))
-	}
 
-	h.sb.write(h.sb.cb.VkCmdBindPipeline(
-		info.commandBuffer,
-		VkPipelineBindPoint_VK_PIPELINE_BIND_POINT_GRAPHICS,
-		info.pipeline.VulkanHandle(),
-	))
-	h.sb.write(h.sb.cb.VkCmdBindVertexBuffers(
-		info.commandBuffer,
-		0, 1,
-		h.sb.MustAllocReadData(info.vertexBuf).Ptr(),
-		h.sb.MustAllocReadData(VkDeviceSize(0)).Ptr(),
-	))
-	h.sb.write(h.sb.cb.VkCmdBindIndexBuffer(
-		info.commandBuffer,
-		info.indexBuf,
-		VkDeviceSize(0),
-		VkIndexType_VK_INDEX_TYPE_UINT32,
-	))
-	h.sb.write(h.sb.cb.VkCmdSetViewport(
-		info.commandBuffer,
-		uint32(0),
-		uint32(1),
-		NewVkViewportᶜᵖ(h.sb.MustAllocReadData(NewVkViewport(h.sb.ta,
-			0, 0, // x, y
-			float32(info.width), float32(info.height), // width, height
-			0, 1, // minDepth, maxDepth
-		)).Ptr()),
-	))
-	h.sb.write(h.sb.cb.VkCmdSetScissor(
-		info.commandBuffer,
-		uint32(0),
-		uint32(1),
-		NewVkRect2Dᶜᵖ(h.sb.MustAllocReadData(NewVkRect2D(h.sb.ta,
-			MakeVkOffset2D(h.sb.ta),
-			NewVkExtent2D(h.sb.ta, info.width, info.height),
-		)).Ptr()),
-	))
-	if info.aspect == VkImageAspectFlagBits_VK_IMAGE_ASPECT_STENCIL_BIT {
-		h.sb.write(h.sb.cb.VkCmdSetStencilWriteMask(
-			info.commandBuffer,
-			VkStencilFaceFlags(VkStencilFaceFlagBits_VK_STENCIL_FRONT_AND_BACK),
-			info.stencilWriteMask,
+		if info.clearStencil {
+			h.sb.write(h.sb.cb.VkCmdClearAttachments(
+				commandBuffer,
+				uint32(1),
+				h.sb.MustAllocReadData([]VkClearAttachment{
+					NewVkClearAttachment(h.sb.ta,
+						VkImageAspectFlags(VkImageAspectFlagBits_VK_IMAGE_ASPECT_STENCIL_BIT), // aspectMask
+						0, // colorAttachment
+						MakeVkClearValue(h.sb.ta), // clearValue
+					),
+				}).Ptr(),
+				uint32(1),
+				h.sb.MustAllocReadData([]VkClearRect{
+					NewVkClearRect(h.sb.ta,
+						NewVkRect2D(h.sb.ta,
+							MakeVkOffset2D(h.sb.ta),
+							NewVkExtent2D(h.sb.ta, info.width, info.height),
+						), // rect
+						// the baseArrayLayer counts from the base layer of the
+						// attachment image view.
+						0, // baseArrayLayer
+						1, // layerCount
+					),
+				}).Ptr(),
+			))
+		}
+
+		h.sb.write(h.sb.cb.VkCmdBindPipeline(
+			commandBuffer,
+			VkPipelineBindPoint_VK_PIPELINE_BIND_POINT_GRAPHICS,
+			info.pipeline.VulkanHandle(),
 		))
-		h.sb.write(h.sb.cb.VkCmdSetStencilReference(
-			info.commandBuffer,
-			VkStencilFaceFlags(VkStencilFaceFlagBits_VK_STENCIL_FRONT_AND_BACK),
-			info.stencilReference,
+		h.sb.write(h.sb.cb.VkCmdBindVertexBuffers(
+			commandBuffer,
+			0, 1,
+			h.sb.MustAllocReadData(info.vertexBuf).Ptr(),
+			h.sb.MustAllocReadData(VkDeviceSize(0)).Ptr(),
 		))
-	}
-	h.sb.write(h.sb.cb.VkCmdBindDescriptorSets(
-		info.commandBuffer,
-		VkPipelineBindPoint_VK_PIPELINE_BIND_POINT_GRAPHICS,
-		info.pipelineLayout.VulkanHandle(),
-		0,
-		1,
-		h.sb.MustAllocReadData(info.descSet.VulkanHandle()).Ptr(),
-		0,
-		NewU32ᶜᵖ(memory.Nullptr),
-	))
-	h.sb.write(h.sb.cb.VkCmdDrawIndexed(
-		info.commandBuffer,
-		6, 1, 0, 0, 0,
-	))
-	h.sb.write(h.sb.cb.VkCmdEndRenderPass(info.commandBuffer))
+		h.sb.write(h.sb.cb.VkCmdBindIndexBuffer(
+			commandBuffer,
+			info.indexBuf,
+			VkDeviceSize(0),
+			VkIndexType_VK_INDEX_TYPE_UINT32,
+		))
+		h.sb.write(h.sb.cb.VkCmdSetViewport(
+			commandBuffer,
+			uint32(0),
+			uint32(1),
+			NewVkViewportᶜᵖ(h.sb.MustAllocReadData(NewVkViewport(h.sb.ta,
+				0, 0, // x, y
+				float32(info.width), float32(info.height), // width, height
+				0, 1, // minDepth, maxDepth
+			)).Ptr()),
+		))
+		h.sb.write(h.sb.cb.VkCmdSetScissor(
+			commandBuffer,
+			uint32(0),
+			uint32(1),
+			NewVkRect2Dᶜᵖ(h.sb.MustAllocReadData(NewVkRect2D(h.sb.ta,
+				MakeVkOffset2D(h.sb.ta),
+				NewVkExtent2D(h.sb.ta, info.width, info.height),
+			)).Ptr()),
+		))
+		if info.aspect == VkImageAspectFlagBits_VK_IMAGE_ASPECT_STENCIL_BIT {
+			h.sb.write(h.sb.cb.VkCmdSetStencilWriteMask(
+				commandBuffer,
+				VkStencilFaceFlags(VkStencilFaceFlagBits_VK_STENCIL_FRONT_AND_BACK),
+				info.stencilWriteMask,
+			))
+			h.sb.write(h.sb.cb.VkCmdSetStencilReference(
+				commandBuffer,
+				VkStencilFaceFlags(VkStencilFaceFlagBits_VK_STENCIL_FRONT_AND_BACK),
+				info.stencilReference,
+			))
+		}
+		h.sb.write(h.sb.cb.VkCmdBindDescriptorSets(
+			commandBuffer,
+			VkPipelineBindPoint_VK_PIPELINE_BIND_POINT_GRAPHICS,
+			info.pipelineLayout.VulkanHandle(),
+			0,
+			1,
+			h.sb.MustAllocReadData(info.descSet.VulkanHandle()).Ptr(),
+			0,
+			NewU32ᶜᵖ(memory.Nullptr),
+		))
+		h.sb.write(h.sb.cb.VkCmdDrawIndexed(
+			commandBuffer,
+			6, 1, 0, 0, 0,
+		))
+		h.sb.write(h.sb.cb.VkCmdEndRenderPass(commandBuffer))
+	})
 }
 
 func (h *ipRenderHandler) createFramebuffer(dev VkDevice, renderPass VkRenderPass, imgViews []VkImageView, width, height uint32) FramebufferObjectʳ {
@@ -2085,11 +2169,15 @@ func (s *ipBufCopyJob) addDst(ctx context.Context, srcAspect, dstAspect VkImageA
 }
 
 type ipBufferCopySession struct {
-	copies    map[ImageObjectʳ][]VkBufferImageCopy
-	content   []bufferSubRangeFillInfo
+	// Copies in the same order of content, all copies have offsets start at 0.
+	copies map[ImageObjectʳ][]VkBufferImageCopy
+	// The buffer content of each VkBufferImageCopy, all sub-range fill info
+	// starts their range at 0.
+	content   map[ImageObjectʳ][]bufferSubRangeFillInfo
 	totalSize uint64
-	job       *ipBufCopyJob
-	sb        *stateBuilder
+	// The source and destination image for this copy session.
+	job *ipBufCopyJob
+	sb  *stateBuilder
 }
 
 // interfaces to interact with image primer
@@ -2097,13 +2185,14 @@ type ipBufferCopySession struct {
 func newImagePrimerBufferCopySession(sb *stateBuilder, job *ipBufCopyJob) *ipBufferCopySession {
 	h := &ipBufferCopySession{
 		copies:  map[ImageObjectʳ][]VkBufferImageCopy{},
-		content: []bufferSubRangeFillInfo{},
+		content: map[ImageObjectʳ][]bufferSubRangeFillInfo{},
 		job:     job,
 		sb:      sb,
 	}
 	for _, dst := range job.srcAspectsToDsts {
 		for _, img := range dst.dstImgs {
 			h.copies[img] = []VkBufferImageCopy{}
+			h.content[img] = []bufferSubRangeFillInfo{}
 		}
 	}
 	return h
@@ -2125,13 +2214,13 @@ func (h *ipBufferCopySession) collectCopiesFromSubresourceRange(srcRng VkImageSu
 				bufFillInfo, bufImgCopy, err := h.getCopyAndData(
 					dstImg, h.job.srcAspectsToDsts[aspect].dstAspect,
 					h.job.srcImg, aspect, layer, level, MakeVkOffset3D(h.sb.ta),
-					extent, h.totalSize)
+					extent)
 				if err != nil {
 					log.E(h.sb.ctx, "[Getting VkBufferImageCopy and raw data for priming data at image: %v, aspect: %v, layer: %v, level: %v] %v", h.job.srcImg.VulkanHandle(), aspect, layer, level, err)
 					continue
 				}
 				h.copies[dstImg] = append(h.copies[dstImg], bufImgCopy)
-				h.content = append(h.content, bufFillInfo)
+				h.content[dstImg] = append(h.content[dstImg], bufFillInfo)
 				h.totalSize += bufFillInfo.size()
 			}
 		})
@@ -2147,46 +2236,39 @@ func (h *ipBufferCopySession) collectCopiesFromSparseImageBindings() {
 				bufFillInfo, bufImgCopy, err := h.getCopyAndData(
 					dstImg, h.job.srcAspectsToDsts[aspect].dstAspect,
 					h.job.srcImg, aspect, layer, level, blockData.Offset(),
-					blockData.Extent(), h.totalSize)
+					blockData.Extent())
 				if err != nil {
 					log.E(h.sb.ctx, "[Getting VkBufferImageCopy and raw data from sparse image binding at image: %v, aspect: %v, layer: %v, level: %v, offset: %v, extent: %v] %v", h.job.srcImg.VulkanHandle(), aspect, layer, level, blockData.Offset(), blockData.Extent(), err)
 					continue
 				}
 				h.copies[dstImg] = append(h.copies[dstImg], bufImgCopy)
-				h.content = append(h.content, bufFillInfo)
+				h.content[dstImg] = append(h.content[dstImg], bufFillInfo)
 				h.totalSize += bufFillInfo.size()
 			}
 		})
 }
 
-func (h *ipBufferCopySession) rolloutBufCopies(submissionQueue QueueObjectʳ, dstImgsOldQueue QueueObjectʳ) error {
+func (h *ipBufferCopySession) rolloutBufCopies(queue VkQueue) error {
 
-	if h.totalSize == 0 {
-		return log.Errf(h.sb.ctx, nil, "[Submit buf -> img copy commands] no valid data to copy")
+	if h.totalSize == 0 || len(h.copies) == 0 || len(h.content) == 0 {
+		return log.Errf(h.sb.ctx, nil, "no content for buf->img copy")
 	}
 
-	scratchBuffer, scratchMemory := h.sb.allocAndFillScratchBuffer(h.sb.s.Devices().Get(h.job.srcImg.Device()), h.content, VkBufferUsageFlagBits_VK_BUFFER_USAGE_TRANSFER_SRC_BIT)
-	defer h.sb.freeScratchBuffer(h.sb.s.Devices().Get(h.job.srcImg.Device()), scratchBuffer, scratchMemory)
-
-	commandBuffer, commandPool := h.sb.getCommandBuffer(submissionQueue)
-	defer h.sb.endSubmitAndDestroyCommandBuffer(submissionQueue, commandBuffer, commandPool)
-
-	oldQueueFamilyIndex := uint32(submissionQueue.Family())
-	if !dstImgsOldQueue.IsNil() {
-		oldQueueFamilyIndex = uint32(dstImgsOldQueue.Family())
+	if len(h.copies) != len(h.content) {
+		return log.Errf(h.sb.ctx, nil, "mismatch number of VkBufferImageCopy: %v and buffer content pieces: %v", len(h.copies), len(h.content))
 	}
-	dstImgBarriers := []VkImageMemoryBarrier{}
+
 	for _, dst := range h.job.srcAspectsToDsts {
 		for _, dstImg := range dst.dstImgs {
-			barrier := NewVkImageMemoryBarrier(h.sb.ta,
+			preCopyDstImgBarrier := NewVkImageMemoryBarrier(h.sb.ta,
 				VkStructureType_VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER, // sType
 				0, // pNext
 				VkAccessFlags((VkAccessFlagBits_VK_ACCESS_MEMORY_WRITE_BIT-1)|VkAccessFlagBits_VK_ACCESS_MEMORY_WRITE_BIT), // srcAccessMask
 				VkAccessFlags((VkAccessFlagBits_VK_ACCESS_MEMORY_WRITE_BIT-1)|VkAccessFlagBits_VK_ACCESS_MEMORY_WRITE_BIT), // dstAccessMask
 				VkImageLayout_VK_IMAGE_LAYOUT_UNDEFINED,                                                                    // oldLayout
 				VkImageLayout_VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,                                                         // newLayout
-				oldQueueFamilyIndex,                                                                                        // srcQueueFamilyIndex
-				uint32(submissionQueue.Family()),                                                                           // dstQueueFamilyIndex
+				queueFamilyIgnore,                                                                                          // srcQueueFamilyIndex
+				queueFamilyIgnore,                                                                                          // dstQueueFamilyIndex
 				dstImg.VulkanHandle(),                                                                                      // image
 				NewVkImageSubresourceRange(h.sb.ta, // subresourceRange
 					VkImageAspectFlags(dst.dstAspect), // aspectMask
@@ -2196,50 +2278,8 @@ func (h *ipBufferCopySession) rolloutBufCopies(submissionQueue QueueObjectʳ, ds
 					dstImg.Info().ArrayLayers(), // layerCount
 				),
 			)
-			dstImgBarriers = append(dstImgBarriers, barrier)
-		}
-	}
 
-	h.sb.write(h.sb.cb.VkCmdPipelineBarrier(
-		commandBuffer,
-		VkPipelineStageFlags(VkPipelineStageFlagBits_VK_PIPELINE_STAGE_ALL_COMMANDS_BIT),
-		VkPipelineStageFlags(VkPipelineStageFlagBits_VK_PIPELINE_STAGE_ALL_COMMANDS_BIT),
-		VkDependencyFlags(0),
-		uint32(0),
-		memory.Nullptr,
-		uint32(1),
-		h.sb.MustAllocReadData(
-			NewVkBufferMemoryBarrier(h.sb.ta,
-				VkStructureType_VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER, // sType
-				0, // pNext
-				VkAccessFlags((VkAccessFlagBits_VK_ACCESS_MEMORY_WRITE_BIT-1)|VkAccessFlagBits_VK_ACCESS_MEMORY_WRITE_BIT), // srcAccessMask
-				VkAccessFlags((VkAccessFlagBits_VK_ACCESS_MEMORY_WRITE_BIT-1)|VkAccessFlagBits_VK_ACCESS_MEMORY_WRITE_BIT), // dstAccessMask
-				uint32(submissionQueue.Family()),                                                                           // srcQueueFamilyIndex
-				uint32(submissionQueue.Family()),                                                                           // dstQueueFamilyIndex
-				scratchBuffer,                                                                                              // buffer
-				0,                                                                                                          // offset
-				VkDeviceSize(h.totalSize), // size
-			)).Ptr(),
-		uint32(len(dstImgBarriers)),
-		h.sb.MustAllocReadData(dstImgBarriers).Ptr(),
-	))
-
-	for _, dst := range h.job.srcAspectsToDsts {
-		for _, dstImg := range dst.dstImgs {
-			h.sb.write(h.sb.cb.VkCmdCopyBufferToImage(
-				commandBuffer,
-				scratchBuffer,
-				dstImg.VulkanHandle(),
-				VkImageLayout_VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
-				uint32(len(h.copies[dstImg])),
-				h.sb.MustAllocReadData(h.copies[dstImg]).Ptr(),
-			))
-		}
-	}
-
-	dstImgBarriers = nil
-	for _, dst := range h.job.srcAspectsToDsts {
-		for _, dstImg := range dst.dstImgs {
+			postCopyDstImgBarriers := []VkImageMemoryBarrier{}
 			walkImageSubresourceRange(h.sb, dstImg, h.sb.imageWholeSubresourceRange(dstImg), func(aspect VkImageAspectFlagBits, layer, level uint32, unused byteSizeAndExtent) {
 				barrier := NewVkImageMemoryBarrier(h.sb.ta,
 					VkStructureType_VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER, // sType
@@ -2248,8 +2288,8 @@ func (h *ipBufferCopySession) rolloutBufCopies(submissionQueue QueueObjectʳ, ds
 					VkAccessFlags((VkAccessFlagBits_VK_ACCESS_MEMORY_WRITE_BIT-1)|VkAccessFlagBits_VK_ACCESS_MEMORY_WRITE_BIT), // dstAccessMask
 					VkImageLayout_VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,                                                         // oldLayout
 					h.job.finalLayout.layoutOf(aspect, layer, level),                                                           // newLayout
-					oldQueueFamilyIndex,                                                                                        // srcQueueFamilyIndex
-					uint32(submissionQueue.Family()),                                                                           // dstQueueFamilyIndex
+					queueFamilyIgnore,                                                                                          // srcQueueFamilyIndex
+					queueFamilyIgnore,                                                                                          // dstQueueFamilyIndex
 					dstImg.VulkanHandle(),                                                                                      // image
 					NewVkImageSubresourceRange(h.sb.ta, // subresourceRange
 						VkImageAspectFlags(aspect), // aspectMask
@@ -2259,35 +2299,111 @@ func (h *ipBufferCopySession) rolloutBufCopies(submissionQueue QueueObjectʳ, ds
 						1,     // layerCount
 					),
 				)
-				dstImgBarriers = append(dstImgBarriers, barrier)
+				postCopyDstImgBarriers = append(postCopyDstImgBarriers, barrier)
 			})
+
+			for len(h.copies[dstImg]) != 0 && len(h.content[dstImg]) != 0 {
+				// log.W(h.sb.ctx, "len(h.copies[dstImg]): %v", len(h.copies[dstImg]))
+				// log.W(h.sb.ctx, "len(h.content[dstImg]): %v", len(h.content[dstImg]))
+				copies := []VkBufferImageCopy{}
+				bufContent := []bufferSubRangeFillInfo{}
+				bufOffset := uint64(0)
+				for i, copy := range h.copies[dstImg] {
+					if bufOffset+h.content[dstImg][i].size() > scratchBufferSize {
+						break
+					}
+					copy.SetBufferOffset(VkDeviceSize(bufOffset))
+					copies = append(copies, copy)
+					content := h.content[dstImg][i]
+					content.setOffsetInBuffer(bufOffset)
+					bufContent = append(bufContent, content)
+					bufOffset += content.size()
+				}
+				if len(copies) == 0 || len(bufContent) == 0 {
+					return log.Errf(h.sb.ctx, nil, "not enough memory to allocate for the scratch buffer for copying image subresource, required size: %v, maximum scratch buffer size: %v", h.content[dstImg][0].size(), scratchBufferSize)
+				}
+				h.copies[dstImg] = h.copies[dstImg][len(copies):]
+				h.content[dstImg] = h.content[dstImg][len(bufContent):]
+				tsk := h.sb.newScratchTaskOnQueue(queue)
+				scratchBuffer := tsk.newBuffer(bufContent, VkBufferUsageFlagBits_VK_BUFFER_USAGE_TRANSFER_SRC_BIT)
+				tsk.deferUntilExecuted(func() {
+					h.sb.write(h.sb.cb.VkDestroyBuffer(h.sb.s.Queues().Get(tsk.queue).Device(), scratchBuffer, memory.Nullptr))
+				})
+
+				tsk.recordCmdBufCommand(func(commandBuffer VkCommandBuffer) {
+					h.sb.write(h.sb.cb.VkCmdPipelineBarrier(
+						commandBuffer,
+						VkPipelineStageFlags(VkPipelineStageFlagBits_VK_PIPELINE_STAGE_ALL_COMMANDS_BIT),
+						VkPipelineStageFlags(VkPipelineStageFlagBits_VK_PIPELINE_STAGE_ALL_COMMANDS_BIT),
+						VkDependencyFlags(0),
+						uint32(0),
+						memory.Nullptr,
+						uint32(1),
+						h.sb.MustAllocReadData(
+							NewVkBufferMemoryBarrier(h.sb.ta,
+								VkStructureType_VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER, // sType
+								0, // pNext
+								VkAccessFlags((VkAccessFlagBits_VK_ACCESS_MEMORY_WRITE_BIT-1)|VkAccessFlagBits_VK_ACCESS_MEMORY_WRITE_BIT), // srcAccessMask
+								VkAccessFlags((VkAccessFlagBits_VK_ACCESS_MEMORY_WRITE_BIT-1)|VkAccessFlagBits_VK_ACCESS_MEMORY_WRITE_BIT), // dstAccessMask
+								queueFamilyIgnore, // srcQueueFamilyIndex
+								queueFamilyIgnore, // dstQueueFamilyIndex
+								scratchBuffer,     // buffer
+								0,                 // offset
+								VkDeviceSize(bufOffset), // size
+							)).Ptr(),
+						uint32(1),
+						h.sb.MustAllocReadData(preCopyDstImgBarrier).Ptr(),
+					))
+				})
+
+				tsk.recordCmdBufCommand(func(commandBuffer VkCommandBuffer) {
+					h.sb.write(h.sb.cb.VkCmdCopyBufferToImage(
+						commandBuffer,
+						scratchBuffer,
+						dstImg.VulkanHandle(),
+						VkImageLayout_VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+						uint32(len(copies)),
+						h.sb.MustAllocReadData(copies).Ptr(),
+					))
+				})
+
+				tsk.recordCmdBufCommand(func(commandBuffer VkCommandBuffer) {
+					h.sb.write(h.sb.cb.VkCmdPipelineBarrier(
+						commandBuffer,
+						VkPipelineStageFlags(VkPipelineStageFlagBits_VK_PIPELINE_STAGE_ALL_COMMANDS_BIT),
+						VkPipelineStageFlags(VkPipelineStageFlagBits_VK_PIPELINE_STAGE_ALL_COMMANDS_BIT),
+						VkDependencyFlags(0),
+						uint32(0),
+						memory.Nullptr,
+						uint32(0),
+						memory.Nullptr,
+						uint32(len(postCopyDstImgBarriers)),
+						h.sb.MustAllocReadData(postCopyDstImgBarriers).Ptr(),
+					))
+				})
+				if err := tsk.commit(); err != nil {
+					return log.Errf(h.sb.ctx, err, "[Committing scratch buffer filling and image copy commands, scratch buffer size: %v]", bufOffset)
+				}
+			}
 		}
 	}
-
-	h.sb.write(h.sb.cb.VkCmdPipelineBarrier(
-		commandBuffer,
-		VkPipelineStageFlags(VkPipelineStageFlagBits_VK_PIPELINE_STAGE_ALL_COMMANDS_BIT),
-		VkPipelineStageFlags(VkPipelineStageFlagBits_VK_PIPELINE_STAGE_ALL_COMMANDS_BIT),
-		VkDependencyFlags(0),
-		uint32(0),
-		memory.Nullptr,
-		uint32(0),
-		memory.Nullptr,
-		uint32(len(dstImgBarriers)),
-		h.sb.MustAllocReadData(dstImgBarriers).Ptr(),
-	))
-
 	return nil
 }
 
 // internal functions of ipBufferCopSessionr
 
-func (h *ipBufferCopySession) getCopyAndData(dstImg ImageObjectʳ, dstAspect VkImageAspectFlagBits, srcImg ImageObjectʳ, srcAspect VkImageAspectFlagBits, layer, level uint32, opaqueBlockOffset VkOffset3D, opaqueBlockExtent VkExtent3D, bufDataOffset uint64) (bufferSubRangeFillInfo, VkBufferImageCopy, error) {
+// getCopyAndData returns the buffer content and the VkBufferImageCopy struct
+// to be used to conduct the data copy from the specific subresource of the src
+// image to the corresponding subresource of the dst image. The returned content
+// and the VkBufferImageCopy assume the copy will be carried out with a buffer
+// range starts from 0, i.e. the bufferOffset of VkBufferImageCopy is 0, and the
+// bufferSubRangeFillInfo's range begin at 0.
+func (h *ipBufferCopySession) getCopyAndData(dstImg ImageObjectʳ, dstAspect VkImageAspectFlagBits, srcImg ImageObjectʳ, srcAspect VkImageAspectFlagBits, layer, level uint32, opaqueBlockOffset VkOffset3D, opaqueBlockExtent VkExtent3D) (bufferSubRangeFillInfo, VkBufferImageCopy, error) {
 	var err error
 	bufImgCopy := NewVkBufferImageCopy(h.sb.ta,
-		VkDeviceSize(bufDataOffset), // bufferOffset
-		0, // bufferRowLength
-		0, // bufferImageHeight
+		VkDeviceSize(0), // bufferOffset
+		0,               // bufferRowLength
+		0,               // bufferImageHeight
 		NewVkImageSubresourceLayers(h.sb.ta, // imageSubresource
 			VkImageAspectFlags(dstAspect), // aspectMask
 			level, // mipLevel
@@ -2369,16 +2485,16 @@ func (h *ipBufferCopySession) getCopyAndData(dstImg ImageObjectʳ, dstAspect VkI
 	}
 
 	if len(unpackedData) != 0 {
-		return newBufferSubRangeFillInfoFromNewData(unpackedData, bufDataOffset), bufImgCopy, nil
+		return newBufferSubRangeFillInfoFromNewData(unpackedData, 0), bufImgCopy, nil
 	}
-	return newBufferSubRangeFillInfoFromSlice(h.sb, dataSlice, bufDataOffset), bufImgCopy, nil
+	return newBufferSubRangeFillInfoFromSlice(h.sb, dataSlice, 0), bufImgCopy, nil
 }
 
 // free functions
 
 func extendToMultipleOf8(dataPtr *[]uint8) {
 	l := uint64(len(*dataPtr))
-	nl := nextMultipleOf8(l)
+	nl := nextMultipleOf(l, 8)
 	zeros := make([]uint8, nl-l)
 	*dataPtr = append(*dataPtr, zeros...)
 }

--- a/gapis/api/vulkan/read_framebuffer.go
+++ b/gapis/api/vulkan/read_framebuffer.go
@@ -239,7 +239,7 @@ func postImageData(ctx context.Context,
 		return
 	}
 
-	queue := imageObject.LastBoundQueue()
+	queue := imageObject.Aspects().Get(aspect).Layers().Get(0).Levels().Get(0).LastBoundQueue()
 	vkQueue := queue.VulkanHandle()
 	vkDevice := queue.Device()
 	device := GetState(s).Devices().Get(vkDevice)

--- a/gapis/api/vulkan/replay.go
+++ b/gapis/api/vulkan/replay.go
@@ -64,6 +64,8 @@ func (a API) GetReplayPriority(ctx context.Context, i *device.Instance, h *captu
 	for _, abi := range devAbis {
 		// Memory layout must match.
 		if !abi.GetMemoryLayout().SameAs(h.GetABI().GetMemoryLayout()) {
+			log.W(ctx, "device abi: %v", abi.GetMemoryLayout())
+			log.W(ctx, "trace abi: %v", h.GetABI().GetMemoryLayout())
 			continue
 		}
 		// If there is no physical devices, the trace must not contain
@@ -77,12 +79,18 @@ func (a API) GetReplayPriority(ctx context.Context, i *device.Instance, h *captu
 			for _, tracePhyInfo := range traceVkDriver.GetPhysicalDevices() {
 				// TODO: More sophisticated rules
 				if devPhyInfo.GetVendorId() != tracePhyInfo.GetVendorId() {
+					log.W(ctx, "dev vendor: %v", devPhyInfo.GetVendorId())
+					log.W(ctx, "trace vendor: %v", tracePhyInfo.GetVendorId())
 					continue
 				}
 				if devPhyInfo.GetDeviceId() != tracePhyInfo.GetDeviceId() {
+					log.W(ctx, "dev device id: %v", devPhyInfo.GetDeviceId())
+					log.W(ctx, "trace device id: %v", tracePhyInfo.GetDeviceId())
 					continue
 				}
 				if devPhyInfo.GetApiVersion() != tracePhyInfo.GetApiVersion() {
+					log.W(ctx, "dev api version: %v", devPhyInfo.GetApiVersion())
+					log.W(ctx, "trace api version: %v", tracePhyInfo.GetApiVersion())
 					continue
 				}
 				return 1

--- a/gapis/api/vulkan/replay.go
+++ b/gapis/api/vulkan/replay.go
@@ -64,8 +64,6 @@ func (a API) GetReplayPriority(ctx context.Context, i *device.Instance, h *captu
 	for _, abi := range devAbis {
 		// Memory layout must match.
 		if !abi.GetMemoryLayout().SameAs(h.GetABI().GetMemoryLayout()) {
-			log.W(ctx, "device abi: %v", abi.GetMemoryLayout())
-			log.W(ctx, "trace abi: %v", h.GetABI().GetMemoryLayout())
 			continue
 		}
 		// If there is no physical devices, the trace must not contain
@@ -79,18 +77,12 @@ func (a API) GetReplayPriority(ctx context.Context, i *device.Instance, h *captu
 			for _, tracePhyInfo := range traceVkDriver.GetPhysicalDevices() {
 				// TODO: More sophisticated rules
 				if devPhyInfo.GetVendorId() != tracePhyInfo.GetVendorId() {
-					log.W(ctx, "dev vendor: %v", devPhyInfo.GetVendorId())
-					log.W(ctx, "trace vendor: %v", tracePhyInfo.GetVendorId())
 					continue
 				}
 				if devPhyInfo.GetDeviceId() != tracePhyInfo.GetDeviceId() {
-					log.W(ctx, "dev device id: %v", devPhyInfo.GetDeviceId())
-					log.W(ctx, "trace device id: %v", tracePhyInfo.GetDeviceId())
 					continue
 				}
 				if devPhyInfo.GetApiVersion() != tracePhyInfo.GetApiVersion() {
-					log.W(ctx, "dev api version: %v", devPhyInfo.GetApiVersion())
-					log.W(ctx, "trace api version: %v", tracePhyInfo.GetApiVersion())
 					continue
 				}
 				return 1

--- a/gapis/api/vulkan/scratch_resources.go
+++ b/gapis/api/vulkan/scratch_resources.go
@@ -1,0 +1,400 @@
+// Copyright (C) 2018 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vulkan
+
+import (
+	"github.com/google/gapid/core/data/id"
+	"github.com/google/gapid/core/log"
+	"github.com/google/gapid/gapis/database"
+	"github.com/google/gapid/gapis/memory"
+)
+
+const (
+	scratchBufferSize = uint64(64 * 1024 * 1024)
+)
+
+type queueFamilyScratchResources struct {
+	sb             *stateBuilder
+	device         VkDevice
+	queueFamily    uint32
+	commandPool    VkCommandPool
+	commandBuffers map[VkQueue]VkCommandBuffer
+	memory         VkDeviceMemory
+	memorySize     VkDeviceSize
+	allocated      uint64
+	postExecuted   map[VkQueue][]func()
+}
+
+func (sb *stateBuilder) getQueueFamilyScratchResources(queue VkQueue) *queueFamilyScratchResources {
+	dev := sb.s.Queues().Get(queue).Device()
+	family := sb.s.Queues().Get(queue).Family()
+	if _, ok := sb.scratchResources[dev]; !ok {
+		sb.scratchResources[dev] = map[uint32]*queueFamilyScratchResources{}
+	}
+	if _, ok := sb.scratchResources[dev][family]; !ok {
+		sb.scratchResources[dev][family] = &queueFamilyScratchResources{
+			sb:             sb,
+			device:         dev,
+			queueFamily:    family,
+			commandPool:    VkCommandPool(0),
+			commandBuffers: map[VkQueue]VkCommandBuffer{},
+			memory:         VkDeviceMemory(0),
+			memorySize:     VkDeviceSize(bufferAllocationSize(scratchBufferSize)),
+			allocated:      uint64(0),
+			postExecuted:   map[VkQueue][]func(){},
+		}
+	}
+	return sb.scratchResources[dev][family]
+}
+
+func (sb *stateBuilder) flushAllScratchResources() {
+	for _, familyInfo := range sb.scratchResources {
+		for _, qr := range familyInfo {
+			qr.flush()
+		}
+	}
+}
+
+func (sb *stateBuilder) freeAllScratchResources() {
+	for _, familyInfo := range sb.scratchResources {
+		for _, qr := range familyInfo {
+			qr.free()
+		}
+	}
+}
+
+func (sb *stateBuilder) flushQueueFamilyScratchResources(queue VkQueue) {
+	qr := sb.getQueueFamilyScratchResources(queue)
+	qr.flush()
+}
+
+func (qr *queueFamilyScratchResources) getCommandPool() VkCommandPool {
+	if qr.commandPool != VkCommandPool(0) {
+		return qr.commandPool
+	}
+	sb := qr.sb
+	commandPoolID := VkCommandPool(newUnusedID(true, func(x uint64) bool {
+		return sb.s.CommandPools().Contains(VkCommandPool(x)) || GetState(sb.newState).CommandPools().Contains(VkCommandPool(x))
+	}))
+	sb.write(sb.cb.VkCreateCommandPool(
+		qr.device,
+		sb.MustAllocReadData(NewVkCommandPoolCreateInfo(sb.ta,
+			VkStructureType_VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO, // sType
+			0, // pNext
+			VkCommandPoolCreateFlags(VkCommandPoolCreateFlagBits_VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT), // flags
+			qr.queueFamily, // queueFamilyIndex
+		)).Ptr(),
+		memory.Nullptr,
+		sb.MustAllocWriteData(commandPoolID).Ptr(),
+		VkResult_VK_SUCCESS,
+	))
+	qr.commandPool = commandPoolID
+	return qr.commandPool
+}
+
+func (qr *queueFamilyScratchResources) getCommandBuffer(queue VkQueue) VkCommandBuffer {
+	sb := qr.sb
+	commandPool := qr.getCommandPool()
+	if _, ok := qr.commandBuffers[queue]; !ok {
+		commandBufferID := VkCommandBuffer(newUnusedID(true, func(x uint64) bool {
+			return sb.s.CommandBuffers().Contains(VkCommandBuffer(x)) || GetState(sb.newState).CommandBuffers().Contains(VkCommandBuffer(x))
+		}))
+		sb.write(sb.cb.VkAllocateCommandBuffers(
+			qr.device,
+			sb.MustAllocReadData(NewVkCommandBufferAllocateInfo(sb.ta,
+				VkStructureType_VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO, // sType
+				0,           // pNext
+				commandPool, // commandPool
+				VkCommandBufferLevel_VK_COMMAND_BUFFER_LEVEL_PRIMARY, // level
+				uint32(1), // commandBufferCount
+			)).Ptr(),
+			sb.MustAllocWriteData(commandBufferID).Ptr(),
+			VkResult_VK_SUCCESS,
+		))
+		qr.commandBuffers[queue] = commandBufferID
+	}
+	commandBuffer := qr.commandBuffers[queue]
+	if GetState(sb.newState).CommandBuffers().Get(commandBuffer).Recording() != RecordingState_RECORDING {
+		sb.write(sb.cb.VkBeginCommandBuffer(
+			commandBuffer,
+			sb.MustAllocReadData(NewVkCommandBufferBeginInfo(sb.ta,
+				VkStructureType_VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO, // sType
+				0, // pNext
+				VkCommandBufferUsageFlags(VkCommandBufferUsageFlagBits_VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT), // flags
+				0, // pInheritanceInfo
+			)).Ptr(),
+			VkResult_VK_SUCCESS,
+		))
+	}
+	return commandBuffer
+}
+
+func (qr *queueFamilyScratchResources) getDeviceMemory() VkDeviceMemory {
+	sb := qr.sb
+	dev := qr.device
+	if qr.memory == VkDeviceMemory(0) {
+		deviceMemory := VkDeviceMemory(newUnusedID(true, func(x uint64) bool {
+			return sb.s.DeviceMemories().Contains(VkDeviceMemory(x)) || GetState(sb.newState).DeviceMemories().Contains(VkDeviceMemory(x))
+		}))
+		memoryTypeIndex := sb.GetScratchBufferMemoryIndex(sb.s.Devices().Get(dev))
+		memorySize := VkDeviceSize(bufferAllocationSize(scratchBufferSize))
+		sb.write(sb.cb.VkAllocateMemory(
+			dev,
+			NewVkMemoryAllocateInfoᶜᵖ(sb.MustAllocReadData(
+				NewVkMemoryAllocateInfo(sb.ta,
+					VkStructureType_VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO, // sType
+					0, // pNext
+					VkDeviceSize(memorySize), // allocationSize
+					memoryTypeIndex,          // memoryTypeIndex
+				)).Ptr()),
+			memory.Nullptr,
+			sb.MustAllocWriteData(deviceMemory).Ptr(),
+			VkResult_VK_SUCCESS,
+		))
+		qr.memory = deviceMemory
+		qr.memorySize = memorySize
+		qr.allocated = uint64(0)
+	}
+	return qr.memory
+}
+
+func (qr *queueFamilyScratchResources) bindAndFillBuffers(totalAllocationSize uint64, buffers map[VkBuffer]scratchBufferInfo) error {
+	sb := qr.sb
+	dev := qr.device
+	if totalAllocationSize > uint64(qr.memorySize) {
+		return log.Errf(sb.ctx, nil, "cannot allocated scratch memory of size: %v, maximum allowed size is: %v", totalAllocationSize, qr.memorySize)
+	}
+	if totalAllocationSize+qr.allocated > uint64(qr.memorySize) {
+		qr.flush()
+		return qr.bindAndFillBuffers(totalAllocationSize, buffers)
+	}
+	deviceMemory := qr.getDeviceMemory()
+	for buf, info := range buffers {
+		sb.write(sb.cb.VkBindBufferMemory(
+			dev, buf, deviceMemory, VkDeviceSize(qr.allocated), VkResult_VK_SUCCESS))
+
+		atData := sb.MustReserve(info.allocationSize)
+		ptrAtData := sb.newState.AllocDataOrPanic(sb.ctx, NewVoidᵖ(atData.Ptr()))
+		sb.write(sb.cb.VkMapMemory(
+			dev, deviceMemory, VkDeviceSize(qr.allocated), VkDeviceSize(info.allocationSize),
+			VkMemoryMapFlags(0), ptrAtData.Ptr(), VkResult_VK_SUCCESS,
+		).AddRead(ptrAtData.Data()).AddWrite(ptrAtData.Data()))
+		ptrAtData.Free()
+
+		for _, r := range info.data {
+			var hash id.ID
+			var err error
+			if r.hasNewData {
+				hash, err = database.Store(sb.ctx, r.data)
+				if err != nil {
+					panic(err)
+				}
+			} else {
+				hash = r.hash
+			}
+			sb.ReadDataAt(hash, atData.Address()+r.rng.First, r.rng.Count)
+		}
+		sb.write(sb.cb.VkFlushMappedMemoryRanges(
+			dev,
+			1,
+			sb.MustAllocReadData(NewVkMappedMemoryRange(sb.ta,
+				VkStructureType_VK_STRUCTURE_TYPE_MAPPED_MEMORY_RANGE, // sType
+				0,                                 // pNext
+				deviceMemory,                      // memory
+				VkDeviceSize(qr.allocated),        // offset
+				VkDeviceSize(info.allocationSize), // size
+			)).Ptr(),
+			VkResult_VK_SUCCESS,
+		))
+
+		sb.write(sb.cb.VkUnmapMemory(dev, deviceMemory))
+		atData.Free()
+		qr.allocated += info.allocationSize
+	}
+	return nil
+}
+
+func (qr *queueFamilyScratchResources) flush() {
+	sb := qr.sb
+	for q, cb := range qr.commandBuffers {
+		// Do not submit executed commandbuffer, state rebuilding does not reuse
+		// recorded commands in command buffers.
+		if GetState(sb.newState).CommandBuffers().Get(cb).Recording() != RecordingState_RECORDING {
+			continue
+		}
+		sb.write(sb.cb.VkEndCommandBuffer(
+			cb,
+			VkResult_VK_SUCCESS,
+		))
+
+		sb.write(sb.cb.VkQueueSubmit(
+			q,
+			1,
+			sb.MustAllocReadData(NewVkSubmitInfo(sb.ta,
+				VkStructureType_VK_STRUCTURE_TYPE_SUBMIT_INFO, // sType
+				0, // pNext
+				0, // waitSemaphoreCount
+				0, // pWaitSemaphores
+				0, // pWaitDstStageMask
+				1, // commandBufferCount
+				NewVkCommandBufferᶜᵖ(sb.MustAllocReadData(cb).Ptr()), // pCommandBuffers
+				0, // signalSemaphoreCount
+				0, // pSignalSemaphores
+			)).Ptr(),
+			VkFence(0),
+			VkResult_VK_SUCCESS,
+		))
+	}
+	for q, cb := range qr.commandBuffers {
+		sb.write(sb.cb.VkQueueWaitIdle(q, VkResult_VK_SUCCESS))
+		sb.write(sb.cb.VkResetCommandBuffer(
+			cb, VkCommandBufferResetFlags(VkCommandBufferResetFlagBits_VK_COMMAND_BUFFER_RESET_RELEASE_RESOURCES_BIT),
+			VkResult_VK_SUCCESS,
+		))
+	}
+	qr.allocated = 0
+	for q, fs := range qr.postExecuted {
+		for _, f := range fs {
+			f()
+		}
+		qr.postExecuted[q] = []func(){}
+	}
+}
+
+func (qr *queueFamilyScratchResources) free() {
+	sb := qr.sb
+	sb.write(sb.cb.VkDestroyCommandPool(qr.device, qr.commandPool, memory.Nullptr))
+	qr.commandPool = VkCommandPool(0)
+	qr.commandBuffers = map[VkQueue]VkCommandBuffer{}
+	sb.write(sb.cb.VkFreeMemory(qr.device, qr.memory, memory.Nullptr))
+	qr.memory = VkDeviceMemory(0)
+	qr.allocated = uint64(0)
+}
+
+type scratchTask struct {
+	sb                  *stateBuilder
+	buffers             map[VkBuffer]scratchBufferInfo
+	totalAllocationSize uint64
+	queue               VkQueue
+	onCommit            []func()
+	cmdBufRecorded      []func(VkCommandBuffer)
+	defered             []func()
+}
+
+type scratchBufferInfo struct {
+	data           []bufferSubRangeFillInfo
+	size           uint64
+	allocationSize uint64
+}
+
+func (sb *stateBuilder) newScratchTaskOnQueue(queue VkQueue) *scratchTask {
+	return &scratchTask{
+		sb:                  sb,
+		buffers:             map[VkBuffer]scratchBufferInfo{},
+		totalAllocationSize: uint64(0),
+		queue:               queue,
+		onCommit:            []func(){},
+		cmdBufRecorded:      []func(VkCommandBuffer){},
+		defered:             []func(){},
+	}
+}
+
+func (t *scratchTask) commit() error {
+	sb := t.sb
+	if t.totalAllocationSize == uint64(0) {
+		return log.Err(sb.ctx, nil, "Nil or empty scratch buffer session")
+	}
+	res := sb.getQueueFamilyScratchResources(t.queue)
+	if err := res.bindAndFillBuffers(t.totalAllocationSize, t.buffers); err != nil {
+		return log.Errf(sb.ctx, err, "commiting scratch buffers")
+	}
+	for _, f := range t.onCommit {
+		f()
+	}
+	cb := res.getCommandBuffer(t.queue)
+	for _, f := range t.cmdBufRecorded {
+		f(cb)
+	}
+	for i := len(t.defered) - 1; i >= 0; i-- {
+		res.postExecuted[t.queue] = append(res.postExecuted[t.queue], t.defered[i])
+	}
+	return nil
+}
+
+func (t *scratchTask) deferUntilCommitted(f ...func()) *scratchTask {
+	t.onCommit = append(t.onCommit, f...)
+	return t
+}
+
+func (t *scratchTask) recordCmdBufCommand(f ...func(cb VkCommandBuffer)) *scratchTask {
+	t.cmdBufRecorded = append(t.cmdBufRecorded, f...)
+	return t
+}
+
+func (t *scratchTask) deferUntilExecuted(f ...func()) *scratchTask {
+	t.defered = append(t.defered, f...)
+	return t
+}
+
+func (t *scratchTask) newBuffer(subRngs []bufferSubRangeFillInfo, usages ...VkBufferUsageFlagBits) VkBuffer {
+	sb := t.sb
+	size := uint64(0)
+	for _, r := range subRngs {
+		if r.rng.Span().End > size {
+			size = r.rng.Span().End
+		}
+	}
+	size = nextMultipleOf(size, 256)
+	buffer := VkBuffer(newUnusedID(true, func(x uint64) bool {
+		return sb.s.Buffers().Contains(VkBuffer(x)) || GetState(sb.newState).Buffers().Contains(VkBuffer(x))
+	}))
+	usageFlags := VkBufferUsageFlags(VkBufferUsageFlagBits_VK_BUFFER_USAGE_TRANSFER_SRC_BIT)
+	for _, u := range usages {
+		usageFlags |= VkBufferUsageFlags(u)
+	}
+	dev := sb.s.Queues().Get(t.queue).Device()
+	sb.write(sb.cb.VkCreateBuffer(
+		dev,
+		sb.MustAllocReadData(
+			NewVkBufferCreateInfo(sb.ta,
+				VkStructureType_VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO, // sType
+				0,                                       // pNext
+				0,                                       // flags
+				VkDeviceSize(size),                      // size
+				usageFlags,                              // usage
+				VkSharingMode_VK_SHARING_MODE_EXCLUSIVE, // sharingMode
+				0, // queueFamilyIndexCount
+				0, // pQueueFamilyIndices
+			)).Ptr(),
+		memory.Nullptr,
+		sb.MustAllocWriteData(buffer).Ptr(),
+		VkResult_VK_SUCCESS,
+	))
+	allocSize := bufferAllocationSize(size)
+
+	t.buffers[buffer] = scratchBufferInfo{data: subRngs, size: size, allocationSize: allocSize}
+	t.totalAllocationSize += allocSize
+	return buffer
+}
+
+// bufferAllocationSize returns the memory allocation size for the given buffer
+// size.
+// Since we cannot guess how much the driver will actually request of us,
+// overallocate by a factor of 2. This should be enough.
+// Align to 0x100 to make validation layers happy. Assuming the buffer memory
+// requirement has an alignment value compatible with 0x100.
+func bufferAllocationSize(bufferSize uint64) uint64 {
+	return nextMultipleOf(bufferSize*2, 256)
+}

--- a/gapis/api/vulkan/state.go
+++ b/gapis/api/vulkan/state.go
@@ -94,7 +94,7 @@ func (st *State) getPresentAttachmentInfo(attachment api.FramebufferAttachment) 
 		}
 		colorImg := st.LastPresentInfo().PresentImages().Get(imageIdx)
 		if !colorImg.IsNil() {
-			queue := colorImg.LastBoundQueue()
+			queue := st.Queues().Get(st.LastPresentInfo().Queue())
 			vkDevice := queue.Device()
 			device := st.Devices().Get(vkDevice)
 			vkPhysicalDevice := device.PhysicalDevice()

--- a/gapis/api/vulkan/vulkan.api
+++ b/gapis/api/vulkan/vulkan.api
@@ -259,6 +259,8 @@ sub ref!ExtensionSet supportedDeviceExtensions() {
   u32 PresentImageCount
   // The images presented in the last present
   map!(u32, ref!ImageObject) PresentImages
+  // The queue on which images are presented
+  VkQueue Queue
 }
 
 enum LastSubmissionType {


### PR DESCRIPTION
This CL does:

0) Lazily reserve 128MB device memory for the use of scratch buffers.

1) Batch buffer->image copy commands, defer the command submissions until
the reserved scratch memory is full. This reduces the number of
VkCommandBufferBegin/End, VkQueueSubmit, VkQueueWaitIdle calls.

2) Batch the commands for 'priming by rendering' and 'priming by imageStore' in the similar way.

3) Track image last bound queue at 'ImageLevel' level.

For now, on a typical Vulkan app, this reduce 30% of the initial
commands. For `gapit report`, saves ~10% of time.