### PR TITLE
gazelle: move prefix from rule to directive

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -15,10 +15,11 @@
 load("@bazel_gazelle//:def.bzl", "gazelle")
 load("//tools/build:rules.bzl", "copy_to")
 
+# gazelle:prefix github.com/google/gapid
+
 gazelle(
     name = "gazelle",
     mode = "fix",
-    prefix = "github.com/google/gapid",
 )
 
 # Alias meant to be used with 'bazel run <alias> -- <arguments>'.

--- a/gapic/src/platform/BUILD.bazel
+++ b/gapic/src/platform/BUILD.bazel
@@ -34,6 +34,10 @@ java_library(
 cc_binary(
     name = "liblinux_glcanvas.so",
     srcs = ["linux/glcanvas.cc"],
+    copts = [
+        "-Iexternal/local_jdk/include",
+        "-Iexternal/local_jdk/include/linux",
+    ],
     linkopts = [
         "-lGL",
         "-lX11",
@@ -42,10 +46,6 @@ cc_binary(
     deps = [
         ":jni.h",
         ":jni_md.h",
-    ],
-    copts = [
-        "-Iexternal/local_jdk/include",
-        "-Iexternal/local_jdk/include/linux",
     ],
 )
 

--- a/gapil/parser/BUILD.bazel
+++ b/gapil/parser/BUILD.bazel
@@ -46,5 +46,6 @@ go_test(
         "//core/text/parse/cst:go_default_library",
         "//core/text/parse/test:go_default_library",
         "//gapil/ast:go_default_library",
+        "//gapil/parser:go_default_library",
     ],
 )

--- a/gapis/resolve/BUILD.bazel
+++ b/gapis/resolve/BUILD.bazel
@@ -60,7 +60,6 @@ go_library(
         "//core/data/dictionary:go_default_library",
         "//core/data/endian:go_default_library",
         "//core/data/id:go_default_library",
-        "//core/data/pod:go_default_library",
         "//core/data/protoutil:go_default_library",
         "//core/event/task:go_default_library",
         "//core/fault:go_default_library",

--- a/test/integration/gles/replay/BUILD.bazel
+++ b/test/integration/gles/replay/BUILD.bazel
@@ -46,6 +46,7 @@ go_library(
         "//gapis/api/gles:go_default_library",
         "//gapis/replay:go_default_library",
         "//gapis/resolve:go_default_library",
+        "//gapis/service:go_default_library",
         "//gapis/service/path:go_default_library",
     ],
 )
@@ -81,7 +82,6 @@ go_test(
         "//gapis/memory:go_default_library",
         "//gapis/replay:go_default_library",
         "//gapis/resolve:go_default_library",
-        "//gapis/service:go_default_library",
         "//gapis/service/path:go_default_library",
         "//test/integration/gles/snippets:go_default_library",
     ],


### PR DESCRIPTION
The attributes passed to the gazelle rule are translated into command
line arguments, which may be replaced if additional arguments are
given on the command line. It's better to set options like "prefix" in
directives (special comments in build files) so that Gazelle will
always see them.

Fixes #2054