### PR TITLE
Fix JRE packaging in the MacOS build.

### DIFF
--- a/kokoro/macos/copy_jre.sh
+++ b/kokoro/macos/copy_jre.sh
@@ -20,7 +20,7 @@ if [ $# -ne 1 ]; then
 	exit
 fi
 
-cp -r $(/usr/libexec/java_home)/jre/ $1/
+cp -r $(/usr/libexec/java_home -v 1.8)/jre/ $1/
 
 # Remove unnecessary files.
 # See http://www.oracle.com/technetwork/java/javase/jre-8-readme-2095710.html


### PR DESCRIPTION
Explicitely request the 1.8 JRE, as the default has changed a while ago to JDK 9 and then 10, which don't have a JRE folder.