### PR TITLE
Do not cache the instruction builder for replay execution

### DIFF
--- a/gapis/api/vulkan/find_issues.go
+++ b/gapis/api/vulkan/find_issues.go
@@ -89,7 +89,6 @@ func (t *findIssues) reportTo(r replay.Result) { t.res = append(t.res, r) }
 
 func (t *findIssues) Transform(ctx context.Context, id api.CmdID, cmd api.Cmd, out transform.Writer) {
 	ctx = log.Enter(ctx, "findIssues")
-	cb := CommandBuilder{Thread: cmd.Thread(), Arena: t.state.Arena}
 
 	mutateErr := cmd.Mutate(ctx, id, t.state, nil /* no builder */)
 	if mutateErr != nil {
@@ -98,6 +97,7 @@ func (t *findIssues) Transform(ctx context.Context, id api.CmdID, cmd api.Cmd, o
 	}
 
 	s := out.State()
+	cb := CommandBuilder{Thread: cmd.Thread(), Arena: out.State().Arena}
 	l := s.MemoryLayout
 	allocated := []api.AllocResult{}
 	defer func() {
@@ -269,7 +269,7 @@ func (t *findIssues) Transform(ctx context.Context, id api.CmdID, cmd api.Cmd, o
 }
 
 func (t *findIssues) Flush(ctx context.Context, out transform.Writer) {
-	cb := CommandBuilder{Thread: 0, Arena: t.state.Arena}
+	cb := CommandBuilder{Thread: 0, Arena: out.State().Arena}
 	for inst, ch := range t.reportCallbacks {
 		out.MutateAndWrite(ctx, api.CmdNoID, cb.ReplayDestroyVkDebugReportCallback(inst, ch))
 		// It is safe to delete keys in loop in Go

--- a/gapis/api/vulkan/replay.go
+++ b/gapis/api/vulkan/replay.go
@@ -690,8 +690,11 @@ func (a API) Replay(
 		transforms.Add(overdraw)
 	}
 
+	if issues == nil {
+		transforms.Add(readFramebuffer, injector)
+	}
+
 	// Cleanup
-	transforms.Add(readFramebuffer, injector)
 	transforms.Add(&destroyResourcesAtEOS{})
 
 	if config.DebugReplay {

--- a/gapis/replay/builder/builder.go
+++ b/gapis/replay/builder/builder.go
@@ -627,8 +627,7 @@ func (b *Builder) Build(ctx context.Context) (gapir.Payload, PostDataHandler, No
 		log.I(ctx, "Resource count:         %d", len(payload.Resources))
 	}
 
-	decoders := make([]postBackDecoder, len(b.decoders))
-	copy(decoders, b.decoders)
+	decoders := b.decoders
 	handlePost := func(pd *gapir.PostData) {
 		// TODO: should we skip it instead of return error?
 		ctx = log.Enter(ctx, "PostDataHandler")
@@ -653,8 +652,7 @@ func (b *Builder) Build(ctx context.Context) (gapir.Payload, PostDataHandler, No
 		})
 	}
 
-	readers := make([]NotificationReader, len(b.notificationReaders))
-	copy(readers, b.notificationReaders)
+	readers := b.notificationReaders
 	handleNotification := func(n *gapir.Notification) {
 		ctx = log.Enter(ctx, "NotificationHandler")
 		if n == nil {

--- a/gapis/replay/builder/builder.go
+++ b/gapis/replay/builder/builder.go
@@ -664,6 +664,19 @@ func (b *Builder) Build(ctx context.Context) (gapir.Payload, PostDataHandler, No
 		})
 	}
 
+	// Clear the builder.
+	defer func() {
+		b.resourceIDToIdx = nil
+		b.threadIDToIdx = nil
+		b.resources = nil
+		b.reservedMemory = memory.RangeList{}
+		b.pointerMemory = memory.RangeList{}
+		b.mappedMemory = mappedMemoryRangeList{}
+		b.instructions = nil
+		b.stack = nil
+		b.Remappings = nil
+	}()
+
 	return payload, handlePost, handleNotification, nil
 }
 


### PR DESCRIPTION
Without this CL, a builder is kept as the closures for postback decoders and notification readers capture the builder, so the instructions and other intermediate stuffs will be kept alive to the end of the  replay execution. This CL fixes this issue.