### PR TITLE
A few more small fixes around images and descriptor sets.

### DIFF
--- a/gapis/api/vulkan/api/coherent_memory.api
+++ b/gapis/api/vulkan/api/coherent_memory.api
@@ -96,10 +96,12 @@ sub void readMemoryInImageBindings(map!(u32, ref!VkDescriptorImageInfo) imageBin
   for _, _, v in imageBindings {
     _ = Samplers[v.Sampler]
     if v.ImageView != as!VkImageView(0) {
-      imageViewObj := ImageViews[v.ImageView]
-      imageObj := imageViewObj.Image
-      rng := imageViewObj.SubresourceRange
-      readImageSubresource(imageObj, rng, v.ImageLayout)
+      if (v.ImageView in ImageViews) {
+        imageViewObj := ImageViews[v.ImageView]
+        imageObj := imageViewObj.Image
+        rng := imageViewObj.SubresourceRange
+        readImageSubresource(imageObj, rng, v.ImageLayout)
+      }
     }
   }
 }

--- a/gapis/api/vulkan/api/descriptor.api
+++ b/gapis/api/vulkan/api/descriptor.api
@@ -248,44 +248,46 @@ cmd VkResult vkAllocateDescriptorSets(
   for i in (0 .. count) {
     handle := ?
     sets[i] = handle
-    object := new!DescriptorSetObject(device, handle,
-      info.descriptorPool)
-    pool := DescriptorPools[info.descriptorPool]
-    pool.DescriptorSets[handle] = object
-    object.Layout = DescriptorSetLayouts[layouts[i]]
-    for j in (0 .. object.Layout.MaximumBinding + 1) {
-      if j in object.Layout.Bindings {
-        binding := object.Layout.Bindings[j]
-        descriptorBinding := DescriptorBinding(
-          BindingType: binding.Type)
-        imageInfos := descriptorBinding.ImageBinding
-        bufferInfos := descriptorBinding.BufferBinding
-        bufferViews := descriptorBinding.BufferViewBindings
-        for k in (0 .. binding.Count) {
-          switch binding.Type {
-            case VK_DESCRIPTOR_TYPE_SAMPLER,
-                VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
-                VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE,
-                VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
-                VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT:
-              imageInfos[k] = new!VkDescriptorImageInfo()
-            case VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER,
-                VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER:
-              bufferViews[k] = as!VkBufferView(0)
-            case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
-                VK_DESCRIPTOR_TYPE_STORAGE_BUFFER,
-                VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC,
-                VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC:
-              bufferInfos[k] = new!VkDescriptorBufferInfo()
+    if (handle != as!VkDescriptorSet(0)) {
+      object := new!DescriptorSetObject(device, handle,
+        info.descriptorPool)
+      pool := DescriptorPools[info.descriptorPool]
+      pool.DescriptorSets[handle] = object
+      object.Layout = DescriptorSetLayouts[layouts[i]]
+      for j in (0 .. object.Layout.MaximumBinding + 1) {
+        if j in object.Layout.Bindings {
+          binding := object.Layout.Bindings[j]
+          descriptorBinding := DescriptorBinding(
+            BindingType: binding.Type)
+          imageInfos := descriptorBinding.ImageBinding
+          bufferInfos := descriptorBinding.BufferBinding
+          bufferViews := descriptorBinding.BufferViewBindings
+          for k in (0 .. binding.Count) {
+            switch binding.Type {
+              case VK_DESCRIPTOR_TYPE_SAMPLER,
+                  VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
+                  VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE,
+                  VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
+                  VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT:
+                imageInfos[k] = new!VkDescriptorImageInfo()
+              case VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER,
+                  VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER:
+                bufferViews[k] = as!VkBufferView(0)
+              case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
+                  VK_DESCRIPTOR_TYPE_STORAGE_BUFFER,
+                  VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC,
+                  VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC:
+                bufferInfos[k] = new!VkDescriptorBufferInfo()
+            }
           }
+          descriptorBinding.ImageBinding = imageInfos
+          descriptorBinding.BufferBinding = bufferInfos
+          descriptorBinding.BufferViewBindings = bufferViews
+          object.Bindings[j] = descriptorBinding
         }
-        descriptorBinding.ImageBinding = imageInfos
-        descriptorBinding.BufferBinding = bufferInfos
-        descriptorBinding.BufferViewBindings = bufferViews
-        object.Bindings[j] = descriptorBinding
       }
+      DescriptorSets[handle] = object
     }
-    DescriptorSets[handle] = object
   }
 
   return ?

--- a/gapis/api/vulkan/api/renderpass_framebuffer.api
+++ b/gapis/api/vulkan/api/renderpass_framebuffer.api
@@ -79,8 +79,10 @@ cmd VkResult vkCreateFramebuffer(
   Framebuffers[handle] = framebufferObject
 
   for _, i, viewObj in framebufferObject.ImageAttachments {
-    viewObj.FramebufferUsers[handle][
-      as!u32(len(viewObj.FramebufferUsers[handle]))] = i
+    if viewObj != null {
+      viewObj.FramebufferUsers[handle][
+        as!u32(len(viewObj.FramebufferUsers[handle]))] = i
+    }
   }
 
   return ?

--- a/gapis/api/vulkan/scratch_resources.go
+++ b/gapis/api/vulkan/scratch_resources.go
@@ -472,6 +472,13 @@ func (t *scratchTask) newBuffer(subRngs []bufferSubRangeFillInfo, usages ...VkBu
 	))
 	allocSize := bufferAllocationSize(size)
 
+	sb.write(sb.cb.VkGetBufferMemoryRequirements(
+		dev,
+		buffer,
+		sb.MustAllocWriteData(NewVkMemoryRequirements(sb.ta,
+			VkDeviceSize(allocSize), VkDeviceSize(256), 0xFFFFFFFF)).Ptr(),
+	))
+
 	t.buffers[buffer] = scratchBufferInfo{data: subRngs, size: size, allocationSize: allocSize}
 	t.totalAllocationSize += allocSize
 	return buffer

--- a/gapis/api/vulkan/state_rebuilder.go
+++ b/gapis/api/vulkan/state_rebuilder.go
@@ -2405,11 +2405,12 @@ func (sb *stateBuilder) createDescriptorPoolAndAllocateDescriptorSets(dp Descrip
 	descSetHandles := make([]VkDescriptorSet, 0, dp.DescriptorSets().Len())
 	descSetLayoutHandles := make([]VkDescriptorSetLayout, 0, dp.DescriptorSets().Len())
 	for vkDescSet, descSetObj := range dp.DescriptorSets().All() {
-		if sb.s.DescriptorSets().Contains(vkDescSet) {
+		if vkDescSet != VkDescriptorSet(0) && sb.s.DescriptorSets().Contains(vkDescSet) && sb.s.DescriptorSetLayouts().Contains(descSetObj.Layout().VulkanHandle()) {
 			descSetHandles = append(descSetHandles, vkDescSet)
 			descSetLayoutHandles = append(descSetLayoutHandles, descSetObj.Layout().VulkanHandle())
 		}
 	}
+
 	if len(descSetHandles) != 0 && len(descSetLayoutHandles) != 0 {
 		sb.write(sb.cb.VkAllocateDescriptorSets(
 			dp.Device(),
@@ -2502,11 +2503,9 @@ func (sb *stateBuilder) writeDescriptorSet(ds DescriptorSetObjectʳ) {
 					continue
 				}
 				if im.Sampler() != 0 && !ns.Samplers().Contains(im.Sampler()) {
-					log.W(sb.ctx, "Sampler %v is invalid, this descriptor[%v] will remain empty", im.Sampler(), ds.VulkanHandle())
 					continue
 				}
 				if im.ImageView() != 0 && !ns.ImageViews().Contains(im.ImageView()) {
-					log.W(sb.ctx, "ImageView %v is invalid, this descriptor[%v] will remain empty", im.Sampler(), ds.VulkanHandle())
 					continue
 				}
 
@@ -2535,7 +2534,6 @@ func (sb *stateBuilder) writeDescriptorSet(ds DescriptorSetObjectʳ) {
 					continue
 				}
 				if buff.Buffer() != 0 && !ns.Buffers().Contains(buff.Buffer()) {
-					log.W(sb.ctx, "Buffer %v is invalid, this descriptor[%v] will remain empty", buff.Buffer(), ds.VulkanHandle())
 					continue
 				}
 				writes = append(writes, NewVkWriteDescriptorSet(sb.ta,
@@ -2561,7 +2559,6 @@ func (sb *stateBuilder) writeDescriptorSet(ds DescriptorSetObjectʳ) {
 					continue
 				}
 				if bv != 0 && !ns.BufferViews().Contains(bv) {
-					log.W(sb.ctx, "BufferView %v is invalid, this descriptor[%v] will remain empty", bv, ds.VulkanHandle())
 					continue
 				}
 				writes = append(writes, NewVkWriteDescriptorSet(sb.ta,


### PR DESCRIPTION
It is valid to call VkAllocateDescriptorSets even in the cases
where it will fail. (1025 sets in a 1024 set pool).

Clean up some warnings that the validation layers were throwing
from the state rebuilder.