### PR TITLE
Make sure we don't use uninitialized memory in BaseSwapchain::Destroy

### DIFF
--- a/core/vulkan/vk_virtual_swapchain/cc/base_swapchain.cpp
+++ b/core/vulkan/vk_virtual_swapchain/cc/base_swapchain.cpp
@@ -69,6 +69,9 @@ BaseSwapchain::BaseSwapchain(VkInstance instance, VkDevice device,
       instance_functions_(instance_functions),
       device_functions_(device_functions),
       swapchain_info_(*swapchain_info),
+      surface_(VK_NULL_HANDLE),
+      swapchain_(VK_NULL_HANDLE),
+      acquire_semaphore_(VK_NULL_HANDLE),
       valid_(false) {
   if (platform_info == nullptr) {
     return;


### PR DESCRIPTION
These fields were not 0-initialized, which led to issues in Destroy if the construction did not complete successfully.