### PR TITLE
Fix SPIRV-Reflect build file missing header

### DIFF
--- a/tools/build/third_party/spirv-reflect.BUILD
+++ b/tools/build/third_party/spirv-reflect.BUILD
@@ -21,6 +21,7 @@ cc_library(
     ],
     hdrs = [
         "spirv_reflect.h",
+        "include/spirv/unified1/spirv.h",
     ],
     copts = ["-std=c99"],
     include_prefix = "third_party/SPIRV-Reflect/",


### PR DESCRIPTION
Since `spirv_reflect.h` includes `spirv.h`, it has to be in `hdrs`.  This was causing build failures on Windows with Bazel 0.14.1