### PR TITLE
A few minor updates to the tracing interface.

### DIFF
--- a/core/os/device/remotessh/commands.go
+++ b/core/os/device/remotessh/commands.go
@@ -112,7 +112,15 @@ func (t sshShellTarget) Start(cmd shell.Cmd) (shell.Process, error) {
 		}
 	}
 
-	if err := session.Start(prefix + cmd.Name + " " + strings.Join(cmd.Args, " ")); err != nil {
+	for _, e := range t.b.env.Keys() {
+		if e != "" {
+			val := text.Quote([]string{t.b.env.Get(e)})[0]
+			prefix = prefix + strings.TrimSpace(e) + "=" + val + " "
+		}
+	}
+
+	val := prefix + cmd.Name + " " + strings.Join(cmd.Args, " ")
+	if err := session.Start(val); err != nil {
 		return nil, err
 	}
 

--- a/core/os/device/remotessh/configuration.go
+++ b/core/os/device/remotessh/configuration.go
@@ -39,6 +39,8 @@ type Configuration struct {
 	// The known_hosts file to use for authentication. Defaults to
 	// ~/.ssh/known_hosts
 	KnownHosts string
+	// Environment variables to set on the connection
+	Env []string
 }
 
 // ReadConfigurations reads a set of configurations from then

--- a/gapis/trace/desktop/BUILD.bazel
+++ b/gapis/trace/desktop/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
     importpath = "github.com/google/gapid/gapis/trace/desktop",
     visibility = ["//visibility:public"],
     deps = [
+        "//core/os/device:go_default_library",
         "//core/os/device/bind:go_default_library",
         "//core/os/process:go_default_library",
         "//core/vulkan/loader:go_default_library",


### PR DESCRIPTION
This allows you to specify environment variables in your
ssh config, (instead of having to add them every time).

It also exposes portWatcher for external use.