### PR TITLE
Switched the map iteration template to refs instead of copies.

### DIFF
--- a/gapis/api/templates/cpp_common.tmpl
+++ b/gapis/api/templates/cpp_common.tmpl
@@ -589,8 +589,8 @@
   {
     {{Template "C++.Type" $.IndexIterator}} {{$i}} = 0;
     for ({{Template "C++.Type" $.Map}}::iterator it = {{Template "C++.Read" $.Map}}.begin(); it != {{Template "C++.Read" $.Map}}.end(); ++it, ++{{$i}}) {
-      {{Template "C++.Type" $.KeyIterator}} {{$k}} = it->first;
-      {{Template "C++.Type" $.ValueIterator}} {{$v}} = it->second;
+      {{Template "C++.Type" $.KeyIterator}}& {{$k}} = it->first;
+      {{Template "C++.Type" $.ValueIterator}}& {{$v}} = it->second;
       {{Template "C++.Block" $.Block}}
     }
   }


### PR DESCRIPTION
This saves an increment/decrement when we have gapil::Ref<>.
Since the api langauge does not allow assignment to
variables, there is no way to modify these anyway.