### PR TITLE
core/cc: Add AsyncBuffer - a threaded ringbuffer queue.

### DIFF
--- a/core/cc/BUILD.bazel
+++ b/core/cc/BUILD.bazel
@@ -63,6 +63,7 @@ cc_test(
     name = "tests",
     size = "small",
     srcs = [
+        "async_buffer_test.cpp",
         "connection_test.cpp",
         "crash_handler_test.cpp",
         "interval_list_test.cpp",

--- a/core/cc/async_buffer.cpp
+++ b/core/cc/async_buffer.cpp
@@ -1,0 +1,118 @@
+/*
+ * Copyright (C) 2018 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "async_buffer.h"
+#include "assert.h"
+
+#ifndef __STDC_FORMAT_MACROS
+#define __STDC_FORMAT_MACROS
+#endif  // __STDC_FORMAT_MACROS
+#include <inttypes.h>
+
+namespace core {
+
+AsyncBuffer::AsyncBuffer(std::shared_ptr<StreamWriter> out, size_t buffer_size)
+    : size_(buffer_size),
+      free_(buffer_size),
+      read_head_(0),
+      write_head_(0),
+      out_(std::move(out)) {
+  GAPID_ASSERT(buffer_size > 0);
+  buffer_ = new uint8_t[buffer_size];
+  thread_ = new std::thread([this]() { worker(); });
+}
+
+AsyncBuffer::~AsyncBuffer() {
+  flush();
+  free_.close();
+  written_.close();
+  thread_->join();
+  delete[] buffer_;
+}
+
+uint64_t AsyncBuffer::write(const void* data, uint64_t size) {
+  auto bytes = reinterpret_cast<const uint8_t*>(data);
+  size_t remaining = size;
+  size_t written = 0;
+  while (remaining > size_) {
+    // Split large writes into ring-buffer sized chunks.
+    written += write_chunk(bytes, size_);
+    bytes += size_;
+    remaining -= size_;
+  }
+
+  written += write_chunk(bytes, remaining);
+  return written;
+}
+
+void AsyncBuffer::flush() { free_.wait_until(size_); }
+
+uint64_t AsyncBuffer::write_chunk(const void* data, uint64_t size) {
+  GAPID_ASSERT(size <= size_);
+
+  auto bytes = reinterpret_cast<const uint8_t*>(data);
+  size_t remaining = size;
+
+  if (!free_.acquire(size)) {
+    GAPID_FATAL("Attempting to write on a destructed AsyncBuffer");
+  }
+
+  if (write_head_ + remaining >= size_) {
+    // write wraps buffer end/start
+    size_t count = size_ - write_head_;
+    memcpy(&buffer_[write_head_], bytes, count);
+    write_head_ = 0;
+    bytes += count;
+    remaining -= count;
+  }
+  if (remaining > 0) {
+    memcpy(&buffer_[write_head_], bytes, remaining);
+    write_head_ += remaining;
+  }
+
+  if (!written_.release(size)) {
+    GAPID_FATAL("Attempting to write on a destructed AsyncBuffer");
+  }
+
+  return size;
+}
+
+void AsyncBuffer::worker() {
+  while (true) {
+    int count = written_.acquire_all();
+    if (count < 0) {
+      return;  // Signal that AsyncBuffer is destructing.
+    }
+
+    size_t remaining = static_cast<size_t>(count);
+    while (remaining > 0) {
+      size_t chunk = std::min(remaining, size_ - read_head_);
+      size_t count = out_->write(&buffer_[read_head_], chunk);
+      GAPID_ASSERT(count <= chunk);
+      remaining -= count;
+      read_head_ += count;
+      if (read_head_ == size_) {
+        read_head_ = 0;
+      }
+    }
+
+    if (!free_.release(count)) {
+      return;  // Signal that AsyncBuffer is destructing.
+    }
+  }
+}
+
+}  // namespace core

--- a/core/cc/async_buffer.h
+++ b/core/cc/async_buffer.h
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2018 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef CORE_ASYNC_BUFFER_H
+#define CORE_ASYNC_BUFFER_H
+
+#include "semaphore.h"
+#include "stream_writer.h"
+
+#include <cstring>
+#include <memory>
+#include <thread>
+
+namespace core {
+
+// AsyncBuffer is a StreamWriter that buffers writes into a fixed size
+// ringbuffer which is streamed out to a downstream StreamWriter on another
+// thread.
+class AsyncBuffer : public StreamWriter {
+ public:
+  AsyncBuffer(std::shared_ptr<StreamWriter> out, size_t buffer_size);
+  ~AsyncBuffer();
+
+  // create constructs and returns an AsyncBuffer in a shared_ptr.
+  static inline std::shared_ptr<AsyncBuffer> create(
+      std::shared_ptr<StreamWriter> out, size_t buffer_size);
+
+  // write appends data to the ringbuffer, blocking if it is full.
+  // write must always be called from the same thread.
+  virtual uint64_t write(const void* data, uint64_t size) override;
+
+  // flush ensures all pending writes have been written downstream before
+  // returning. flush must be called on the same thread as the writes.
+  void flush();
+
+ private:
+  // write_chunk writes a block that is smaller than size_
+  uint64_t write_chunk(const void* data, uint64_t size);
+
+  void worker();
+
+  uint8_t* buffer_;    // the ringbuffer
+  const size_t size_;  // total size of the buffer
+  Semaphore written_;  // number of bytes written (pending) in the ring buffer
+  Semaphore free_;     // number of bytes free in the ring buffer
+  size_t read_head_;   // read head byte offset in the ringbuffer
+  size_t write_head_;  // write head byte offset in the ringbuffer
+  std::shared_ptr<StreamWriter> out_;  // the downstream StreamWriter
+  std::thread* thread_;
+};
+
+std::shared_ptr<AsyncBuffer> AsyncBuffer::create(
+    std::shared_ptr<StreamWriter> out, size_t buffer_size) {
+  return std::shared_ptr<AsyncBuffer>(new AsyncBuffer(out, buffer_size));
+}
+
+}  // namespace core
+
+#endif  // CORE_ASYNC_BUFFER_H

--- a/core/cc/async_buffer_test.cpp
+++ b/core/cc/async_buffer_test.cpp
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2018 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "async_buffer.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <string>
+
+using ::testing::_;
+using ::testing::DoAll;
+using ::testing::ElementsAre;
+using ::testing::ElementsAreArray;
+using ::testing::StrictMock;
+using ::testing::WithArg;
+
+namespace core {
+namespace test {
+namespace {
+
+class Sink : public StreamWriter {
+ public:
+  Sink(std::vector<uint8_t>* buf) : buf_(buf) {}
+
+  virtual uint64_t write(const void* data, uint64_t size) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    auto bytes = reinterpret_cast<const uint8_t*>(data);
+    buf_->insert(buf_->end(), bytes, bytes + size);
+    return size;
+  }
+
+  std::vector<uint8_t>* buf_;
+};
+
+class AsyncBufferTest : public ::testing::TestWithParam<size_t> {
+ protected:
+  void init(size_t buffer_size) {
+    std::unique_ptr<Sink> sink(new Sink(&output_));
+    buffer_.reset(new AsyncBuffer(std::move(sink), buffer_size));
+  }
+
+  virtual void SetUp() override {
+    size_t size = 1 << 10;
+    test_data_.reserve(size);
+    uint32_t h = 0x3e20b923;
+    for (size_t i = 0; i < size; i++) {
+      test_data_.push_back(static_cast<uint8_t>(h));
+      h = (h * 31) ^ h;
+    }
+  }
+
+  std::vector<uint8_t> test_data_;
+  std::vector<uint8_t> output_;
+  std::unique_ptr<AsyncBuffer> buffer_;
+};
+
+}  // anonymous namespace
+
+INSTANTIATE_TEST_CASE_P(buffer_sizes, AsyncBufferTest,
+                        ::testing::Values(1, 10, 100, 1000, 10000));
+
+TEST_P(AsyncBufferTest, Write) {
+  init(GetParam());
+  auto written = buffer_->write(&test_data_[0], test_data_.size());
+  EXPECT_EQ(test_data_.size(), written);
+  buffer_->flush();
+  EXPECT_THAT(output_, ElementsAreArray(test_data_.begin(), test_data_.end()));
+}
+
+}  // namespace test
+}  // namespace core

--- a/core/cc/semaphore.h
+++ b/core/cc/semaphore.h
@@ -24,37 +24,82 @@ namespace core {
 
 class Semaphore {
  public:
-  inline Semaphore(unsigned int count = 0);
+  inline Semaphore(unsigned int inital_count = 0);
 
-  // acquire takes a counter from the semaphore, blocking until one is
-  // available.
-  inline void acquire();
+  // acquire takes count counters from the semaphore, blocking until count are
+  // available, or the semaphore is closed.
+  // If the semaphore is closed false is returned.
+  inline bool acquire(int count = 1);
 
-  // release returns a counter to the semaphore, possibly unblocking a call
+  // acquire_all takes all counters from the semaphore, blocking until at least
+  // one is available, or the semaphore is closed. The number of counters
+  // acquired is returned, or -1 if the semaphore is closed.
+  inline int acquire_all();
+
+  // wait_until blocks until the counter reaches at least count, without taking
+  // any counters from the semaphore.
+  // If the semaphore is closed false is returned.
+  inline bool wait_until(int count = 1);
+
+  // release returns count counters to the semaphore, possibly unblocking a call
   // to acquire().
-  inline void release();
+  // If the semaphore is closed false is returned.
+  inline bool release(int count = 1);
+
+  // close unblocks any blocking calls on the semaphore, and makes all future
+  // calls return their closed value.
+  inline void close();
 
  private:
   Semaphore(const Semaphore&) = delete;
   Semaphore& operator=(const Semaphore&) = delete;
 
-  std::mutex mMutex;
-  std::condition_variable mSignal;
-  int mCount;
+  std::mutex mutex_;
+  std::condition_variable signal_;
+  int count_;
+  bool closed_;
 };
 
-Semaphore::Semaphore(unsigned int count /* = 0 */) : mCount(count) {}
+Semaphore::Semaphore(unsigned int inital_count /* = 0 */)
+    : count_(inital_count), closed_(false) {}
 
-inline void Semaphore::acquire() {
-  std::unique_lock<std::mutex> lock(mMutex);
-  mSignal.wait(lock, [this] { return this->mCount > 0; });
-  --mCount;
+inline bool Semaphore::acquire(int count /* = 1 */) {
+  std::unique_lock<std::mutex> lock(mutex_);
+  signal_.wait(lock,
+               [this, count] { return this->count_ >= count || closed_; });
+  count_ -= count;
+  return !closed_;
 }
 
-inline void Semaphore::release() {
-  std::unique_lock<std::mutex> lock(mMutex);
-  ++mCount;
-  mSignal.notify_one();
+inline int Semaphore::acquire_all() {
+  std::unique_lock<std::mutex> lock(mutex_);
+  signal_.wait(lock, [this] { return this->count_ > 0 || closed_; });
+  auto count = count_;
+  count_ = 0;
+  if (closed_) {
+    return -1;
+  }
+  return count;
+}
+
+inline bool Semaphore::wait_until(int count /* = 1 */) {
+  std::unique_lock<std::mutex> lock(mutex_);
+  signal_.wait(lock,
+               [this, count] { return this->count_ >= count || closed_; });
+  return !closed_;
+}
+
+inline bool Semaphore::release(int count /* = 1 */) {
+  std::unique_lock<std::mutex> lock(mutex_);
+  count_ += count;
+  signal_.notify_all();
+  return !closed_;
+}
+
+inline void Semaphore::close() {
+  std::unique_lock<std::mutex> lock(mutex_);
+  closed_ = true;
+  signal_.notify_all();
 }
 
 }  // namespace core

--- a/core/cc/stream_writer.h
+++ b/core/cc/stream_writer.h
@@ -24,6 +24,8 @@ namespace core {
 // StreamWriter is a pure-virtual interface used to write data streams.
 class StreamWriter {
  public:
+  virtual ~StreamWriter() {}
+
   // write attempts to write size bytes from data to the stream, blocking
   // until all data is written. Returns the number of bytes successfully
   // written, which may be less than size if the stream was closed or there
@@ -35,9 +37,6 @@ class StreamWriter {
   // Note: T must be a plain-old-data type.
   template <typename T>
   inline bool write(const T& s);
-
- protected:
-  virtual ~StreamWriter() {}
 };
 
 template <typename T>


### PR DESCRIPTION
This can be placed in between the `PackEncoder` and the `ConnectionStream` to buffer the writes and perform socket IO on a separate thread.