### PR TITLE
Drop the global lock around most of the Vulkan API commands

### DIFF
--- a/gapis/api/templates/api_spy.cpp.tmpl
+++ b/gapis/api/templates/api_spy.cpp.tmpl
@@ -229,8 +229,8 @@
           observer->observeTimestamp();
         }
 
-        {{if (GetAnnotation $ "blocking")}}
-          unlock();
+        {{if (GetAnnotation $ "threadsafe")}}
+        unlock();
         {{end}}
         {{/* Perform the call */}}
         {{if not (GetAnnotation $ "synthetic")}}
@@ -243,8 +243,8 @@
             mImports.{{Template "CmdName" $}}({{Template "C++.CallArguments" $}});
           {{end}}
         {{end}}
-        {{if (GetAnnotation $ "blocking")}}
-          lock(observer);
+        {{if (GetAnnotation $ "threadsafe")}}
+        lock(observer);
         {{end}}
 ¶
         {{if IsVoid $.Return.Type}}

--- a/gapis/api/vulkan/api/copy_clear_commands.api
+++ b/gapis/api/vulkan/api/copy_clear_commands.api
@@ -176,6 +176,7 @@ sub void copyBufferToBuffer(ref!BufferObject dstBuf, VkDeviceSize dstOffset, ref
 
 @threadSafety("app")
 @indirect("VkCommandBuffer", "VkDevice")
+@threadsafe
 cmd void vkCmdCopyBuffer(
     VkCommandBuffer     commandBuffer,
     VkBuffer            srcBuffer,
@@ -296,6 +297,7 @@ sub void dovkCmdCopyImage(ref!vkCmdCopyImageArgs args) {
 
 @threadSafety("app")
 @indirect("VkCommandBuffer", "VkDevice")
+@threadsafe
 cmd void vkCmdCopyImage(
     VkCommandBuffer    commandBuffer,
     VkImage            srcImage,
@@ -340,6 +342,7 @@ sub void dovkCmdBlitImage(ref!vkCmdBlitImageArgs dispatch) {
 
 @threadSafety("app")
 @indirect("VkCommandBuffer", "VkDevice")
+@threadsafe
 cmd void vkCmdBlitImage(
     VkCommandBuffer    commandBuffer,
     VkImage            srcImage,
@@ -485,6 +488,7 @@ sub void dovkCmdCopyBufferToImage(ref!vkCmdCopyBufferToImageArgs args) {
 
 @threadSafety("app")
 @indirect("VkCommandBuffer", "VkDevice")
+@threadsafe
 cmd void vkCmdCopyBufferToImage(
     VkCommandBuffer          commandBuffer,
     VkBuffer                 srcBuffer,
@@ -522,6 +526,7 @@ sub void dovkCmdCopyImageToBuffer(ref!vkCmdCopyImageToBufferArgs dispatch) {
 
 @threadSafety("app")
 @indirect("VkCommandBuffer", "VkDevice")
+@threadsafe
 cmd void vkCmdCopyImageToBuffer(
     VkCommandBuffer          commandBuffer,
     VkImage                  srcImage,
@@ -569,6 +574,7 @@ sub void dovkCmdUpdateBuffer(ref!vkCmdUpdateBufferArgs args) {
 
 @threadSafety("app")
 @indirect("VkCommandBuffer", "VkDevice")
+@threadsafe
 cmd void vkCmdUpdateBuffer(
     VkCommandBuffer commandBuffer,
     VkBuffer        dstBuffer,
@@ -611,6 +617,7 @@ sub void dovkCmdFillBuffer(ref!vkCmdFillBufferArgs args) {
 
 @threadSafety("app")
 @indirect("VkCommandBuffer", "VkDevice")
+@threadsafe
 cmd void vkCmdFillBuffer(
     VkCommandBuffer commandBuffer,
     VkBuffer        dstBuffer,
@@ -646,6 +653,7 @@ sub void dovkCmdClearColorImage(ref!vkCmdClearColorImageArgs args) {
 
 @threadSafety("app")
 @indirect("VkCommandBuffer", "VkDevice")
+@threadsafe
 cmd void vkCmdClearColorImage(
     VkCommandBuffer                commandBuffer,
     VkImage                        image,
@@ -687,6 +695,7 @@ sub void dovkCmdClearDepthStencilImage(ref!vkCmdClearDepthStencilImageArgs args)
 
 @threadSafety("app")
 @indirect("VkCommandBuffer", "VkDevice")
+@threadsafe
 cmd void vkCmdClearDepthStencilImage(
     VkCommandBuffer                 commandBuffer,
     VkImage                         image,
@@ -726,6 +735,7 @@ sub void dovkCmdClearAttachments(ref!vkCmdClearAttachmentsArgs args) {
 
 @threadSafety("app")
 @indirect("VkCommandBuffer", "VkDevice")
+@threadsafe
 cmd void vkCmdClearAttachments(
     VkCommandBuffer          commandBuffer,
     u32                      attachmentCount,
@@ -782,6 +792,7 @@ sub void dovkCmdResolveImage(ref!vkCmdResolveImageArgs args) {
 
 @threadSafety("app")
 @indirect("VkCommandBuffer", "VkDevice")
+@threadsafe
 cmd void vkCmdResolveImage(
     VkCommandBuffer       commandBuffer,
     VkImage               srcImage,

--- a/gapis/api/vulkan/api/descriptor.api
+++ b/gapis/api/vulkan/api/descriptor.api
@@ -522,6 +522,7 @@ sub map!(u32, DescriptorSetCopy) RewriteWriteDescriptorCopies
 }
 
 @indirect("VkDevice")
+@threadsafe
 cmd void vkUpdateDescriptorSets(
     VkDevice                    device,
     u32                         descriptorWriteCount,
@@ -752,6 +753,7 @@ sub void dovkCmdBindDescriptorSets(ref!vkCmdBindDescriptorSetsArgs args) {
 
 @threadSafety("app")
 @indirect("VkCommandBuffer", "VkDevice")
+@threadsafe
 cmd void vkCmdBindDescriptorSets(
     VkCommandBuffer        commandBuffer,
     VkPipelineBindPoint    pipelineBindPoint,
@@ -798,6 +800,7 @@ sub void dovkCmdPushConstants(ref!vkCmdPushConstantsArgs args) {
 }
 
 @indirect("VkCommandBuffer", "VkDevice")
+@threadsafe
 cmd void vkCmdPushConstants(
     VkCommandBuffer    commandBuffer,
     VkPipelineLayout   layout,

--- a/gapis/api/vulkan/api/device.api
+++ b/gapis/api/vulkan/api/device.api
@@ -116,7 +116,7 @@ cmd void vkDestroyDevice(
 
 @threadSafety("system")
 @indirect("VkDevice")
-@blocking
+@threadsafe
 cmd VkResult vkDeviceWaitIdle(
     VkDevice device) {
   if !(device in Devices) { vkErrorInvalidDevice(device) }

--- a/gapis/api/vulkan/api/draw_commands.api
+++ b/gapis/api/vulkan/api/draw_commands.api
@@ -59,6 +59,7 @@ sub void dovkCmdBindIndexBuffer(ref!vkCmdBindIndexBufferArgs buffer) {
 
 @threadSafety("app")
 @indirect("VkCommandBuffer", "VkDevice")
+@threadsafe
 cmd void vkCmdBindIndexBuffer(
     VkCommandBuffer commandBuffer,
     VkBuffer        buffer,
@@ -104,6 +105,7 @@ sub void dovkCmdBindVertexBuffers(ref!vkCmdBindVertexBuffersArgs bind) {
 
 @threadSafety("app")
 @indirect("VkCommandBuffer", "VkDevice")
+@threadsafe
 cmd void vkCmdBindVertexBuffers(
     VkCommandBuffer     commandBuffer,
     u32                 firstBinding,
@@ -148,6 +150,7 @@ sub void dovkCmdDraw(ref!vkCmdDrawArgs draw) {
 @threadSafety("app")
 @indirect("VkCommandBuffer", "VkDevice")
 @executed_draw
+@threadsafe
 cmd void vkCmdDraw(
     VkCommandBuffer commandBuffer,
     u32             vertexCount,
@@ -200,6 +203,7 @@ sub void dovkCmdDrawIndexed(ref!vkCmdDrawIndexedArgs draw) {
 @threadSafety("app")
 @indirect("VkCommandBuffer", "VkDevice")
 @executed_draw
+@threadsafe
 cmd void vkCmdDrawIndexed(
     VkCommandBuffer commandBuffer,
     u32             indexCount,
@@ -246,6 +250,7 @@ sub void dovkCmdDrawIndirect(ref!vkCmdDrawIndirectArgs draw) {
 @threadSafety("app")
 @indirect("VkCommandBuffer", "VkDevice")
 @executed_draw
+@threadsafe
 cmd void vkCmdDrawIndirect(
     VkCommandBuffer commandBuffer,
     VkBuffer        buffer,
@@ -289,6 +294,7 @@ sub void dovkCmdDrawIndexedIndirect(ref!vkCmdDrawIndexedIndirectArgs draw) {
 @threadSafety("app")
 @indirect("VkCommandBuffer", "VkDevice")
 @executed_draw
+@threadsafe
 cmd void vkCmdDrawIndexedIndirect(
     VkCommandBuffer commandBuffer,
     VkBuffer        buffer,
@@ -319,6 +325,7 @@ sub void dovkCmdDispatch(ref!vkCmdDispatchArgs args) {
 @threadSafety("app")
 @indirect("VkCommandBuffer", "VkDevice")
 @executed_draw
+@threadsafe
 cmd void vkCmdDispatch(
     VkCommandBuffer commandBuffer,
     u32             groupCountX,
@@ -350,6 +357,7 @@ sub void dovkCmdDispatchIndirect(ref!vkCmdDispatchIndirectArgs dispatch) {
 @threadSafety("app")
 @indirect("VkCommandBuffer", "VkDevice")
 @executed_draw
+@threadsafe
 cmd void vkCmdDispatchIndirect(
     VkCommandBuffer commandBuffer,
     VkBuffer        buffer,

--- a/gapis/api/vulkan/api/pipeline.api
+++ b/gapis/api/vulkan/api/pipeline.api
@@ -780,6 +780,7 @@ sub void dovkCmdSetDepthBias(ref!vkCmdSetDepthBiasArgs args) {
 
 @threadSafety("app")
 @indirect("VkCommandBuffer", "VkDevice")
+@threadsafe
 cmd void vkCmdSetDepthBias(
     VkCommandBuffer commandBuffer,
     f32             depthBiasConstantFactor,
@@ -922,6 +923,7 @@ sub void dovkCmdSetStencilReference(ref!vkCmdSetStencilReferenceArgs args) {
 
 @threadSafety("app")
 @indirect("VkCommandBuffer", "VkDevice")
+@threadsafe
 cmd void vkCmdSetStencilReference(
     VkCommandBuffer    commandBuffer,
     VkStencilFaceFlags faceMask,

--- a/gapis/api/vulkan/api/pipeline.api
+++ b/gapis/api/vulkan/api/pipeline.api
@@ -50,6 +50,7 @@
 
 @threadSafety("system")
 @indirect("VkDevice")
+@threadsafe
 cmd VkResult vkCreatePipelineLayout(
     VkDevice                          device,
     const VkPipelineLayoutCreateInfo* pCreateInfo,
@@ -220,6 +221,7 @@ class CreatedGraphicsPipelines {
 }
 
 @indirect("VkDevice")
+@threadsafe
 cmd VkResult vkCreateGraphicsPipelines(
     VkDevice                            device,
     VkPipelineCache                     pipelineCache,
@@ -445,6 +447,7 @@ class CreatedComputePipelines {
 }
 
 @indirect("VkDevice")
+@threadsafe
 cmd VkResult vkCreateComputePipelines(
     VkDevice                           device,
     VkPipelineCache                    pipelineCache,
@@ -538,6 +541,7 @@ cmd void vkDestroyPipeline(
 }
 
 @indirect("VkDevice")
+@threadsafe
 cmd VkResult vkCreateShaderModule(
     VkDevice                        device,
     const VkShaderModuleCreateInfo* pCreateInfo,
@@ -660,6 +664,7 @@ sub void dovkCmdBindPipeline(ref!vkCmdBindPipelineArgs args) {
 
 @threadSafety("app")
 @indirect("VkCommandBuffer", "VkDevice")
+@threadsafe
 cmd void vkCmdBindPipeline(
     VkCommandBuffer     commandBuffer,
     VkPipelineBindPoint pipelineBindPoint,
@@ -685,6 +690,7 @@ sub void dovkCmdSetViewport(ref!vkCmdSetViewportArgs args) {
 
 @threadSafety("app")
 @indirect("VkCommandBuffer", "VkDevice")
+@threadsafe
 cmd void vkCmdSetViewport(
     VkCommandBuffer   commandBuffer,
     u32               firstViewport,
@@ -717,6 +723,7 @@ sub void dovkCmdSetScissor(ref!vkCmdSetScissorArgs args) {
 
 @threadSafety("app")
 @indirect("VkCommandBuffer", "VkDevice")
+@threadsafe
 cmd void vkCmdSetScissor(
     VkCommandBuffer commandBuffer,
     u32             firstScissor,
@@ -748,6 +755,7 @@ sub void dovkCmdSetLineWidth(ref!vkCmdSetLineWidthArgs args) {
 
 @threadSafety("app")
 @indirect("VkCommandBuffer", "VkDevice")
+@threadsafe
 cmd void vkCmdSetLineWidth(
     VkCommandBuffer commandBuffer,
     f32             lineWidth) {
@@ -803,6 +811,7 @@ sub void dovkCmdSetBlendConstants(ref!vkCmdSetBlendConstantsArgs args) {
 
 @threadSafety("app")
 @indirect("VkCommandBuffer", "VkDevice")
+@threadsafe
 cmd void vkCmdSetBlendConstants(
               VkCommandBuffer commandBuffer,
     @readonly f32[4]          blendConstants) {
@@ -830,6 +839,7 @@ sub void dovkCmdSetDepthBounds(ref!vkCmdSetDepthBoundsArgs args) {
 
 @threadSafety("app")
 @indirect("VkCommandBuffer", "VkDevice")
+@threadsafe
 cmd void vkCmdSetDepthBounds(
     VkCommandBuffer commandBuffer,
     f32             minDepthBounds,
@@ -856,6 +866,7 @@ sub void dovkCmdSetStencilCompareMask(ref!vkCmdSetStencilCompareMaskArgs args) {
 
 @threadSafety("app")
 @indirect("VkCommandBuffer", "VkDevice")
+@threadsafe
 cmd void vkCmdSetStencilCompareMask(
     VkCommandBuffer    commandBuffer,
     VkStencilFaceFlags faceMask,
@@ -883,6 +894,7 @@ sub void dovkCmdSetStencilWriteMask(ref!vkCmdSetStencilWriteMaskArgs args) {
 
 @threadSafety("app")
 @indirect("VkCommandBuffer", "VkDevice")
+@threadsafe
 cmd void vkCmdSetStencilWriteMask(
     VkCommandBuffer    commandBuffer,
     VkStencilFaceFlags faceMask,

--- a/gapis/api/vulkan/api/query_pool.api
+++ b/gapis/api/vulkan/api/query_pool.api
@@ -98,7 +98,7 @@ cmd void vkDestroyQueryPool(
 
 @threadSafety("system")
 @indirect("VkDevice")
-@blocking
+@threadsafe
 @no_replay
 // GetQueryPoolResults has no semantic impact
 // on replay, so avoid replaying it. It can cause

--- a/gapis/api/vulkan/api/queue.api
+++ b/gapis/api/vulkan/api/queue.api
@@ -189,7 +189,7 @@ cmd VkResult vkQueueSubmit(
 
 @threadSafety("system")
 @indirect("VkQueue", "VkDevice")
-@blocking
+@threadsafe
 cmd VkResult vkQueueWaitIdle(
     VkQueue queue) {
   if !(queue in Queues) { vkErrorInvalidQueue(queue) }

--- a/gapis/api/vulkan/api/synchronization.api
+++ b/gapis/api/vulkan/api/synchronization.api
@@ -112,7 +112,7 @@ cmd VkResult vkGetFenceStatus(
 
 @threadSafety("system")
 @indirect("VkDevice")
-@blocking
+@threadsafe
 cmd VkResult vkWaitForFences(
     VkDevice       device,
     u32            fenceCount,

--- a/gapis/api/vulkan/extensions/khr_swapchain.api
+++ b/gapis/api/vulkan/extensions/khr_swapchain.api
@@ -226,7 +226,7 @@ cmd VkResult vkGetSwapchainImagesKHR(
 @extension("VK_KHR_swapchain")
 @indirect("VkDevice")
 @custom
-@blocking
+@threadsafe
 cmd VkResult vkAcquireNextImageKHR(
     VkDevice       device,
     VkSwapchainKHR swapchain,


### PR DESCRIPTION
Unlock before calling the underlying API command calls, and lock again after
return from the underlying API command calls.

This improves the tracing performance, especially when the application
builds Vulkan pipelines in multiple threads.