### PR TITLE
gapis/service/path: Add ResolveConfig

### DIFF
--- a/cmd/gapit/commands.go
+++ b/cmd/gapit/commands.go
@@ -86,7 +86,7 @@ func (verb *commandsVerb) Run(ctx context.Context, flags flag.FlagSet) error {
 
 	treePath.MaxChildren = int32(verb.MaxChildren)
 
-	boxedTree, err := client.Get(ctx, treePath.Path())
+	boxedTree, err := client.Get(ctx, treePath.Path(), nil)
 	if err != nil {
 		return log.Err(ctx, err, "Failed to load the command tree")
 	}
@@ -101,7 +101,7 @@ func (verb *commandsVerb) Run(ctx context.Context, flags flag.FlagSet) error {
 		}
 		client.Find(ctx, req, func(r *service.FindResponse) error {
 			p := r.GetCommandTreeNode()
-			boxedNode, err := client.Get(ctx, p.Path())
+			boxedNode, err := client.Get(ctx, p.Path(), nil)
 			if err != nil {
 				return err
 			}
@@ -138,7 +138,7 @@ func traverseCommandTree(
 		return task.StopReason(ctx)
 	}
 
-	boxedNode, err := c.Get(ctx, p.Path())
+	boxedNode, err := c.Get(ctx, p.Path(), nil)
 	if err != nil {
 		return log.Errf(ctx, err, "Failed to load the node at: %v", p)
 	}

--- a/cmd/gapit/common.go
+++ b/cmd/gapit/common.go
@@ -42,7 +42,7 @@ import (
 func (f CommandFilterFlags) commandFilter(ctx context.Context, client service.Service, p *path.Capture) (*path.CommandFilter, error) {
 	filter := &path.CommandFilter{}
 	if f.Context >= 0 {
-		contexts, err := client.Get(ctx, p.Contexts().Path())
+		contexts, err := client.Get(ctx, p.Contexts().Path(), nil)
 		if err != nil {
 			return nil, log.Err(ctx, err, "Failed to load the contexts")
 		}
@@ -128,7 +128,7 @@ func getDevice(ctx context.Context, client client.Client, capture *path.Capture,
 	}
 	for i := 0; i < len(paths); i++ {
 		p := paths[i]
-		o, err := client.Get(ctx, p.Path())
+		o, err := client.Get(ctx, p.Path(), nil)
 		if err != nil {
 			return nil, log.Err(ctx, err, "Couldn't resolve device")
 		}
@@ -250,7 +250,7 @@ func getADBDevice(ctx context.Context, pattern string) (adb.Device, error) {
 }
 
 func getEvents(ctx context.Context, client service.Service, p *path.Events) ([]*service.Event, error) {
-	b, err := client.Get(ctx, p.Path())
+	b, err := client.Get(ctx, p.Path(), nil)
 	if err != nil {
 		return nil, log.Errf(ctx, err, "Couldn't get events at: %v", p)
 	}
@@ -258,7 +258,7 @@ func getEvents(ctx context.Context, client service.Service, p *path.Events) ([]*
 }
 
 func getCommand(ctx context.Context, client service.Service, p *path.Command) (*api.Command, error) {
-	boxedCmd, err := client.Get(ctx, p.Path())
+	boxedCmd, err := client.Get(ctx, p.Path(), nil)
 	if err != nil {
 		return nil, log.Errf(ctx, err, "Couldn't load command at: %v", p)
 	}
@@ -272,7 +272,7 @@ func getConstantSet(ctx context.Context, client service.Service, p *path.Constan
 	if cs, ok := constantSetCache[key]; ok {
 		return cs, nil
 	}
-	boxedConstants, err := client.Get(ctx, p.Path())
+	boxedConstants, err := client.Get(ctx, p.Path(), nil)
 	if err != nil {
 		return nil, log.Errf(ctx, err, "Couldn't local constant set at: %v", p)
 	}
@@ -318,7 +318,7 @@ func printCommand(ctx context.Context, client service.Service, p *path.Command, 
 		mp := p.MemoryAfter(0, 0, math.MaxUint64)
 		mp.ExcludeData = true
 		mp.ExcludeObserved = true
-		boxedMemory, err := client.Get(ctx, mp.Path())
+		boxedMemory, err := client.Get(ctx, mp.Path(), nil)
 		if err != nil {
 			return log.Err(ctx, err, "Couldn't fetch memory observations")
 		}
@@ -346,7 +346,7 @@ func printCommand(ctx context.Context, client service.Service, p *path.Command, 
 func printMemoryData(ctx context.Context, client service.Service, p *path.Command, rng *service.MemoryRange) error {
 	mp := p.MemoryAfter(0, rng.Base, rng.Size)
 	mp.ExcludeObserved = true
-	boxedMemory, err := client.Get(ctx, mp.Path())
+	boxedMemory, err := client.Get(ctx, mp.Path(), nil)
 	if err != nil {
 		return log.Err(ctx, err, "Couldn't fetch memory observations")
 	}
@@ -383,7 +383,7 @@ func filterDevices(ctx context.Context, flags *DeviceFlags, gapis client.Client)
 
 	out := []*path.Device{}
 	for _, dev := range devices {
-		dd, err := gapis.Get(ctx, dev.Path())
+		dd, err := gapis.Get(ctx, dev.Path(), nil)
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/gapit/devices.go
+++ b/cmd/gapit/devices.go
@@ -52,7 +52,7 @@ func (verb *devicesVerb) Run(ctx context.Context, flags flag.FlagSet) error {
 	stdout := os.Stdout
 	for i, p := range devices {
 		fmt.Fprintf(stdout, "-- Device %v: %v --\n", i, p.ID.ID())
-		o, err := client.Get(ctx, p.Path())
+		o, err := client.Get(ctx, p.Path(), nil)
 		if err != nil {
 			fmt.Fprintf(stdout, "%v\n", log.Err(ctx, err, "Couldn't resolve device"))
 			continue

--- a/cmd/gapit/dump.go
+++ b/cmd/gapit/dump.go
@@ -60,13 +60,13 @@ func (verb *dumpVerb) Run(ctx context.Context, flags flag.FlagSet) error {
 		return log.Err(ctx, err, "Failed to load the capture file")
 	}
 
-	boxedCapture, err := client.Get(ctx, cp.Path())
+	boxedCapture, err := client.Get(ctx, cp.Path(), nil)
 	if err != nil {
 		return log.Err(ctx, err, "Failed to load the capture")
 	}
 	c := boxedCapture.(*service.Capture)
 
-	boxedCommands, err := client.Get(ctx, cp.Commands().Path())
+	boxedCommands, err := client.Get(ctx, cp.Commands().Path(), nil)
 	if err != nil {
 		return log.Err(ctx, err, "Failed to acquire the capture's commands")
 	}

--- a/cmd/gapit/dump_shaders.go
+++ b/cmd/gapit/dump_shaders.go
@@ -64,14 +64,14 @@ func (verb *dumpShadersVerb) Run(ctx context.Context, flags flag.FlagSet) error 
 		return log.Errf(ctx, err, "Failed to load the capture file '%v'", filepath)
 	}
 
-	boxedResources, err := client.Get(ctx, capture.Resources().Path())
+	boxedResources, err := client.Get(ctx, capture.Resources().Path(), nil)
 	if err != nil {
 		return log.Err(ctx, err, "Could not find the capture's resources")
 	}
 	resources := boxedResources.(*service.Resources)
 
 	if verb.At == -1 {
-		boxedCapture, err := client.Get(ctx, capture.Path())
+		boxedCapture, err := client.Get(ctx, capture.Path(), nil)
 		if err != nil {
 			return log.Err(ctx, err, "Failed to load the capture")
 		}
@@ -86,7 +86,7 @@ func (verb *dumpShadersVerb) Run(ctx context.Context, flags flag.FlagSet) error 
 					continue
 				}
 				resourcePath := capture.Command(uint64(verb.At)).ResourceAfter(v.ID)
-				resourceData, err := client.Get(ctx, resourcePath.Path())
+				resourceData, err := client.Get(ctx, resourcePath.Path(), nil)
 				if err != nil {
 					log.E(ctx, "Could not get data for shader: %v %v", v, err)
 					continue

--- a/cmd/gapit/memory.go
+++ b/cmd/gapit/memory.go
@@ -64,7 +64,7 @@ func (verb *memoryVerb) Run(ctx context.Context, flags flag.FlagSet) error {
 	}
 
 	if len(verb.At) == 0 {
-		boxedCapture, err := client.Get(ctx, capture.Path())
+		boxedCapture, err := client.Get(ctx, capture.Path(), nil)
 		if err != nil {
 			return log.Err(ctx, err, "Failed to load the capture")
 		}
@@ -74,7 +74,7 @@ func (verb *memoryVerb) Run(ctx context.Context, flags flag.FlagSet) error {
 	boxedVal, err := client.Get(ctx, (&path.Metrics{
 		Command:         capture.Command(verb.At[0], verb.At[1:]...),
 		MemoryBreakdown: true,
-	}).Path())
+	}).Path(), nil)
 	if err != nil {
 		return log.Errf(ctx, err, "Failed to load metrics")
 	}
@@ -89,7 +89,7 @@ func (verb *memoryVerb) Run(ctx context.Context, flags flag.FlagSet) error {
 		boxedConstants, err := client.Get(ctx, (&path.ConstantSet{
 			API:   mem.API,
 			Index: uint32(mem.AllocationFlagsIndex),
-		}).Path())
+		}).Path(), nil)
 		if err != nil {
 			return log.Errf(ctx, err, "Failed to load allocation flag names")
 		}

--- a/cmd/gapit/packages.go
+++ b/cmd/gapit/packages.go
@@ -61,14 +61,14 @@ func (verb *packagesVerb) Run(ctx context.Context, flags flag.FlagSet) error {
 	}
 
 	for _, p := range devices {
-		o, err := client.Get(ctx, p.Path())
+		o, err := client.Get(ctx, p.Path(), nil)
 		if err != nil {
 			fmt.Fprintf(os.Stdout, "%v\n", log.Err(ctx, err, "Couldn't resolve device"))
 			continue
 		}
 		d := o.(*device.Instance)
 
-		cfg, err := client.Get(ctx, (&path.DeviceTraceConfiguration{Device: p}).Path())
+		cfg, err := client.Get(ctx, (&path.DeviceTraceConfiguration{Device: p}).Path(), nil)
 		if err != nil {
 			fmt.Fprintf(os.Stdout, "%v\n", log.Err(ctx, err, "Couldn't get device config"))
 			return err

--- a/cmd/gapit/replace_resource.go
+++ b/cmd/gapit/replace_resource.go
@@ -79,14 +79,14 @@ func (verb *replaceResourceVerb) Run(ctx context.Context, flags flag.FlagSet) er
 		return log.Errf(ctx, err, "Failed to load the capture file '%v'", captureFilepath)
 	}
 
-	boxedResources, err := client.Get(ctx, capture.Resources().Path())
+	boxedResources, err := client.Get(ctx, capture.Resources().Path(), nil)
 	if err != nil {
 		return log.Err(ctx, err, "Could not find the capture's resources")
 	}
 	resources := boxedResources.(*service.Resources)
 
 	if verb.At == -1 {
-		boxedCapture, err := client.Get(ctx, capture.Path())
+		boxedCapture, err := client.Get(ctx, capture.Path(), nil)
 		if err != nil {
 			return log.Err(ctx, err, "Failed to load the capture")
 		}
@@ -119,7 +119,7 @@ func (verb *replaceResourceVerb) Run(ctx context.Context, flags flag.FlagSet) er
 		for i, v := range shaderResources {
 			ids[i] = v.ID
 			resourcePath := capture.Command(uint64(verb.At)).ResourceAfter(v.ID)
-			rd, err := client.Get(ctx, resourcePath.Path())
+			rd, err := client.Get(ctx, resourcePath.Path(), nil)
 			if err != nil {
 				log.Errf(ctx, err, "Could not get data for shader: %v", v)
 				return err
@@ -135,7 +135,7 @@ func (verb *replaceResourceVerb) Run(ctx context.Context, flags flag.FlagSet) er
 		resourcePath = capture.Command(uint64(verb.At)).ResourcesAfter(ids).Path()
 	}
 
-	newResourcePath, err := client.Set(ctx, resourcePath, resourceData)
+	newResourcePath, err := client.Set(ctx, resourcePath, resourceData, nil)
 	if err != nil {
 		return log.Errf(ctx, err, "Could not update resource data: %v", resourcePath)
 	}

--- a/cmd/gapit/report.go
+++ b/cmd/gapit/report.go
@@ -91,13 +91,13 @@ func (verb *reportVerb) Run(ctx context.Context, flags flag.FlagSet) error {
 		return log.Err(ctx, err, "Failed to build the CommandFilter")
 	}
 
-	boxedCommands, err := client.Get(ctx, capturePath.Commands().Path())
+	boxedCommands, err := client.Get(ctx, capturePath.Commands().Path(), nil)
 	if err != nil {
 		return log.Err(ctx, err, "Failed to acquire the capture's commands")
 	}
 	commands := boxedCommands.(*service.Commands).List
 
-	boxedReport, err := client.Get(ctx, capturePath.Report(device, filter).Path())
+	boxedReport, err := client.Get(ctx, capturePath.Report(device, filter).Path(), nil)
 	if err != nil {
 		return log.Err(ctx, err, "Failed to acquire the capture's report")
 	}

--- a/cmd/gapit/screenshot.go
+++ b/cmd/gapit/screenshot.go
@@ -127,12 +127,12 @@ func (verb *screenshotVerb) getSingleFrame(ctx context.Context, cmd *path.Comman
 	if err != nil {
 		return nil, log.Errf(ctx, err, "GetFramebufferAttachment failed")
 	}
-	iio, err := client.Get(ctx, iip.Path())
+	iio, err := client.Get(ctx, iip.Path(), nil)
 	if err != nil {
 		return nil, log.Errf(ctx, err, "Get frame image.Info failed")
 	}
 	ii := iio.(*img.Info)
-	dataO, err := client.Get(ctx, path.NewBlob(ii.Bytes.ID()).Path())
+	dataO, err := client.Get(ctx, path.NewBlob(ii.Bytes.ID()).Path(), nil)
 	if err != nil {
 		return nil, log.Errf(ctx, err, "Get frame image data failed")
 	}

--- a/cmd/gapit/state.go
+++ b/cmd/gapit/state.go
@@ -72,14 +72,14 @@ func (verb *stateVerb) Run(ctx context.Context, flags flag.FlagSet) error {
 	}
 
 	if len(verb.At) == 0 {
-		boxedCapture, err := client.Get(ctx, c.Path())
+		boxedCapture, err := client.Get(ctx, c.Path(), nil)
 		if err != nil {
 			return log.Err(ctx, err, "Failed to load the capture")
 		}
 		verb.At = []uint64{uint64(boxedCapture.(*service.Capture).NumCommands) - 1}
 	}
 
-	boxedTree, err := client.Get(ctx, c.Command(uint64(verb.At[0]), verb.At[1:]...).StateAfter().Tree().Path())
+	boxedTree, err := client.Get(ctx, c.Command(uint64(verb.At[0]), verb.At[1:]...).StateAfter().Tree().Path(), nil)
 	if err != nil {
 		return log.Err(ctx, err, "Failed to load the command tree")
 	}
@@ -119,7 +119,7 @@ func traverseStateTree(
 		return task.StopReason(ctx)
 	}
 
-	boxedNode, err := c.Get(ctx, p.Path())
+	boxedNode, err := c.Get(ctx, p.Path(), nil)
 	if err != nil {
 		return log.Errf(ctx, err, "Failed to load the node at: %v", p)
 	}

--- a/cmd/gapit/stats.go
+++ b/cmd/gapit/stats.go
@@ -119,7 +119,7 @@ func (verb *infoVerb) drawCallStats(ctx context.Context, client client.Client, c
 	boxedVal, err := client.Get(ctx, (&path.Stats{
 		Capture:  c,
 		DrawCall: true,
-	}).Path())
+	}).Path(), nil)
 	if err != nil {
 		return 0, sint.HistogramStats{}, err
 	}

--- a/cmd/gapit/stresstest.go
+++ b/cmd/gapit/stresstest.go
@@ -64,7 +64,7 @@ func (verb *stresstestVerb) Run(ctx context.Context, flags flag.FlagSet) error {
 		return log.Err(ctx, err, "Failed to load the capture file")
 	}
 
-	boxedCapture, err := client.Get(ctx, c.Path())
+	boxedCapture, err := client.Get(ctx, c.Path(), nil)
 	if err != nil {
 		return log.Err(ctx, err, "Failed to load the capture")
 	}
@@ -91,14 +91,14 @@ func (verb *stresstestVerb) Run(ctx context.Context, flags flag.FlagSet) error {
 
 				switch method {
 				case getStateAfter:
-					boxedTree, err := client.Get(ctx, c.Command(at).StateAfter().Tree().Path())
+					boxedTree, err := client.Get(ctx, c.Command(at).StateAfter().Tree().Path(), nil)
 					if err == nil {
 						tree := boxedTree.(*service.StateTree)
-						client.Get(ctx, tree.Root.Path())
+						client.Get(ctx, tree.Root.Path(), nil)
 					}
 
 				case getMesh:
-					boxedMesh, err := client.Get(ctx, c.Command(at).Mesh(path.NewMeshOptions(true)).Path())
+					boxedMesh, err := client.Get(ctx, c.Command(at).Mesh(path.NewMeshOptions(true)).Path(), nil)
 					if err == nil {
 						mesh := boxedMesh.(*api.Mesh)
 						_ = mesh

--- a/cmd/gapit/sxs_video.go
+++ b/cmd/gapit/sxs_video.go
@@ -52,12 +52,12 @@ type videoFrame struct {
 
 // getFBO fetches the framebuffer observation of the command.
 func getFBO(ctx context.Context, client service.Service, a *path.Command) (*img.Data, error) {
-	obj, err := client.Get(ctx, a.FramebufferObservation().Path())
+	obj, err := client.Get(ctx, a.FramebufferObservation().Path(), nil)
 	if err != nil {
 		return nil, err
 	}
 	ii := obj.(*img.Info)
-	obj, err = client.Get(ctx, path.NewBlob(ii.Bytes.ID()).Path())
+	obj, err = client.Get(ctx, path.NewBlob(ii.Bytes.ID()).Path(), nil)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/gapit/trace.go
+++ b/cmd/gapit/trace.go
@@ -101,7 +101,7 @@ func (verb *traceVerb) Run(ctx context.Context, flags flag.FlagSet) error {
 				continue
 			}
 
-			dd, err := client.Get(ctx, dev.Path())
+			dd, err := client.Get(ctx, dev.Path(), nil)
 			if err != nil {
 				return err
 			}

--- a/cmd/gapit/video.go
+++ b/cmd/gapit/video.go
@@ -337,12 +337,12 @@ func getFrame(ctx context.Context, maxWidth, maxHeight int, cmd *path.Command, d
 	if err != nil {
 		return nil, log.Errf(ctx, err, "GetFramebufferAttachment failed at %v", cmd)
 	}
-	iio, err := client.Get(ctx, iip.Path())
+	iio, err := client.Get(ctx, iip.Path(), nil)
 	if err != nil {
 		return nil, log.Errf(ctx, err, "Get frame image.Info failed at %v", cmd)
 	}
 	ii := iio.(*img.Info)
-	dataO, err := client.Get(ctx, path.NewBlob(ii.Bytes.ID()).Path())
+	dataO, err := client.Get(ctx, path.NewBlob(ii.Bytes.ID()).Path(), nil)
 	if err != nil {
 		return nil, log.Errf(ctx, err, "Get frame image data failed at %v", cmd)
 	}

--- a/gapis/api/gles/BUILD.bazel
+++ b/gapis/api/gles/BUILD.bazel
@@ -113,7 +113,6 @@ go_library(
         "//core/math/u64:go_default_library",
         "//core/memory/arena:go_default_library",  # keep
         "//core/os/device:go_default_library",
-        "//core/os/device/bind:go_default_library",
         "//core/stream:go_default_library",
         "//core/stream/fmts:go_default_library",
         "//core/text:go_default_library",

--- a/gapis/api/gles/draw_call_mesh.go
+++ b/gapis/api/gles/draw_call_mesh.go
@@ -32,14 +32,14 @@ import (
 )
 
 // drawCallMesh builds a mesh for dc at p.
-func drawCallMesh(ctx context.Context, dc drawCall, p *path.Mesh) (*api.Mesh, error) {
+func drawCallMesh(ctx context.Context, dc drawCall, p *path.Mesh, r *path.ResolveConfig) (*api.Mesh, error) {
 	cmdPath := path.FindCommand(p)
 	if cmdPath == nil {
 		log.W(ctx, "Couldn't find command at path '%v'", p)
 		return nil, nil
 	}
 
-	s, err := resolve.GlobalState(ctx, cmdPath.GlobalStateAfter())
+	s, err := resolve.GlobalState(ctx, cmdPath.GlobalStateAfter(), r)
 	if err != nil {
 		return nil, err
 	}

--- a/gapis/api/gles/gles.go
+++ b/gapis/api/gles/gles.go
@@ -41,11 +41,11 @@ func (s *State) GetContext(thread uint64) Contextʳ {
 // Root returns the path to the root of the state to display. It can vary based
 // on filtering mode. Returning nil, nil indicates there is no state to show at
 // this point in the capture.
-func (s *State) Root(ctx context.Context, p *path.State) (path.Node, error) {
+func (s *State) Root(ctx context.Context, p *path.State, r *path.ResolveConfig) (path.Node, error) {
 	if p.Context == nil || !p.Context.IsValid() {
 		return p, nil
 	}
-	c, err := resolve.Context(ctx, p.After.Capture.Context(p.Context.ID()))
+	c, err := resolve.Context(ctx, p.After.Capture.Context(p.Context.ID()), r)
 	if err != nil {
 		return nil, err
 	}
@@ -257,9 +257,9 @@ func (API) Context(s *api.GlobalState, thread uint64) api.Context {
 }
 
 // Mesh implements the api.MeshProvider interface.
-func (API) Mesh(ctx context.Context, o interface{}, p *path.Mesh) (*api.Mesh, error) {
+func (API) Mesh(ctx context.Context, o interface{}, p *path.Mesh, r *path.ResolveConfig) (*api.Mesh, error) {
 	if dc, ok := o.(drawCall); ok {
-		return drawCallMesh(ctx, dc, p)
+		return drawCallMesh(ctx, dc, p, r)
 	}
 	return nil, nil
 }

--- a/gapis/api/gles/links.go
+++ b/gapis/api/gles/links.go
@@ -23,15 +23,15 @@ import (
 
 // objects returns the path to the Objects field of the currently bound
 // context, and the context at p.
-func objects(ctx context.Context, p path.Node) (*path.Field, Contextʳ, error) {
+func objects(ctx context.Context, p path.Node, r *path.ResolveConfig) (*path.Field, Contextʳ, error) {
 	if cmdPath := path.FindCommand(p); cmdPath != nil {
-		cmd, err := resolve.Cmd(ctx, cmdPath)
+		cmd, err := resolve.Cmd(ctx, cmdPath, r)
 		if err != nil {
 			return nil, NilContextʳ, err
 		}
 		thread := cmd.Thread()
 
-		stateObj, err := resolve.State(ctx, cmdPath.StateAfter())
+		stateObj, err := resolve.State(ctx, cmdPath.StateAfter(), r)
 		if err != nil {
 			return nil, NilContextʳ, err
 		}
@@ -47,8 +47,8 @@ func objects(ctx context.Context, p path.Node) (*path.Field, Contextʳ, error) {
 
 // Link returns the link to the attribute vertex array in the state block.
 // If nil, nil is returned then the path cannot be followed.
-func (o AttributeLocation) Link(ctx context.Context, p path.Node) (path.Node, error) {
-	i, c, err := objects(ctx, p)
+func (o AttributeLocation) Link(ctx context.Context, p path.Node, r *path.ResolveConfig) (path.Node, error) {
+	i, c, err := objects(ctx, p, r)
 	if i == nil {
 		return nil, err
 	}
@@ -64,8 +64,8 @@ func (o AttributeLocation) Link(ctx context.Context, p path.Node) (path.Node, er
 
 // Link returns the link to the buffer object in the state block.
 // If nil, nil is returned then the path cannot be followed.
-func (o BufferId) Link(ctx context.Context, p path.Node) (path.Node, error) {
-	i, c, err := objects(ctx, p)
+func (o BufferId) Link(ctx context.Context, p path.Node, r *path.ResolveConfig) (path.Node, error) {
+	i, c, err := objects(ctx, p, r)
 	if i == nil || !c.Objects().Buffers().Contains(o) {
 		return nil, err
 	}
@@ -74,8 +74,8 @@ func (o BufferId) Link(ctx context.Context, p path.Node) (path.Node, error) {
 
 // Link returns the link to the framebuffer object in the state block.
 // If nil, nil is returned then the path cannot be followed.
-func (o FramebufferId) Link(ctx context.Context, p path.Node) (path.Node, error) {
-	i, c, err := objects(ctx, p)
+func (o FramebufferId) Link(ctx context.Context, p path.Node, r *path.ResolveConfig) (path.Node, error) {
+	i, c, err := objects(ctx, p, r)
 	if i == nil || !c.Objects().Framebuffers().Contains(o) {
 		return nil, err
 	}
@@ -84,8 +84,8 @@ func (o FramebufferId) Link(ctx context.Context, p path.Node) (path.Node, error)
 
 // Link returns the link to the program in the state block.
 // If nil, nil is returned then the path cannot be followed.
-func (o ProgramId) Link(ctx context.Context, p path.Node) (path.Node, error) {
-	i, c, err := objects(ctx, p)
+func (o ProgramId) Link(ctx context.Context, p path.Node, r *path.ResolveConfig) (path.Node, error) {
+	i, c, err := objects(ctx, p, r)
 	if i == nil || !c.Objects().Programs().Contains(o) {
 		return nil, err
 	}
@@ -94,8 +94,8 @@ func (o ProgramId) Link(ctx context.Context, p path.Node) (path.Node, error) {
 
 // Link returns the link to the query object in the state block.
 // If nil, nil is returned then the path cannot be followed.
-func (o QueryId) Link(ctx context.Context, p path.Node) (path.Node, error) {
-	i, c, err := objects(ctx, p)
+func (o QueryId) Link(ctx context.Context, p path.Node, r *path.ResolveConfig) (path.Node, error) {
+	i, c, err := objects(ctx, p, r)
 	if i == nil || !c.Objects().Queries().Contains(o) {
 		return nil, err
 	}
@@ -104,8 +104,8 @@ func (o QueryId) Link(ctx context.Context, p path.Node) (path.Node, error) {
 
 // Link returns the link to the renderbuffer object in the state block.
 // If nil, nil is returned then the path cannot be followed.
-func (o RenderbufferId) Link(ctx context.Context, p path.Node) (path.Node, error) {
-	i, c, err := objects(ctx, p)
+func (o RenderbufferId) Link(ctx context.Context, p path.Node, r *path.ResolveConfig) (path.Node, error) {
+	i, c, err := objects(ctx, p, r)
 	if i == nil || !c.Objects().Renderbuffers().Contains(o) {
 		return nil, err
 	}
@@ -114,8 +114,8 @@ func (o RenderbufferId) Link(ctx context.Context, p path.Node) (path.Node, error
 
 // Link returns the link to the shader object in the state block.
 // If nil, nil is returned then the path cannot be followed.
-func (o ShaderId) Link(ctx context.Context, p path.Node) (path.Node, error) {
-	i, c, err := objects(ctx, p)
+func (o ShaderId) Link(ctx context.Context, p path.Node, r *path.ResolveConfig) (path.Node, error) {
+	i, c, err := objects(ctx, p, r)
 	if i == nil || !c.Objects().Shaders().Contains(o) {
 		return nil, err
 	}
@@ -124,8 +124,8 @@ func (o ShaderId) Link(ctx context.Context, p path.Node) (path.Node, error) {
 
 // Link returns the link to the texture object in the state block.
 // If nil, nil is returned then the path cannot be followed.
-func (o TextureId) Link(ctx context.Context, p path.Node) (path.Node, error) {
-	i, c, err := objects(ctx, p)
+func (o TextureId) Link(ctx context.Context, p path.Node, r *path.ResolveConfig) (path.Node, error) {
+	i, c, err := objects(ctx, p, r)
 	if i == nil || !c.Objects().Textures().Contains(o) {
 		return nil, err
 	}
@@ -134,13 +134,13 @@ func (o TextureId) Link(ctx context.Context, p path.Node) (path.Node, error) {
 
 // Link returns the link to the uniform in the state block.
 // If nil, nil is returned then the path cannot be followed.
-func (o UniformIndex) Link(ctx context.Context, p path.Node) (path.Node, error) {
-	i, c, err := objects(ctx, p)
+func (o UniformIndex) Link(ctx context.Context, p path.Node, r *path.ResolveConfig) (path.Node, error) {
+	i, c, err := objects(ctx, p, r)
 	if i == nil {
 		return nil, err
 	}
 
-	cmd, err := resolve.Cmd(ctx, path.FindCommand(p))
+	cmd, err := resolve.Cmd(ctx, path.FindCommand(p), r)
 	if err != nil {
 		return nil, err
 	}
@@ -170,13 +170,13 @@ func (o UniformIndex) Link(ctx context.Context, p path.Node) (path.Node, error) 
 
 // Link returns the link to the uniform in the state block.
 // If nil, nil is returned then the path cannot be followed.
-func (o UniformLocation) Link(ctx context.Context, p path.Node) (path.Node, error) {
-	i, c, err := objects(ctx, p)
+func (o UniformLocation) Link(ctx context.Context, p path.Node, r *path.ResolveConfig) (path.Node, error) {
+	i, c, err := objects(ctx, p, r)
 	if i == nil {
 		return nil, err
 	}
 
-	cmd, err := resolve.Cmd(ctx, path.FindCommand(p))
+	cmd, err := resolve.Cmd(ctx, path.FindCommand(p), r)
 	if err != nil {
 		return nil, err
 	}
@@ -205,8 +205,8 @@ func (o UniformLocation) Link(ctx context.Context, p path.Node) (path.Node, erro
 
 // Link returns the link to the vertex array in the state block.
 // If nil, nil is returned then the path cannot be followed.
-func (o VertexArrayId) Link(ctx context.Context, p path.Node) (path.Node, error) {
-	i, c, err := objects(ctx, p)
+func (o VertexArrayId) Link(ctx context.Context, p path.Node, r *path.ResolveConfig) (path.Node, error) {
+	i, c, err := objects(ctx, p, r)
 	if i == nil || !c.Objects().VertexArrays().Contains(o) {
 		return nil, err
 	}
@@ -215,8 +215,8 @@ func (o VertexArrayId) Link(ctx context.Context, p path.Node) (path.Node, error)
 
 // Link returns the link to the transform feedback in the state block.
 // If nil, nil is returned then the path cannot be followed.
-func (o TransformFeedbackId) Link(ctx context.Context, p path.Node) (path.Node, error) {
-	i, c, err := objects(ctx, p)
+func (o TransformFeedbackId) Link(ctx context.Context, p path.Node, r *path.ResolveConfig) (path.Node, error) {
+	i, c, err := objects(ctx, p, r)
 	if i == nil || !c.Objects().TransformFeedbacks().Contains(o) {
 		return nil, err
 	}

--- a/gapis/api/gles/resources.go
+++ b/gapis/api/gles/resources.go
@@ -216,8 +216,14 @@ func (t Textureʳ) ResourceData(ctx context.Context, s *api.GlobalState) (*api.R
 	return nil, &service.ErrDataUnavailable{Reason: messages.ErrNoTextureData(t.ResourceHandle())}
 }
 
-func (t Textureʳ) SetResourceData(ctx context.Context, at *path.Command,
-	data *api.ResourceData, resources api.ResourceMap, edits api.ReplaceCallback) error {
+func (t Textureʳ) SetResourceData(
+	ctx context.Context,
+	at *path.Command,
+	data *api.ResourceData,
+	resources api.ResourceMap,
+	edits api.ReplaceCallback,
+	r *path.ResolveConfig) error {
+
 	return fmt.Errorf("SetResourceData is not supported for Texture")
 }
 
@@ -306,7 +312,8 @@ func (s Shaderʳ) SetResourceData(
 	at *path.Command,
 	data *api.ResourceData,
 	resourceIDs api.ResourceMap,
-	edits api.ReplaceCallback) error {
+	edits api.ReplaceCallback,
+	r *path.ResolveConfig) error {
 
 	cmdIdx := at.Indices[0]
 	if len(at.Indices) > 1 {
@@ -315,7 +322,7 @@ func (s Shaderʳ) SetResourceData(
 
 	// Dirty. TODO: Make separate type for getting info for a single resource.
 	capturePath := at.Capture
-	resources, err := resolve.Resources(ctx, capturePath)
+	resources, err := resolve.Resources(ctx, capturePath, r)
 	if err != nil {
 		return err
 	}
@@ -599,7 +606,13 @@ func uniformValue(ctx context.Context, s *api.GlobalState, kind api.UniformType,
 	}
 }
 
-func (p Programʳ) SetResourceData(ctx context.Context, at *path.Command,
-	data *api.ResourceData, resources api.ResourceMap, edits api.ReplaceCallback) error {
+func (p Programʳ) SetResourceData(
+	ctx context.Context,
+	at *path.Command,
+	data *api.ResourceData,
+	resources api.ResourceMap,
+	edits api.ReplaceCallback,
+	r *path.ResolveConfig) error {
+
 	return fmt.Errorf("SetResourceData is not supported for Program")
 }

--- a/gapis/api/gvr/extension.go
+++ b/gapis/api/gvr/extension.go
@@ -72,11 +72,11 @@ func findContextByCommand(ctxs []*api.ContextInfo, ty reflect.Type) *api.Context
 	return best
 }
 
-func isReprojectionContext(ctx context.Context, p *path.Context) bool {
+func isReprojectionContext(ctx context.Context, p *path.Context, r *path.ResolveConfig) bool {
 	if p == nil {
 		return false
 	}
-	c, err := resolve.Context(ctx, p)
+	c, err := resolve.Context(ctx, p, r)
 	if c == nil || err != nil {
 		return false
 	}
@@ -84,11 +84,11 @@ func isReprojectionContext(ctx context.Context, p *path.Context) bool {
 	return ok
 }
 
-func getRenderContextID(ctx context.Context, p *path.Contexts) *api.ContextID {
+func getRenderContextID(ctx context.Context, p *path.Contexts, r *path.ResolveConfig) *api.ContextID {
 	if p == nil {
 		return nil
 	}
-	ctxs, err := resolve.Contexts(ctx, p)
+	ctxs, err := resolve.Contexts(ctx, p, r)
 	if err != nil {
 		return nil
 	}
@@ -100,8 +100,8 @@ func getRenderContextID(ctx context.Context, p *path.Contexts) *api.ContextID {
 	return nil
 }
 
-func newReprojectionGroupers(ctx context.Context, p *path.CommandTree) []cmdgrouper.Grouper {
-	if !isReprojectionContext(ctx, p.Capture.Context(p.GetFilter().GetContext().ID())) {
+func newReprojectionGroupers(ctx context.Context, p *path.CommandTree, r *path.ResolveConfig) []cmdgrouper.Grouper {
+	if !isReprojectionContext(ctx, p.Capture.Context(p.GetFilter().GetContext().ID()), r) {
 		return nil
 	}
 	glFenceSync := func(cond gles.GLenum) func(cmd, prev api.Cmd) bool {
@@ -187,8 +187,8 @@ func (n noSubFrameEventGrouper) Build(end api.CmdID) []cmdgrouper.Group {
 	return out
 }
 
-func newReprojectionEvents(ctx context.Context, p *path.Events) extensions.EventProvider {
-	if !isReprojectionContext(ctx, p.Capture.Context(p.GetFilter().GetContext().ID())) {
+func newReprojectionEvents(ctx context.Context, p *path.Events, r *path.ResolveConfig) extensions.EventProvider {
+	if !isReprojectionContext(ctx, p.Capture.Context(p.GetFilter().GetContext().ID()), r) {
 		return nil
 	}
 
@@ -217,8 +217,8 @@ func newReprojectionEvents(ctx context.Context, p *path.Events) extensions.Event
 	}
 }
 
-func eventFilter(ctx context.Context, p *path.Events) extensions.EventFilter {
-	renderCtxID := getRenderContextID(ctx, p.Capture.Contexts())
+func eventFilter(ctx context.Context, p *path.Events, r *path.ResolveConfig) extensions.EventFilter {
+	renderCtxID := getRenderContextID(ctx, p.Capture.Contexts(), r)
 	if renderCtxID == nil {
 		return nil
 	}

--- a/gapis/api/gvr/gvr.go
+++ b/gapis/api/gvr/gvr.go
@@ -33,7 +33,7 @@ var _ = replay.QueryFramebufferAttachment(API{})
 // Root returns the path to the root of the state to display. It can vary based
 // on filtering mode. Returning nil, nil indicates there is no state to show at
 // this point in the capture.
-func (s *State) Root(ctx context.Context, p *path.State) (path.Node, error) {
+func (s *State) Root(ctx context.Context, p *path.State, r *path.ResolveConfig) (path.Node, error) {
 	return nil, nil
 }
 
@@ -106,7 +106,7 @@ func (API) Context(s *api.GlobalState, thread uint64) api.Context {
 }
 
 // Mesh implements the api.MeshProvider interface.
-func (API) Mesh(ctx context.Context, o interface{}, p *path.Mesh) (*api.Mesh, error) {
+func (API) Mesh(ctx context.Context, o interface{}, p *path.Mesh, r *path.ResolveConfig) (*api.Mesh, error) {
 	return nil, nil
 }
 

--- a/gapis/api/mesh.go
+++ b/gapis/api/mesh.go
@@ -33,7 +33,7 @@ import (
 type MeshProvider interface {
 	// Mesh returns the mesh representation of the object o.
 	// If nil, nil then the object cannot be represented as a mesh.
-	Mesh(ctx context.Context, o interface{}, p *path.Mesh) (*Mesh, error)
+	Mesh(ctx context.Context, o interface{}, p *path.Mesh, r *path.ResolveConfig) (*Mesh, error)
 }
 
 // Faceted returns a new mesh with each shared vertex split, and each normal set

--- a/gapis/api/resource.go
+++ b/gapis/api/resource.go
@@ -46,7 +46,13 @@ type Resource interface {
 	ResourceData(ctx context.Context, s *GlobalState) (*ResourceData, error)
 
 	// SetResourceData sets resource data in a new capture.
-	SetResourceData(ctx context.Context, at *path.Command, data *ResourceData, resources ResourceMap, edits ReplaceCallback) error
+	SetResourceData(
+		ctx context.Context,
+		at *path.Command,
+		data *ResourceData,
+		resources ResourceMap,
+		edits ReplaceCallback,
+		r *path.ResolveConfig) error
 }
 
 // ResourceMeta represents resource with a state information obtained during building.

--- a/gapis/api/state.go
+++ b/gapis/api/state.go
@@ -79,7 +79,7 @@ type State interface {
 	// Root returns the path to the root of the state to display. It can vary
 	// based on filtering mode. Returning nil, nil indicates there is no state
 	// to show at this point in the capture.
-	Root(ctx context.Context, p *path.State) (path.Node, error)
+	Root(ctx context.Context, p *path.State, r *path.ResolveConfig) (path.Node, error)
 
 	// SetupInitialState sanitizes deserialized state to make it valid.
 	// It can fill in any derived data which we choose not to serialize,

--- a/gapis/api/templates/api.go.tmpl
+++ b/gapis/api/templates/api.go.tmpl
@@ -844,7 +844,7 @@ import (
   // Link returns a path which can be used to view memory which is referenced
   // by the slice s.
   // If nil, nil is returned then the path cannot be followed.
-  func (s {{$slice_ty}}) Link(ϟctx context.Context, ϟp path.Node) (path.Node, error) {
+  func (s {{$slice_ty}}) Link(ϟctx context.Context, ϟp path.Node, ϟr *path.ResolveConfig) (path.Node, error) {
     if cmd := path.FindCommand(ϟp); cmd != nil {
       return cmd.MemoryAfter(uint32(s.Pool()), s.Base(), s.Size()), nil
     }
@@ -992,7 +992,7 @@ import (
   // is a path to the command and resulting path is a path to an object
   // identified by p. Once resolved the command will return a representation
   // of the value of the instance after the command has executed.
-  func (p {{$ptr_ty}}) Link(ϟctx context.Context, ϟp path.Node) (path.Node, error) {
+  func (p {{$ptr_ty}}) Link(ϟctx context.Context, ϟp path.Node, ϟr *path.ResolveConfig) (path.Node, error) {
     if cmd := path.FindCommand(ϟp); cmd != nil {
       return cmd.MemoryAfter(uint32(ϟmem.ApplicationPool), uint64(p), 0), nil
     }

--- a/gapis/api/test/test.go
+++ b/gapis/api/test/test.go
@@ -38,7 +38,7 @@ func (API) Context(*api.GlobalState, uint64) api.Context { return nil }
 // Root returns the path to the root of the state to display. It can vary based
 // on filtering mode. Returning nil, nil indicates there is no state to show at
 // this point in the capture.
-func (s *State) Root(ctx context.Context, p *path.State) (path.Node, error) {
+func (s *State) Root(ctx context.Context, p *path.State, r *path.ResolveConfig) (path.Node, error) {
 	return p, nil
 }
 

--- a/gapis/api/vulkan/draw_call_mesh.go
+++ b/gapis/api/vulkan/draw_call_mesh.go
@@ -28,14 +28,14 @@ import (
 )
 
 // drawCallMesh builds a mesh for dc at p.
-func drawCallMesh(ctx context.Context, dc *VkQueueSubmit, p *path.Mesh) (*api.Mesh, error) {
+func drawCallMesh(ctx context.Context, dc *VkQueueSubmit, p *path.Mesh, r *path.ResolveConfig) (*api.Mesh, error) {
 	cmdPath := path.FindCommand(p)
 	if cmdPath == nil {
 		log.W(ctx, "Couldn't find command at path '%v'", p)
 		return nil, nil
 	}
 
-	s, err := resolve.GlobalState(ctx, cmdPath.GlobalStateAfter())
+	s, err := resolve.GlobalState(ctx, cmdPath.GlobalStateAfter(), r)
 	if err != nil {
 		return nil, err
 	}

--- a/gapis/api/vulkan/resources.go
+++ b/gapis/api/vulkan/resources.go
@@ -703,8 +703,14 @@ func (t ImageObjectʳ) ResourceData(ctx context.Context, s *api.GlobalState) (*a
 	}
 }
 
-func (t ImageObjectʳ) SetResourceData(ctx context.Context, at *path.Command,
-	data *api.ResourceData, resources api.ResourceMap, edits api.ReplaceCallback) error {
+func (t ImageObjectʳ) SetResourceData(
+	ctx context.Context,
+	at *path.Command,
+	data *api.ResourceData,
+	resources api.ResourceMap,
+	edits api.ReplaceCallback,
+	r *path.ResolveConfig) error {
+
 	return fmt.Errorf("SetResourceData is not supported for ImageObject")
 }
 
@@ -752,14 +758,15 @@ func (shader ShaderModuleObjectʳ) SetResourceData(
 	at *path.Command,
 	data *api.ResourceData,
 	resourceIDs api.ResourceMap,
-	edits api.ReplaceCallback) error {
+	edits api.ReplaceCallback,
+	r *path.ResolveConfig) error {
 
 	ctx = log.Enter(ctx, "ShaderModuleObject.SetResourceData()")
 
 	cmdIdx := at.Indices[0]
 
 	// Dirty. TODO: Make separate type for getting info for a single resource.
-	resources, err := resolve.Resources(ctx, at.Capture)
+	resources, err := resolve.Resources(ctx, at.Capture, r)
 	if err != nil {
 		return err
 	}

--- a/gapis/api/vulkan/vulkan.go
+++ b/gapis/api/vulkan/vulkan.go
@@ -74,7 +74,7 @@ func (API) Context(s *api.GlobalState, thread uint64) api.Context {
 // Root returns the path to the root of the state to display. It can vary based
 // on filtering mode. Returning nil, nil indicates there is no state to show at
 // this point in the capture.
-func (*State) Root(ctx context.Context, p *path.State) (path.Node, error) {
+func (*State) Root(ctx context.Context, p *path.State, r *path.ResolveConfig) (path.Node, error) {
 	return p, nil
 }
 
@@ -125,10 +125,10 @@ func (API) GetFramebufferAttachmentInfo(
 }
 
 // Mesh implements the api.MeshProvider interface
-func (API) Mesh(ctx context.Context, o interface{}, p *path.Mesh) (*api.Mesh, error) {
+func (API) Mesh(ctx context.Context, o interface{}, p *path.Mesh, r *path.ResolveConfig) (*api.Mesh, error) {
 	switch dc := o.(type) {
 	case *VkQueueSubmit:
-		return drawCallMesh(ctx, dc, p)
+		return drawCallMesh(ctx, dc, p, r)
 	}
 	return nil, &service.ErrDataUnavailable{Reason: messages.ErrMeshNotAvailable()}
 }

--- a/gapis/client/client.go
+++ b/gapis/client/client.go
@@ -82,8 +82,11 @@ func (c *client) CheckForUpdates(ctx context.Context, includePrereleases bool) (
 	return res.GetRelease(), nil
 }
 
-func (c *client) Get(ctx context.Context, p *path.Any) (interface{}, error) {
-	res, err := c.client.Get(ctx, &service.GetRequest{Path: p})
+func (c *client) Get(ctx context.Context, p *path.Any, r *path.ResolveConfig) (interface{}, error) {
+	res, err := c.client.Get(ctx, &service.GetRequest{
+		Path:   p,
+		Config: r,
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -93,10 +96,11 @@ func (c *client) Get(ctx context.Context, p *path.Any) (interface{}, error) {
 	return res.GetValue().Get(), nil
 }
 
-func (c *client) Set(ctx context.Context, p *path.Any, v interface{}) (*path.Any, error) {
+func (c *client) Set(ctx context.Context, p *path.Any, v interface{}, r *path.ResolveConfig) (*path.Any, error) {
 	res, err := c.client.Set(ctx, &service.SetRequest{
-		Path:  p,
-		Value: service.NewValue(v),
+		Path:   p,
+		Value:  service.NewValue(v),
+		Config: r,
 	})
 	if err != nil {
 		return nil, err
@@ -104,8 +108,11 @@ func (c *client) Set(ctx context.Context, p *path.Any, v interface{}) (*path.Any
 	return res.GetPath(), nil
 }
 
-func (c *client) Follow(ctx context.Context, p *path.Any) (*path.Any, error) {
-	res, err := c.client.Follow(ctx, &service.FollowRequest{Path: p})
+func (c *client) Follow(ctx context.Context, p *path.Any, r *path.ResolveConfig) (*path.Any, error) {
+	res, err := c.client.Follow(ctx, &service.FollowRequest{
+		Path:   p,
+		Config: r,
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/gapis/extensions/extensions.go
+++ b/gapis/extensions/extensions.go
@@ -51,11 +51,11 @@ type Extension struct {
 	// contexts.
 	AdjustContexts func(context.Context, []*api.ContextInfo)
 	// Custom command groupers.
-	CmdGroupers func(ctx context.Context, p *path.CommandTree) []cmdgrouper.Grouper
+	CmdGroupers func(ctx context.Context, p *path.CommandTree, r *path.ResolveConfig) []cmdgrouper.Grouper
 	// Custom events provider.
-	Events func(ctx context.Context, p *path.Events) EventProvider
+	Events func(ctx context.Context, p *path.Events, r *path.ResolveConfig) EventProvider
 	// Custom events filters.
-	EventFilter func(ctx context.Context, p *path.Events) EventFilter
+	EventFilter func(ctx context.Context, p *path.Events, r *path.ResolveConfig) EventFilter
 }
 
 // Register registers the extension e.

--- a/gapis/extensions/unity/unity.go
+++ b/gapis/extensions/unity/unity.go
@@ -26,7 +26,7 @@ import (
 func init() {
 	extensions.Register(extensions.Extension{
 		Name: "Unity",
-		CmdGroupers: func(ctx context.Context, p *path.CommandTree) []cmdgrouper.Grouper {
+		CmdGroupers: func(ctx context.Context, p *path.CommandTree, r *path.ResolveConfig) []cmdgrouper.Grouper {
 			return []cmdgrouper.Grouper{
 				newStateResetGrouper(),
 			}

--- a/gapis/replay/batch.go
+++ b/gapis/replay/batch.go
@@ -55,6 +55,8 @@ func findABI(ml *device.MemoryLayout, abis []*device.ABI) *device.ABI {
 func (m *Manager) batch(ctx context.Context, e []scheduler.Executable, b scheduler.Batch) {
 	batch := b.Key.(batchKey)
 
+	ctx = PutDevice(ctx, path.NewDevice(batch.device))
+
 	d := bind.GetRegistry(ctx).Device(batch.device)
 
 	requests := make([]RequestAndResult, len(e))

--- a/gapis/replay/context.go
+++ b/gapis/replay/context.go
@@ -18,6 +18,7 @@ import (
 	"context"
 
 	"github.com/google/gapid/core/context/keys"
+	"github.com/google/gapid/gapis/service/path"
 )
 
 type contextMgrKeyTy string
@@ -37,4 +38,23 @@ func GetManager(ctx context.Context) *Manager {
 		panic(string(contextMgrKey + " not present"))
 	}
 	return val.(*Manager)
+}
+
+type contextDeviceKeyTy string
+
+const contextDeviceKey = contextDeviceKeyTy("replayDeviceID")
+
+// PutDevice attaches a target replay device to a Context.
+func PutDevice(ctx context.Context, m *path.Device) context.Context {
+	return keys.WithValue(ctx, contextDeviceKey, m)
+}
+
+// GetDevice retrieves the target replay device from a context previously
+// annotated by PutDevice.
+func GetDevice(ctx context.Context) *path.Device {
+	val := ctx.Value(contextDeviceKey)
+	if val == nil {
+		return nil
+	}
+	return val.(*path.Device)
 }

--- a/gapis/replay/manager.go
+++ b/gapis/replay/manager.go
@@ -17,7 +17,6 @@ package replay
 import (
 	"context"
 	"sync"
-
 	"time"
 
 	"github.com/google/gapid/core/data/id"

--- a/gapis/resolve/BUILD.bazel
+++ b/gapis/resolve/BUILD.bazel
@@ -106,6 +106,7 @@ go_test(
         "//core/log:go_default_library",
         "//core/memory/arena:go_default_library",
         "//core/os/device:go_default_library",
+        "//core/os/device/bind:go_default_library",
         "//gapis/api:go_default_library",
         "//gapis/api/test:go_default_library",
         "//gapis/capture:go_default_library",

--- a/gapis/resolve/as.go
+++ b/gapis/resolve/as.go
@@ -25,8 +25,8 @@ import (
 )
 
 // As resolves and returns the object at p transformed to the requested type.
-func As(ctx context.Context, p *path.As) (interface{}, error) {
-	o, err := ResolveInternal(ctx, p.Parent())
+func As(ctx context.Context, p *path.As, r *path.ResolveConfig) (interface{}, error) {
+	o, err := ResolveInternal(ctx, p.Parent(), r)
 	if err != nil {
 		return nil, err
 	}

--- a/gapis/resolve/commands.go
+++ b/gapis/resolve/commands.go
@@ -29,7 +29,7 @@ import (
 )
 
 // Commands resolves and returns the command list from the path p.
-func Commands(ctx context.Context, p *path.Commands) (*service.Commands, error) {
+func Commands(ctx context.Context, p *path.Commands, r *path.ResolveConfig) (*service.Commands, error) {
 	c, err := capture.ResolveFromPath(ctx, p.Capture)
 	if err != nil {
 		return nil, err
@@ -78,7 +78,7 @@ func NCmds(ctx context.Context, p *path.Capture, n uint64) ([]api.Cmd, error) {
 }
 
 // Cmd resolves and returns the command from the path p.
-func Cmd(ctx context.Context, p *path.Command) (api.Cmd, error) {
+func Cmd(ctx context.Context, p *path.Command, r *path.ResolveConfig) (api.Cmd, error) {
 	cmdIdx := p.Indices[0]
 	if len(p.Indices) > 1 {
 		snc, err := SyncData(ctx, p.Capture)
@@ -132,8 +132,8 @@ func Cmd(ctx context.Context, p *path.Command) (api.Cmd, error) {
 }
 
 // Parameter resolves and returns the parameter from the path p.
-func Parameter(ctx context.Context, p *path.Parameter) (interface{}, error) {
-	obj, err := ResolveInternal(ctx, p.Parent())
+func Parameter(ctx context.Context, p *path.Parameter, r *path.ResolveConfig) (interface{}, error) {
+	obj, err := ResolveInternal(ctx, p.Parent(), r)
 	if err != nil {
 		return nil, err
 	}
@@ -153,8 +153,8 @@ func Parameter(ctx context.Context, p *path.Parameter) (interface{}, error) {
 }
 
 // Result resolves and returns the command's result from the path p.
-func Result(ctx context.Context, p *path.Result) (interface{}, error) {
-	obj, err := ResolveInternal(ctx, p.Parent())
+func Result(ctx context.Context, p *path.Result, r *path.ResolveConfig) (interface{}, error) {
+	obj, err := ResolveInternal(ctx, p.Parent(), r)
 	if err != nil {
 		return nil, err
 	}

--- a/gapis/resolve/constant_set.go
+++ b/gapis/resolve/constant_set.go
@@ -24,7 +24,7 @@ import (
 )
 
 // ConstantSet resolves and returns the constant set from the path p.
-func ConstantSet(ctx context.Context, p *path.ConstantSet) (*service.ConstantSet, error) {
+func ConstantSet(ctx context.Context, p *path.ConstantSet, r *path.ResolveConfig) (*service.ConstantSet, error) {
 	apiID := api.ID(p.API.ID.ID())
 	api := api.Find(apiID)
 	if api == nil {

--- a/gapis/resolve/contexts.go
+++ b/gapis/resolve/contexts.go
@@ -31,8 +31,8 @@ import (
 )
 
 // Contexts resolves the list of contexts belonging to a capture.
-func Contexts(ctx context.Context, p *path.Contexts) ([]*api.ContextInfo, error) {
-	obj, err := database.Build(ctx, &ContextListResolvable{Capture: p.Capture})
+func Contexts(ctx context.Context, p *path.Contexts, r *path.ResolveConfig) ([]*api.ContextInfo, error) {
+	obj, err := database.Build(ctx, &ContextListResolvable{Capture: p.Capture, Config: r})
 	if err != nil {
 		return nil, err
 	}
@@ -40,8 +40,8 @@ func Contexts(ctx context.Context, p *path.Contexts) ([]*api.ContextInfo, error)
 }
 
 // ContextsByID resolves the list of contexts belonging to a capture.
-func ContextsByID(ctx context.Context, p *path.Contexts) (map[api.ContextID]*api.ContextInfo, error) {
-	ctxs, err := Contexts(ctx, p)
+func ContextsByID(ctx context.Context, p *path.Contexts, r *path.ResolveConfig) (map[api.ContextID]*api.ContextInfo, error) {
+	ctxs, err := Contexts(ctx, p, r)
 	if err != nil {
 		return nil, err
 	}
@@ -53,8 +53,8 @@ func ContextsByID(ctx context.Context, p *path.Contexts) (map[api.ContextID]*api
 }
 
 // Context resolves the single context.
-func Context(ctx context.Context, p *path.Context) (*api.ContextInfo, error) {
-	contexts, err := Contexts(ctx, p.Capture.Contexts())
+func Context(ctx context.Context, p *path.Context, r *path.ResolveConfig) (*api.ContextInfo, error) {
+	contexts, err := Contexts(ctx, p.Capture.Contexts(), r)
 	if err != nil {
 		return nil, err
 	}
@@ -83,7 +83,7 @@ type Named interface {
 
 // Resolve implements the database.Resolver interface.
 func (r *ContextListResolvable) Resolve(ctx context.Context) (interface{}, error) {
-	ctx = capture.Put(ctx, r.Capture)
+	ctx = setupContext(ctx, r.Capture, r.Config)
 
 	c, err := capture.Resolve(ctx)
 	if err != nil {

--- a/gapis/resolve/events.go
+++ b/gapis/resolve/events.go
@@ -25,7 +25,7 @@ import (
 )
 
 // Events resolves and returns the event list from the path p.
-func Events(ctx context.Context, p *path.Events) (*service.Events, error) {
+func Events(ctx context.Context, p *path.Events, r *path.ResolveConfig) (*service.Events, error) {
 	c, err := capture.ResolveFromPath(ctx, p.Capture)
 	if err != nil {
 		return nil, err
@@ -36,7 +36,7 @@ func Events(ctx context.Context, p *path.Events) (*service.Events, error) {
 		return nil, err
 	}
 
-	filter, err := buildFilter(ctx, p.Capture, p.Filter, sd)
+	filter, err := buildFilter(ctx, p.Capture, p.Filter, sd, r)
 	if err != nil {
 		return nil, err
 	}
@@ -45,7 +45,7 @@ func Events(ctx context.Context, p *path.Events) (*service.Events, error) {
 	filters := CommandFilters{filter}
 	for _, e := range extensions.Get() {
 		if f := e.EventFilter; f != nil {
-			if filter := CommandFilter(f(ctx, p)); filter != nil {
+			if filter := CommandFilter(f(ctx, p, r)); filter != nil {
 				filters = append(filters, filter)
 			}
 		}
@@ -56,7 +56,7 @@ func Events(ctx context.Context, p *path.Events) (*service.Events, error) {
 	eps := []extensions.EventProvider{}
 	for _, e := range extensions.Get() {
 		if e.Events != nil {
-			if ep := e.Events(ctx, p); ep != nil {
+			if ep := e.Events(ctx, p, r); ep != nil {
 				eps = append(eps, ep)
 			}
 		}

--- a/gapis/resolve/filter.go
+++ b/gapis/resolve/filter.go
@@ -40,14 +40,20 @@ func (l CommandFilters) All(id api.CmdID, cmd api.Cmd, s *api.GlobalState) bool 
 	return true
 }
 
-func buildFilter(ctx context.Context, p *path.Capture, f *path.CommandFilter, sd *sync.Data) (CommandFilter, error) {
+func buildFilter(
+	ctx context.Context,
+	p *path.Capture,
+	f *path.CommandFilter,
+	sd *sync.Data,
+	r *path.ResolveConfig) (CommandFilter, error) {
+
 	filters := CommandFilters{
 		func(id api.CmdID, cmd api.Cmd, s *api.GlobalState) bool {
 			return !sd.Hidden.Contains(id)
 		},
 	}
 	if f := f.GetContext(); f.IsValid() {
-		c, err := Context(ctx, p.Context(f.ID()))
+		c, err := Context(ctx, p.Context(f.ID()), r)
 		if err != nil {
 			return nil, err
 		}

--- a/gapis/resolve/follow.go
+++ b/gapis/resolve/follow.go
@@ -25,8 +25,8 @@ import (
 
 // Follow resolves the path to the object that the value at Path links to.
 // If the value at Path does not link to anything then nil is returned.
-func Follow(ctx context.Context, p *path.Any) (*path.Any, error) {
-	obj, err := database.Build(ctx, &FollowResolvable{Path: p})
+func Follow(ctx context.Context, p *path.Any, r *path.ResolveConfig) (*path.Any, error) {
+	obj, err := database.Build(ctx, &FollowResolvable{Path: p, Config: r})
 	if err != nil {
 		return nil, err
 	}
@@ -35,7 +35,7 @@ func Follow(ctx context.Context, p *path.Any) (*path.Any, error) {
 
 // Resolve implements the database.Resolver interface.
 func (r *FollowResolvable) Resolve(ctx context.Context) (interface{}, error) {
-	obj, err := ResolveInternal(ctx, r.Path.Node())
+	obj, err := ResolveInternal(ctx, r.Path.Node(), r.Config)
 	if err != nil {
 		return nil, err
 	}
@@ -45,7 +45,7 @@ func (r *FollowResolvable) Resolve(ctx context.Context) (interface{}, error) {
 		return nil, &service.ErrPathNotFollowable{Path: r.Path}
 	}
 
-	link, err := linker.Link(ctx, r.Path.Node())
+	link, err := linker.Link(ctx, r.Path.Node(), r.Config)
 	if err != nil {
 		return link, err
 	}

--- a/gapis/resolve/framebuffer_attachment.go
+++ b/gapis/resolve/framebuffer_attachment.go
@@ -39,7 +39,9 @@ func FramebufferAttachment(
 	attachment api.FramebufferAttachment,
 	settings *service.RenderSettings,
 	hints *service.UsageHints,
+	config *path.ResolveConfig,
 ) (*path.ImageInfo, error) {
+
 	if replaySettings.Device == nil {
 		devices, err := devices.ForReplay(ctx, after.Capture)
 		if err != nil {
@@ -53,7 +55,7 @@ func FramebufferAttachment(
 
 	// Check the command is valid. If we don't do it here, we'll likely get an
 	// error deep in the bowels of the framebuffer data resolve.
-	if _, err := Cmd(ctx, after); err != nil {
+	if _, err := Cmd(ctx, after, config); err != nil {
 		return nil, err
 	}
 
@@ -63,6 +65,7 @@ func FramebufferAttachment(
 		Attachment:     attachment,
 		Settings:       settings,
 		Hints:          hints,
+		Config:         config,
 	})
 
 	if err != nil {
@@ -73,7 +76,7 @@ func FramebufferAttachment(
 
 // Resolve implements the database.Resolver interface.
 func (r *FramebufferAttachmentResolvable) Resolve(ctx context.Context) (interface{}, error) {
-	changes, err := FramebufferChanges(ctx, r.After.Capture)
+	changes, err := FramebufferChanges(ctx, r.After.Capture, r.Config)
 	if err != nil {
 		return FramebufferAttachmentInfo{}, err
 	}

--- a/gapis/resolve/framebuffer_attachment_data.go
+++ b/gapis/resolve/framebuffer_attachment_data.go
@@ -18,7 +18,6 @@ import (
 	"context"
 
 	"github.com/google/gapid/core/log"
-	"github.com/google/gapid/gapis/capture"
 	"github.com/google/gapid/gapis/messages"
 	"github.com/google/gapid/gapis/replay"
 	"github.com/google/gapid/gapis/service"
@@ -28,14 +27,14 @@ import (
 // Resolve implements the database.Resolver interface.
 func (r *FramebufferAttachmentBytesResolvable) Resolve(ctx context.Context) (interface{}, error) {
 	c := path.FindCapture(r.After)
-	ctx = capture.Put(ctx, c)
+	ctx = setupContext(ctx, c, r.Config)
 
 	intent := replay.Intent{
 		Device:  r.ReplaySettings.Device,
 		Capture: c,
 	}
 
-	after, err := Cmd(ctx, r.After)
+	after, err := Cmd(ctx, r.After, r.Config)
 	if err != nil {
 		return nil, err
 	}

--- a/gapis/resolve/framebuffer_changes.go
+++ b/gapis/resolve/framebuffer_changes.go
@@ -30,8 +30,8 @@ import (
 
 // FramebufferChanges returns the list of attachment changes over the span of
 // the entire capture.
-func FramebufferChanges(ctx context.Context, c *path.Capture) (*AttachmentFramebufferChanges, error) {
-	obj, err := database.Build(ctx, &FramebufferChangesResolvable{Capture: c})
+func FramebufferChanges(ctx context.Context, c *path.Capture, r *path.ResolveConfig) (*AttachmentFramebufferChanges, error) {
+	obj, err := database.Build(ctx, &FramebufferChangesResolvable{Capture: c, Config: r})
 	if err != nil {
 		return nil, err
 	}
@@ -62,7 +62,7 @@ const errNoAPI = fault.Const("Command has no API")
 
 // Resolve implements the database.Resolver interface.
 func (r *FramebufferChangesResolvable) Resolve(ctx context.Context) (interface{}, error) {
-	ctx = capture.Put(ctx, r.Capture)
+	ctx = setupContext(ctx, r.Capture, r.Config)
 
 	c, err := capture.Resolve(ctx)
 	if err != nil {

--- a/gapis/resolve/framebuffer_observation.go
+++ b/gapis/resolve/framebuffer_observation.go
@@ -26,8 +26,8 @@ import (
 
 // FramebufferObservation returns the framebuffer observation for the given
 // command.
-func FramebufferObservation(ctx context.Context, p *path.FramebufferObservation) (*image.Info, error) {
-	obj, err := database.Build(ctx, &FramebufferObservationResolvable{Path: p})
+func FramebufferObservation(ctx context.Context, p *path.FramebufferObservation, r *path.ResolveConfig) (*image.Info, error) {
+	obj, err := database.Build(ctx, &FramebufferObservationResolvable{Path: p, Config: r})
 	if err != nil {
 		return nil, err
 	}
@@ -36,7 +36,7 @@ func FramebufferObservation(ctx context.Context, p *path.FramebufferObservation)
 
 // Resolve implements the database.Resolver interface.
 func (r *FramebufferObservationResolvable) Resolve(ctx context.Context) (interface{}, error) {
-	cmd, err := Cmd(ctx, r.Path.Command)
+	cmd, err := Cmd(ctx, r.Path.Command, r.Config)
 	if err != nil {
 		return nil, err
 	}

--- a/gapis/resolve/get.go
+++ b/gapis/resolve/get.go
@@ -17,20 +17,18 @@ package resolve
 import (
 	"context"
 
-	"github.com/google/gapid/gapis/capture"
 	"github.com/google/gapid/gapis/database"
 	"github.com/google/gapid/gapis/service/path"
 )
 
 // Get resolves the object, value or memory at p.
-func Get(ctx context.Context, p *path.Any) (interface{}, error) {
-	return database.Build(ctx, &GetResolvable{Path: p})
+func Get(ctx context.Context, p *path.Any, r *path.ResolveConfig) (interface{}, error) {
+	return database.Build(ctx, &GetResolvable{Path: p, Config: r})
 }
 
 // Resolve implements the database.Resolver interface.
 func (r *GetResolvable) Resolve(ctx context.Context) (interface{}, error) {
-	if c := path.FindCapture(r.Path.Node()); c != nil {
-		ctx = capture.Put(ctx, c)
-	}
-	return ResolveService(ctx, r.Path.Node())
+	c := path.FindCapture(r.Path.Node())
+	ctx = setupContext(ctx, c, r.Config)
+	return ResolveService(ctx, r.Path.Node(), r.Config)
 }

--- a/gapis/resolve/get_set_test.go
+++ b/gapis/resolve/get_set_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/google/gapid/core/log"
 	"github.com/google/gapid/core/memory/arena"
 	"github.com/google/gapid/core/os/device"
+	"github.com/google/gapid/core/os/device/bind"
 	"github.com/google/gapid/gapis/api"
 	"github.com/google/gapid/gapis/api/test"
 	"github.com/google/gapid/gapis/capture"
@@ -50,6 +51,7 @@ func newPathTest(ctx context.Context) *path.Capture {
 
 func TestGet(t *testing.T) {
 	ctx := log.Testing(t)
+	ctx = bind.PutRegistry(ctx, bind.NewRegistry())
 	ctx = database.Put(ctx, database.NewInMemory(ctx))
 
 	p := newPathTest(ctx)
@@ -156,7 +158,7 @@ func TestGet(t *testing.T) {
 			Path:   sB.Field("Map").MapIndex("rabbit").Path(),
 		}},
 	} {
-		got, err := Get(ctx, test.path.Path())
+		got, err := Get(ctx, test.path.Path(), nil)
 		assert.For(ctx, "Get(%v) value", test.path).That(got).DeepEquals(test.val)
 		assert.For(ctx, "Get(%v) error", test.path).ThatError(err).DeepEquals(test.err)
 	}
@@ -164,6 +166,7 @@ func TestGet(t *testing.T) {
 
 func TestSet(t *testing.T) {
 	ctx := log.Testing(t)
+	ctx = bind.PutRegistry(ctx, bind.NewRegistry())
 	ctx = database.Put(ctx, database.NewInMemory(ctx))
 
 	p := newPathTest(ctx)
@@ -264,7 +267,7 @@ func TestSet(t *testing.T) {
 	} {
 		ctx := log.V{"path": test.path, "value": test.val}.Bind(ctx)
 
-		path, err := Set(ctx, test.path.Path(), test.val)
+		path, err := Set(ctx, test.path.Path(), test.val, nil)
 		assert.For(ctx, "Set").ThatError(err).DeepEquals(test.err)
 
 		if (path == nil) == (err == nil) {
@@ -278,7 +281,7 @@ func TestSet(t *testing.T) {
 			ctx := log.V{"changed_path": path}.Bind(ctx)
 
 			// Get the changed value
-			got, err := Get(ctx, path)
+			got, err := Get(ctx, path, nil)
 			assert.For(ctx, "Get(changed_path) error").ThatError(err).Succeeded()
 			ctx = log.V{"got": got}.Bind(ctx)
 

--- a/gapis/resolve/memory.go
+++ b/gapis/resolve/memory.go
@@ -29,8 +29,8 @@ import (
 )
 
 // Memory resolves and returns the memory from the path p.
-func Memory(ctx context.Context, p *path.Memory) (*service.Memory, error) {
-	ctx = capture.Put(ctx, path.FindCapture(p))
+func Memory(ctx context.Context, p *path.Memory, rc *path.ResolveConfig) (*service.Memory, error) {
+	ctx = setupContext(ctx, path.FindCapture(p), rc)
 
 	cmdIdx := p.After.Indices[0]
 	fullCmdIdx := p.After.Indices

--- a/gapis/resolve/mesh.go
+++ b/gapis/resolve/mesh.go
@@ -25,12 +25,12 @@ import (
 )
 
 // Mesh resolves and returns the Mesh from the path p.
-func Mesh(ctx context.Context, p *path.Mesh) (*api.Mesh, error) {
-	obj, err := ResolveInternal(ctx, p.Parent())
+func Mesh(ctx context.Context, p *path.Mesh, r *path.ResolveConfig) (*api.Mesh, error) {
+	obj, err := ResolveInternal(ctx, p.Parent(), r)
 	if err != nil {
 		return nil, err
 	}
-	mesh, err := meshFor(ctx, obj, p)
+	mesh, err := meshFor(ctx, obj, p, r)
 	switch {
 	case err != nil:
 		return nil, err
@@ -41,12 +41,12 @@ func Mesh(ctx context.Context, p *path.Mesh) (*api.Mesh, error) {
 	}
 }
 
-func meshFor(ctx context.Context, o interface{}, p *path.Mesh) (*api.Mesh, error) {
+func meshFor(ctx context.Context, o interface{}, p *path.Mesh, r *path.ResolveConfig) (*api.Mesh, error) {
 	switch o := o.(type) {
 	case api.APIObject:
 		if a := o.API(); a != nil {
 			if mp, ok := a.(api.MeshProvider); ok {
-				return mp.Mesh(ctx, o, p)
+				return mp.Mesh(ctx, o, p, r)
 			}
 		}
 
@@ -64,7 +64,7 @@ func meshFor(ctx context.Context, o interface{}, p *path.Mesh) (*api.Mesh, error
 			s, e := o.Commands.From[0], o.Commands.To[0]
 			for i := e; int64(i) >= int64(s); i-- {
 				p := o.Commands.Capture.Command(i).Mesh(p.Options)
-				if mesh, err := meshFor(ctx, cmds[i], p); mesh != nil || err != nil {
+				if mesh, err := meshFor(ctx, cmds[i], p, r); mesh != nil || err != nil {
 					return mesh, err
 				}
 			}
@@ -80,7 +80,7 @@ func meshFor(ctx context.Context, o interface{}, p *path.Mesh) (*api.Mesh, error
 				cmd := append([]uint64{}, o.Commands.From[1:]...)
 				cmd[lastSubcommand-1] = i
 				p := o.Commands.Capture.Command(o.Commands.From[0], cmd...).Mesh(p.Options)
-				if mesh, err := meshFor(ctx, cmds[o.Commands.From[0]], p); mesh != nil || err != nil {
+				if mesh, err := meshFor(ctx, cmds[o.Commands.From[0]], p, r); mesh != nil || err != nil {
 					return mesh, err
 				}
 			}

--- a/gapis/resolve/metrics.go
+++ b/gapis/resolve/metrics.go
@@ -25,10 +25,10 @@ import (
 	"github.com/google/gapid/gapis/service/path"
 )
 
-func Metrics(ctx context.Context, p *path.Metrics) (*api.Metrics, error) {
+func Metrics(ctx context.Context, p *path.Metrics, r *path.ResolveConfig) (*api.Metrics, error) {
 	res := api.Metrics{}
 	if p.MemoryBreakdown {
-		breakdown, err := memoryBreakdown(ctx, p.Command)
+		breakdown, err := memoryBreakdown(ctx, p.Command, r)
 		if err != nil {
 			return nil, log.Errf(ctx, err, "Failed to get memory breakdown")
 		}
@@ -37,8 +37,8 @@ func Metrics(ctx context.Context, p *path.Metrics) (*api.Metrics, error) {
 	return &res, nil
 }
 
-func memoryBreakdown(ctx context.Context, c *path.Command) (*api.MemoryBreakdown, error) {
-	cmd, err := Cmd(ctx, c)
+func memoryBreakdown(ctx context.Context, c *path.Command, r *path.ResolveConfig) (*api.MemoryBreakdown, error) {
+	cmd, err := Cmd(ctx, c, r)
 	if err != nil {
 		return nil, err
 	}
@@ -47,13 +47,13 @@ func memoryBreakdown(ctx context.Context, c *path.Command) (*api.MemoryBreakdown
 		return nil, &service.ErrDataUnavailable{Reason: messages.ErrStateUnavailable()}
 	}
 
-	state, err := GlobalState(ctx, c.GlobalStateAfter())
+	state, err := GlobalState(ctx, c.GlobalStateAfter(), r)
 	if err != nil {
 		return nil, err
 	}
 	if ml, ok := a.(api.MemoryBreakdownProvider); ok {
 		return ml.MemoryBreakdown(state)
-	} else {
-		return nil, fmt.Errorf("Memory breakdown not supported for API %v", a.Name())
 	}
+	return nil, fmt.Errorf("Memory breakdown not supported for API %v", a.Name())
+
 }

--- a/gapis/resolve/report.go
+++ b/gapis/resolve/report.go
@@ -30,8 +30,8 @@ import (
 )
 
 // Report resolves the report for the given path.
-func Report(ctx context.Context, p *path.Report) (*service.Report, error) {
-	obj, err := database.Build(ctx, &ReportResolvable{Path: p})
+func Report(ctx context.Context, p *path.Report, r *path.ResolveConfig) (*service.Report, error) {
+	obj, err := database.Build(ctx, &ReportResolvable{Path: p, Config: r})
 	if err != nil {
 		return nil, err
 	}
@@ -51,7 +51,7 @@ func (r *ReportResolvable) newReportItem(s log.Severity, c uint64, m *stringtabl
 
 // Resolve implements the database.Resolver interface.
 func (r *ReportResolvable) Resolve(ctx context.Context) (interface{}, error) {
-	ctx = capture.Put(ctx, r.Path.Capture)
+	ctx = setupContext(ctx, r.Path.Capture, r.Config)
 
 	c, err := capture.Resolve(ctx)
 	if err != nil {
@@ -65,7 +65,7 @@ func (r *ReportResolvable) Resolve(ctx context.Context) (interface{}, error) {
 		return nil, err
 	}
 
-	filter, err := buildFilter(ctx, r.Path.Capture, r.Path.Filter, sd)
+	filter, err := buildFilter(ctx, r.Path.Capture, r.Path.Filter, sd, r.Config)
 	if err != nil {
 		return nil, err
 	}

--- a/gapis/resolve/resolvables.proto
+++ b/gapis/resolve/resolvables.proto
@@ -24,10 +24,12 @@ import "gapis/service/service.proto";
 
 message ContextListResolvable {
   path.Capture capture = 1;
+  path.ResolveConfig config = 2;
 }
 
 message CommandTreeResolvable {
   path.CommandTree path = 1;
+  path.ResolveConfig config = 2;
 }
 
 message EventsResolvable {
@@ -36,6 +38,7 @@ message EventsResolvable {
 
 message FollowResolvable {
   path.Any path = 1;
+  path.ResolveConfig config = 2;
 }
 
 message FramebufferAttachmentResolvable {
@@ -44,10 +47,12 @@ message FramebufferAttachmentResolvable {
   api.FramebufferAttachment attachment = 3;
   service.RenderSettings settings = 4;
   service.UsageHints hints = 5;
+  path.ResolveConfig config = 6;
 }
 
 message FramebufferChangesResolvable {
   path.Capture capture = 1;
+  path.ResolveConfig config = 2;
 }
 
 message FramebufferAttachmentBytesResolvable {
@@ -60,11 +65,13 @@ message FramebufferAttachmentBytesResolvable {
   service.UsageHints hints = 7;
   image.Format image_format = 8;
   uint32 framebuffer_index = 9;
+  path.ResolveConfig config = 10;
 }
 
 // Get resolves the object, value or memory at Path.
 message GetResolvable {
   path.Any path = 1;
+  path.ResolveConfig config = 2;
 }
 
 message IndexLimitsResolvable {
@@ -76,31 +83,38 @@ message IndexLimitsResolvable {
 
 message ReportResolvable {
   path.Report path = 1;
+  path.ResolveConfig config = 2;
 }
 
 message ResourcesResolvable {
   path.Capture capture = 1;
+  path.ResolveConfig config = 2;
 }
 
 message ResourceDataResolvable {
   path.ResourceData path = 1;
+  path.ResolveConfig config = 2;
 }
 
 message AllResourceDataResolvable {
   path.Command after = 1;
+  path.ResolveConfig config = 2;
 }
 
 message ResourceMetaResolvable {
   repeated path.ID IDs = 1;
   path.Command after = 2;
+  path.ResolveConfig config = 3;
 }
 
 message GlobalStateResolvable {
   path.GlobalState path = 1;
+  path.ResolveConfig config = 2;
 }
 
 message StateResolvable {
   path.State path = 1;
+  path.ResolveConfig config = 2;
 }
 
 message SynchronizationResolvable {
@@ -110,13 +124,16 @@ message SynchronizationResolvable {
 message StateTreeResolvable {
   path.State path = 1;
   int32 array_group_size = 2;
+  path.ResolveConfig config = 3;
 }
 
 message SetResolvable {
   path.Any path = 1;
   service.Value value = 2;
+  path.ResolveConfig config = 3;
 }
 
 message FramebufferObservationResolvable {
   path.FramebufferObservation path = 1;
+  path.ResolveConfig config = 2;
 }

--- a/gapis/resolve/resource_data.go
+++ b/gapis/resolve/resource_data.go
@@ -39,7 +39,8 @@ type ResolvedResources struct {
 // Resolve builds a ResolvedResources object for all of the resources
 // at the path r.After
 func (r *AllResourceDataResolvable) Resolve(ctx context.Context) (interface{}, error) {
-	ctx = capture.Put(ctx, r.After.Capture)
+	ctx = setupContext(ctx, r.After.Capture, r.Config)
+
 	resources, err := buildResources(ctx, r.After)
 
 	if err != nil {
@@ -118,8 +119,8 @@ func buildResources(ctx context.Context, p *path.Command) (*ResolvedResources, e
 
 // ResourceData resolves the data of the specified resource at the specified
 // point in the capture.
-func ResourceData(ctx context.Context, p *path.ResourceData) (interface{}, error) {
-	obj, err := database.Build(ctx, &ResourceDataResolvable{Path: p})
+func ResourceData(ctx context.Context, p *path.ResourceData, r *path.ResolveConfig) (interface{}, error) {
+	obj, err := database.Build(ctx, &ResourceDataResolvable{Path: p, Config: r})
 	if err != nil {
 		return nil, err
 	}
@@ -128,7 +129,7 @@ func ResourceData(ctx context.Context, p *path.ResourceData) (interface{}, error
 
 // Resolve implements the database.Resolver interface.
 func (r *ResourceDataResolvable) Resolve(ctx context.Context) (interface{}, error) {
-	resources, err := database.Build(ctx, &AllResourceDataResolvable{After: r.Path.After})
+	resources, err := database.Build(ctx, &AllResourceDataResolvable{After: r.Path.After, Config: r.Config})
 	if err != nil {
 		return nil, err
 	}

--- a/gapis/resolve/resource_meta.go
+++ b/gapis/resolve/resource_meta.go
@@ -24,8 +24,8 @@ import (
 )
 
 // ResourceMeta returns the metadata for the specified resource.
-func ResourceMeta(ctx context.Context, ids []*path.ID, after *path.Command) (*api.ResourceMeta, error) {
-	obj, err := database.Build(ctx, &ResourceMetaResolvable{IDs: ids, After: after})
+func ResourceMeta(ctx context.Context, ids []*path.ID, after *path.Command, r *path.ResolveConfig) (*api.ResourceMeta, error) {
+	obj, err := database.Build(ctx, &ResourceMetaResolvable{IDs: ids, After: after, Config: r})
 	if err != nil {
 		return nil, err
 	}
@@ -34,7 +34,7 @@ func ResourceMeta(ctx context.Context, ids []*path.ID, after *path.Command) (*ap
 
 // Resolve implements the database.Resolver interface.
 func (r *ResourceMetaResolvable) Resolve(ctx context.Context) (interface{}, error) {
-	resources, err := database.Build(ctx, &AllResourceDataResolvable{After: r.After})
+	resources, err := database.Build(ctx, &AllResourceDataResolvable{After: r.After, Config: r.Config})
 	if err != nil {
 		return nil, err
 	}

--- a/gapis/resolve/resources.go
+++ b/gapis/resolve/resources.go
@@ -29,8 +29,8 @@ import (
 )
 
 // Resources resolves all the resources used by the specified capture.
-func Resources(ctx context.Context, c *path.Capture) (*service.Resources, error) {
-	obj, err := database.Build(ctx, &ResourcesResolvable{Capture: c})
+func Resources(ctx context.Context, c *path.Capture, r *path.ResolveConfig) (*service.Resources, error) {
+	obj, err := database.Build(ctx, &ResourcesResolvable{Capture: c, Config: r})
 	if err != nil {
 		return nil, err
 	}
@@ -39,7 +39,7 @@ func Resources(ctx context.Context, c *path.Capture) (*service.Resources, error)
 
 // Resolve implements the database.Resolver interface.
 func (r *ResourcesResolvable) Resolve(ctx context.Context) (interface{}, error) {
-	ctx = capture.Put(ctx, r.Capture)
+	ctx = setupContext(ctx, r.Capture, r.Config)
 
 	c, err := capture.Resolve(ctx)
 	if err != nil {

--- a/gapis/resolve/state_tree.go
+++ b/gapis/resolve/state_tree.go
@@ -32,8 +32,12 @@ import (
 )
 
 // StateTree resolves the specified state tree path.
-func StateTree(ctx context.Context, c *path.StateTree) (*service.StateTree, error) {
-	id, err := database.Store(ctx, &StateTreeResolvable{Path: c.State, ArrayGroupSize: c.ArrayGroupSize})
+func StateTree(ctx context.Context, c *path.StateTree, r *path.ResolveConfig) (*service.StateTree, error) {
+	id, err := database.Store(ctx, &StateTreeResolvable{
+		Path:           c.State,
+		ArrayGroupSize: c.ArrayGroupSize,
+		Config:         r,
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -93,7 +97,7 @@ func deref(v reflect.Value) reflect.Value {
 }
 
 // StateTreeNode resolves the specified command tree node path.
-func StateTreeNode(ctx context.Context, p *path.StateTreeNode) (*service.StateTreeNode, error) {
+func StateTreeNode(ctx context.Context, p *path.StateTreeNode, r *path.ResolveConfig) (*service.StateTreeNode, error) {
 	boxed, err := database.Resolve(ctx, p.Tree.ID())
 	if err != nil {
 		return nil, err
@@ -103,7 +107,7 @@ func StateTreeNode(ctx context.Context, p *path.StateTreeNode) (*service.StateTr
 
 // StateTreeNodeForPath returns the path to the StateTreeNode representing the
 // path p.
-func StateTreeNodeForPath(ctx context.Context, p *path.StateTreeNodeForPath) (*path.StateTreeNode, error) {
+func StateTreeNodeForPath(ctx context.Context, p *path.StateTreeNodeForPath, r *path.ResolveConfig) (*path.StateTreeNode, error) {
 	boxed, err := database.Resolve(ctx, p.Tree.ID())
 	if err != nil {
 		return nil, err
@@ -367,12 +371,12 @@ func stateValuePreview(v reflect.Value) (*box.Value, bool) {
 // Resolve builds and returns a *StateTree for the path.StateTreeNode.
 // Resolve implements the database.Resolver interface.
 func (r *StateTreeResolvable) Resolve(ctx context.Context) (interface{}, error) {
-	globalState, err := GlobalState(ctx, r.Path.After.GlobalStateAfter())
+	globalState, err := GlobalState(ctx, r.Path.After.GlobalStateAfter(), r.Config)
 	if err != nil {
 		return nil, err
 	}
 
-	rootObj, rootPath, apiID, err := state(ctx, r.Path)
+	rootObj, rootPath, apiID, err := state(ctx, r.Path, r.Config)
 	if err != nil {
 		return nil, err
 	}

--- a/gapis/resolve/stats.go
+++ b/gapis/resolve/stats.go
@@ -25,10 +25,10 @@ import (
 )
 
 // Stats resolves and returns the stats list from the path p.
-func Stats(ctx context.Context, p *path.Stats) (*service.Stats, error) {
+func Stats(ctx context.Context, p *path.Stats, r *path.ResolveConfig) (*service.Stats, error) {
 	stats := &service.Stats{}
 	if p.DrawCall {
-		err := drawCallStats(ctx, p.Capture, stats)
+		err := drawCallStats(ctx, p.Capture, stats, r)
 		if err != nil {
 			return nil, err
 		}
@@ -36,7 +36,7 @@ func Stats(ctx context.Context, p *path.Stats) (*service.Stats, error) {
 	return stats, nil
 }
 
-func drawCallStats(ctx context.Context, capt *path.Capture, stats *service.Stats) error {
+func drawCallStats(ctx context.Context, capt *path.Capture, stats *service.Stats, r *path.ResolveConfig) error {
 	d, err := SyncData(ctx, capt)
 	if err != nil {
 		return err
@@ -56,7 +56,7 @@ func drawCallStats(ctx context.Context, capt *path.Capture, stats *service.Stats
 	events, err := Events(ctx, &path.Events{
 		Capture:     capt,
 		LastInFrame: true,
-	})
+	}, r)
 	if err != nil {
 		return err
 	}
@@ -79,7 +79,7 @@ func drawCallStats(ctx context.Context, capt *path.Capture, stats *service.Stats
 			cmd, err := Cmd(ctx, &path.Command{
 				Capture: capt,
 				Indices: []uint64(idx),
-			})
+			}, r)
 			if err != nil {
 				return err
 			}

--- a/gapis/server/grpc.go
+++ b/gapis/server/grpc.go
@@ -165,7 +165,7 @@ func (s *grpcServer) CheckForUpdates(ctx xctx.Context, req *service.CheckForUpda
 
 func (s *grpcServer) Get(ctx xctx.Context, req *service.GetRequest) (*service.GetResponse, error) {
 	defer s.inRPC()()
-	res, err := s.handler.Get(s.bindCtx(ctx), req.Path)
+	res, err := s.handler.Get(s.bindCtx(ctx), req.Path, req.Config)
 	if err := service.NewError(err); err != nil {
 		return &service.GetResponse{Res: &service.GetResponse_Error{Error: err}}, nil
 	}
@@ -175,7 +175,7 @@ func (s *grpcServer) Get(ctx xctx.Context, req *service.GetRequest) (*service.Ge
 
 func (s *grpcServer) Set(ctx xctx.Context, req *service.SetRequest) (*service.SetResponse, error) {
 	defer s.inRPC()()
-	res, err := s.handler.Set(s.bindCtx(ctx), req.Path, req.Value.Get())
+	res, err := s.handler.Set(s.bindCtx(ctx), req.Path, req.Value.Get(), req.Config)
 	if err := service.NewError(err); err != nil {
 		return &service.SetResponse{Res: &service.SetResponse_Error{Error: err}}, nil
 	}
@@ -184,7 +184,7 @@ func (s *grpcServer) Set(ctx xctx.Context, req *service.SetRequest) (*service.Se
 
 func (s *grpcServer) Follow(ctx xctx.Context, req *service.FollowRequest) (*service.FollowResponse, error) {
 	defer s.inRPC()()
-	res, err := s.handler.Follow(s.bindCtx(ctx), req.Path)
+	res, err := s.handler.Follow(s.bindCtx(ctx), req.Path, req.Config)
 	if err := service.NewError(err); err != nil {
 		return &service.FollowResponse{Res: &service.FollowResponse_Error{Error: err}}, nil
 	}

--- a/gapis/server/server.go
+++ b/gapis/server/server.go
@@ -265,35 +265,38 @@ func (s *server) GetFramebufferAttachment(
 	if err := after.Validate(); err != nil {
 		return nil, log.Errf(ctx, err, "Invalid path: %v", after)
 	}
-	return resolve.FramebufferAttachment(ctx, replaySettings, after, attachment, settings, hints)
+	r := &path.ResolveConfig{
+		ReplayDevice: replaySettings.Device,
+	}
+	return resolve.FramebufferAttachment(ctx, replaySettings, after, attachment, settings, hints, r)
 }
 
-func (s *server) Get(ctx context.Context, p *path.Any) (interface{}, error) {
+func (s *server) Get(ctx context.Context, p *path.Any, c *path.ResolveConfig) (interface{}, error) {
 	ctx = log.Enter(ctx, "Get")
 	if err := p.Validate(); err != nil {
 		return nil, log.Errf(ctx, err, "Invalid path: %v", p)
 	}
-	v, err := resolve.Get(ctx, p)
+	v, err := resolve.Get(ctx, p, c)
 	if err != nil {
 		return nil, err
 	}
 	return v, nil
 }
 
-func (s *server) Set(ctx context.Context, p *path.Any, v interface{}) (*path.Any, error) {
+func (s *server) Set(ctx context.Context, p *path.Any, v interface{}, r *path.ResolveConfig) (*path.Any, error) {
 	ctx = log.Enter(ctx, "Set")
 	if err := p.Validate(); err != nil {
 		return nil, log.Errf(ctx, err, "Invalid path: %v", p)
 	}
-	return resolve.Set(ctx, p, v)
+	return resolve.Set(ctx, p, v, r)
 }
 
-func (s *server) Follow(ctx context.Context, p *path.Any) (*path.Any, error) {
+func (s *server) Follow(ctx context.Context, p *path.Any, r *path.ResolveConfig) (*path.Any, error) {
 	ctx = log.Enter(ctx, "Follow")
 	if err := p.Validate(); err != nil {
 		return nil, log.Errf(ctx, err, "Invalid path: %v", p)
 	}
-	return resolve.Follow(ctx, p)
+	return resolve.Follow(ctx, p, r)
 }
 
 func (s *server) GetLogStream(ctx context.Context, handler log.Handler) error {

--- a/gapis/service/path/linker.go
+++ b/gapis/service/path/linker.go
@@ -20,5 +20,5 @@ import "context"
 type Linker interface {
 	// Link returns the link to the pointee of this object at p.
 	// If nil, nil is returned then the path cannot be followed.
-	Link(ctx context.Context, p Node) (Node, error)
+	Link(ctx context.Context, p Node, r *ResolveConfig) (Node, error)
 }

--- a/gapis/service/path/path.proto
+++ b/gapis/service/path/path.proto
@@ -479,3 +479,8 @@ message Thumbnail {
 
   bool disable_optimization = 7;
 }
+
+message ResolveConfig {
+  // The device to use for any replays when resolving paths.
+  path.Device replay_device = 1;
+}

--- a/gapis/service/service.go
+++ b/gapis/service/service.go
@@ -106,16 +106,16 @@ type Service interface {
 		hints *UsageHints) (*path.ImageInfo, error)
 
 	// Get resolves and returns the object, value or memory at the path p.
-	Get(ctx context.Context, p *path.Any) (interface{}, error)
+	Get(ctx context.Context, p *path.Any, c *path.ResolveConfig) (interface{}, error)
 
 	// Set creates a copy of the capture referenced by p, but with the object, value
 	// or memory at p replaced with v. The path returned is identical to p, but with
 	// the base changed to refer to the new capture.
-	Set(ctx context.Context, p *path.Any, v interface{}) (*path.Any, error)
+	Set(ctx context.Context, p *path.Any, v interface{}, c *path.ResolveConfig) (*path.Any, error)
 
 	// Follow returns the path to the object that the value at p links to.
 	// If the value at p does not link to anything then nil is returned.
-	Follow(ctx context.Context, p *path.Any) (*path.Any, error)
+	Follow(ctx context.Context, p *path.Any, c *path.ResolveConfig) (*path.Any, error)
 
 	// BeginCPUProfile starts CPU self-profiling of the server.
 	// If the CPU is already being profiled then this function will return an

--- a/gapis/service/service.proto
+++ b/gapis/service/service.proto
@@ -146,6 +146,8 @@ message Release {
 
 message GetRequest {
   path.Any path = 1;
+  // Config to use when resolving paths.
+  path.ResolveConfig config = 2;
 }
 
 message GetResponse {
@@ -158,6 +160,8 @@ message GetResponse {
 message SetRequest {
   path.Any path = 1;
   Value value = 2;
+  // Config to use when resolving paths.
+  path.ResolveConfig config = 3;
 }
 
 message SetResponse {
@@ -169,6 +173,8 @@ message SetResponse {
 
 message FollowRequest {
   path.Any path = 1;
+  // Config to use when resolving paths.
+  path.ResolveConfig config = 2;
 }
 
 message FollowResponse {
@@ -331,6 +337,8 @@ message FindRequest {
   bool is_case_sensitive = 7;
   // If true, the search will wrap.
   bool wrap = 8;
+  // Config to use when resolving paths.
+  path.ResolveConfig config = 9;
 }
 
 message FindResponse {

--- a/test/integration/gles/replay/check.go
+++ b/test/integration/gles/replay/check.go
@@ -76,7 +76,7 @@ func checkReport(ctx context.Context, c *path.Capture, d *device.Instance, cmds 
 		defer done.Done()
 	}
 
-	report, err := resolve.Report(ctx, c.Report(path.NewDevice(d.ID.ID()), nil))
+	report, err := resolve.Report(ctx, c.Report(path.NewDevice(d.ID.ID()), nil), nil)
 	assert.For(ctx, "err").ThatError(err).Succeeded()
 
 	got := []string{}
@@ -120,14 +120,14 @@ func checkTextureBuffer(ctx context.Context, c *path.Capture, d *device.Instance
 
 	cmdPath := c.Command(uint64(after))
 
-	cmd, err := resolve.Cmd(ctx, cmdPath)
+	cmd, err := resolve.Cmd(ctx, cmdPath, nil)
 	if !assert.For(ctx, "resolve cmd").ThatError(err).Succeeded() {
 		return
 	}
 
 	thread := cmd.Thread()
 
-	globalState, err := resolve.GlobalState(ctx, cmdPath.GlobalStateAfter())
+	globalState, err := resolve.GlobalState(ctx, cmdPath.GlobalStateAfter(), nil)
 	if !assert.For(ctx, "resolve global state").ThatError(err).Succeeded() {
 		return
 	}

--- a/test/integration/gles/replay/gles_test.go
+++ b/test/integration/gles/replay/gles_test.go
@@ -228,7 +228,7 @@ func TestMultiContextCapture(t *testing.T) {
 	c := mergeCaptures(ctx, t1, t2, t3)
 	maybeExportCapture(ctx, c)
 
-	contexts, err := resolve.Contexts(ctx, c.Contexts())
+	contexts, err := resolve.Contexts(ctx, c.Contexts(), nil)
 	assert.For(ctx, "err").ThatError(err).Succeeded()
 	assert.For(ctx, "len").That(len(contexts)).Equals(3)
 }

--- a/test/integration/service/service_test.go
+++ b/test/integration/service/service_test.go
@@ -231,7 +231,7 @@ func TestGet(t *testing.T) {
 		{capture.Resources(), T((*service.Resources)(nil))},
 	} {
 		ctx = log.V{"path": test.path}.Bind(ctx)
-		got, err := server.Get(ctx, test.path.Path())
+		got, err := server.Get(ctx, test.path.Path(), nil)
 		assert.For(ctx, "err").ThatError(err).Succeeded()
 		if test.ty.Kind() == reflect.Interface {
 			assert.For(ctx, "got").That(got).Implements(test.ty)


### PR DESCRIPTION
Pass this to `Get()`, `Set()`, `Follow()` and `Find()`.
Propagate the ResolveConfig thoughout the resolve package.

This is used to specify the replay device for resolving state data pulled back from the GPU.