### PR TITLE
 Pre-resolve dependency graph

### DIFF
--- a/gapis/api/vulkan/replay.go
+++ b/gapis/api/vulkan/replay.go
@@ -551,7 +551,7 @@ func (a API) Replay(
 		if opt {
 			// If we have not set up the dependency graph, do it now.
 			if dceInfo.ft == nil {
-				ft, err := dependencygraph.GetFootprint(ctx, intent.Device)
+				ft, err := dependencygraph.GetFootprint(ctx, intent.Capture)
 				if err != nil {
 					return 0, err
 				}

--- a/gapis/replay/builder/builder.go
+++ b/gapis/replay/builder/builder.go
@@ -627,6 +627,9 @@ func (b *Builder) Build(ctx context.Context) (gapir.Payload, PostDataHandler, No
 		log.I(ctx, "Resource count:         %d", len(payload.Resources))
 	}
 
+	// Make a copy of the reference of the finished decoder list to cut off the
+	// connection between the builder and furture uses of the decoders so that
+	// the builder do not need to be kept alive when using these decoders.
 	decoders := b.decoders
 	handlePost := func(pd *gapir.PostData) {
 		// TODO: should we skip it instead of return error?
@@ -652,6 +655,9 @@ func (b *Builder) Build(ctx context.Context) (gapir.Payload, PostDataHandler, No
 		})
 	}
 
+	// Make a copy of the reference of the finished notification reader list to
+	// cut off the connection between the builder and future uses of the readers
+	// so that the builder do not need to be kept alive when using these readers.
 	readers := b.notificationReaders
 	handleNotification := func(n *gapir.Notification) {
 		ctx = log.Enter(ctx, "NotificationHandler")

--- a/gapis/server/BUILD.bazel
+++ b/gapis/server/BUILD.bazel
@@ -43,6 +43,7 @@ go_library(
         "//gapis/replay:go_default_library",
         "//gapis/replay/devices:go_default_library",
         "//gapis/resolve:go_default_library",
+        "//gapis/resolve/dependencygraph:go_default_library",
         "//gapis/service:go_default_library",
         "//gapis/service/path:go_default_library",
         "//gapis/stringtable:go_default_library",


### PR DESCRIPTION
Resolve the dependency graph in parallel immediately once the capture
data is resolve. This speed up the GAPIS side a bit (~30 sec for a
typical Vulkan app, 1.8G trace file) for buliding the instructions to
get the framebuffer data from the replay device.

based on #2172 