### PR TITLE
MEC: Fix internal format when re-creating textures.

### DIFF
--- a/gapic/src/main/com/google/gapid/views/ReportView.java
+++ b/gapic/src/main/com/google/gapid/views/ReportView.java
@@ -159,10 +159,11 @@ public class ReportView extends Composite implements Tab, Capture.Listener, Repo
 
   private void updateReport() {
     loading.stopLoading();
-    if (models.reports.getData().report.getGroupsCount() == 0) {
+    Service.Report report = models.reports.getData().report;
+    if (report.getGroupsCount() == 0) {
       loading.showMessage(smile("Rock on! No issues found in this trace."));
     } else {
-      viewer.setInput(models.reports.getData());
+      viewer.setInput(report);
       viewer.setSelection(
           new TreeSelection(new TreePath(new Object[] { viewer.getInput() })), true);
     }


### PR DESCRIPTION
We, internally, represent some of the GLES 2.0 texture internal formats with constants that are not actually part of GLES (specifically the sized `LUMINANCE_ALPHA`, `LUMINANCE`, and `ALPHA` formats). Thus, when recreating these textures, this mapping needs to be undone.

Fixes #2147