### PR TITLE
Fix test failures caused by dependency graph change and dense map

### DIFF
--- a/gapil/compiler/plugins/encoder/test/test.cpp
+++ b/gapil/compiler/plugins/encoder/test/test.cpp
@@ -43,20 +43,21 @@ T* create_ref(arena* arena, ref** p) {
 extern "C" {
 
 void create_map_u32(arena* arena, map** p) {
-  create_map<gapil::Map<uint32_t, uint32_t> >(arena, p);
+  create_map<gapil::Map<uint32_t, uint32_t, false> >(arena, p);
 }
 
 void insert_map_u32(map* m, uint32_t k, uint32_t v) {
-  auto& map = *reinterpret_cast<gapil::Map<uint32_t, uint32_t>*>(&m);
+  auto& map = *reinterpret_cast<gapil::Map<uint32_t, uint32_t, false>*>(&m);
   map[k] = v;
 }
 
 void create_map_string(arena* arena, map** p) {
-  create_map<gapil::Map<string_t, string_t> >(arena, p);
+  create_map<gapil::Map<string_t, string_t, false> >(arena, p);
 }
 
 void insert_map_string(map* m, const char* k, const char* v) {
-  auto& map = *reinterpret_cast<gapil::Map<gapil::String, gapil::String>*>(&m);
+  auto& map =
+      *reinterpret_cast<gapil::Map<gapil::String, gapil::String, false>*>(&m);
   map[gapil::String(map.arena(), k)] = gapil::String(map.arena(), v);
 }
 

--- a/gapil/runtime/cc/map_test.cpp
+++ b/gapil/runtime/cc/map_test.cpp
@@ -31,9 +31,9 @@ class MapTest : public ::testing::Test {
   core::Arena arena;
 };
 
-using MapTestTypes = ::testing::Types<gapil::Map<uint32_t, uint32_t>,
-                                      gapil::Map<uint16_t, uint32_t>,
-                                      gapil::Map<uint32_t, uint64_t>>;
+using MapTestTypes = ::testing::Types<gapil::Map<uint32_t, uint32_t, false>,
+                                      gapil::Map<uint16_t, uint32_t, false>,
+                                      gapil::Map<uint32_t, uint64_t, false>>;
 
 TYPED_TEST_CASE(MapTest, MapTestTypes);
 
@@ -150,7 +150,7 @@ class CppMapTest : public ::testing::Test {
 };
 
 TEST_F(CppMapTest, string_as_value) {
-  auto map = gapil::Map<uint32_t, gapil::String>(&arena);
+  auto map = gapil::Map<uint32_t, gapil::String, false>(&arena);
 
   EXPECT_EQ(0, map.count());
 
@@ -204,7 +204,7 @@ class non_movable_object {
 };
 
 TEST_F(CppMapTest, non_movable_object) {
-  auto map = gapil::Map<uint32_t, non_movable_object>(&arena);
+  auto map = gapil::Map<uint32_t, non_movable_object, false>(&arena);
 
   auto a = reinterpret_cast<arena_t*>(&arena);
 
@@ -259,7 +259,7 @@ class movable_object {
 };
 
 TEST_F(CppMapTest, movable_object) {
-  auto map = gapil::Map<uint32_t, movable_object>(&arena);
+  auto map = gapil::Map<uint32_t, movable_object, false>(&arena);
 
   auto a = reinterpret_cast<arena_t*>(&arena);
 

--- a/gapis/api/vulkan/footprint_builder_test.go
+++ b/gapis/api/vulkan/footprint_builder_test.go
@@ -33,8 +33,8 @@ func TestSubBinding(t *testing.T) {
 	ctx := log.Testing(t)
 	resSize := uint64(2048)
 	memOffset := uint64(1024)
-	span := memorySpan{
-		span:   interval.U64Span{Start: memOffset, End: memOffset + resSize},
+	span := &memorySpan{
+		sp:     interval.U64Span{Start: memOffset, End: memOffset + resSize},
 		memory: VkDeviceMemory(0xabcd),
 	}
 	newSubBindingForTest := func(ctx context.Context, base *resBinding, offset, size uint64) *resBinding {
@@ -67,15 +67,15 @@ func TestSubBinding(t *testing.T) {
 
 	validSubBoundData(0, 2048, spanBase, spanBase)
 	validSubBoundData(0, vkWholeSize, spanBase, spanBase)
-	validSubBoundData(1024, 512, spanBase, newResBinding(ctx, nil, 1024, 512, memorySpan{
-		span: interval.U64Span{
+	validSubBoundData(1024, 512, spanBase, newResBinding(ctx, nil, 1024, 512, &memorySpan{
+		sp: interval.U64Span{
 			Start: memOffset + uint64(1024),
 			End:   memOffset + uint64(1024) + uint64(512),
 		},
 		memory: VkDeviceMemory(0xabcd),
 	}))
-	validSubBoundData(512, vkWholeSize, spanBase, newResBinding(ctx, nil, 512, 1536, memorySpan{
-		span: interval.U64Span{
+	validSubBoundData(512, vkWholeSize, spanBase, newResBinding(ctx, nil, 512, 1536, &memorySpan{
+		sp: interval.U64Span{
 			Start: memOffset + uint64(512),
 			End:   memOffset + resSize,
 		},


### PR DESCRIPTION
However, this does not fix all the test failures.

Test still fail:
//gapil/bapi:go_default_test

And things should be done in future CL:
Add test for the dense map. Current tests about the map want the map
capacity to be specific values, which can be easily broken by the dense
map.