### PR TITLE
gapic: Move RPC logic from the views into the models

### DIFF
--- a/gapic/src/main/com/google/gapid/MainWindow.java
+++ b/gapic/src/main/com/google/gapid/MainWindow.java
@@ -567,7 +567,7 @@ public class MainWindow extends ApplicationWindow {
       Framebuffer(Location.Center, View.Framebuffer, "Framebuffer", FramebufferView::new),
       Textures(Location.Center, View.Textures, "Textures", TextureView::new),
       Geometry(Location.Center, View.Geometry, "Geometry", (p, c, m, w) -> new GeometryView(p, m, w)),
-      Shaders(Location.Center, View.Shaders, "Shaders", ShaderView::new),
+      Shaders(Location.Center, View.Shaders, "Shaders", (p, c, m, w) -> new ShaderView(p, m, w)),
       Report(Location.Center, View.Report, "Report", (p, c, m, w) -> new ReportView(p, m, w)),
       Log(Location.Center, View.Log, "Log", (p, c, m, w) -> new LogView(p, w)),
 

--- a/gapic/src/main/com/google/gapid/MainWindow.java
+++ b/gapic/src/main/com/google/gapid/MainWindow.java
@@ -566,7 +566,7 @@ public class MainWindow extends ApplicationWindow {
 
       Framebuffer(Location.Center, View.Framebuffer, "Framebuffer", FramebufferView::new),
       Textures(Location.Center, View.Textures, "Textures", TextureView::new),
-      Geometry(Location.Center, View.Geometry, "Geometry", GeometryView::new),
+      Geometry(Location.Center, View.Geometry, "Geometry", (p, c, m, w) -> new GeometryView(p, m, w)),
       Shaders(Location.Center, View.Shaders, "Shaders", ShaderView::new),
       Report(Location.Center, View.Report, "Report", (p, c, m, w) -> new ReportView(p, m, w)),
       Log(Location.Center, View.Log, "Log", (p, c, m, w) -> new LogView(p, w)),

--- a/gapic/src/main/com/google/gapid/MainWindow.java
+++ b/gapic/src/main/com/google/gapid/MainWindow.java
@@ -564,8 +564,8 @@ public class MainWindow extends ApplicationWindow {
     public static enum Type {
       ApiCalls(Location.Left, View.Commands, "Commands", CommandTree::new),
 
-      Framebuffer(Location.Center, View.Framebuffer, "Framebuffer", FramebufferView::new),
-      Textures(Location.Center, View.Textures, "Textures", TextureView::new),
+      Framebuffer(Location.Center, View.Framebuffer, "Framebuffer", (p, c, m, w) -> new FramebufferView(p, m, w)),
+      Textures(Location.Center, View.Textures, "Textures", (p, c, m, w) -> new TextureView(p, m, w)),
       Geometry(Location.Center, View.Geometry, "Geometry", (p, c, m, w) -> new GeometryView(p, m, w)),
       Shaders(Location.Center, View.Shaders, "Shaders", (p, c, m, w) -> new ShaderView(p, m, w)),
       Report(Location.Center, View.Report, "Report", (p, c, m, w) -> new ReportView(p, m, w)),

--- a/gapic/src/main/com/google/gapid/MainWindow.java
+++ b/gapic/src/main/com/google/gapid/MainWindow.java
@@ -572,7 +572,7 @@ public class MainWindow extends ApplicationWindow {
       Log(Location.Center, View.Log, "Log", (p, c, m, w) -> new LogView(p, w)),
 
       ApiState(Location.Right, View.State, "State", (p, c, m, w) -> new StateView(p, m, w)),
-      Memory(Location.Right, View.Memory, "Memory", MemoryView::new);
+      Memory(Location.Right, View.Memory, "Memory", (p, c, m, w) -> new MemoryView(p, m, w));
 
       public final Location defaultLocation;
       public final View view;

--- a/gapic/src/main/com/google/gapid/MainWindow.java
+++ b/gapic/src/main/com/google/gapid/MainWindow.java
@@ -571,7 +571,7 @@ public class MainWindow extends ApplicationWindow {
       Report(Location.Center, View.Report, "Report", (p, c, m, w) -> new ReportView(p, m, w)),
       Log(Location.Center, View.Log, "Log", (p, c, m, w) -> new LogView(p, w)),
 
-      ApiState(Location.Right, View.State, "State", StateView::new),
+      ApiState(Location.Right, View.State, "State", (p, c, m, w) -> new StateView(p, m, w)),
       Memory(Location.Right, View.Memory, "Memory", MemoryView::new);
 
       public final Location defaultLocation;

--- a/gapic/src/main/com/google/gapid/MainWindow.java
+++ b/gapic/src/main/com/google/gapid/MainWindow.java
@@ -562,7 +562,7 @@ public class MainWindow extends ApplicationWindow {
      * Information about the available tabs.
      */
     public static enum Type {
-      ApiCalls(Location.Left, View.Commands, "Commands", CommandTree::new),
+      ApiCalls(Location.Left, View.Commands, "Commands", (p, c, m, w) -> new CommandTree(p, m, w)),
 
       Framebuffer(Location.Center, View.Framebuffer, "Framebuffer", (p, c, m, w) -> new FramebufferView(p, m, w)),
       Textures(Location.Center, View.Textures, "Textures", (p, c, m, w) -> new TextureView(p, m, w)),

--- a/gapic/src/main/com/google/gapid/image/FetchedImage.java
+++ b/gapic/src/main/com/google/gapid/image/FetchedImage.java
@@ -104,10 +104,6 @@ public class FetchedImage implements MultiLayerAndLevelImage {
             Math.min(level, image.getLevelCount() - 1)), (l) -> l.getImageData()));
   }
 
-  public static ListenableFuture<ImageData> loadThumbnail(Client client, Path.Thumbnail path) {
-    return loadThumbnail(client, path, i -> {/* do nothing */});
-  }
-
   public static ListenableFuture<ImageData> loadThumbnail(
       Client client, Path.Thumbnail path, Consumer<Info> onInfo) {
     return loadImage(Futures.transform(client.get(thumbnail(path)), value -> {

--- a/gapic/src/main/com/google/gapid/models/ApiState.java
+++ b/gapic/src/main/com/google/gapid/models/ApiState.java
@@ -27,6 +27,7 @@ import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.gapid.models.CommandStream.CommandIndex;
 import com.google.gapid.proto.service.Service;
+import com.google.gapid.proto.service.box.Box;
 import com.google.gapid.proto.service.path.Path;
 import com.google.gapid.rpc.Rpc;
 import com.google.gapid.rpc.RpcException;
@@ -162,6 +163,10 @@ public class ApiState
 
     return Futures.transform(client.get(Paths.stateTree(((RootNode)getData()).tree, path)),
         value -> value.getPath().getStateTreeNode());
+  }
+
+  public ListenableFuture<Box.Value> loadValue(Node node) {
+    return Futures.transform(client.get(node.getData().getValuePath()), Service.Value::getBox);
   }
 
   public static class Node {

--- a/gapic/src/main/com/google/gapid/models/CommandStream.java
+++ b/gapic/src/main/com/google/gapid/models/CommandStream.java
@@ -27,6 +27,7 @@ import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.SettableFuture;
 import com.google.gapid.models.ApiContext.FilteringContext;
 import com.google.gapid.proto.service.Service;
 import com.google.gapid.proto.service.api.API;
@@ -146,6 +147,12 @@ public class CommandStream extends ModelBase.ForPath<CommandStream.Node, Void, C
         }
       });
     }
+  }
+
+  public ListenableFuture<Service.FindResponse> search(Service.FindRequest request) {
+    SettableFuture<Service.FindResponse> result = SettableFuture.create();
+    client.streamSearch(request, result::set);
+    return result;
   }
 
   @Override

--- a/gapic/src/main/com/google/gapid/models/Geometries.java
+++ b/gapic/src/main/com/google/gapid/models/Geometries.java
@@ -1,0 +1,369 @@
+/*
+ * Copyright (C) 2018 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.gapid.models;
+
+import static com.google.gapid.glviewer.Geometry.isPolygon;
+import static com.google.gapid.rpc.UiErrorCallback.error;
+import static com.google.gapid.rpc.UiErrorCallback.success;
+import static com.google.gapid.util.Logging.throttleLogRpcError;
+import static com.google.gapid.util.Paths.meshAfter;
+import static java.util.logging.Level.WARNING;
+
+import com.google.common.base.Objects;
+import com.google.common.collect.Maps;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.gapid.glviewer.geo.Model;
+import com.google.gapid.models.CommandStream.CommandIndex;
+import com.google.gapid.proto.service.api.API;
+import com.google.gapid.proto.service.path.Path;
+import com.google.gapid.proto.service.vertex.Vertex;
+import com.google.gapid.proto.stringtable.Stringtable;
+import com.google.gapid.rpc.Rpc;
+import com.google.gapid.rpc.RpcException;
+import com.google.gapid.rpc.UiErrorCallback.ResultOrError;
+import com.google.gapid.server.Client;
+import com.google.gapid.server.Client.DataUnavailableException;
+import com.google.gapid.util.Events;
+import com.google.gapid.util.Loadable;
+import com.google.gapid.util.MoreFutures;
+import com.google.gapid.util.Paths;
+import com.google.gapid.util.Streams;
+import com.google.protobuf.ByteString;
+
+import org.eclipse.swt.widgets.Shell;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.FloatBuffer;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.logging.Logger;
+
+/**
+ * Model responsible for loading draw call geometry data.
+ */
+public class Geometries
+    extends ModelBase<Geometries.Data, Geometries.Source, Loadable.Message, Geometries.Listener> {
+  private static final Logger LOG = Logger.getLogger(ApiState.class.getName());
+
+  private static final Stringtable.Msg NO_MESH_ERR = Strings.create("ERR_MESH_NOT_AVAILABLE");
+  protected static final Vertex.BufferFormat POS_NORM_XYZ_F32 = Vertex.BufferFormat.newBuilder()
+      .addStreams(Vertex.StreamFormat.newBuilder()
+          .setSemantic(Vertex.Semantic.newBuilder()
+              .setType(Vertex.Semantic.Type.Position)
+              .setIndex(0))
+          .setFormat(Streams.FMT_XYZ_F32))
+      .addStreams(Vertex.StreamFormat.newBuilder()
+          .setSemantic(Vertex.Semantic.newBuilder()
+              .setType(Vertex.Semantic.Type.Normal)
+              .setIndex(0))
+          .setFormat(Streams.FMT_XYZ_F32))
+      .build();
+
+  public Geometries(Shell shell, Analytics analytics, Client client, CommandStream commands) {
+    super(LOG, shell, analytics, client, Listener.class);
+
+    commands.addListener(new CommandStream.Listener() {
+      @Override
+      public void onCommandsSelected(CommandIndex selection) {
+        load(new Source(selection, null), false);
+      }
+    });
+  }
+
+  /**
+   * Reloads the models using the provided semantics. Has no effect if no command is currently
+   * selected or if the semantics haven't changed.
+   */
+  public void updateSemantics(VertexSemantics semantics) {
+    Source src = getSource();
+    if (src != null) {
+      load(src.withSemantics(semantics), false);
+    }
+  }
+
+  public VertexSemantics getSemantics() {
+    return (isLoaded()) ? getData().semantics : getSource().semantics;
+  }
+
+  @Override
+  protected ListenableFuture<Data> doLoad(Source s) {
+    return Futures.transformAsync(fetchMeshMetadata(s.command, s.semantics), semantics -> {
+      ListenableFuture<Model> originalFuture = fetchModel(meshAfter(
+          s.command, semantics.getOptions().build(), POS_NORM_XYZ_F32));
+      ListenableFuture<Model> facetedFuture = fetchModel(meshAfter(
+          s.command, semantics.getOptions().setFaceted(true).build(), POS_NORM_XYZ_F32));
+      return MoreFutures.combine(Arrays.asList(originalFuture, facetedFuture), models -> {
+        MoreFutures.Result<Model> original = models.get(0);
+        MoreFutures.Result<Model> faceted = models.get(1);
+        if (original.hasFailed() && faceted.hasFailed()) {
+          // Both failed, so get the error from the original model's call.
+          throw original.error;
+        } else if (original.succeeded() && original.result.getNormals() == null) {
+          // The original model has no normals, but the geometry doesn't support faceted normals.
+          return new Data(semantics, null, faceted.result);
+        } else if (original.succeeded() && !isPolygon(original.result.getPrimitive())) {
+          // TODO: if gapis returns an error for the faceted request, this is not needed.
+          return new Data(semantics, null, original.result);
+        } else {
+          return new Data(semantics, original.result, faceted.result);
+        }
+      });
+    });
+  }
+
+  @Override
+  protected ResultOrError<Data, Loadable.Message> processResult(Rpc.Result<Data> result) {
+    try {
+      return success(result.get());
+    } catch (DataUnavailableException e) {
+      // TODO: don't assume that it's because of not selecting a draw call.
+      return success(new Data(getSource().semantics, null, null));
+    } catch (RpcException e) {
+      LOG.log(WARNING, "Failed to load the geometry", e);
+      return error(Loadable.Message.error(e));
+    } catch (ExecutionException e) {
+      if (!shell.isDisposed()) {
+        throttleLogRpcError(LOG, "Failed to load the geometry", e);
+      }
+      return error(Loadable.Message.error("Failed to load the geometry"));
+    }
+  }
+
+  @Override
+  protected void updateError(Loadable.Message error) {
+    listeners.fire().onGeometryLoaded(error);
+  }
+
+  @Override
+  protected void fireLoadStartEvent() {
+    listeners.fire().onGeometryLoadingStart();
+  }
+
+  @Override
+  protected void fireLoadedEvent() {
+    listeners.fire().onGeometryLoaded(null);
+  }
+
+  private ListenableFuture<VertexSemantics> fetchMeshMetadata(
+      CommandIndex command, VertexSemantics currentSemantics) {
+    return Futures.transform(client.get(meshAfter(command, Paths.NODATA_MESH_OPTIONS)),
+        value -> new VertexSemantics(value.getMesh(), currentSemantics));
+  }
+
+  private ListenableFuture<Model> fetchModel(Path.Any path) {
+    return Futures.transformAsync(client.get(path), value -> fetchModel(value.getMesh()));
+  }
+
+  private static ListenableFuture<Model> fetchModel(API.Mesh mesh) {
+    Vertex.Buffer vb = mesh.getVertexBuffer();
+    float[] positions = null;
+    float[] normals = null;
+
+    for (Vertex.Stream stream : vb.getStreamsList()) {
+      switch (stream.getSemantic().getType()) {
+        case Position:
+          positions = byteStringToFloatArray(stream.getData());
+          break;
+        case Normal:
+          normals = byteStringToFloatArray(stream.getData());
+          break;
+        default:
+          // Ignore.
+      }
+    }
+
+    API.DrawPrimitive primitive = mesh.getDrawPrimitive();
+    if (positions == null || (normals == null && isPolygon(primitive))) {
+      return Futures.immediateFailedFuture(
+          new DataUnavailableException(NO_MESH_ERR, new Client.Stack(() -> "")));
+    }
+
+    int[] indices = mesh.getIndexBuffer().getIndicesList().stream().mapToInt(x -> x).toArray();
+    Model model = new Model(primitive, mesh.getStats(), positions, normals, indices);
+    return Futures.immediateFuture(model);
+  }
+
+  private static float[] byteStringToFloatArray(ByteString bytes) {
+    byte[] data = bytes.toByteArray();
+    FloatBuffer buffer = ByteBuffer.wrap(data).order(ByteOrder.LITTLE_ENDIAN).asFloatBuffer();
+    float[] out = new float[data.length / 4];
+    buffer.get(out);
+    return out;
+  }
+
+  public static class Source {
+    public final CommandIndex command;
+    public final VertexSemantics semantics;
+
+    public Source(CommandIndex command, VertexSemantics semantics) {
+      this.command = command;
+      this.semantics = semantics;
+    }
+
+    public Source withSemantics(VertexSemantics newSemantics) {
+      return new Source(command, newSemantics);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+      if (obj == this) {
+        return true;
+      } else if (!(obj instanceof Source)) {
+        return false;
+      }
+      Source s = (Source)obj;
+      return Objects.equal(command, s.command) && Objects.equal(semantics, s.semantics);
+    }
+
+    @Override
+    public int hashCode() {
+      return 31 * command.hashCode() + (semantics == null ? 0 : semantics.hashCode());
+    }
+  }
+
+  public static class Data {
+    public final VertexSemantics semantics;
+    public final Model original;
+    public final Model faceted;
+
+    public Data(VertexSemantics semantics, Model original, Model faceted) {
+      this.semantics = semantics;
+      this.original = original;
+      this.faceted = faceted;
+    }
+
+    public boolean hasFaceted() {
+      return faceted != null;
+    }
+
+    public boolean hasOriginal() {
+      return original != null;
+    }
+  }
+
+  public static class VertexSemantics {
+    public final Element[] elements;
+
+    private VertexSemantics(Element[] elements) {
+      this.elements = elements;
+    }
+
+    public VertexSemantics(API.Mesh mesh, VertexSemantics current) {
+      Map<String, Vertex.Semantic.Type> assigned = Maps.newHashMap();
+      if (current != null) {
+        for (Element e : current.elements) {
+          assigned.put(e.name, e.semantic);
+        }
+      }
+
+      this.elements = new Element[mesh.getVertexBuffer().getStreamsCount()];
+      for (int i = 0; i < elements.length; i++) {
+        elements[i] = Element.get(mesh.getVertexBuffer().getStreams(i), assigned);
+      }
+      Arrays.sort(elements, (e1, e2) -> e1.name.compareTo(e2.name));
+    }
+
+    public VertexSemantics copy() {
+      return new VertexSemantics(elements.clone());
+    }
+
+    // TODO: this breaks immutability. Call .copy() before calling assign().
+    public void assign(int idx, Vertex.Semantic.Type semantic) {
+      Element e = elements[idx];
+      elements[idx] = new Element(e.name, e.type, semantic);
+    }
+
+    public Path.MeshOptions.Builder getOptions() {
+      Path.MeshOptions.Builder r = Path.MeshOptions.newBuilder();
+      Arrays.stream(elements)
+          .forEach(e -> r.addVertexSemantics(Path.MeshOptions.SemanticHint.newBuilder()
+              .setName(e.name)
+              .setType(e.semantic)));
+      return r;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+      if (obj == this) {
+        return true;
+      } else if (!(obj instanceof VertexSemantics)) {
+        return false;
+      }
+      return Arrays.equals(elements, ((VertexSemantics)obj).elements);
+    }
+
+    @Override
+    public int hashCode() {
+      return Arrays.hashCode(elements);
+    }
+
+    public static class Element {
+      public final String name;
+      public final String type;
+      public final Vertex.Semantic.Type semantic;
+
+      public Element(String name, String type, Vertex.Semantic.Type semantic) {
+        this.name = name;
+        this.type = type;
+        this.semantic = semantic;
+      }
+
+      public static Element get(Vertex.Stream s, Map<String, Vertex.Semantic.Type> assigned) {
+        Vertex.Semantic.Type type = assigned.get(s.getName());
+        if (type == null) {
+          type = s.getSemantic().getType();
+        }
+        return new Element(s.getName(), Streams.toString(s.getFormat()), type);
+      }
+
+      @Override
+      public boolean equals(Object obj) {
+        if (obj == this) {
+          return true;
+        } else if (!(obj instanceof Element)) {
+          return false;
+        }
+        Element e = (Element)obj;
+        return name.equals(e.name) && type.equals(e.type) && semantic == e.semantic;
+      }
+
+      @Override
+      public int hashCode() {
+        int h = name.hashCode();
+        h = 31 * h + type.hashCode();
+        h = 31 * h + semantic.hashCode();
+        return h;
+      }
+    }
+  }
+
+  public static interface Listener extends Events.Listener {
+    /**
+     * Event indicating that geometry data is being loaded.
+     */
+    public default void onGeometryLoadingStart() { /* empty */ }
+
+    /**
+     * Event indicating that the geometry data has finished loading.
+     *
+     * @param error the loading error or {@code null} if loading was successful.
+     */
+    public default void onGeometryLoaded(Loadable.Message error) { /* empty */ }
+  }
+}

--- a/gapic/src/main/com/google/gapid/models/Memory.java
+++ b/gapic/src/main/com/google/gapid/models/Memory.java
@@ -1,0 +1,398 @@
+/*
+ * Copyright (C) 2018 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.gapid.models;
+
+import static com.google.gapid.util.Paths.memoryAfter;
+import static com.google.gapid.util.Ranges.memory;
+import static com.google.gapid.util.Ranges.merge;
+import static com.google.gapid.util.Ranges.relative;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.primitives.UnsignedLongs;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.gapid.models.CommandStream.CommandIndex;
+import com.google.gapid.models.CommandStream.Observation;
+import com.google.gapid.proto.service.Service;
+import com.google.gapid.server.Client;
+import com.google.gapid.util.Events;
+import com.google.gapid.util.Ranges;
+
+import org.eclipse.swt.widgets.Shell;
+
+import java.lang.ref.SoftReference;
+import java.nio.charset.Charset;
+import java.util.BitSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Logger;
+
+/**
+ * Model responsible for loading memory pool data. This model requests segments as equally sized
+ * pages and maintains a cache of fetched pages.
+ */
+public class Memory extends ModelBase<Memory.Data, Memory.Source, Void, Memory.Listener> {
+  private static final Logger LOG = Logger.getLogger(Memory.class.getName());
+
+  private final CommandStream commands;
+
+  public Memory(Shell shell, Analytics analytics, Client client, CommandStream commands) {
+    super(LOG, shell, analytics, client, Listener.class);
+    this.commands = commands;
+
+    commands.addListener(new CommandStream.Listener() {
+      @Override
+      public void onCommandsSelected(CommandIndex selection) {
+        load(new Source(selection, getPool()), false);
+      }
+    });
+  }
+
+  public int getPool() {
+    Source source = getSource();
+    return (source == null) ? 0 : source.pool;
+  }
+
+  public void setPool(int pool) {
+    Source source = getSource();
+    if (source != null) {
+      load(source.withPool(pool), false);
+    }
+  }
+
+  @Override
+  protected ListenableFuture<Data> doLoad(Source source) {
+    return Futures.transform(commands.getObservations(source.command),
+        obs -> new Data(client, source, obs));
+  }
+
+  @Override
+  protected void fireLoadStartEvent() {
+    listeners.fire().onMemoryLoadingStart();
+  }
+
+  @Override
+  protected void fireLoadedEvent() {
+    listeners.fire().onMemoryLoaded();
+  }
+
+
+  public static class Source {
+    public final CommandIndex command;
+    public final int pool;
+
+    public Source(CommandIndex command, int pool) {
+      this.command = command;
+      this.pool = pool;
+    }
+
+    public Source withPool(int newPool) {
+      return new Source(command, newPool);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+      if (obj == this) {
+        return true;
+      } else if (!(obj instanceof Source)) {
+        return false;
+      }
+      Source s = (Source)obj;
+      return command.equals(s.command) && pool == s.pool;
+    }
+
+    @Override
+    public int hashCode() {
+      return 31 * command.hashCode() + pool;
+    }
+  }
+
+  public static class Data {
+    private static final long MAX_ADDR = -1;
+    private static final int PAGE_SIZE = 0x10000;
+
+    private final Client client;
+    private final Source src;
+    private final Observation[] observations;
+    private final Map<Long, SoftReference<Segment>> cache = Maps.newHashMap();
+
+    public Data(Client client, Source src, Observation[] observations) {
+      this.client = client;
+      this.src = src;
+      this.observations = observations;
+    }
+
+    public int getPool() {
+      return src.pool;
+    }
+
+    public long getEndAddress() {
+      return MAX_ADDR; // TODO
+    }
+
+    public Observation[] getObservations() {
+      return observations;
+    }
+
+    public ListenableFuture<Segment> load(long offset, int length) {
+      length = (int)UnsignedLongs.min(MAX_ADDR - offset, length - 1) + 1;
+
+      long firstPage = getPageForOffset(offset);
+      long lastPage = getPageForOffset(offset + length - 1);
+      if (firstPage == lastPage) {
+        return getPage(firstPage, getOffsetInPage(offset), length);
+      }
+      List<ListenableFuture<Segment>> futures = Lists.newArrayList();
+      futures.add(getPage(firstPage, getOffsetInPage(offset), PAGE_SIZE - getOffsetInPage(offset)));
+      for (long page = firstPage + 1, left = length - PAGE_SIZE + getOffsetInPage(offset);
+          page <= lastPage; page++, left -= PAGE_SIZE) {
+        futures.add(getPage(page, 0, (int)Math.min(left, PAGE_SIZE)));
+      }
+
+      final int totalLength = length;
+      return Futures.transform(
+          Futures.allAsList(futures), segments -> Segment.combine(segments, totalLength));
+    }
+
+    private ListenableFuture<Segment> getPage(long page, int offset, int length) {
+      return Futures.transform(getFromCacheOrServer(page),
+          memory -> memory.subSegment(offset, length));
+    }
+
+    private ListenableFuture<Segment> getFromCacheOrServer(long page) {
+      Segment cached = null;
+      synchronized (cache) {
+        SoftReference<Segment> reference = cache.get(page);
+        if (reference != null) {
+          cached = reference.get();
+          if (cached == null) {
+            cache.remove(page);
+          }
+        }
+      }
+      if (cached != null) {
+        return Futures.immediateFuture(cached);
+      }
+
+      return Futures.transform(getFromServer(page), mem -> {
+        addToCache(page, mem);
+        return mem;
+      });
+    }
+
+    private void addToCache(long page, Segment data) {
+      synchronized (cache) {
+        cache.put(page, new SoftReference<Segment>(data));
+      }
+    }
+
+    private ListenableFuture<Segment> getFromServer(long page) {
+      return Futures.transform(
+          client.get(memoryAfter(src.command, src.pool, getOffsetForPage(page), PAGE_SIZE)),
+          Segment::new);
+    }
+
+    private static long getPageForOffset(long offset) {
+      return Long.divideUnsigned(offset, PAGE_SIZE);
+    }
+
+    private static long getOffsetForPage(long page) {
+      return page * PAGE_SIZE;
+    }
+
+    private static int getOffsetInPage(long offset) {
+      return (int)Long.remainderUnsigned(offset, PAGE_SIZE);
+    }
+  }
+
+  /**
+   * A segment of memory data.
+   */
+  public static class Segment {
+    private final byte[] data;
+    private final BitSet known;
+    private final int offset;
+    private final int length;
+
+    private final List<Service.MemoryRange> reads;
+    private final List<Service.MemoryRange> writes;
+
+    private Segment(byte[] data, BitSet known, int offset, int length,
+        List<Service.MemoryRange> reads, List<Service.MemoryRange> writes) {
+      this.data = data;
+      this.offset = offset;
+      this.length = length;
+      this.known = known;
+      this.reads = reads;
+      this.writes = writes;
+    }
+
+    public Segment(Service.Value value) {
+      Service.Memory mem = value.getMemory();
+      data = mem.getData().toByteArray();
+      offset = 0;
+      known = computeKnown(mem);
+      length = data.length;
+      reads = merge(mem.getReadsList());
+      writes = merge(mem.getWritesList());
+    }
+
+    public static Segment combine(List<Segment> segments, int length) {
+      byte[] data = new byte[length];
+      BitSet known = new BitSet(length);
+      int done = 0;
+
+      List<Service.MemoryRange> reads = Lists.newArrayList();
+      List<Service.MemoryRange> writes = Lists.newArrayList();
+
+      for (Iterator<Segment> it = segments.iterator(); it.hasNext() && done < length; ) {
+        Segment segment = it.next();
+        int count = Math.min(length - done, segment.length);
+        System.arraycopy(segment.data, segment.offset, data, done, count);
+        for (int i = 0; i < count; ++i) {
+          known.set(done + i, segment.known.get(segment.offset + i));
+        }
+
+        for (Service.MemoryRange range : segment.reads) {
+          reads.add((done == 0 && segment.offset == 0) ?
+              range : memory(done - segment.offset + range.getBase(), range.getSize()));
+        }
+        for (Service.MemoryRange range : segment.writes) {
+          writes.add((done == 0 && segment.offset == 0) ?
+              range : memory(done - segment.offset + range.getBase(), range.getSize()));
+        }
+
+        done += count;
+      }
+      return new Segment(data, known, 0, done, merge(reads), merge(writes));
+    }
+
+    public Segment subSegment(int start, int count) {
+      return new Segment(
+          data, known, offset + start, Math.min(count, length - start), reads, writes);
+    }
+
+    public String asString(int start, int count) {
+      return new String(
+          data, offset + start, Math.min(count, length - start), Charset.forName("US-ASCII"));
+    }
+
+    public int length() {
+      return length;
+    }
+
+    public boolean getByteKnown(int off, int size) {
+      if (off < 0 || size < 0 || offset + off + size > data.length) {
+        return false;
+      }
+      if (known == null) {
+        return true;
+      }
+      for (int o = off; o < off + size; o++) {
+        if (!known.get(offset + o)) {
+          return false;
+        }
+      }
+      return true;
+    }
+
+    public boolean getByteKnown(int off) {
+      return getByteKnown(off, 1);
+    }
+
+    public int getByte(int off) {
+      return data[offset + off] & 0xFF;
+    }
+
+    public boolean getShortKnown(int off) {
+      return getByteKnown(off, 2);
+    }
+
+    public boolean getIntKnown(int off) {
+      return getByteKnown(off, 4);
+    }
+
+    public int getShort(int off) {
+      off += offset;
+      // TODO: figure out BigEndian vs LittleEndian.
+      return (data[off + 0] & 0xFF) |
+          ((data[off + 1] & 0xFF) << 8);
+    }
+
+    public int getInt(int off) {
+      off += offset;
+      // TODO: figure out BigEndian vs LittleEndian.
+      return (data[off + 0] & 0xFF) |
+          ((data[off + 1] & 0xFF) << 8) |
+          ((data[off + 2] & 0xFF) << 16) |
+          (data[off + 3] << 24);
+    }
+
+    public boolean getLongKnown(int off) {
+      return getByteKnown(off, 8);
+    }
+
+    public long getLong(int off) {
+      // TODO: figure out BigEndian vs LittleEndian.
+      return (getInt(off) & 0xFFFFFFFFL) | ((long)getInt(off + 4) << 32);
+    }
+
+    public boolean hasReads() {
+      return !reads.isEmpty();
+    }
+
+    public boolean hasWrites() {
+      return !writes.isEmpty();
+    }
+
+    public Iterator<Service.MemoryRange> getReads() {
+      return adjustedRanges(reads);
+    }
+
+    public Iterator<Service.MemoryRange> getWrites() {
+      return adjustedRanges(writes);
+    }
+
+    private Iterator<Service.MemoryRange> adjustedRanges(List<Service.MemoryRange> ranges) {
+      return ranges.stream()
+          .filter(r -> Ranges.overlap(r, offset, length))
+          .map(r -> relative(offset, length, r))
+          .iterator();
+    }
+
+    private static BitSet computeKnown(Service.Memory data) {
+      BitSet known = new BitSet(data.getData().size());
+      for (Service.MemoryRange rng : data.getObservedList()) {
+        known.set((int)rng.getBase(), (int)rng.getBase() + (int)rng.getSize());
+      }
+      return known;
+    }
+  }
+
+  public static interface Listener extends Events.Listener {
+    /**
+     * Event indicating that memory data is being loaded.
+     */
+    public default void onMemoryLoadingStart() { /* empty */ }
+
+    /**
+     * Event indicating that the memory data has finished loading.
+     */
+    public default void onMemoryLoaded() { /* empty */ }
+  }
+}

--- a/gapic/src/main/com/google/gapid/models/Models.java
+++ b/gapic/src/main/com/google/gapid/models/Models.java
@@ -34,11 +34,12 @@ public class Models {
   public final Reports reports;
   public final Thumbnails thumbs;
   public final ConstantSets constants;
+  public final Geometries geos;
 
   public Models(Settings settings, Analytics analytics, Follower follower, Capture capture,
       Devices devices, CommandStream commands, ApiContext contexts, Timeline timeline,
       Resources resources, ApiState state, Reports reports, Thumbnails thumbs,
-      ConstantSets constants) {
+      ConstantSets constants, Geometries geos) {
     this.settings = settings;
     this.analytics = analytics;
     this.follower = follower;
@@ -52,6 +53,7 @@ public class Models {
     this.reports = reports;
     this.thumbs = thumbs;
     this.constants = constants;
+    this.geos = geos;
   }
 
   public static Models create(
@@ -68,8 +70,9 @@ public class Models {
     ApiState state = new ApiState(shell, analytics, client, follower, commands, contexts, constants);
     Reports reports = new Reports(shell, analytics, client, capture, devices, contexts);
     Thumbnails thumbs = new Thumbnails(client, devices, capture, settings);
+    Geometries geometries = new Geometries(shell, analytics, client, commands);
     return new Models(settings, analytics, follower, capture, devices, commands, contexts, timeline,
-        resources, state, reports, thumbs, constants);
+        resources, state, reports, thumbs, constants, geometries);
   }
 
   public void dispose() {

--- a/gapic/src/main/com/google/gapid/models/Models.java
+++ b/gapic/src/main/com/google/gapid/models/Models.java
@@ -35,11 +35,12 @@ public class Models {
   public final Thumbnails thumbs;
   public final ConstantSets constants;
   public final Geometries geos;
+  public final Memory memory;
 
   public Models(Settings settings, Analytics analytics, Follower follower, Capture capture,
       Devices devices, CommandStream commands, ApiContext contexts, Timeline timeline,
       Resources resources, ApiState state, Reports reports, Thumbnails thumbs,
-      ConstantSets constants, Geometries geos) {
+      ConstantSets constants, Geometries geos, Memory memory) {
     this.settings = settings;
     this.analytics = analytics;
     this.follower = follower;
@@ -54,6 +55,7 @@ public class Models {
     this.thumbs = thumbs;
     this.constants = constants;
     this.geos = geos;
+    this.memory = memory;
   }
 
   public static Models create(
@@ -71,8 +73,9 @@ public class Models {
     Reports reports = new Reports(shell, analytics, client, capture, devices, contexts);
     Thumbnails thumbs = new Thumbnails(client, devices, capture, settings);
     Geometries geometries = new Geometries(shell, analytics, client, commands);
+    Memory memory = new Memory(shell, analytics, client, commands);
     return new Models(settings, analytics, follower, capture, devices, commands, contexts, timeline,
-        resources, state, reports, thumbs, constants, geometries);
+        resources, state, reports, thumbs, constants, geometries, memory);
   }
 
   public void dispose() {

--- a/gapic/src/main/com/google/gapid/models/Models.java
+++ b/gapic/src/main/com/google/gapid/models/Models.java
@@ -66,7 +66,7 @@ public class Models {
     ApiContext contexts = new ApiContext(shell, analytics, client, capture);
     Timeline timeline = new Timeline(shell, analytics, client, capture, contexts);
     CommandStream commands = new CommandStream(shell, analytics, client, capture, contexts, constants);
-    Resources resources = new Resources(shell, analytics, client, capture);
+    Resources resources = new Resources(shell, analytics, client, capture, commands);
     ApiState state = new ApiState(shell, analytics, client, follower, commands, contexts, constants);
     Reports reports = new Reports(shell, analytics, client, capture, devices, contexts);
     Thumbnails thumbs = new Thumbnails(client, devices, capture, settings);

--- a/gapic/src/main/com/google/gapid/models/Models.java
+++ b/gapic/src/main/com/google/gapid/models/Models.java
@@ -32,14 +32,14 @@ public class Models {
   public final Resources resources;
   public final ApiState state;
   public final Reports reports;
-  public final Thumbnails thumbs;
+  public final ImagesModel images;
   public final ConstantSets constants;
   public final Geometries geos;
   public final Memory memory;
 
   public Models(Settings settings, Analytics analytics, Follower follower, Capture capture,
       Devices devices, CommandStream commands, ApiContext contexts, Timeline timeline,
-      Resources resources, ApiState state, Reports reports, Thumbnails thumbs,
+      Resources resources, ApiState state, Reports reports, ImagesModel images,
       ConstantSets constants, Geometries geos, Memory memory) {
     this.settings = settings;
     this.analytics = analytics;
@@ -52,7 +52,7 @@ public class Models {
     this.resources = resources;
     this.state = state;
     this.reports = reports;
-    this.thumbs = thumbs;
+    this.images = images;
     this.constants = constants;
     this.geos = geos;
     this.memory = memory;
@@ -71,11 +71,11 @@ public class Models {
     Resources resources = new Resources(shell, analytics, client, capture, commands);
     ApiState state = new ApiState(shell, analytics, client, follower, commands, contexts, constants);
     Reports reports = new Reports(shell, analytics, client, capture, devices, contexts);
-    Thumbnails thumbs = new Thumbnails(client, devices, capture, settings);
+    ImagesModel images = new ImagesModel(client, devices, capture, settings);
     Geometries geometries = new Geometries(shell, analytics, client, commands);
     Memory memory = new Memory(shell, analytics, client, commands);
     return new Models(settings, analytics, follower, capture, devices, commands, contexts, timeline,
-        resources, state, reports, thumbs, constants, geometries, memory);
+        resources, state, reports, images, constants, geometries, memory);
   }
 
   public void dispose() {

--- a/gapic/src/main/com/google/gapid/models/Resources.java
+++ b/gapic/src/main/com/google/gapid/models/Resources.java
@@ -15,15 +15,32 @@
  */
 package com.google.gapid.models;
 
+import static com.google.gapid.util.Paths.resourceAfter;
+import static java.util.Collections.emptyList;
+
+import com.google.common.collect.Lists;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.gapid.models.CommandStream.CommandIndex;
 import com.google.gapid.proto.service.Service;
+import com.google.gapid.proto.service.Service.Resource;
+import com.google.gapid.proto.service.api.API;
+import com.google.gapid.proto.service.api.API.ResourceType;
 import com.google.gapid.proto.service.path.Path;
+import com.google.gapid.rpc.Rpc;
+import com.google.gapid.rpc.Rpc.Result;
+import com.google.gapid.rpc.RpcException;
+import com.google.gapid.rpc.UiCallback;
 import com.google.gapid.server.Client;
 import com.google.gapid.util.Events;
+import com.google.gapid.util.Paths;
 
 import org.eclipse.swt.widgets.Shell;
 
 import java.util.List;
+import java.util.concurrent.ExecutionException;
 import java.util.logging.Logger;
+import java.util.stream.Stream;
 
 /**
  * Model containing the capture resources (textures, shaders, etc.) metadata.
@@ -32,8 +49,14 @@ public class Resources
     extends CaptureDependentModel.ForValue<Service.Resources, Resources.Listener> {
   private static final Logger LOG = Logger.getLogger(Resources.class.getName());
 
-  public Resources(Shell shell, Analytics analytics, Client client, Capture capture) {
+  protected final Capture capture;
+  private final CommandStream commands;
+
+  public Resources(
+      Shell shell, Analytics analytics, Client client, Capture capture, CommandStream commands) {
     super(LOG, shell, analytics, client, Listener.class, capture);
+    this.capture = capture;
+    this.commands = commands;
   }
 
   @Override
@@ -61,6 +84,95 @@ public class Resources
 
   public List<Service.ResourcesByType> getResources() {
     return getData().getTypesList();
+  }
+
+  public ResourceList getResources(API.ResourceType type) {
+    if (!isLoaded() || commands.getSelectedCommands() == null) {
+      return new ResourceList(type, emptyList(), false);
+    }
+
+    Path.Command after = commands.getSelectedCommands().getCommand();
+    List<Service.Resource> resources = Lists.newArrayList();
+    boolean complete = true;
+    for (Service.ResourcesByType rs : getData().getTypesList()) {
+      if (rs.getType() != type) {
+        continue;
+      }
+
+      for (Service.Resource r : rs.getResourcesList()) {
+        if (Paths.compare(firstAccess(r), after) <= 0) {
+          resources.add(r);
+        } else {
+          complete = false;
+        }
+      }
+    }
+    return new ResourceList(type, resources, complete);
+  }
+
+  public Path.ResourceData getResourcePath(Service.Resource resource) {
+    CommandIndex after = commands.getSelectedCommands();
+    return (after == null) ? null : Path.ResourceData.newBuilder()
+        .setAfter(after.getCommand())
+        .setID(resource.getID())
+        .build();
+  }
+
+  public ListenableFuture<API.ResourceData> loadResource(Service.Resource resource) {
+    CommandIndex after = commands.getSelectedCommands();
+    if (after == null) {
+      return Futures.immediateFailedFuture(new RuntimeException("No command selected"));
+    }
+
+    return Futures.transform(
+        client.get(resourceAfter(after, resource.getID())), Service.Value::getResourceData);
+  }
+
+  public void updateResource(Service.Resource resource, API.ResourceData data) {
+    CommandIndex after = commands.getSelectedCommands();
+    if (after == null) {
+      return;
+    }
+
+    Rpc.listen(client.set(resourceAfter(after, resource.getID()), Service.Value.newBuilder()
+        .setResourceData(data)
+        .build()), new UiCallback<Path.Any, Path.Capture>(shell, LOG) {
+      @Override
+      protected Path.Capture onRpcThread(Result<Path.Any> result)
+          throws RpcException, ExecutionException {
+        // TODO this should probably be able to handle any path.
+        return result.get().getResourceData().getAfter().getCapture();
+      }
+
+      @Override
+      protected void onUiThread(Path.Capture result) {
+        capture.updateCapture(result, null);
+      }
+    });
+  }
+
+  private static Path.Command firstAccess(Service.Resource info) {
+    return (info.getAccessesCount() == 0) ? null : info.getAccesses(0);
+  }
+
+  public static class ResourceList {
+    public final API.ResourceType type;
+    public final List<Service.Resource> resources;
+    public final boolean complete;
+
+    public ResourceList(ResourceType type, List<Resource> resources, boolean complete) {
+      this.type = type;
+      this.resources = resources;
+      this.complete = complete;
+    }
+
+    public boolean isEmpty() {
+      return resources.isEmpty();
+    }
+
+    public Stream<Service.Resource> stream() {
+      return resources.stream();
+    }
   }
 
   public static interface Listener extends Events.Listener {

--- a/gapic/src/main/com/google/gapid/models/Thumbnails.java
+++ b/gapic/src/main/com/google/gapid/models/Thumbnails.java
@@ -16,7 +16,6 @@
 package com.google.gapid.models;
 
 import static com.google.gapid.image.FetchedImage.loadThumbnail;
-import static com.google.gapid.util.Paths.thumbnail;
 
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
@@ -25,6 +24,7 @@ import com.google.gapid.proto.service.path.Path;
 import com.google.gapid.server.Client;
 import com.google.gapid.util.Events;
 import com.google.gapid.util.Events.ListenerCollection;
+import com.google.gapid.util.Paths;
 
 import org.eclipse.swt.graphics.ImageData;
 import org.eclipse.swt.internal.DPIUtil;
@@ -74,15 +74,34 @@ public class Thumbnails {
 
   public ListenableFuture<ImageData> getThumbnail(
       Path.Command command, int size, Consumer<Image.Info> onInfo) {
-    return Futures.transform(loadThumbnail(client, thumbnail(command, THUMB_PIXELS, settings.disableReplayOptimization), onInfo),
+    return Futures.transform(loadThumbnail(client, thumbnail(command), onInfo),
         image -> processImage(image, size));
   }
 
   public ListenableFuture<ImageData> getThumbnail(
       Path.CommandTreeNode node, int size, Consumer<Image.Info> onInfo) {
-    return Futures.transform(loadThumbnail(client, thumbnail(node, THUMB_PIXELS, settings.disableReplayOptimization), onInfo),
+    return Futures.transform(loadThumbnail(client, thumbnail(node), onInfo),
         image -> processImage(image, size));
   }
+
+  public ListenableFuture<ImageData> getThumbnail(
+      Path.ResourceData resource, int size, Consumer<Image.Info> onInfo) {
+    return Futures.transform(loadThumbnail(client, thumbnail(resource), onInfo),
+        image -> processImage(image, size));
+  }
+
+  private Path.Thumbnail thumbnail(Path.Command command) {
+    return Paths.thumbnail(command, THUMB_PIXELS, settings.disableReplayOptimization);
+  }
+
+  private Path.Thumbnail thumbnail(Path.CommandTreeNode node) {
+    return Paths.thumbnail(node, THUMB_PIXELS, settings.disableReplayOptimization);
+  }
+
+  private Path.Thumbnail thumbnail(Path.ResourceData resource) {
+    return Paths.thumbnail(resource, THUMB_PIXELS, settings.disableReplayOptimization);
+  }
+
 
   private static ImageData processImage(ImageData image, int size) {
     size = DPIUtil.autoScaleUp(size);

--- a/gapic/src/main/com/google/gapid/util/MoreFutures.java
+++ b/gapic/src/main/com/google/gapid/util/MoreFutures.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2018 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.gapid.util;
+
+import com.google.common.collect.Lists;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.Uninterruptibles;
+
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+
+/**
+ * Additional utilities for {@link ListenableFuture ListenableFutures}.
+ */
+public class MoreFutures {
+  private MoreFutures() {
+  }
+
+  public static <I, O> ListenableFuture<O> combine(
+      Iterable<ListenableFuture<I>> futures, Combiner<List<Result<I>>, O> fun) {
+    return Futures.whenAllComplete(futures).call(() -> {
+      List<Result<I>> results = Lists.newArrayList();
+      for (ListenableFuture<I> future : futures) {
+        results.add(Result.getUninterruptibly(future));
+      }
+      return fun.apply(results);
+    });
+  }
+
+  public static <I, O> ListenableFuture<O> combineAsync(
+      Iterable<ListenableFuture<I>> futures, Combiner<List<Result<I>>, ListenableFuture<O>> fun) {
+    return Futures.whenAllComplete(futures).callAsync(() -> {
+      List<Result<I>> results = Lists.newArrayList();
+      for (ListenableFuture<I> future : futures) {
+        results.add(Result.getUninterruptibly(future));
+      }
+      return fun.apply(results);
+    });
+  }
+
+  public static interface Combiner<I, O> {
+    public O apply(I input) throws ExecutionException;
+  }
+
+  public static class Result<T> {
+    public final T result;
+    public final ExecutionException error;
+
+    private Result(T result, ExecutionException error) {
+      this.result = result;
+      this.error = error;
+    }
+
+    public static <T> Result<T> getUninterruptibly(ListenableFuture<T> future) {
+      try {
+        return new Result<T>(Uninterruptibles.getUninterruptibly(future), null);
+      } catch (ExecutionException e) {
+        return new Result<T>(null, e);
+      }
+    }
+
+    public boolean hasFailed() {
+      return error != null;
+    }
+
+    public boolean succeeded() {
+      return error == null;
+    }
+
+    public Throwable getCause() {
+      return (error == null) ? null : error.getCause();
+    }
+  }
+}

--- a/gapic/src/main/com/google/gapid/util/Paths.java
+++ b/gapic/src/main/com/google/gapid/util/Paths.java
@@ -99,12 +99,16 @@ public class Paths {
         Path.StateTreeNodeForPath.newBuilder().setTree(tree).setMember(statePath)).build();
   }
 
-  public static Path.Any memoryAfter(Path.Command after, int pool, long address, long size) {
-    if (after == null) {
+  public static Path.Any memoryAfter(CommandIndex index, int pool, long address, long size) {
+    if (index == null) {
       return null;
     }
-    return Path.Any.newBuilder().setMemory(
-        Path.Memory.newBuilder().setAfter(after).setPool(pool).setAddress(address).setSize(size))
+    return Path.Any.newBuilder()
+        .setMemory(Path.Memory.newBuilder()
+            .setAfter(index.getCommand())
+            .setPool(pool)
+            .setAddress(address)
+            .setSize(size))
         .build();
   }
 
@@ -112,8 +116,13 @@ public class Paths {
     if (index == null || range == null) {
       return null;
     }
-    return Path.Any.newBuilder().setMemory(Path.Memory.newBuilder().setAfter(index.getCommand())
-        .setPool(pool).setAddress(range.getBase()).setSize(range.getSize())).build();
+    return Path.Any.newBuilder()
+        .setMemory(Path.Memory.newBuilder()
+            .setAfter(index.getCommand())
+            .setPool(pool)
+            .setAddress(range.getBase())
+            .setSize(range.getSize()))
+        .build();
   }
 
   public static Path.Any observationsAfter(CommandIndex index, int pool) {

--- a/gapic/src/main/com/google/gapid/util/Paths.java
+++ b/gapic/src/main/com/google/gapid/util/Paths.java
@@ -191,21 +191,34 @@ public class Paths {
         .setAs(Path.As.newBuilder().setResourceData(resource).setImageFormat(format)).build();
   }
 
-  public static Path.Thumbnail thumbnail(Path.ResourceData resource, int size, boolean disableOptimization) {
-    return Path.Thumbnail.newBuilder().setResource(resource)
-        .setDesiredFormat(Images.FMT_RGBA_U8_NORM).setDesiredMaxHeight(size)
-        .setDesiredMaxWidth(size).setDisableOptimization(disableOptimization).build();
+  public static Path.Thumbnail thumbnail(Path.Command command, int size, boolean disableOpt) {
+    return Path.Thumbnail.newBuilder()
+        .setCommand(command)
+        .setDesiredFormat(Images.FMT_RGBA_U8_NORM)
+        .setDesiredMaxHeight(size)
+        .setDesiredMaxWidth(size)
+        .setDisableOptimization(disableOpt)
+        .build();
   }
 
-  public static Path.Thumbnail thumbnail(Path.Command command, int size, boolean disableOptimization) {
-    return Path.Thumbnail.newBuilder().setCommand(command).setDesiredFormat(Images.FMT_RGBA_U8_NORM)
-        .setDesiredMaxHeight(size).setDesiredMaxWidth(size).setDisableOptimization(disableOptimization).build();
+  public static Path.Thumbnail thumbnail(Path.CommandTreeNode node, int size, boolean disableOpt) {
+    return Path.Thumbnail.newBuilder()
+        .setCommandTreeNode(node)
+        .setDesiredFormat(Images.FMT_RGBA_U8_NORM)
+        .setDesiredMaxHeight(size)
+        .setDesiredMaxWidth(size)
+        .setDisableOptimization(disableOpt)
+        .build();
   }
 
-  public static Path.Thumbnail thumbnail(Path.CommandTreeNode node, int size, boolean disableOptimization) {
-    return Path.Thumbnail.newBuilder().setCommandTreeNode(node)
-        .setDesiredFormat(Images.FMT_RGBA_U8_NORM).setDesiredMaxHeight(size)
-        .setDesiredMaxWidth(size).setDisableOptimization(disableOptimization).build();
+  public static Path.Thumbnail thumbnail(Path.ResourceData resource, int size, boolean disableOpt) {
+    return Path.Thumbnail.newBuilder()
+        .setResource(resource)
+        .setDesiredFormat(Images.FMT_RGBA_U8_NORM)
+        .setDesiredMaxHeight(size)
+        .setDesiredMaxWidth(size)
+        .setDisableOptimization(disableOpt)
+        .build();
   }
 
   public static Path.Any thumbnail(Path.Thumbnail thumb) {

--- a/gapic/src/main/com/google/gapid/util/Ranges.java
+++ b/gapic/src/main/com/google/gapid/util/Ranges.java
@@ -18,6 +18,9 @@ package com.google.gapid.util;
 import com.google.common.primitives.UnsignedLongs;
 import com.google.gapid.proto.service.Service;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * Range utilities.
  */
@@ -33,7 +36,69 @@ public class Ranges {
   }
 
   public static boolean contains(Service.MemoryRange range, long value) {
-    return UnsignedLongs.compare(range.getBase(), value) <= 0 &&
-        UnsignedLongs.compare(range.getBase() + range.getSize(), value) > 0;
+    return contains(range.getBase(), range.getSize(), value);
+  }
+
+  public static boolean contains(long base, long size, long value) {
+    return UnsignedLongs.compare(base, value) <= 0 &&
+        UnsignedLongs.compare(base + size, value) > 0;
+  }
+
+  public static boolean overlap(Service.MemoryRange range, long base, long size) {
+    return overlap(range.getBase(), range.getSize(), base, size);
+  }
+
+  public static boolean overlap(long base1, long size1, long base2, long size2) {
+    return base1 < base2 + size2 && base2 < base1 + size1;
+  }
+
+  /**
+   * Returns the intersection of the ranges, relative to {@code base}. The ranges must overlap.
+   */
+  public static Service.MemoryRange relative(long base, long size, Service.MemoryRange range) {
+    long b = Math.max(base, range.getBase());
+    long s = Math.min(base + size, range.getBase() + range.getSize()) - b;
+    return memory(b - base, s);
+  }
+
+  // r1 must contain r2.base.
+  public static Service.MemoryRange merge(Service.MemoryRange r1, Service.MemoryRange r2) {
+    long base = r1.getBase(), size = r2.getBase() + r2.getSize() - base;
+    return (size <= r1.getSize()) ? r1 : memory(base, size);
+  }
+
+  /**
+   * Merges overlapping and adjacent ranges. Notes: sorts the list.
+   */
+  public static List<Service.MemoryRange> merge(List<Service.MemoryRange> ranges) {
+    if (ranges.size() < 2) {
+      return ranges;
+    }
+
+    return ranges.stream()
+      .sorted((r1, r2) -> {
+        int r = Long.compare(r1.getBase(), r2.getBase());
+        if (r == 0) {
+          // sort by size descending, so that small ones are easily absorbed.
+          r = Long.compare(r2.getSize(), r1.getSize());
+        }
+        return r;
+      })
+      .sequential()
+      .collect(ArrayList::new, (list, range) -> {
+        if (list.isEmpty()) {
+          list.add(range);
+        } else {
+          Service.MemoryRange last = list.get(list.size() - 1);
+          if (range.getBase() <= last.getBase() + last.getSize()) {
+            list.set(list.size() - 1, merge(last, range));
+          } else {
+            list.add(range);
+          }
+        }
+      }, (x, y) -> {
+        // Sequential streams don't need a combiner.
+        throw new UnsupportedOperationException();
+      });
   }
 }

--- a/gapic/src/main/com/google/gapid/views/CommandTree.java
+++ b/gapic/src/main/com/google/gapid/views/CommandTree.java
@@ -17,7 +17,7 @@ package com.google.gapid.views;
 
 import static com.google.gapid.image.Images.noAlpha;
 import static com.google.gapid.models.Follower.nullPrefetcher;
-import static com.google.gapid.models.Thumbnails.THUMB_SIZE;
+import static com.google.gapid.models.ImagesModel.THUMB_SIZE;
 import static com.google.gapid.util.Colors.getRandomColor;
 import static com.google.gapid.util.Colors.lerp;
 import static com.google.gapid.util.Loadable.MessageType.Error;
@@ -37,7 +37,7 @@ import com.google.gapid.models.CommandStream.CommandIndex;
 import com.google.gapid.models.CommandStream.Node;
 import com.google.gapid.models.Follower;
 import com.google.gapid.models.Models;
-import com.google.gapid.models.Thumbnails;
+import com.google.gapid.models.ImagesModel;
 import com.google.gapid.proto.service.Service;
 import com.google.gapid.proto.service.Service.ClientAction;
 import com.google.gapid.proto.service.api.API;
@@ -83,7 +83,7 @@ import java.util.logging.Logger;
  * API command view displaying the commands with their hierarchy grouping in a tree.
  */
 public class CommandTree extends Composite implements Tab, Capture.Listener, CommandStream.Listener,
-    ApiContext.Listener, Thumbnails.Listener {
+    ApiContext.Listener, ImagesModel.Listener {
   protected static final Logger LOG = Logger.getLogger(CommandTree.class.getName());
 
   private final Client client;
@@ -110,12 +110,12 @@ public class CommandTree extends Composite implements Tab, Capture.Listener, Com
     models.capture.addListener(this);
     models.commands.addListener(this);
     models.contexts.addListener(this);
-    models.thumbs.addListener(this);
+    models.images.addListener(this);
     addListener(SWT.Dispose, e -> {
       models.capture.removeListener(this);
       models.commands.removeListener(this);
       models.contexts.removeListener(this);
-      models.thumbs.removeListener(this);
+      models.images.removeListener(this);
     });
 
     search.addListener(Events.Search, e -> search(e.text, (e.detail & Events.REGEX) != 0));
@@ -424,13 +424,13 @@ public class CommandTree extends Composite implements Tab, Capture.Listener, Com
 
     @Override
     protected boolean shouldShowImage(CommandStream.Node node) {
-      return models.thumbs.isReady() &&
+      return models.images.isReady() &&
           node.getData() != null && !node.getData().getGroup().isEmpty();
     }
 
     @Override
     protected ListenableFuture<ImageData> loadImage(CommandStream.Node node, int size) {
-      return noAlpha(models.thumbs.getThumbnail(
+      return noAlpha(models.images.getThumbnail(
           node.getPath(Path.CommandTreeNode.newBuilder()).build(), size, i -> { /*noop*/ }));
     }
 

--- a/gapic/src/main/com/google/gapid/views/GotoMemory.java
+++ b/gapic/src/main/com/google/gapid/views/GotoMemory.java
@@ -62,7 +62,7 @@ public class GotoMemory {
         return;
       }
       models.follower.gotoMemory(memoryAfter(
-          models.commands.getSelectedCommands().getCommand(), pool, address, 0).getMemory());
+          models.commands.getSelectedCommands(), pool, address, 0).getMemory());
     }
   }
 

--- a/gapic/src/main/com/google/gapid/views/StateView.java
+++ b/gapic/src/main/com/google/gapid/views/StateView.java
@@ -38,7 +38,6 @@ import com.google.gapid.proto.service.path.Path;
 import com.google.gapid.rpc.Rpc;
 import com.google.gapid.rpc.RpcException;
 import com.google.gapid.rpc.UiCallback;
-import com.google.gapid.server.Client;
 import com.google.gapid.util.Loadable;
 import com.google.gapid.util.Messages;
 import com.google.gapid.util.Paths;
@@ -80,7 +79,7 @@ public class StateView extends Composite
   protected List<Path.Any> scheduledExpandedPaths;
   protected Point scheduledScrollPos;
 
-  public StateView(Composite parent, Client client, Models models, Widgets widgets) {
+  public StateView(Composite parent, Models models, Widgets widgets) {
     super(parent, SWT.NONE);
     this.models = models;
 
@@ -128,12 +127,12 @@ public class StateView extends Composite
         }
 
         TextViewer.showViewTextPopup(getShell(), widgets, data.getName() + ":",
-            Futures.transform(client.get(data.getValuePath()),
+            Futures.transform(models.state.loadValue(node),
                 // Formatter.toString(<string value>) formats the string as "<string>". This makes
                 // sense in all but this context, so we simply strip them here rather than
                 // complicate the formatting code.
                 v -> stripQuotes(Formatter.toString(
-                    v.getBox(),  models.constants.getConstants(data.getConstants()), false))));
+                    v, models.constants.getConstants(data.getConstants()), false))));
       }
     });
     tree.setPopupMenu(popup, StateView::canShowPopup);

--- a/gapic/src/main/com/google/gapid/views/ThumbnailScrubber.java
+++ b/gapic/src/main/com/google/gapid/views/ThumbnailScrubber.java
@@ -16,7 +16,7 @@
 package com.google.gapid.views;
 
 import static com.google.gapid.image.Images.noAlpha;
-import static com.google.gapid.models.Thumbnails.THUMB_SIZE;
+import static com.google.gapid.models.ImagesModel.THUMB_SIZE;
 import static com.google.gapid.util.Loadable.MessageType.Error;
 import static com.google.gapid.util.Loadable.MessageType.Info;
 import static com.google.gapid.widgets.Widgets.scheduleIfNotDisposed;
@@ -28,7 +28,7 @@ import com.google.gapid.models.Capture;
 import com.google.gapid.models.CommandStream;
 import com.google.gapid.models.CommandStream.CommandIndex;
 import com.google.gapid.models.Models;
-import com.google.gapid.models.Thumbnails;
+import com.google.gapid.models.ImagesModel;
 import com.google.gapid.models.Timeline;
 import com.google.gapid.proto.service.Service;
 import com.google.gapid.util.Loadable;
@@ -57,7 +57,7 @@ import java.util.List;
  * Scrubber view displaying thumbnails of the frames in the current capture.
  */
 public class ThumbnailScrubber extends Composite implements Tab, Capture.Listener,
-    CommandStream.Listener, ApiContext.Listener, Timeline.Listener, Thumbnails.Listener {
+    CommandStream.Listener, ApiContext.Listener, Timeline.Listener, ImagesModel.Listener {
   private final Models models;
   private final LoadablePanel<Carousel> loading;
   private final Carousel carousel;
@@ -69,7 +69,7 @@ public class ThumbnailScrubber extends Composite implements Tab, Capture.Listene
     setLayout(new FillLayout(SWT.VERTICAL));
 
     loading = new LoadablePanel<Carousel>(this, widgets,
-        panel -> new Carousel(panel, models.thumbs, widgets));
+        panel -> new Carousel(panel, models.images, widgets));
     carousel = loading.getContents();
 
     carousel.addContentListener(SWT.MouseDown, e -> {
@@ -84,13 +84,13 @@ public class ThumbnailScrubber extends Composite implements Tab, Capture.Listene
     models.contexts.addListener(this);
     models.timeline.addListener(this);
     models.commands.addListener(this);
-    models.thumbs.addListener(this);
+    models.images.addListener(this);
     addListener(SWT.Dispose, e -> {
       models.capture.removeListener(this);
       models.contexts.removeListener(this);
       models.timeline.removeListener(this);
       models.commands.removeListener(this);
-      models.thumbs.removeListener(this);
+      models.images.removeListener(this);
       carousel.reset();
     });
   }
@@ -237,12 +237,12 @@ public class ThumbnailScrubber extends Composite implements Tab, Capture.Listene
   private static class Carousel extends HorizontalList implements LoadingIndicator.Repaintable {
     private static final int MIN_SIZE = 80;
 
-    private final Thumbnails thumbs;
+    private final ImagesModel thumbs;
     private final Widgets widgets;
     private List<Data> datas = Collections.emptyList();
     private int selectedIndex = -1;
 
-    public Carousel(Composite parent, Thumbnails thumbs, Widgets widgets) {
+    public Carousel(Composite parent, ImagesModel thumbs, Widgets widgets) {
       super(parent);
       this.thumbs = thumbs;
       this.widgets = widgets;

--- a/gapic/src/main/com/google/gapid/widgets/LinkifiedTreeWithImages.java
+++ b/gapic/src/main/com/google/gapid/widgets/LinkifiedTreeWithImages.java
@@ -15,7 +15,7 @@
  */
 package com.google.gapid.widgets;
 
-import static com.google.gapid.models.Thumbnails.THUMB_SIZE;
+import static com.google.gapid.models.ImagesModel.THUMB_SIZE;
 import static com.google.gapid.util.GeoUtils.vertCenter;
 
 import com.google.common.collect.Maps;

--- a/gapic/src/main/com/google/gapid/widgets/LoadableImageWidget.java
+++ b/gapic/src/main/com/google/gapid/widgets/LoadableImageWidget.java
@@ -15,7 +15,7 @@
  */
 package com.google.gapid.widgets;
 
-import com.google.gapid.models.Thumbnails;
+import com.google.gapid.models.ImagesModel;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.GC;
@@ -34,7 +34,7 @@ public class LoadableImageWidget extends Canvas {
   private LoadableImageWidget(Composite parent) {
     super(parent, SWT.BORDER);
 
-    setSize(Thumbnails.THUMB_SIZE, Thumbnails.THUMB_SIZE);
+    setSize(ImagesModel.THUMB_SIZE, ImagesModel.THUMB_SIZE);
     addListener(SWT.Paint, e -> paint(e.gc));
     addListener(SWT.Dispose, e -> image.dispose());
   }


### PR DESCRIPTION
This is in preparation for most RPC calls requiring a replay device and cleans up a blurry separation of concerns.