### PR TITLE
Do not crash when built without Android support.

### DIFF
--- a/core/os/android/adb/device.go
+++ b/core/os/android/adb/device.go
@@ -159,6 +159,10 @@ func newDevice(ctx context.Context, serial string, status bind.Status) (*binding
 		}
 	}
 
+	if d.To.Configuration == nil ||
+		d.To.Configuration.Hardware == nil {
+		return nil, log.Errf(ctx, nil, "Cannot get device information")
+	}
 	d.Instance().Name = d.To.Configuration.Hardware.Name
 	if i := d.Instance(); i.ID == nil || allZero(i.ID.Data) {
 		// Generate an identifier for the device based on it's details.

--- a/gapis/trace/android/trace.go
+++ b/gapis/trace/android/trace.go
@@ -117,10 +117,10 @@ func (t *androidTracer) PreferredRootUri(ctx context.Context) (string, error) {
 
 func (t *androidTracer) APITraceOptions(ctx context.Context) []tracer.APITraceOptions {
 	options := make([]tracer.APITraceOptions, 0, 2)
-	if t.b.Instance().Configuration.Drivers.Opengl.Version != "" {
+	if t.b.Instance().GetConfiguration().GetDrivers().GetOpengl().GetVersion() != "" {
 		options = append(options, tracer.GLESTraceOptions())
 	}
-	if len(t.b.Instance().Configuration.Drivers.Vulkan.PhysicalDevices) > 0 {
+	if len(t.b.Instance().GetConfiguration().GetDrivers().GetVulkan().GetPhysicalDevices()) > 0 {
 		options = append(options, tracer.VulkanTraceOptions())
 	}
 	return options


### PR DESCRIPTION
If you build without Android support, and plug an android
device in, bad things happen.

This fixes that by not showing any Android device if built without
support.