### PR TITLE
kokoro/presubmit: Add a dot argument to find

### DIFF
--- a/kokoro/presubmit/presubmit.sh
+++ b/kokoro/presubmit/presubmit.sh
@@ -50,7 +50,7 @@ function check() {
 }
 
 function run_clang_format() {
-  find -name "*.h" -o -name "*.cpp" -o -name "*.mm" -o -name "*.proto" | xargs $CLANG_FORMAT -i -style=Google
+  find . -name "*.h" -o -name "*.cpp" -o -name "*.mm" -o -name "*.proto" | xargs $CLANG_FORMAT -i -style=Google
 }
 
 function run_buildifier() {


### PR DESCRIPTION
Without it, on my mac I get:

```
Running check clang-format... find: illegal option -- n
usage: find [-H | -L | -P] [-EXdsx] [-f path] path ... [expression]
       find [-H | -L | -P] [-EXdsx] -f path [path ...] [expression]
```