### PR TITLE
Do not cache the capture data in database if the capture is from a file

### DIFF
--- a/gapis/capture/capture.proto
+++ b/gapis/capture/capture.proto
@@ -20,6 +20,15 @@ option go_package = "github.com/google/gapid/gapis/capture";
 
 import "core/os/device/device.proto";
 
+message Source {
+  oneof src {
+    // Path of the capture file.
+    string file_path = 1;
+    // The capture data in blob data form.
+    bytes raw_bytes = 2;
+  }
+}
+
 // Record holds all the data for an entire capture.
 message Record {
   // Name of the capture.

--- a/gapis/replay/builder/builder.go
+++ b/gapis/replay/builder/builder.go
@@ -627,6 +627,9 @@ func (b *Builder) Build(ctx context.Context) (gapir.Payload, PostDataHandler, No
 		log.I(ctx, "Resource count:         %d", len(payload.Resources))
 	}
 
+	// Make a copy of the reference of the finished decoder list to cut off the
+	// connection between the builder and furture uses of the decoders so that
+	// the builder do not need to be kept alive when using these decoders.
 	decoders := b.decoders
 	handlePost := func(pd *gapir.PostData) {
 		// TODO: should we skip it instead of return error?
@@ -652,6 +655,9 @@ func (b *Builder) Build(ctx context.Context) (gapir.Payload, PostDataHandler, No
 		})
 	}
 
+	// Make a copy of the reference of the finished notification reader list to
+	// cut off the connection between the builder and future uses of the readers
+	// so that the builder do not need to be kept alive when using these readers.
 	readers := b.notificationReaders
 	handleNotification := func(n *gapir.Notification) {
 		ctx = log.Enter(ctx, "NotificationHandler")

--- a/gapis/server/server.go
+++ b/gapis/server/server.go
@@ -171,7 +171,8 @@ func (s *server) ImportCapture(ctx context.Context, name string, data []uint8) (
 	ctx = status.Start(ctx, "RPC ImportCapture")
 	defer status.Finish(ctx)
 	ctx = log.Enter(ctx, "ImportCapture")
-	p, err := capture.Import(ctx, name, data)
+	src := &capture.Source{Src: &capture.Source_RawBytes{RawBytes: data}}
+	p, err := capture.Import(ctx, name, src)
 	if err != nil {
 		return nil, err
 	}
@@ -220,18 +221,8 @@ func (s *server) LoadCapture(ctx context.Context, path string) (*path.Capture, e
 	}
 	name := filepath.Base(path)
 
-	f, err := os.Open(path)
-	if err != nil {
-		return nil, err
-	}
-	defer f.Close()
-
-	in, err := ReadFile(f)
-	if err != nil {
-		return nil, err
-	}
-
-	p, err := capture.Import(ctx, name, in)
+	src := &capture.Source{Src: &capture.Source_FilePath{FilePath: path}}
+	p, err := capture.Import(ctx, name, src)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
If the capture data is stored in a trace file, do not cache the data in raw bytes again in the database.

This CL reduce memory usage, for a typical application, around 2-4GB.