### PR TITLE
Copy depth aspect by rendering in overdraw

### DIFF
--- a/gapii/cc/vulkan_extras.cpp
+++ b/gapii/cc/vulkan_extras.cpp
@@ -741,16 +741,11 @@ uint32_t VulkanSpy::SpyOverride_vkCreateBuffer(
 uint32_t VulkanSpy::SpyOverride_vkCreateImage(
     VkDevice device, const VkImageCreateInfo* pCreateInfo,
     const VkAllocationCallbacks* pAllocator, VkImage* pImage) {
-  if (is_suspended() || is_observing()) {
-    VkImageCreateInfo override_create_info = *pCreateInfo;
-    override_create_info.musage |=
-        VkImageUsageFlagBits::VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
-    return mImports.mVkDeviceFunctions[device].vkCreateImage(
-        device, &override_create_info, pAllocator, pImage);
-  } else {
-    return mImports.mVkDeviceFunctions[device].vkCreateImage(
-        device, pCreateInfo, pAllocator, pImage);
-  }
+  VkImageCreateInfo override_create_info = *pCreateInfo;
+  override_create_info.musage |=
+      VkImageUsageFlagBits::VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
+  return mImports.mVkDeviceFunctions[device].vkCreateImage(
+      device, &override_create_info, pAllocator, pImage);
 }
 
 uint32_t VulkanSpy::SpyOverride_vkCreateSwapchainKHR(


### PR DESCRIPTION
Specifically do this for the store end (i.e. new depth/stencil image to
old image), so that we don't have to add TRANSFER_DST to all depth
images.

Additionally, remove the conditions in gapii and always add the transfer_src flag to images, so that we can use it to copy from at the start of the overdraw renderpass.