### PR TITLE
Add core/app/linker

### DIFF
--- a/core/app/linker/BUILD.bazel
+++ b/core/app/linker/BUILD.bazel
@@ -1,0 +1,32 @@
+# Copyright (C) 2018 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "linker.go",
+        "linker_posix.go",
+        "linker_windows.go",
+    ],
+    cgo = True,
+    clinkopts = select({
+        "//tools/build:linux": ["-ldl"],
+        "//tools/build:darwin": [],
+        "//tools/build:windows": [],
+    }),  # keep
+    importpath = "github.com/google/gapid/core/app/linker",
+    visibility = ["//visibility:public"],
+)

--- a/core/app/linker/linker.go
+++ b/core/app/linker/linker.go
@@ -1,0 +1,17 @@
+// Copyright (C) 2018 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package linker provides functions for findings addresses of app functions by
+// name.
+package linker

--- a/core/app/linker/linker_posix.go
+++ b/core/app/linker/linker_posix.go
@@ -1,0 +1,32 @@
+// Copyright (C) 2018 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package linker
+
+// #define _GNU_SOURCE // required for RTLD_DEFAULT
+// #include <dlfcn.h>
+// #include <stdint.h>
+// #include <stdlib.h>
+//
+// uintptr_t proc_address(char* name) {
+//   void* ptr = dlsym(RTLD_DEFAULT, name);
+//   free(name);
+//   return (uintptr_t)ptr;
+// }
+import "C"
+
+// ProcAddress returns the address of the function with the given name.
+func ProcAddress(name string) uintptr {
+	return uintptr(C.proc_address(C.CString(name)))
+}

--- a/core/app/linker/linker_windows.go
+++ b/core/app/linker/linker_windows.go
@@ -1,0 +1,26 @@
+// Copyright (C) 2018 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package linker
+
+import "syscall"
+
+// ProcAddress returns the address of the function with the given name.
+func ProcAddress(name string) uintptr {
+	proc, err := syscall.GetProcAddress(0, name)
+	if err != nil {
+		return nil
+	}
+	return proc
+}


### PR DESCRIPTION
Exposes `ProcAddress` function which translates to `dlsym` or `GetProcAddress`.