### PR TITLE
Vulkan: Still read memory when descriptor sets are bound

### DIFF
--- a/gapis/api/vulkan/api/descriptor.api
+++ b/gapis/api/vulkan/api/descriptor.api
@@ -719,6 +719,29 @@ sub void dovkCmdBindDescriptorSets(ref!vkCmdBindDescriptorSetsArgs args) {
                 dynamic_offset_index.Val
             }
             bufferBindingOffsets[as!u32(i)][as!u32(j)][as!u32(k)] = binding_offset
+            if (bufferBinding.Buffer in Buffers) {
+              bufferObject := Buffers[bufferBinding.Buffer]
+              readMemoryInBuffer(bufferObject, binding_offset, bufferBinding.Range)
+            }
+          }
+          for k in (0 .. len(binding.BufferViewBindings)) {
+            buffer_view := binding.BufferViewBindings[as!u32(k)]
+            if (buffer_view != as!VkBufferView(0)) {
+              buffer_view_object := BufferViews[buffer_view]
+              readMemoryInBuffer(buffer_view_object.Buffer, buffer_view_object.Offset, buffer_view_object.Range)
+            }
+          }
+          for k in (0 .. len(binding.ImageBinding)) {
+            imageBinding := binding.ImageBinding[as!u32(k)]
+            _ = Samplers[imageBinding.Sampler]
+            if (imageBinding.ImageView != as!VkImageView(0)) {
+              if imageBinding.ImageView in ImageViews {
+                imageViewObj := ImageViews[imageBinding.ImageView]
+                imageObj := imageViewObj.Image
+                rng := imageViewObj.SubresourceRange
+                readImageSubresource(imageObj, rng)
+              }
+            }
           }
         }
       }


### PR DESCRIPTION
This fixes the problem introduced in #2175