### PR TITLE
Fix gapit trace error when multiple targets match

### DIFF
--- a/cmd/gapit/packages.go
+++ b/cmd/gapit/packages.go
@@ -96,7 +96,7 @@ func (verb *packagesVerb) traversePackageTree(
 		return task.StopReason(ctx)
 	}
 
-	node, err := c.TraceTargetTreeNode(ctx, &service.TraceTargetTreeRequest{
+	node, err := c.TraceTargetTreeNode(ctx, &service.TraceTargetTreeNodeRequest{
 		Device:  d,
 		Uri:     uri,
 		Density: float32(verb.IconDensity),

--- a/gapic/src/main/com/google/gapid/server/Client.java
+++ b/gapic/src/main/com/google/gapid/server/Client.java
@@ -242,7 +242,7 @@ public class Client {
     return call(() -> String.format(
         "RPC->traceTargetTreeNode(%s, %s, %g)", shortDebugString(device), uri, density),
         stack -> Futures.transformAsync(
-            client.getTraceTargetTreeNode(Service.TraceTargetTreeRequest.newBuilder()
+            client.getTraceTargetTreeNode(Service.TraceTargetTreeNodeRequest.newBuilder()
                 .setDevice(device)
                 .setUri(uri)
                 .setDensity(density)

--- a/gapic/src/main/com/google/gapid/server/GapidClient.java
+++ b/gapic/src/main/com/google/gapid/server/GapidClient.java
@@ -61,8 +61,8 @@ public interface GapidClient {
       Service.EnableAnalyticsRequest request);
   public ListenableFuture<Service.ClientEventResponse> postClientEvent(
       Service.ClientEventRequest request);
-  public ListenableFuture<Service.TraceTargetTreeResponse> getTraceTargetTreeNode(
-      Service.TraceTargetTreeRequest request);
+  public ListenableFuture<Service.TraceTargetTreeNodeResponse> getTraceTargetTreeNode(
+      Service.TraceTargetTreeNodeRequest request);
   public ListenableFuture<Void> streamLog(Consumer<Log.Message> onLogMessage);
   public ListenableFuture<Void> streamSearch(
       Service.FindRequest request, Consumer<Service.FindResponse> onResult);

--- a/gapic/src/main/com/google/gapid/server/GapidClientGrpc.java
+++ b/gapic/src/main/com/google/gapid/server/GapidClientGrpc.java
@@ -30,8 +30,8 @@ import com.google.gapid.proto.service.Service.EnableAnalyticsResponse;
 import com.google.gapid.proto.service.Service.EnableCrashReportingRequest;
 import com.google.gapid.proto.service.Service.EnableCrashReportingResponse;
 import com.google.gapid.proto.service.Service.PingRequest;
-import com.google.gapid.proto.service.Service.TraceTargetTreeRequest;
-import com.google.gapid.proto.service.Service.TraceTargetTreeResponse;
+import com.google.gapid.proto.service.Service.TraceTargetTreeNodeRequest;
+import com.google.gapid.proto.service.Service.TraceTargetTreeNodeResponse;
 
 import java.util.function.Consumer;
 
@@ -170,8 +170,8 @@ public class GapidClientGrpc implements GapidClient {
   }
 
   @Override
-  public ListenableFuture<TraceTargetTreeResponse> getTraceTargetTreeNode(
-      TraceTargetTreeRequest request) {
+  public ListenableFuture<TraceTargetTreeNodeResponse> getTraceTargetTreeNode(
+      TraceTargetTreeNodeRequest request) {
     return client.traceTargetTreeNode(request);
   }
 

--- a/gapis/client/client.go
+++ b/gapis/client/client.go
@@ -338,7 +338,7 @@ func (c *client) ClientEvent(ctx context.Context, req *service.ClientEventReques
 }
 
 // TraceTargetTreeNode returns a node in the trace target tree for the given device
-func (c *client) TraceTargetTreeNode(ctx context.Context, req *service.TraceTargetTreeRequest) (*service.TraceTargetTreeNode, error) {
+func (c *client) TraceTargetTreeNode(ctx context.Context, req *service.TraceTargetTreeNodeRequest) (*service.TraceTargetTreeNode, error) {
 	res, err := c.client.TraceTargetTreeNode(ctx, req)
 	if err != nil {
 		return nil, err
@@ -349,9 +349,9 @@ func (c *client) TraceTargetTreeNode(ctx context.Context, req *service.TraceTarg
 	return res.GetNode(), nil
 }
 
-// FindTraceTarget returns a node in the trace target tree for the given device
-func (c *client) FindTraceTarget(ctx context.Context, req *service.FindTraceTargetRequest) (*service.TraceTargetTreeNode, error) {
-	res, err := c.client.FindTraceTarget(ctx, req)
+// FindTraceTargets returns trace targets matching the given search parameters.
+func (c *client) FindTraceTargets(ctx context.Context, req *service.FindTraceTargetsRequest) ([]*service.TraceTargetTreeNode, error) {
+	res, err := c.client.FindTraceTargets(ctx, req)
 
 	if err != nil {
 		return nil, err
@@ -359,7 +359,7 @@ func (c *client) FindTraceTarget(ctx context.Context, req *service.FindTraceTarg
 	if err := res.GetError(); err != nil {
 		return nil, err.Get()
 	}
-	return res.GetNode(), nil
+	return res.GetNodes().GetNodes(), nil
 }
 
 type traceHandler struct {

--- a/gapis/server/grpc.go
+++ b/gapis/server/grpc.go
@@ -367,22 +367,28 @@ func (s *grpcServer) ClientEvent(ctx xctx.Context, req *service.ClientEventReque
 	return &service.ClientEventResponse{}, nil
 }
 
-func (s *grpcServer) TraceTargetTreeNode(ctx xctx.Context, req *service.TraceTargetTreeRequest) (*service.TraceTargetTreeResponse, error) {
+func (s *grpcServer) TraceTargetTreeNode(ctx xctx.Context, req *service.TraceTargetTreeNodeRequest) (*service.TraceTargetTreeNodeResponse, error) {
 	defer s.inRPC()()
 	res, err := s.handler.TraceTargetTreeNode(s.bindCtx(ctx), req)
 	if err := service.NewError(err); err != nil {
-		return &service.TraceTargetTreeResponse{Val: &service.TraceTargetTreeResponse_Error{Error: err}}, nil
+		return &service.TraceTargetTreeNodeResponse{Val: &service.TraceTargetTreeNodeResponse_Error{Error: err}}, nil
 	}
-	return &service.TraceTargetTreeResponse{Val: &service.TraceTargetTreeResponse_Node{Node: res}}, nil
+	return &service.TraceTargetTreeNodeResponse{Val: &service.TraceTargetTreeNodeResponse_Node{Node: res}}, nil
 }
 
-func (s *grpcServer) FindTraceTarget(ctx xctx.Context, req *service.FindTraceTargetRequest) (*service.TraceTargetTreeResponse, error) {
+func (s *grpcServer) FindTraceTargets(ctx xctx.Context, req *service.FindTraceTargetsRequest) (*service.FindTraceTargetsResponse, error) {
 	defer s.inRPC()()
-	res, err := s.handler.FindTraceTarget(s.bindCtx(ctx), req)
+	res, err := s.handler.FindTraceTargets(s.bindCtx(ctx), req)
 	if err := service.NewError(err); err != nil {
-		return &service.TraceTargetTreeResponse{Val: &service.TraceTargetTreeResponse_Error{Error: err}}, nil
+		return &service.FindTraceTargetsResponse{Val: &service.FindTraceTargetsResponse_Error{Error: err}}, nil
 	}
-	return &service.TraceTargetTreeResponse{Val: &service.TraceTargetTreeResponse_Node{Node: res}}, nil
+	return &service.FindTraceTargetsResponse{
+		Val: &service.FindTraceTargetsResponse_Nodes{
+			Nodes: &service.TraceTargetTreeNodes{
+				Nodes: res,
+			},
+		},
+	}, nil
 }
 
 func (s *grpcServer) Trace(conn service.Gapid_TraceServer) error {

--- a/gapis/server/server.go
+++ b/gapis/server/server.go
@@ -445,7 +445,7 @@ func (s *server) ClientEvent(ctx context.Context, req *service.ClientEventReques
 	return nil
 }
 
-func (s *server) TraceTargetTreeNode(ctx context.Context, req *service.TraceTargetTreeRequest) (*service.TraceTargetTreeNode, error) {
+func (s *server) TraceTargetTreeNode(ctx context.Context, req *service.TraceTargetTreeNodeRequest) (*service.TraceTargetTreeNode, error) {
 	tttn, err := trace.TraceTargetTreeNode(ctx, *req.Device, req.Uri, req.Density)
 	if err != nil {
 		return nil, err
@@ -463,22 +463,25 @@ func (s *server) TraceTargetTreeNode(ctx context.Context, req *service.TraceTarg
 	}, nil
 }
 
-func (s *server) FindTraceTarget(ctx context.Context, req *service.FindTraceTargetRequest) (*service.TraceTargetTreeNode, error) {
-	tttn, err := trace.FindTraceTarget(ctx, *req.Device, req.Uri)
+func (s *server) FindTraceTargets(ctx context.Context, req *service.FindTraceTargetsRequest) ([]*service.TraceTargetTreeNode, error) {
+	nodes, err := trace.FindTraceTargets(ctx, *req.Device, req.Uri)
 	if err != nil {
 		return nil, err
 	}
-
-	return &service.TraceTargetTreeNode{
-		Name:                tttn.Name,
-		Icon:                tttn.Icon,
-		Uri:                 tttn.URI,
-		ParentUri:           tttn.Parent,
-		ChildrenUris:        tttn.Children,
-		TraceUri:            tttn.TraceURI,
-		FriendlyApplication: tttn.ApplicationName,
-		FriendlyExecutable:  tttn.ExecutableName,
-	}, nil
+	out := make([]*service.TraceTargetTreeNode, len(nodes))
+	for i, n := range nodes {
+		out[i] = &service.TraceTargetTreeNode{
+			Name:                n.Name,
+			Icon:                n.Icon,
+			Uri:                 n.URI,
+			ParentUri:           n.Parent,
+			ChildrenUris:        n.Children,
+			TraceUri:            n.TraceURI,
+			FriendlyApplication: n.ApplicationName,
+			FriendlyExecutable:  n.ExecutableName,
+		}
+	}
+	return out, nil
 }
 
 func optionsToTraceOptions(opts *service.TraceOptions) tracer.TraceOptions {

--- a/gapis/service/service.go
+++ b/gapis/service/service.go
@@ -151,11 +151,11 @@ type Service interface {
 	// If the user has not opted-in for analytics then this call does nothing.
 	ClientEvent(ctx context.Context, req *ClientEventRequest) error
 
-	// FindTraceTarget returns a node that can be used by searching the given string
-	FindTraceTarget(ctx context.Context, req *FindTraceTargetRequest) (*TraceTargetTreeNode, error)
+	// FindTraceTargets returns trace targets matching the given search parameters.
+	FindTraceTargets(ctx context.Context, req *FindTraceTargetsRequest) ([]*TraceTargetTreeNode, error)
 
 	// TraceTargetTreeNode returns a node in the trace target tree for the given device
-	TraceTargetTreeNode(ctx context.Context, req *TraceTargetTreeRequest) (*TraceTargetTreeNode, error)
+	TraceTargetTreeNode(ctx context.Context, req *TraceTargetTreeNodeRequest) (*TraceTargetTreeNode, error)
 
 	// Trace controls setting up, starting and ending a trace
 	Trace(ctx context.Context) (TraceHandler, error)

--- a/gapis/service/service.proto
+++ b/gapis/service/service.proto
@@ -554,15 +554,15 @@ service Gapid {
   rpc ClientEvent(ClientEventRequest) returns (ClientEventResponse) {
   }
 
-  // FindTraceTarget returns a trace target node if there is a single
-  // unique option.
-  rpc FindTraceTarget(FindTraceTargetRequest)
-      returns (TraceTargetTreeResponse) {
+  // FindTraceTargets returns trace targets matching the given search
+  // parameters.
+  rpc FindTraceTargets(FindTraceTargetsRequest)
+      returns (FindTraceTargetsResponse) {
   }
 
   // TraceTargetTreeNode returns information about the trace target
-  rpc TraceTargetTreeNode(TraceTargetTreeRequest)
-      returns (TraceTargetTreeResponse) {
+  rpc TraceTargetTreeNode(TraceTargetTreeNodeRequest)
+      returns (TraceTargetTreeNodeResponse) {
   }
 
   // Trace returns a steam that can be used to start and stop
@@ -929,20 +929,31 @@ message TraceTargetTreeNode {
   string friendly_executable = 8;
 }
 
-message TraceTargetTreeRequest {
+message TraceTargetTreeNodes {
+  repeated TraceTargetTreeNode nodes = 1;
+}
+
+message TraceTargetTreeNodeRequest {
   path.Device device = 1;
   string uri = 2;
   float density = 3;
 }
 
-message FindTraceTargetRequest {
+message TraceTargetTreeNodeResponse {
+  oneof val {
+    TraceTargetTreeNode node = 1;
+    Error error = 2;
+  }
+}
+
+message FindTraceTargetsRequest {
   path.Device device = 1;
   string uri = 2;
 }
 
-message TraceTargetTreeResponse {
+message FindTraceTargetsResponse {
   oneof val {
-    TraceTargetTreeNode node = 1;
+    TraceTargetTreeNodes nodes = 1;
     Error error = 2;
   }
 }

--- a/gapis/trace/desktop/trace.go
+++ b/gapis/trace/desktop/trace.go
@@ -109,7 +109,7 @@ func (t *DesktopTracer) APITraceOptions(ctx context.Context) []tracer.APITraceOp
 	return options
 }
 
-func (t *DesktopTracer) FindTraceTarget(ctx context.Context, str string) (*tracer.TraceTargetTreeNode, error) {
+func (t *DesktopTracer) FindTraceTargets(ctx context.Context, str string) ([]*tracer.TraceTargetTreeNode, error) {
 	isFile, err := t.b.IsFile(ctx, str)
 	if err != nil {
 		return nil, err
@@ -128,7 +128,7 @@ func (t *DesktopTracer) FindTraceTarget(ctx context.Context, str string) (*trace
 		}
 	}
 
-	tttn := &tracer.TraceTargetTreeNode{
+	node := &tracer.TraceTargetTreeNode{
 		Name:            file,
 		Icon:            nil,
 		URI:             str,
@@ -139,7 +139,7 @@ func (t *DesktopTracer) FindTraceTarget(ctx context.Context, str string) (*trace
 		ExecutableName:  file,
 	}
 
-	return tttn, nil
+	return []*tracer.TraceTargetTreeNode{node}, nil
 }
 
 func (t *DesktopTracer) GetTraceTargetNode(ctx context.Context, uri string, iconDensity float32) (*tracer.TraceTargetTreeNode, error) {

--- a/gapis/trace/trace_tree.go
+++ b/gapis/trace/trace_tree.go
@@ -32,12 +32,12 @@ func TraceTargetTreeNode(ctx context.Context, device path.Device, uri string, de
 	return tracer.GetTraceTargetNode(ctx, uri, density)
 }
 
-// FindTraceTarget finds returns a unique trace target tree node if it exists
-func FindTraceTarget(ctx context.Context, device path.Device, uri string) (*tracer.TraceTargetTreeNode, error) {
+// FindTraceTargets returns trace targets matching the given search parameters.
+func FindTraceTargets(ctx context.Context, device path.Device, uri string) ([]*tracer.TraceTargetTreeNode, error) {
 	mgr := GetManager(ctx)
 	tracer, ok := mgr.tracers[device.ID.ID()]
 	if !ok {
 		return nil, log.Errf(ctx, nil, "Could not find tracer for device %d", device.ID.ID())
 	}
-	return tracer.FindTraceTarget(ctx, uri)
+	return tracer.FindTraceTargets(ctx, uri)
 }

--- a/gapis/trace/tracer/tracer.go
+++ b/gapis/trace/tracer/tracer.go
@@ -91,9 +91,9 @@ type Tracer interface {
 	// GetTraceTargetNode returns a TraceTargetTreeNode for the given URI
 	// on the device
 	GetTraceTargetNode(ctx context.Context, uri string, iconDensity float32) (*TraceTargetTreeNode, error)
-	// FindTraceTarget finds and returns a unique TraceTargetTreenode for a given
-	// search string on the device
-	FindTraceTarget(ctx context.Context, uri string) (*TraceTargetTreeNode, error)
+	// FindTraceTargets finds TraceTargetTreeNodes for a given search string on
+	// the device
+	FindTraceTargets(ctx context.Context, uri string) ([]*TraceTargetTreeNode, error)
 
 	// SetupTrace starts the application on the device, and causes it to wait
 	// for the trace to be started. It returns the process that was created, as


### PR DESCRIPTION
Return the full list of candidates from `FindTraceTargets` so the client can display the ambigious match.

Also renamed the Request and Response structures of `TraceTargetTreeNode`, as these were inconsistent.