### PR TITLE
Adds a presubmit check that veriefies the //:tests target.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -103,6 +103,7 @@ test_suite(
     name = "tests",
     # bazel query --output label 'kind(".*_test rule", //...)'
     tests = [
+        # __BEGIN_TESTS
         "//core/app/analytics:go_default_test",
         "//core/app/auth:go_default_test",
         "//core/app/benchmark:go_default_test",
@@ -195,5 +196,6 @@ test_suite(
         "//test/integration/replay:go_default_test",
         "//test/integration/service:go_default_test",
         "//test/robot/stash/grpc:go_default_test",
+        # __END_TESTS
     ],
 )


### PR DESCRIPTION
Makes sure that all tests in the project are referenced by that target.