### PR TITLE
Vulkan: Reduce the num of cmds for state rebuilding again

### DIFF
--- a/gapis/api/vulkan/api/command_buffer_control.api
+++ b/gapis/api/vulkan/api/command_buffer_control.api
@@ -107,9 +107,10 @@ cmd VkResult vkResetCommandPool(
 ////////////////////
 
 enum RecordingState {
-  NOT_STARTED = 0,
-  RECORDING   = 1,
-  COMPLETED   = 2
+  NOT_STARTED  = 0,
+  RECORDING    = 1,
+  COMPLETED    = 2,
+  TO_BE_RESET  = 3
 }
 
 @internal class CommandBufferBegin {

--- a/gapis/api/vulkan/api/queue.api
+++ b/gapis/api/vulkan/api/queue.api
@@ -113,6 +113,9 @@ cmd VkResult vkQueueSubmit(
       if cb.Recording != COMPLETED {
         vkErrorCommandBufferIncomplete(command_buffers[j])
       }
+      if (as!u32(cb.BeginInfo.Flags) & as!u32(VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT)) != as!u32(0) {
+        cb.Recording = TO_BE_RESET
+      }
       for k in (0 .. len(cb.CommandReferences)) {
         ref := cb.CommandReferences[as!u32(k)]
         LastBoundQueue.PendingCommands[len(LastBoundQueue.PendingCommands)]


### PR DESCRIPTION
This CL reduce the number of state rebuild commands of a typical Vulkan
application by 70%, and save the `gapit report` time by ~8%.

1) Do not recover the commands in submitted one-time-submit command
buffers.

2) Call vkAllocateDescriptorSets for each descriptor pool, instead of
each descriptor set.

3) For scratch tasks, when binding and filling the scratch buffers, call
vkMapMemory, vkFlushMappedMemoryRanges and vkUnmapMemory only once for
the whole task, instead of once for each scratch buffer.