### PR TITLE
core\cc: Optimize resource hashing

### DIFF
--- a/core/cc/id.cpp
+++ b/core/cc/id.cpp
@@ -28,11 +28,10 @@ namespace {
 
 void hash(const void* ptr, uint64_t size, core::Id& out) {
   auto buf = reinterpret_cast<const char*>(ptr);
-  auto len = static_cast<size_t>(size);
-  auto hash128 = CityHash128(buf, len);
-  auto hash32 = CityHash32(buf, len);
-  memcpy(&out.data[0], &hash128, 16);
-  memcpy(&out.data[16], &hash32, 4);
+  auto hash = CityHash128(buf, static_cast<size_t>(size));
+  memcpy(&out.data[0], &hash, 16);
+  auto len = static_cast<uint32_t>(size);
+  memcpy(&out.data[16], &len, 4);
 }
 
 }  // anonymous namespace


### PR DESCRIPTION
We were previously hashing the data twice (16 byte hash + 4 byte hash) to build a 20-byte combined hash.

Instead, perform a 16 byte hash, and append the 4-byte length as the extra entropy.