### PR TITLE
Fix the client to work if compiled with JDK 9.

### DIFF
--- a/gapic/src/main/com/google/gapid/image/ArrayImage.java
+++ b/gapic/src/main/com/google/gapid/image/ArrayImage.java
@@ -15,6 +15,7 @@
  */
 package com.google.gapid.image;
 
+import static com.google.gapid.util.Buffers.nativeBuffer;
 import static com.google.gapid.util.Caches.getUnchecked;
 import static com.google.gapid.util.Caches.softCache;
 import static com.google.gapid.util.Colors.DARK_LUMINANCE8_THRESHOLD;
@@ -29,7 +30,6 @@ import com.google.gapid.proto.stream.Stream;
 import com.google.gapid.util.Colors;
 
 import org.eclipse.swt.graphics.ImageData;
-import org.lwjgl.BufferUtils;
 import org.lwjgl.opengl.GL11;
 import org.lwjgl.opengl.GL30;
 
@@ -91,10 +91,7 @@ public abstract class ArrayImage implements com.google.gapid.image.Image {
 
   @Override
   public void uploadToTexture(Texture texture) {
-    ByteBuffer buffer = (ByteBuffer)BufferUtils.createByteBuffer(data.length)
-        .put(data)
-        .flip();
-    texture.loadData(width, height, internalFormat, format, type, buffer);
+    texture.loadData(width, height, internalFormat, format, type, nativeBuffer(data));
   }
 
   @Override

--- a/gapic/src/main/com/google/gapid/util/Buffers.java
+++ b/gapic/src/main/com/google/gapid/util/Buffers.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2018 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.gapid.util;
+
+import org.lwjgl.BufferUtils;
+
+import java.nio.Buffer;
+import java.nio.ByteBuffer;
+
+/**
+ * Utilities to deal with {@link Buffer Buffers}.
+ */
+public class Buffers {
+  private Buffers() {
+  }
+
+  // To work around JDK 9.
+  public static <T extends Buffer> T flip(T buffer) {
+    buffer.flip();
+    return buffer;
+  }
+
+  public static ByteBuffer nativeBuffer(byte[] data) {
+    return flip(BufferUtils.createByteBuffer(data.length).put(data));
+  }
+}

--- a/gapic/src/platform/linux/com/google/gapid/glcanvas/GlCanvas.java
+++ b/gapic/src/platform/linux/com/google/gapid/glcanvas/GlCanvas.java
@@ -35,6 +35,7 @@ import org.lwjgl.system.MemoryStack;
 import org.lwjgl.system.linux.X11;
 import org.lwjgl.system.linux.XVisualInfo;
 
+import java.nio.Buffer;
 import java.nio.IntBuffer;
 import java.util.logging.Logger;
 
@@ -131,7 +132,7 @@ public abstract class GlCanvas extends Canvas {
       }
       set(attr, X11.None, X11.None);
 
-      attr.flip();
+      ((Buffer)attr).flip(); // cast is there to work with JDK9.
       PointerBuffer configs = GLX13.glXChooseFBConfig(display, X11.XDefaultScreen(display), attr);
       if (configs == null || configs.capacity() < 1) {
         LOG.log(SEVERE, "glXChooseFBConfig returned no matching configs");


### PR DESCRIPTION
There are some API backward incompatibles if building with JDK 9, but running on JDK 1.8. This change works around the incompatibility, where subclasses of `java.nio.Buffer` (e.g. `IntBuffer`) now override the `.flip()` method to return the subclass. E.g. `IntBuffer.flip()` in JDK 9 returns `IntBuffer`, whereas in JDK 1.8, it did not override `Buffer.flip()`, which returns `Buffer`.

Note, bazel 0.16 now uses JDK 9 by default to build.

Fixes #2145