### PR TITLE
Drop the raw bytes of loaded captures

### DIFF
--- a/gapis/capture/capture.go
+++ b/gapis/capture/capture.go
@@ -236,6 +236,15 @@ func Import(ctx context.Context, name string, data []byte) (*path.Capture, error
 	captures = append(captures, id)
 	capturesLock.Unlock()
 
+	p := &path.Capture{ID: path.NewID(id)}
+
+	// Ensure the capture can be read by resolving it now, and drop the raw
+	// data to save memory.
+	if _, err = ResolveFromPath(ctx, p); err != nil {
+		return nil, err
+	}
+	database.Delete(ctx, dataID)
+
 	return &path.Capture{ID: path.NewID(id)}, nil
 }
 

--- a/gapis/database/database.go
+++ b/gapis/database/database.go
@@ -32,6 +32,9 @@ type Database interface {
 	Resolve(context.Context, id.ID) (interface{}, error)
 	// Contains returns true if the database has an entry for the specified id.
 	Contains(context.Context, id.ID) bool
+	// Deletes returns true if the database has an entry for the specified id
+	// and the entry is deleted successfully.
+	Deletes(context.Context, id.ID) bool
 }
 
 // Store stores v to the database held by the context.
@@ -42,6 +45,12 @@ func Store(ctx context.Context, v interface{}) (id.ID, error) {
 // Resolve resolves id with the database held by the context.
 func Resolve(ctx context.Context, id id.ID) (interface{}, error) {
 	return Get(ctx).Resolve(ctx, id)
+}
+
+// Delete deletes the record of the given id and returns true if the record
+// exists. Otherwise returns false.
+func Delete(ctx context.Context, id id.ID) bool {
+	return Get(ctx).Deletes(ctx, id)
 }
 
 // Build stores resolvable into d, and then resolves and returns the resolved

--- a/gapis/database/memory.go
+++ b/gapis/database/memory.go
@@ -275,3 +275,14 @@ func (d *memory) Contains(ctx context.Context, id id.ID) (res bool) {
 	_, got := d.records[id]
 	return got
 }
+
+// Implements Database
+func (d *memory) Deletes(ctx context.Context, id id.ID) bool {
+	d.mutex.Lock()
+	defer d.mutex.Unlock()
+	if _, got := d.records[id]; got {
+		delete(d.records, id)
+		return true
+	}
+	return false
+}


### PR DESCRIPTION
Once a capture is loaded, delete its raw bytes data from database. This
can save memory.