### PR TITLE
Trace Target Picker Enhancements

### DIFF
--- a/gapic/src/main/com/google/gapid/models/TraceTargets.java
+++ b/gapic/src/main/com/google/gapid/models/TraceTargets.java
@@ -177,6 +177,14 @@ public class TraceTargets
       return data;
     }
 
+    public boolean isTraceable() {
+      return data != null && !data.getTraceUri().isEmpty();
+    }
+
+    public Target getTraceTarget() {
+      return isTraceable() ? new Target(data.getTraceUri(), data.getFriendlyApplication()) : null;
+    }
+
     public ListenableFuture<Node> load(
         Shell shell, Supplier<ListenableFuture<Service.TraceTargetTreeNode>> loader) {
       if (data != null) {
@@ -213,6 +221,16 @@ public class TraceTargets
     @Override
     public String toString() {
       return parent + "/" + uri + (data == null ? "" : " " + data.getName());
+    }
+  }
+
+  public static class Target {
+    public final String url;
+    public final String friendlyName;
+
+    public Target(String url, String friendlyName) {
+      this.url = url;
+      this.friendlyName = friendlyName;
     }
   }
 

--- a/gapic/src/main/com/google/gapid/models/TraceTargets.java
+++ b/gapic/src/main/com/google/gapid/models/TraceTargets.java
@@ -128,6 +128,7 @@ public class TraceTargets
   public static class Node {
     private final Node parent;
     private final String uri;
+    private final int depth;
     private Node[] children;
     private Service.TraceTargetTreeNode data;
     private ListenableFuture<Node> loadFuture;
@@ -140,6 +141,7 @@ public class TraceTargets
     public Node(Node parent, String uri) {
       this.parent = parent;
       this.uri = uri;
+      this.depth = (parent == null) ? 0 : parent.depth + 1;
     }
 
     public Node getParent() {
@@ -148,6 +150,10 @@ public class TraceTargets
 
     public String getUri() {
       return uri;
+    }
+
+    public int getDepth() {
+      return depth;
     }
 
     public int getChildCount() {

--- a/gapic/src/main/com/google/gapid/views/TraceTargetPickerDialog.java
+++ b/gapic/src/main/com/google/gapid/views/TraceTargetPickerDialog.java
@@ -198,6 +198,10 @@ public class TraceTargetPickerDialog extends DialogBase implements TraceTargets.
 
     tree.getTree().addListener(SWT.Selection, e -> {
       selected = cast(((TreeItem)e.item).getData());
+      Button ok = getButton(IDialogConstants.OK_ID);
+      if (ok != null) {
+        ok.setEnabled(selected != null && selected.isTraceable());
+      }
     });
 
     if (lastLoadError != null) {
@@ -216,9 +220,7 @@ public class TraceTargetPickerDialog extends DialogBase implements TraceTargets.
   protected void createButtonsForButtonBar(Composite parent) {
     Button ok = createButton(parent, IDialogConstants.OK_ID, IDialogConstants.OK_LABEL, true);
     createButton(parent, IDialogConstants.CANCEL_ID, IDialogConstants.CANCEL_LABEL, false);
-
     ok.setEnabled(false);
-    tree.getTree().addListener(SWT.Selection, e -> ok.setEnabled(selected != null));
   }
 
   protected static TraceTargets.Node cast(Object element) {

--- a/gapic/src/main/com/google/gapid/views/TracerDialog.java
+++ b/gapic/src/main/com/google/gapid/views/TracerDialog.java
@@ -281,7 +281,8 @@ public class TracerDialog {
           protected String createAndShowDialog(String current) {
             DeviceCaptureInfo dev = getSelectedDevice();
             if (dev != null) {
-              TraceTarget target = showTraceTargetPicker(dev, current, getShell(), models, widgets);
+              TraceTargets.Target target =
+                  showTraceTargetPicker(dev, current, getShell(), models, widgets);
               if (target != null) {
                 friendlyName = target.friendlyName;
                 if (!userHasChangedOutputFile) {
@@ -290,7 +291,7 @@ public class TracerDialog {
                 }
 
                 // Setting the text ourselves so we cancel the event.
-                setText(target.uri);
+                setText(target.url);
                 userHasChangedTarget = false; // cancel the modify event from set call.
               }
             }
@@ -478,7 +479,7 @@ public class TracerDialog {
         }
       }
 
-      protected static TraceTarget showTraceTargetPicker(
+      protected static TraceTargets.Target showTraceTargetPicker(
           DeviceCaptureInfo dev, String current, Shell shell, Models models, Widgets widgets) {
         if (dev.config.getServerLocalPath()) {
           // We are local, show a system file browser dialog.
@@ -491,7 +492,7 @@ public class TracerDialog {
           dialog.setText(Messages.CAPTURE_EXECUTABLE);
           String exe = dialog.open();
           if (exe != null) {
-            return new TraceTarget(exe, new File(exe).getName());
+            return new TraceTargets.Target(exe, new File(exe).getName());
           }
         } else {
           // Use the server to query the trace target tree.
@@ -499,10 +500,7 @@ public class TracerDialog {
               new TraceTargetPickerDialog(shell, models, dev.targets, widgets);
           if (dialog.open() == Window.OK) {
             TraceTargets.Node node = dialog.getSelected();
-            Service.TraceTargetTreeNode data = (node == null) ? null : node.getData();
-            if (data != null) {
-              return new TraceTarget(data.getUri(), data.getFriendlyApplication());
-            }
+            return (node == null) ? null : node.getTraceTarget();
           }
         }
         return null;
@@ -644,16 +642,6 @@ public class TracerDialog {
         }
         String dir = directory.getText();
         return dir.isEmpty() ? new File(name) : new File(dir, name);
-      }
-    }
-
-    private static class TraceTarget {
-      public final String uri;
-      public final String friendlyName;
-
-      public TraceTarget(String uri, String friendlyName) {
-        this.uri = uri;
-        this.friendlyName = friendlyName;
       }
     }
   }

--- a/gapis/trace/android/trace.go
+++ b/gapis/trace/android/trace.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strings"
 	"time"
 
@@ -150,6 +151,7 @@ func (t *androidTracer) GetTraceTargetNode(ctx context.Context, uri string, icon
 		for _, x := range packages.Packages {
 			r.Children = append(r.Children, x.Name)
 		}
+		sort.Strings(r.Children)
 		return r, nil
 	}
 
@@ -212,6 +214,7 @@ func (t *androidTracer) GetTraceTargetNode(ctx context.Context, uri string, icon
 			pkgName,
 			"",
 		}
+		sort.Sort(actions(activity.Actions))
 		for _, a := range activity.Actions {
 			r.Children = append(r.Children, fmt.Sprintf("%s:%s/%s", a.Name, pkgName, activityName))
 		}
@@ -234,6 +237,7 @@ func (t *androidTracer) GetTraceTargetNode(ctx context.Context, uri string, icon
 
 	var firstActivity *pkginfo.Activity
 	var defaultAction string
+	sort.Sort(activities(pkg.Activities))
 	for _, activity := range pkg.Activities {
 		if len(activity.Actions) > 0 {
 			r.Children = append(r.Children, fmt.Sprintf("%s/%s", pkgName, activity.Name))
@@ -254,6 +258,18 @@ func (t *androidTracer) GetTraceTargetNode(ctx context.Context, uri string, icon
 	r.TraceURI = defaultAction
 	return r, nil
 }
+
+type activities []*pkginfo.Activity
+
+func (a activities) Len() int           { return len(a) }
+func (a activities) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+func (a activities) Less(i, j int) bool { return a[i].Name < a[j].Name }
+
+type actions []*pkginfo.Action
+
+func (a actions) Len() int           { return len(a) }
+func (a actions) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+func (a actions) Less(i, j int) bool { return a[i].Name < a[j].Name }
 
 // findBestAction returns the best action candidate for tracing from the given
 // list. It is either the launch action, the "main" action if no launch action


### PR DESCRIPTION
- Disable the button if the selected node is not traceable.
- Use the correct URI for tracing.
- Android: Prefer main actions if there are multiple actions, none marked as the launch action
- Android: Consider the filtering of activities without actions, when choosing the default activity for an app.
- Android: Sort trace targets.
- Add the filtering back in the UI