### PR TITLE
Fix the build on OSX.

### DIFF
--- a/tools/bazel.rc
+++ b/tools/bazel.rc
@@ -22,7 +22,7 @@ build --define GAPID_BUILD_NUMBER=0 --define GAPID_BUILD_SHA=developer
 build --nolegacy_whole_archive
 
 # Config used by the build servers to dump symbols.
-build:symbols --copt="-g" --strip=never
+build:symbols --copt="-g"
 
 # Config that will exclude Android from the //:pkg target.
 build:nodroid --define NO_ANDROID=1


### PR DESCRIPTION
Remove the `--strip always` option from the symbols config. This isn't needed since `-c opt` doesn't strip anyways and we are not dumping go symbols.

This is a work around for an issue in rules_go (https://github.com/bazelbuild/rules_go/issues/1591).

Fixes #2045