### PR TITLE
Remove the link-time dependency on libXCB.

### DIFF
--- a/gapir/cc/BUILD.bazel
+++ b/gapir/cc/BUILD.bazel
@@ -87,7 +87,6 @@ cc_library(
     copts = cc_copts(),
     linkopts = select({
         "//tools/build:linux": [
-            "-lxcb",
         ],
         "//tools/build:darwin": [
             "-framework Cocoa",


### PR DESCRIPTION
We still require the headers, but not the library to be present.
This is useful if you want to run gapir on headless machines.