### PR TITLE
Vulkan dependency graph

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -189,6 +189,7 @@ test_suite(
         "//gapis/replay/scheduler:go_default_test",
         "//gapis/resolve:go_default_test",
         "//gapis/resolve/dependencygraph:go_default_test",
+        "//gapis/resolve/dependencygraph2:go_default_test",
         "//gapis/service/box:go_default_test",
         "//gapis/shadertools:go_default_test",
         "//gapis/shadertools/cc:tests",

--- a/cmd/gapit/BUILD.bazel
+++ b/cmd/gapit/BUILD.bazel
@@ -39,6 +39,7 @@ go_library(
         "stresstest.go",
         "sxs_video.go",
         "trace.go",
+        "trim.go",
         "unpack.go",
         "video.go",
     ],

--- a/cmd/gapit/flags.go
+++ b/cmd/gapit/flags.go
@@ -286,4 +286,16 @@ type (
 		}
 		Compute bool `help:"print out the most recently bound compute pipeline instead of graphics pipeline"`
 	}
+	TrimFlags struct {
+		Gapis         GapisFlags
+		Gapir         GapirFlags
+		Commands      bool           `help:"Treat every command as its own frame"`
+		ExtraCommands flags.U64Slice `help:"Additional commands to include (along with their dependencies)"`
+		Frames        struct {
+			Start int `help:"first frame to include (default 0)"`
+			Count int `help:"number of frames to include: -1 for all frames (default -1)"`
+		}
+		Out string `help:"gfxtrace file to save the trimmed capture"`
+		CommandFilterFlags
+	}
 )

--- a/cmd/gapit/trim.go
+++ b/cmd/gapit/trim.go
@@ -1,0 +1,149 @@
+// Copyright (C) 2018 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"flag"
+	"io/ioutil"
+	"path/filepath"
+
+	"github.com/google/gapid/core/app"
+	"github.com/google/gapid/core/log"
+	"github.com/google/gapid/gapis/service"
+	"github.com/google/gapid/gapis/service/path"
+)
+
+type trimVerb struct{ TrimFlags }
+
+func init() {
+	verb := &trimVerb{}
+	verb.Frames.Count = allTheWay
+
+	app.AddVerb(&app.Verb{
+		Name:      "trim",
+		ShortHelp: "(WIP) Trims a gfx trace to the dependencies of the requested frames",
+		Action:    verb,
+	})
+}
+
+func (verb *trimVerb) Run(ctx context.Context, flags flag.FlagSet) error {
+	if flags.NArg() != 1 {
+		app.Usage(ctx, "Exactly one gfx trace file expected, got %d", flags.NArg())
+		return nil
+	}
+
+	filepath, err := filepath.Abs(flags.Arg(0))
+	if err != nil {
+		return log.Errf(ctx, err, "Finding file: %v", flags.Arg(0))
+	}
+
+	client, err := getGapis(ctx, verb.Gapis, verb.Gapir)
+	if err != nil {
+		return log.Err(ctx, err, "Failed to connect to the GAPIS server")
+	}
+	defer client.Close()
+
+	capture, err := client.LoadCapture(ctx, filepath)
+	if err != nil {
+		return log.Errf(ctx, err, "LoadCapture(%v)", filepath)
+	}
+
+	eofEvents, err := verb.eofEvents(ctx, capture, client)
+	if err != nil {
+		return err
+	}
+
+	dceRequest := verb.getDCERequest(eofEvents, capture)
+	if len(dceRequest) > 0 {
+		capture, err = client.DCECapture(ctx, capture, dceRequest)
+		if err != nil {
+			return log.Errf(ctx, err, "DCECapture(%v, %v)", capture, dceRequest)
+		}
+	}
+
+	data, err := client.ExportCapture(ctx, capture)
+	if err != nil {
+		return log.Errf(ctx, err, "ExportCapture(%v)", capture)
+	}
+
+	output := verb.Out
+	if output == "" {
+		output = "trimmed.gfxtrace"
+	}
+	if err := ioutil.WriteFile(output, data, 0666); err != nil {
+		return log.Errf(ctx, err, "Writing file: %v", output)
+	}
+	return nil
+}
+
+func (verb *trimVerb) eofEvents(ctx context.Context, capture *path.Capture, client service.Service) ([]*service.Event, error) {
+	filter, err := verb.CommandFilterFlags.commandFilter(ctx, client, capture)
+	if err != nil {
+		return nil, log.Err(ctx, err, "Couldn't get filter")
+	}
+	requestEvents := path.Events{
+		Capture:     capture,
+		LastInFrame: true,
+		Filter:      filter,
+	}
+
+	if verb.Commands {
+		requestEvents.LastInFrame = false
+		requestEvents.AllCommands = true
+	}
+
+	// Get the end-of-frame events.
+	eofEvents, err := getEvents(ctx, client, &requestEvents)
+	if err != nil {
+		return nil, log.Err(ctx, err, "Couldn't get frame events")
+	}
+
+	lastFrame := verb.Frames.Start
+	if verb.Frames.Count > 0 {
+		lastFrame += verb.Frames.Count - 1
+	}
+	if lastFrame >= len(eofEvents) {
+		return nil, log.Errf(ctx, nil, "Requested frame %d, but capture only contains %d frames", lastFrame, len(eofEvents))
+	}
+
+	return eofEvents, nil
+}
+
+func (verb *trimVerb) getDCERequest(eofEvents []*service.Event, p *path.Capture) []*path.Command {
+	frameCount := verb.Frames.Count
+	if frameCount < 0 {
+		frameCount = len(eofEvents) - verb.Frames.Start + 1
+	}
+	dceRequest := make([]*path.Command, 0, frameCount+len(verb.ExtraCommands))
+	for i := 0; i < frameCount; i++ {
+		indices := eofEvents[verb.Frames.Start+i].Command.Indices
+		newIndices := make([]uint64, len(indices))
+		copy(newIndices, indices)
+		cmd := &path.Command{
+			Capture: p,
+			Indices: newIndices,
+		}
+		dceRequest = append(dceRequest, cmd)
+	}
+	for _, id := range verb.ExtraCommands {
+		cmd := &path.Command{
+			Capture: p,
+			Indices: []uint64{id},
+		}
+		dceRequest = append(dceRequest, cmd)
+	}
+	return dceRequest
+}

--- a/gapii/cc/vulkan_extras.cpp
+++ b/gapii/cc/vulkan_extras.cpp
@@ -443,6 +443,9 @@ void VulkanSpy::unmapMemory(CallObserver*, gapil::Slice<uint8_t>) {}
 void VulkanSpy::recordFenceSignal(CallObserver*, uint64_t) {}
 void VulkanSpy::recordFenceWait(CallObserver*, uint64_t) {}
 void VulkanSpy::recordFenceReset(CallObserver*, uint64_t) {}
+void VulkanSpy::recordAcquireNextImage(CallObserver*, uint64_t, uint32_t) {}
+void VulkanSpy::recordPresentSwapchainImage(CallObserver*, uint64_t, uint32_t) {
+}
 
 bool VulkanSpy::hasDynamicProperty(CallObserver* observer,
                                    const VkPipelineDynamicStateCreateInfo* info,

--- a/gapii/cc/vulkan_extras.cpp
+++ b/gapii/cc/vulkan_extras.cpp
@@ -440,6 +440,9 @@ void VulkanSpy::untrackMappedCoherentMemory(CallObserver*, uint64_t start,
 
 void VulkanSpy::mapMemory(CallObserver*, void**, gapil::Slice<uint8_t>) {}
 void VulkanSpy::unmapMemory(CallObserver*, gapil::Slice<uint8_t>) {}
+void VulkanSpy::recordFenceSignal(CallObserver*, uint64_t) {}
+void VulkanSpy::recordFenceWait(CallObserver*, uint64_t) {}
+void VulkanSpy::recordFenceReset(CallObserver*, uint64_t) {}
 
 bool VulkanSpy::hasDynamicProperty(CallObserver* observer,
                                    const VkPipelineDynamicStateCreateInfo* info,

--- a/gapil/compiler/testutils/cmd.go
+++ b/gapil/compiler/testutils/cmd.go
@@ -93,6 +93,11 @@ func (c *Cmd) Clone(arena.Arena) api.Cmd {
 	return &clone
 }
 
+// Alive returns true if this command should be marked alive for DCE
+func (c *Cmd) Alive() bool {
+	return false
+}
+
 // Extras is a helper wrapper around an api.CmdExtras has helpers methods for
 // adding read and writ observations.
 type Extras struct {

--- a/gapil/compiler/testutils/cmd.go
+++ b/gapil/compiler/testutils/cmd.go
@@ -74,7 +74,9 @@ func (c *Cmd) Extras() *api.CmdExtras {
 }
 
 // Mutate stubs the api.Cmd interface.
-func (c *Cmd) Mutate(context.Context, api.CmdID, *api.GlobalState, *builder.Builder) error { return nil }
+func (c *Cmd) Mutate(context.Context, api.CmdID, *api.GlobalState, *builder.Builder, api.StateWatcher) error {
+	return nil
+}
 
 // Encode implements the executor.Encodable interface to encode the command to
 // a buffer used by the compiler generated execute function.

--- a/gapis/api/BUILD.bazel
+++ b/gapis/api/BUILD.bazel
@@ -37,6 +37,7 @@ go_library(
         "memory_breakdown.go",
         "mesh.go",
         "property.go",
+        "reference.go",
         "resource.go",
         "service.go",
         "state.go",

--- a/gapis/api/BUILD.bazel
+++ b/gapis/api/BUILD.bazel
@@ -44,6 +44,7 @@ go_library(
         "subcmd_idx.go",
         "subcmd_idx_trie.go",
         "texture.go",
+        "watcher.go",
     ],
     embed = [":api_go_proto"],
     importpath = "github.com/google/gapid/gapis/api",

--- a/gapis/api/cmd.go
+++ b/gapis/api/cmd.go
@@ -58,7 +58,7 @@ type Cmd interface {
 
 	// Mutate mutates the State using the command. If the builder argument is
 	// not nil then it will call the replay function on the builder.
-	Mutate(context.Context, CmdID, *GlobalState, *builder.Builder) error
+	Mutate(context.Context, CmdID, *GlobalState, *builder.Builder, StateWatcher) error
 
 	// Clone makes a shallow copy of this command.
 	Clone(arena.Arena) Cmd

--- a/gapis/api/cmd.go
+++ b/gapis/api/cmd.go
@@ -62,6 +62,9 @@ type Cmd interface {
 
 	// Clone makes a shallow copy of this command.
 	Clone(arena.Arena) Cmd
+
+	// Alive returns true if this command should be marked alive for DCE
+	Alive() bool
 }
 
 const (

--- a/gapis/api/cmd_foreach.go
+++ b/gapis/api/cmd_foreach.go
@@ -62,9 +62,10 @@ func ForeachCmd(ctx context.Context, cmds []Cmd, cb func(context.Context, CmdID,
 }
 
 // MutateCmds calls Mutate on each of cmds.
-func MutateCmds(ctx context.Context, state *GlobalState, builder *builder.Builder, cmds ...Cmd) {
+func MutateCmds(ctx context.Context, state *GlobalState, builder *builder.Builder,
+	watcher StateWatcher, cmds ...Cmd) {
 	ForeachCmd(ctx, cmds, func(ctx context.Context, id CmdID, cmd Cmd) error {
-		cmd.Mutate(ctx, id, state, builder)
+		cmd.Mutate(ctx, id, state, builder, watcher)
 		return nil
 	})
 }

--- a/gapis/api/gles/compat_buffers.go
+++ b/gapis/api/gles/compat_buffers.go
@@ -67,7 +67,7 @@ func (m *bufferCompat) modifyBufferData(ctx context.Context, out transform.Write
 	s := out.State()
 
 	// Get the target buffer.
-	buf, err := subGetBoundBuffer(ctx, nil, api.CmdNoID, nil, s, GetState(s), cb.Thread, nil, target)
+	buf, err := subGetBoundBuffer(ctx, nil, api.CmdNoID, nil, s, GetState(s), cb.Thread, nil, nil, target)
 	if buf.IsNil() || err != nil {
 		// Unknown buffer
 		modify()

--- a/gapis/api/gles/compat_test.go
+++ b/gapis/api/gles/compat_test.go
@@ -101,7 +101,7 @@ func TestGlVertexAttribPointerCompatTest(t *testing.T) {
 	s := newState(ctx)
 	var found bool
 	err = api.ForeachCmd(ctx, r.Cmds, func(ctx context.Context, id api.CmdID, cmd api.Cmd) error {
-		if err := cmd.Mutate(ctx, id, s, nil); err != nil {
+		if err := cmd.Mutate(ctx, id, s, nil, nil); err != nil {
 			return err
 		}
 

--- a/gapis/api/gles/custom_replay.go
+++ b/gapis/api/gles/custom_replay.go
@@ -253,20 +253,20 @@ func (i GLeglImageOES) value(b *builder.Builder, cmd api.Cmd, s *api.GlobalState
 	return value.AbsolutePointer(i)
 }
 
-func (ω *EglCreateContext) Mutate(ctx context.Context, id api.CmdID, s *api.GlobalState, b *builder.Builder) error {
-	err := ω.mutate(ctx, id, s, nil)
+func (ω *EglCreateContext) Mutate(ctx context.Context, id api.CmdID, s *api.GlobalState, b *builder.Builder, w api.StateWatcher) error {
+	err := ω.mutate(ctx, id, s, nil, w)
 	if b == nil || err != nil {
 		return err
 	}
 	ctxID := uint32(GetState(s).EGLContexts().Get(ω.Result()).Identifier())
 	cb := CommandBuilder{Thread: ω.Thread(), Arena: s.Arena}
-	return cb.ReplayCreateRenderer(ctxID).Mutate(ctx, id, s, b)
+	return cb.ReplayCreateRenderer(ctxID).Mutate(ctx, id, s, b, nil)
 }
 
-func (ω *EglMakeCurrent) Mutate(ctx context.Context, id api.CmdID, s *api.GlobalState, b *builder.Builder) error {
+func (ω *EglMakeCurrent) Mutate(ctx context.Context, id api.CmdID, s *api.GlobalState, b *builder.Builder, w api.StateWatcher) error {
 	prevContext := GetState(s).Contexts().Get(ω.Thread())
 	existed := GetState(s).EGLContexts().Contains(ω.Context())
-	err := ω.mutate(ctx, id, s, nil)
+	err := ω.mutate(ctx, id, s, nil, w)
 	if b == nil || err != nil {
 		return err
 	}
@@ -276,12 +276,12 @@ func (ω *EglMakeCurrent) Mutate(ctx context.Context, id api.CmdID, s *api.Globa
 			return nil
 		}
 		ctxID := uint32(prevContext.Identifier())
-		return cb.ReplayUnbindRenderer(ctxID).Mutate(ctx, id, s, b)
+		return cb.ReplayUnbindRenderer(ctxID).Mutate(ctx, id, s, b, nil)
 	}
 	ctxID := uint32(GetState(s).EGLContexts().Get(ω.Context()).Identifier())
 	if !existed {
 		// The eglCreateContext call was missing, so fake it (can happen on Samsung).
-		if err := cb.ReplayCreateRenderer(ctxID).Mutate(ctx, id, s, b); err != nil {
+		if err := cb.ReplayCreateRenderer(ctxID).Mutate(ctx, id, s, b, nil); err != nil {
 			return err
 		}
 	}
@@ -295,39 +295,39 @@ func (ω *EglMakeCurrent) Mutate(ctx context.Context, id api.CmdID, s *api.Globa
 			cs.BackbufferDepthFmt(),
 			cs.BackbufferStencilFmt(),
 		)
-		if err := cmd.Mutate(ctx, id, s, b); err != nil {
+		if err := cmd.Mutate(ctx, id, s, b, nil); err != nil {
 			return err
 		}
 		resetViewportScissor = cs.ResetViewportScissor()
 	}
-	if err := cb.ReplayBindRenderer(ctxID, resetViewportScissor).Mutate(ctx, id, s, b); err != nil {
+	if err := cb.ReplayBindRenderer(ctxID, resetViewportScissor).Mutate(ctx, id, s, b, nil); err != nil {
 		return err
 	}
 	return nil
 }
 
-func (ω *WglCreateContext) Mutate(ctx context.Context, id api.CmdID, s *api.GlobalState, b *builder.Builder) error {
-	err := ω.mutate(ctx, id, s, nil)
+func (ω *WglCreateContext) Mutate(ctx context.Context, id api.CmdID, s *api.GlobalState, b *builder.Builder, w api.StateWatcher) error {
+	err := ω.mutate(ctx, id, s, nil, w)
 	if b == nil || err != nil {
 		return err
 	}
 	ctxID := uint32(GetState(s).WGLContexts().Get(ω.Result()).Identifier())
 	cb := CommandBuilder{Thread: ω.Thread(), Arena: s.Arena}
-	return cb.ReplayCreateRenderer(ctxID).Mutate(ctx, id, s, b)
+	return cb.ReplayCreateRenderer(ctxID).Mutate(ctx, id, s, b, nil)
 }
 
-func (ω *WglCreateContextAttribsARB) Mutate(ctx context.Context, id api.CmdID, s *api.GlobalState, b *builder.Builder) error {
-	err := ω.mutate(ctx, id, s, nil)
+func (ω *WglCreateContextAttribsARB) Mutate(ctx context.Context, id api.CmdID, s *api.GlobalState, b *builder.Builder, w api.StateWatcher) error {
+	err := ω.mutate(ctx, id, s, nil, w)
 	if b == nil || err != nil {
 		return err
 	}
 	ctxID := uint32(GetState(s).WGLContexts().Get(ω.Result()).Identifier())
 	cb := CommandBuilder{Thread: ω.Thread(), Arena: s.Arena}
-	return cb.ReplayCreateRenderer(ctxID).Mutate(ctx, id, s, b)
+	return cb.ReplayCreateRenderer(ctxID).Mutate(ctx, id, s, b, nil)
 }
 
-func (ω *WglMakeCurrent) Mutate(ctx context.Context, id api.CmdID, s *api.GlobalState, b *builder.Builder) error {
-	err := ω.mutate(ctx, id, s, nil)
+func (ω *WglMakeCurrent) Mutate(ctx context.Context, id api.CmdID, s *api.GlobalState, b *builder.Builder, w api.StateWatcher) error {
+	err := ω.mutate(ctx, id, s, nil, w)
 	if b == nil || err != nil {
 		return err
 	}
@@ -336,21 +336,21 @@ func (ω *WglMakeCurrent) Mutate(ctx context.Context, id api.CmdID, s *api.Globa
 	}
 	ctxID := uint32(GetState(s).WGLContexts().Get(ω.Hglrc()).Identifier())
 	cb := CommandBuilder{Thread: ω.Thread(), Arena: s.Arena}
-	return cb.ReplayBindRenderer(ctxID, false).Mutate(ctx, id, s, b)
+	return cb.ReplayBindRenderer(ctxID, false).Mutate(ctx, id, s, b, nil)
 }
 
-func (ω *CGLCreateContext) Mutate(ctx context.Context, id api.CmdID, s *api.GlobalState, b *builder.Builder) error {
-	err := ω.mutate(ctx, id, s, nil)
+func (ω *CGLCreateContext) Mutate(ctx context.Context, id api.CmdID, s *api.GlobalState, b *builder.Builder, w api.StateWatcher) error {
+	err := ω.mutate(ctx, id, s, nil, w)
 	if b == nil || err != nil {
 		return err
 	}
 	ctxID := uint32(GetState(s).CGLContexts().Get(ω.Ctx().MustRead(ctx, ω, s, b)).Identifier())
 	cb := CommandBuilder{Thread: ω.Thread(), Arena: s.Arena}
-	return cb.ReplayCreateRenderer(ctxID).Mutate(ctx, id, s, b)
+	return cb.ReplayCreateRenderer(ctxID).Mutate(ctx, id, s, b, nil)
 }
 
-func (ω *CGLSetCurrentContext) Mutate(ctx context.Context, id api.CmdID, s *api.GlobalState, b *builder.Builder) error {
-	err := ω.mutate(ctx, id, s, nil)
+func (ω *CGLSetCurrentContext) Mutate(ctx context.Context, id api.CmdID, s *api.GlobalState, b *builder.Builder, w api.StateWatcher) error {
+	err := ω.mutate(ctx, id, s, nil, w)
 	if b == nil || err != nil {
 		return err
 	}
@@ -359,31 +359,31 @@ func (ω *CGLSetCurrentContext) Mutate(ctx context.Context, id api.CmdID, s *api
 	}
 	ctxID := uint32(GetState(s).CGLContexts().Get(ω.Ctx()).Identifier())
 	cb := CommandBuilder{Thread: ω.Thread(), Arena: s.Arena}
-	return cb.ReplayBindRenderer(ctxID, false).Mutate(ctx, id, s, b)
+	return cb.ReplayBindRenderer(ctxID, false).Mutate(ctx, id, s, b, nil)
 }
 
-func (ω *GlXCreateContext) Mutate(ctx context.Context, id api.CmdID, s *api.GlobalState, b *builder.Builder) error {
-	err := ω.mutate(ctx, id, s, nil)
+func (ω *GlXCreateContext) Mutate(ctx context.Context, id api.CmdID, s *api.GlobalState, b *builder.Builder, w api.StateWatcher) error {
+	err := ω.mutate(ctx, id, s, nil, w)
 	if b == nil || err != nil {
 		return err
 	}
 	ctxID := uint32(GetState(s).GLXContexts().Get(ω.Result()).Identifier())
 	cb := CommandBuilder{Thread: ω.Thread(), Arena: s.Arena}
-	return cb.ReplayCreateRenderer(ctxID).Mutate(ctx, id, s, b)
+	return cb.ReplayCreateRenderer(ctxID).Mutate(ctx, id, s, b, nil)
 }
 
-func (ω *GlXCreateNewContext) Mutate(ctx context.Context, id api.CmdID, s *api.GlobalState, b *builder.Builder) error {
-	err := ω.mutate(ctx, id, s, nil)
+func (ω *GlXCreateNewContext) Mutate(ctx context.Context, id api.CmdID, s *api.GlobalState, b *builder.Builder, w api.StateWatcher) error {
+	err := ω.mutate(ctx, id, s, nil, w)
 	if b == nil || err != nil {
 		return err
 	}
 	ctxID := uint32(GetState(s).GLXContexts().Get(ω.Result()).Identifier())
 	cb := CommandBuilder{Thread: ω.Thread(), Arena: s.Arena}
-	return cb.ReplayCreateRenderer(ctxID).Mutate(ctx, id, s, b)
+	return cb.ReplayCreateRenderer(ctxID).Mutate(ctx, id, s, b, nil)
 }
 
-func (ω *GlXMakeContextCurrent) Mutate(ctx context.Context, id api.CmdID, s *api.GlobalState, b *builder.Builder) error {
-	err := ω.mutate(ctx, id, s, nil)
+func (ω *GlXMakeContextCurrent) Mutate(ctx context.Context, id api.CmdID, s *api.GlobalState, b *builder.Builder, w api.StateWatcher) error {
+	err := ω.mutate(ctx, id, s, nil, w)
 	if b == nil || err != nil {
 		return err
 	}
@@ -392,7 +392,7 @@ func (ω *GlXMakeContextCurrent) Mutate(ctx context.Context, id api.CmdID, s *ap
 	}
 	ctxID := uint32(GetState(s).GLXContexts().Get(ω.Ctx()).Identifier())
 	cb := CommandBuilder{Thread: ω.Thread(), Arena: s.Arena}
-	return cb.ReplayBindRenderer(ctxID, false).Mutate(ctx, id, s, b)
+	return cb.ReplayBindRenderer(ctxID, false).Mutate(ctx, id, s, b, nil)
 }
 
 // Force all attributes to use the capture-observed locations during replay.
@@ -411,7 +411,7 @@ func bindAttribLocations(ctx context.Context, cmd api.Cmd, id api.CmdID, s *api.
 					log.E(ctx, "Can not set location for built-in attribute: %v", cmd)
 					continue
 				}
-				if err := cmd.Mutate(ctx, id, s, b); err != nil {
+				if err := cmd.Mutate(ctx, id, s, b, nil); err != nil {
 					return err
 				}
 			}
@@ -431,7 +431,7 @@ func bindUniformBlocks(ctx context.Context, cmd api.Cmd, id api.CmdID, s *api.Gl
 			defer tmp.Free()
 			cmd := cb.GlGetUniformBlockIndex(pid, tmp.Ptr(), UniformBlockIndex(i)).
 				AddRead(tmp.Data())
-			if err := cmd.Mutate(ctx, id, s, b); err != nil {
+			if err := cmd.Mutate(ctx, id, s, b, nil); err != nil {
 				return err
 			}
 		}
@@ -439,31 +439,31 @@ func bindUniformBlocks(ctx context.Context, cmd api.Cmd, id api.CmdID, s *api.Gl
 	return nil
 }
 
-func (cmd *GlProgramBinaryOES) Mutate(ctx context.Context, id api.CmdID, s *api.GlobalState, b *builder.Builder) error {
+func (cmd *GlProgramBinaryOES) Mutate(ctx context.Context, id api.CmdID, s *api.GlobalState, b *builder.Builder, w api.StateWatcher) error {
 	if err := bindAttribLocations(ctx, cmd, id, s, b, cmd.Program()); err != nil {
 		return err
 	}
-	if err := cmd.mutate(ctx, id, s, b); err != nil {
+	if err := cmd.mutate(ctx, id, s, b, w); err != nil {
 		return err
 	}
 	return bindUniformBlocks(ctx, cmd, id, s, b, cmd.Program())
 }
 
-func (cmd *GlLinkProgram) Mutate(ctx context.Context, id api.CmdID, s *api.GlobalState, b *builder.Builder) error {
+func (cmd *GlLinkProgram) Mutate(ctx context.Context, id api.CmdID, s *api.GlobalState, b *builder.Builder, w api.StateWatcher) error {
 	if err := bindAttribLocations(ctx, cmd, id, s, b, cmd.Program()); err != nil {
 		return err
 	}
-	if err := cmd.mutate(ctx, id, s, b); err != nil {
+	if err := cmd.mutate(ctx, id, s, b, w); err != nil {
 		return err
 	}
 	return bindUniformBlocks(ctx, cmd, id, s, b, cmd.Program())
 }
 
-func (cmd *GlProgramBinary) Mutate(ctx context.Context, id api.CmdID, s *api.GlobalState, b *builder.Builder) error {
+func (cmd *GlProgramBinary) Mutate(ctx context.Context, id api.CmdID, s *api.GlobalState, b *builder.Builder, w api.StateWatcher) error {
 	if err := bindAttribLocations(ctx, cmd, id, s, b, cmd.Program()); err != nil {
 		return err
 	}
-	if err := cmd.mutate(ctx, id, s, b); err != nil {
+	if err := cmd.mutate(ctx, id, s, b, w); err != nil {
 		return err
 	}
 	return bindUniformBlocks(ctx, cmd, id, s, b, cmd.Program())

--- a/gapis/api/gles/dead_code_elimination_test.go
+++ b/gapis/api/gles/dead_code_elimination_test.go
@@ -235,7 +235,7 @@ func TestDeadCommandRemoval(t *testing.T) {
 		c, _ := capture.Resolve(ctx)
 		s := c.NewState(ctx)
 		err = api.ForeachCmd(ctx, cmds, func(ctx context.Context, id api.CmdID, cmd api.Cmd) error {
-			if err := cmd.Mutate(ctx, id, s, nil); err != nil {
+			if err := cmd.Mutate(ctx, id, s, nil, nil); err != nil {
 				return fmt.Errorf("%v: %v: %v", id, cmd, err)
 			}
 			return nil

--- a/gapis/api/gles/dependency_graph_behaviour_provider.go
+++ b/gapis/api/gles/dependency_graph_behaviour_provider.go
@@ -131,7 +131,7 @@ func (*GlesDependencyGraphBehaviourProvider) GetBehaviourForCommand(
 	ctx context.Context, s *api.GlobalState, id api.CmdID, cmd api.Cmd, g *dependencygraph.DependencyGraph) dependencygraph.CmdBehaviour {
 	b := dependencygraph.CmdBehaviour{}
 	c := GetContext(s, cmd.Thread())
-	if err := cmd.Mutate(ctx, id, s, nil /* builder */); err != nil {
+	if err := cmd.Mutate(ctx, id, s, nil /* builder */, nil /* watcher */); err != nil {
 		log.W(ctx, "Command %v %v: %v", id, cmd, err)
 		return dependencygraph.CmdBehaviour{Aborted: true}
 	}
@@ -232,7 +232,7 @@ func (*GlesDependencyGraphBehaviourProvider) GetBehaviourForCommand(
 				texData, _ := getTextureDataAndSize(ctx, cmd, id, s, c.Bound().TextureUnit(), cmd.Target(), cmd.Level())
 				b.Modify(g, texData)
 			case *GlGenerateMipmap:
-				tex, err := subGetBoundTextureOrErrorInvalidEnum(ctx, cmd, id, nil, s, GetState(s), cmd.Thread(), nil, cmd.Target())
+				tex, err := subGetBoundTextureOrErrorInvalidEnum(ctx, cmd, id, nil, s, GetState(s), cmd.Thread(), nil, nil, cmd.Target())
 				if err != nil {
 					log.E(ctx, "Can not find bound texture %v", cmd.Target())
 				}
@@ -300,14 +300,14 @@ func getAllUsedTextureData(ctx context.Context, cmd api.Cmd, id api.CmdID, s *ap
 		if uniform.Type() == GLenum_GL_FLOAT_VEC4 || uniform.Type() == GLenum_GL_FLOAT_MAT4 {
 			continue // Optimization - skip the two most common types which we know are not samplers.
 		}
-		target, _ := subGetTextureTargetFromSamplerType(ctx, cmd, id, nil, s, GetState(s), cmd.Thread(), nil, uniform.Type())
+		target, _ := subGetTextureTargetFromSamplerType(ctx, cmd, id, nil, s, GetState(s), cmd.Thread(), nil, nil, uniform.Type())
 		if target == GLenum_GL_NONE {
 			continue // Not a sampler type
 		}
 		units := AsU32ˢ(s.Arena, uniform.Values(), s.MemoryLayout).MustRead(ctx, cmd, s, nil)
 		for _, unit := range units {
 			if tu := c.Objects().TextureUnits().Get(TextureUnitId(unit)); !tu.IsNil() {
-				tex, err := subGetBoundTextureForUnit(ctx, cmd, id, nil, s, GetState(s), cmd.Thread(), nil, tu, target)
+				tex, err := subGetBoundTextureForUnit(ctx, cmd, id, nil, s, GetState(s), cmd.Thread(), nil, nil, tu, target)
 				if !tex.IsNil() && err == nil {
 					if !tex.EGLImage().IsNil() {
 						stateKeys = append(stateKeys, eglImageDataKey{tex.EGLImage()})
@@ -330,7 +330,7 @@ func getTextureDataAndSize(
 	target GLenum,
 	level GLint) (dependencygraph.StateKey, dependencygraph.StateKey) {
 
-	tex, err := subGetBoundTextureForUnit(ctx, cmd, id, nil, s, GetState(s), cmd.Thread(), nil, unit, target)
+	tex, err := subGetBoundTextureForUnit(ctx, cmd, id, nil, s, GetState(s), cmd.Thread(), nil, nil, unit, target)
 	if tex.IsNil() || err != nil {
 		log.E(ctx, "Can not find texture %v in unit %v", target, unit)
 		return nil, nil

--- a/gapis/api/gles/externs.go
+++ b/gapis/api/gles/externs.go
@@ -38,6 +38,7 @@ type externs struct {
 	cmdID api.CmdID
 	s     *api.GlobalState
 	b     *rb.Builder
+	w     api.StateWatcher
 }
 
 func (e externs) mapMemory(slice memory.Slice) {

--- a/gapis/api/gles/find_issues.go
+++ b/gapis/api/gles/find_issues.go
@@ -94,7 +94,7 @@ func (t *findIssues) Transform(ctx context.Context, id api.CmdID, cmd api.Cmd, o
 	ctx = log.Enter(ctx, "findIssues")
 	cb := CommandBuilder{Thread: cmd.Thread(), Arena: t.state.Arena}
 	t.lastGlError = GLenum_GL_NO_ERROR
-	mutateErr := cmd.Mutate(ctx, id, t.state, nil /* no builder */)
+	mutateErr := cmd.Mutate(ctx, id, t.state, nil /* no builder */, nil /* no watcher */)
 
 	mutatorsGlError := t.lastGlError
 	if e := FindErrorState(cmd.Extras()); e != nil {

--- a/gapis/api/gles/image.go
+++ b/gapis/api/gles/image.go
@@ -34,13 +34,13 @@ func (i Imageʳ) getUnsizedFormatAndType() (unsizedFormat, ty GLenum) {
 }
 
 func cubemapFaceToLayer(target GLenum) GLint {
-	layer, _ := subCubemapFaceToLayer(nil, nil, api.CmdNoID, nil, &api.GlobalState{}, nil, 0, nil, target)
+	layer, _ := subCubemapFaceToLayer(nil, nil, api.CmdNoID, nil, &api.GlobalState{}, nil, 0, nil, nil, target)
 	return layer
 }
 
 // getSizedFormatFromTuple returns sized format from unsized format and component type.
 func getSizedFormatFromTuple(unsizedFormat, ty GLenum) (sizedFormat GLenum) {
-	sf, _ := subGetSizedFormatFromTuple(nil, nil, api.CmdNoID, nil, &api.GlobalState{}, nil, 0, nil, unsizedFormat, ty)
+	sf, _ := subGetSizedFormatFromTuple(nil, nil, api.CmdNoID, nil, &api.GlobalState{}, nil, 0, nil, nil, unsizedFormat, ty)
 	if sf == GLenum_GL_NONE {
 		panic(fmt.Errorf("Unknown unsized format: %v, %v", unsizedFormat, ty))
 	}
@@ -55,7 +55,7 @@ func getUnsizedFormatAndType(sizedFormat GLenum) (unsizedFormat, ty GLenum) {
 
 // GetSizedFormatInfoOrPanic is wrapper for the 'GetSizedFormatInfo' api subroutine.
 func GetSizedFormatInfoOrPanic(sizedFormat GLenum) SizedFormatInfo {
-	info, _ := subGetSizedFormatInfo(nil, nil, api.CmdNoID, nil, &api.GlobalState{}, nil, 0, nil, sizedFormat)
+	info, _ := subGetSizedFormatInfo(nil, nil, api.CmdNoID, nil, &api.GlobalState{}, nil, 0, nil, nil, sizedFormat)
 	if info.SizedFormat() == GLenum_GL_NONE {
 		panic(fmt.Errorf("Unknown sized format: %v", sizedFormat))
 	}
@@ -122,7 +122,7 @@ var glChannelToStreamChannel = map[GLenum]stream.Channel{
 
 // getUncompressedStreamFormat returns the decoding format which can be used to read single pixel.
 func getUncompressedStreamFormat(unsizedFormat, ty GLenum) (format *stream.Format, err error) {
-	info, _ := subGetUnsizedFormatInfo(nil, nil, api.CmdNoID, nil, &api.GlobalState{}, nil, 0, nil, unsizedFormat)
+	info, _ := subGetUnsizedFormatInfo(nil, nil, api.CmdNoID, nil, &api.GlobalState{}, nil, 0, nil, nil, unsizedFormat)
 	if info.Count() == 0 {
 		return nil, fmt.Errorf("Unknown unsized format: %v", unsizedFormat)
 	}

--- a/gapis/api/gles/state_builder.go
+++ b/gapis/api/gles/state_builder.go
@@ -156,7 +156,7 @@ func (sb *stateBuilder) write(cmd api.Cmd) {
 		fn(cmd)
 	}
 	sb.preCmd = sb.preCmd[:0]
-	if err := cmd.Mutate(sb.ctx, api.CmdNoID, sb.newState, nil); err != nil {
+	if err := cmd.Mutate(sb.ctx, api.CmdNoID, sb.newState, nil, nil); err != nil {
 		log.W(sb.ctx, "Initial cmd %v: %v - %v", len(sb.cmds), cmd, err)
 	} else {
 		log.D(sb.ctx, "Initial cmd %v: %v", len(sb.cmds), cmd)

--- a/gapis/api/gles/texture_compat.go
+++ b/gapis/api/gles/texture_compat.go
@@ -141,7 +141,7 @@ func (tc *textureCompat) convertFormat(
 		}
 
 		// Luminance/Alpha is not supported on desktop so convert it to R/G.
-		if t, err := subGetBoundTextureOrErrorInvalidEnum(ctx, nil, api.CmdNoID, nil, s, GetState(s), cmd.Thread(), nil, target); err == nil {
+		if t, err := subGetBoundTextureOrErrorInvalidEnum(ctx, nil, api.CmdNoID, nil, s, GetState(s), cmd.Thread(), nil, nil, target); err == nil {
 			if laCompat, ok := luminanceAlphaCompat[internalformat.get()]; ok {
 				internalformat.set(laCompat.rgFormat)
 				tc.compatSwizzle[t] = laCompat.compatSwizzle
@@ -202,7 +202,7 @@ func (tc *textureCompat) postTexParameter(ctx context.Context, target, parameter
 	s := out.State()
 	switch parameter {
 	case GLenum_GL_TEXTURE_SWIZZLE_R, GLenum_GL_TEXTURE_SWIZZLE_G, GLenum_GL_TEXTURE_SWIZZLE_B, GLenum_GL_TEXTURE_SWIZZLE_A:
-		if t, err := subGetBoundTextureOrErrorInvalidEnum(ctx, nil, api.CmdNoID, nil, s, GetState(s), cmd.Thread(), nil, target); err == nil {
+		if t, err := subGetBoundTextureOrErrorInvalidEnum(ctx, nil, api.CmdNoID, nil, s, GetState(s), cmd.Thread(), nil, nil, target); err == nil {
 			_, curr := tc.getSwizzle(t, parameter)
 			// The tex parameter was recently mutated, so set the original swizzle from current state.
 			tc.origSwizzle[parameter][t] = curr

--- a/gapis/api/gles/tweaker.go
+++ b/gapis/api/gles/tweaker.go
@@ -66,7 +66,7 @@ func (t *tweaker) getCapability(ctx context.Context, name GLenum) bool {
 	o := a.Extras().Observations()
 	s := t.out.State()
 	i := GLuint(0) // capability index.
-	res, err := subGetCapability(ctx, a, t.dID, o, s, GetState(s), a.Thread(), nil, name, i)
+	res, err := subGetCapability(ctx, a, t.dID, o, s, GetState(s), a.Thread(), nil, nil, name, i)
 	if err != nil {
 		return false
 	}

--- a/gapis/api/gvr/framebindings.go
+++ b/gapis/api/gvr/framebindings.go
@@ -97,7 +97,7 @@ func (r *FrameBindingsResolvable) Resolve(ctx context.Context) (interface{}, err
 				}
 			}
 		}
-		cmd.Mutate(ctx, id, s, nil)
+		cmd.Mutate(ctx, id, s, nil, nil)
 		return nil
 	})
 

--- a/gapis/api/reference.go
+++ b/gapis/api/reference.go
@@ -1,0 +1,47 @@
+// Copyright (C) 2018 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import (
+	"sync/atomic"
+)
+
+// RefID is a type used to identify instances of the reference types used in the API models.
+type RefID uint64
+
+// NilRefID identifies a nil reference in the API models.
+const NilRefID = RefID(0)
+
+// Reference is an interface which exposes a unique identifier.
+// Reference types in the API models should implement this interface.
+type Reference interface {
+	RefID() RefID
+}
+
+var lastRefID uint64
+
+// NewRefID creates a new RefID.
+// This RefID is unique within the process.
+func NewRefID() RefID {
+	return RefID(atomic.AddUint64(&lastRefID, 1))
+}
+
+// NilReference is a type representing a nil reference where an implementation
+// of the `Reference` interface is expected.
+type NilReference struct{}
+
+func (NilReference) RefID() RefID {
+	return NilRefID
+}

--- a/gapis/api/sync/sync.go
+++ b/gapis/api/sync/sync.go
@@ -80,7 +80,7 @@ type writer struct {
 func (s *writer) State() *api.GlobalState { return s.state }
 
 func (s *writer) MutateAndWrite(ctx context.Context, id api.CmdID, cmd api.Cmd) {
-	cmd.Mutate(ctx, id, s.state, nil)
+	cmd.Mutate(ctx, id, s.state, nil, nil)
 	s.cmds = append(s.cmds, cmd)
 }
 
@@ -175,7 +175,7 @@ func MutateWithSubcommands(ctx context.Context, c *path.Capture, cmds []api.Cmd,
 		if sync, ok := cmd.API().(SynchronizedAPI); ok {
 			sync.MutateSubcommands(ctx, id, cmd, s, preSubCmdCb, postSubCmdCb)
 		} else {
-			cmd.Mutate(ctx, id, s, nil)
+			cmd.Mutate(ctx, id, s, nil, nil)
 		}
 		postCmdCb(s, api.SubCmdIdx{uint64(id)}, cmd)
 		return nil

--- a/gapis/api/templates/api.go.tmpl
+++ b/gapis/api/templates/api.go.tmpl
@@ -1713,6 +1713,14 @@ import (
   }
 
   func (ϟc *{{$name}}) RefID() ϟapi.RefID { return ϟc.refID }
+
+  func (ϟc *{{$name}}) Alive() bool {
+    {{if GetAnnotation $ "alive"}}
+      return true
+    {{else}}
+      return false
+    {{end}}
+  }
 {{end}}
 
 

--- a/gapis/api/templates/api.go.tmpl
+++ b/gapis/api/templates/api.go.tmpl
@@ -388,6 +388,33 @@ import (
     return m
   }
 
+  func (m {{$name}}) CreateHandleʷ(ϟctx context.Context, ϟw ϟapi.StateWatcher, key {{$key}}, val {{$value}}) {{$name}} {
+    if ϟw != nil {
+      ϟw.OnSet(ϟctx, m, ϟapi.MapIndexFragment{key},
+        {{Template "Reference" "Type" $.ValueType "Val" "(*m.Map)[key]"}},
+        {{Template "Reference" "Type" $.ValueType "Val" "val"}})
+      if _, ok := (*m.Map)[key]; !ok {
+        ϟw.OpenForwardDependency(ϟctx, key)
+      }
+    }
+    (*m.Map)[key] = val
+    return m
+  }
+
+  func (m {{$name}}) DestroyHandleʷ(ϟctx context.Context, ϟw ϟapi.StateWatcher, key {{$key}}) {
+    if m.Map != nil {
+      if ϟw != nil {
+        ϟw.OnSet(ϟctx, m, ϟapi.MapIndexFragment{key},
+          {{Template "Reference" "Type" $.ValueType "Val" "(*m.Map)[key]"}},
+          ϟapi.NilReference{})
+        if _, ok := (*m.Map)[key]; ok {
+          ϟw.CloseForwardDependency(ϟctx, key)
+        }
+      }
+      delete(*m.Map, key)
+    }
+  }
+
   func (m {{$name}}) Contains(key {{$key}}) (ok bool) {
     if m.Map != nil {
       _, ok = (*m.Map)[key]

--- a/gapis/api/templates/api.go.tmpl
+++ b/gapis/api/templates/api.go.tmpl
@@ -166,6 +166,7 @@ import (
 
   type {{$name}} struct {
     data *[{{$ty.Size}}]{{$el}}
+    refID ϟapi.RefID
     uncompareable
   }
 
@@ -173,7 +174,10 @@ import (
   var Nil{{$name}} = New{{$name}}(constantArena)
 
   func New{{$name}}(ϟa arena.Arena, els... {{$el}}) {{$name}} {
-    out := {{$name}}{ data: &[{{$ty.Size}}]{{$el}}{} }
+    out := {{$name}}{
+      data: &[{{$ty.Size}}]{{$el}}{},
+      refID: ϟapi.NewRefID(),
+    }
     for i := 0; i < {{$ty.Size}}; i++ {
       if i < len(els) {
         out.Set(i, els[i])
@@ -184,14 +188,49 @@ import (
     return out
   }
 
-  func (a {{$name}}) Get(i int) {{$el}} { return a.data[i] }
+  func (a {{$name}}) Get(i int) {{$el}} {
+    return a.data[i]
+  }
 
-  func (a {{$name}}) Set(i int, v {{$el}}) { a.data[i] = v }
+  func (a {{$name}}) Getʷ(ϟctx context.Context, ϟw ϟapi.StateWatcher, i int) {{$el}} {
+    v := a.data[i]
+    if ϟw != nil {
+      ϟw.OnGet(ϟctx, a, ϟapi.ArrayIndexFragment{i}, {{Template "Reference" "Type"  $ty.ValueType "Val" "v"}})
+    }
+    return v
+  }
+
+  func (a {{$name}}) Set(i int, v {{$el}}) {
+    a.data[i] = v
+  }
+
+  func (a {{$name}}) Setʷ(ϟctx context.Context, ϟw ϟapi.StateWatcher, i int, v {{$el}}) {
+    if ϟw != nil {
+      ϟw.OnSet(ϟctx, a, ϟapi.ArrayIndexFragment{i},
+        {{Template "Reference" "Type" $ty.ValueType "Val" "a.data[i]"}},
+        {{Template "Reference" "Type" $ty.ValueType "Val" "v"}})
+    }
+    a.data[i] = v
+  }
 
   // Equals returns true if the array is equal to o.
   func (a {{$name}}) Equals(o {{$name}}) bool {
     for i, c := 0, {{$ty.Size}}; i < c; i++ {
-      if !({{Template "Go.Equal" "Type" $ty.ValueType "LHS" "a.Get(i)" "RHS" "o.Get(i)"}}) {
+      if !({{Template "Equal" "Type" $ty.ValueType "LHS" "a.Get(i)" "RHS" "o.Get(i)"}}) {
+        return false
+      }
+    }
+    return true
+  }
+
+  // Equals returns true if the array is equal to o.
+  func (a {{$name}}) Equalsʷ(ϟctx context.Context, ϟw ϟapi.StateWatcher, o {{$name}}) bool {
+    if ϟw != nil {
+      ϟw.OnGet(ϟctx, a, ϟapi.CompleteFragment{}, ϟapi.NilReference{})
+      ϟw.OnGet(ϟctx, o, ϟapi.CompleteFragment{}, ϟapi.NilReference{})
+    }
+    for i, c := 0, {{$ty.Size}}; i < c; i++ {
+      if !({{Template "Equal" "Type" $ty.ValueType "LHS" "a.Getʷ(ϟctx, ϟw, i)" "RHS" "o.Getʷ(ϟctx, ϟw, i)" "Watch" true}}) {
         return false
       }
     }
@@ -225,12 +264,33 @@ import (
 
   // Clone makes a deep copy of this static array, using ϟa for allocations.
   func (m {{$name}}) Clone(ϟa arena.Arena, ϟseen ϟapi.CloneContext) {{$name}} {
-    out := {{$name}}{ data: &[{{$ty.Size}}]{{$el}}{} }
+    out := {{$name}}{
+      data: &[{{$ty.Size}}]{{$el}}{},
+      refID: ϟapi.NewRefID(),
+    }
     for i := 0; i < {{$ty.Size}}; i++ {
       out.Set(i, {{Template "Clone" "Type" $ty.ValueType "Src" "m.Get(i)"}})
     }
     return out
   }
+
+  // Clone makes a deep copy of this static array, using ϟa for allocations.
+  func (m {{$name}}) Cloneʷ(ϟctx context.Context, ϟw ϟapi.StateWatcher, ϟa arena.Arena, ϟseen ϟapi.CloneContext) {{$name}} {
+    out := {{$name}}{
+      data: &[{{$ty.Size}}]{{$el}}{},
+      refID: ϟapi.NewRefID(),
+    }
+    if ϟw != nil {
+      ϟw.OnGet(ϟctx, m, ϟapi.CompleteFragment{}, ϟapi.NilReference{})
+      ϟw.OnSet(ϟctx, out, ϟapi.CompleteFragment{}, ϟapi.NilReference{}, ϟapi.NilReference{})
+    }
+    for i := 0; i < {{$ty.Size}}; i++ {
+      out.Setʷ(ϟctx, ϟw, i, {{Template "Clone" "Type" $ty.ValueType "Src" "m.Getʷ(ϟctx, ϟw, i)" "Watch" true}})
+    }
+    return out
+  }
+
+  func (c {{$name}}) RefID() ϟapi.RefID { return c.refID }
 {{end}}
 
 
@@ -247,12 +307,17 @@ import (
   {{$value := Macro "Go.Type" $.ValueType}}
 
   type {{$name}} struct {
-    Map *map[{{$key}}]{{$value}}
-    a   arena.Arena
+    Map   *map[{{$key}}]{{$value}}
+    a     arena.Arena
+    refID ϟapi.RefID
   }
 
   func New{{$name}}(ϟa arena.Arena) {{$name}} {
-    return {{$name}} { &map[{{$key}}]{{$value}}{}, ϟa }
+    return {{$name}} {
+      Map: &map[{{$key}}]{{$value}}{},
+      a: ϟa,
+      refID: ϟapi.NewRefID(),
+    }
   }
 
   // Arena returns the memory arena used to allocate this map.
@@ -263,6 +328,18 @@ import (
     v, ok := (*m.Map)[key]
     if !ok {
       v = {{Template "Go.Null" $.ValueType}}
+    }
+    return v
+  }
+
+  func (m {{$name}}) Getʷ(ϟctx context.Context, ϟw ϟapi.StateWatcher, key {{$key}}) {{$value}} {
+    ϟa := m.a; _ = ϟa
+    v, ok := (*m.Map)[key]
+    if !ok {
+      v = {{Template "Go.Null" $.ValueType}}
+    }
+    if ϟw != nil {
+      ϟw.OnGet(ϟctx, m, ϟapi.MapIndexFragment{key}, {{Template "Reference" "Type" $.ValueType "Val" "v"}})
     }
     return v
   }
@@ -280,7 +357,33 @@ import (
     return
   }
 
+  func (m {{$name}}) Lookupʷ(ϟctx context.Context, ϟw ϟapi.StateWatcher, key {{$key}}) (v {{$value}}, ok bool) {
+    ϟa := m.a; _ = ϟa
+    if m.Map != nil {
+      v, ok = (*m.Map)[key]
+    }
+    {{if $init := Macro "Go.Null" $.ValueType}}
+      if !ok {
+        v = {{$init}}
+      }
+    {{end}}
+    if ϟw != nil {
+      ϟw.OnGet(ϟctx, m, ϟapi.MapIndexFragment{key}, {{Template "Reference" "Type" $.ValueType "Val" "v"}})
+    }
+    return
+  }
+
   func (m {{$name}}) Add(key {{$key}}, val {{$value}}) {{$name}} {
+    (*m.Map)[key] = val
+    return m
+  }
+
+  func (m {{$name}}) Addʷ(ϟctx context.Context, ϟw ϟapi.StateWatcher, key {{$key}}, val {{$value}}) {{$name}} {
+    if ϟw != nil {
+      ϟw.OnSet(ϟctx, m, ϟapi.MapIndexFragment{key},
+        {{Template "Reference" "Type" $.ValueType "Val" "(*m.Map)[key]"}},
+        {{Template "Reference" "Type" $.ValueType "Val" "val"}})
+    }
     (*m.Map)[key] = val
     return m
   }
@@ -292,8 +395,34 @@ import (
     return
   }
 
+  func (m {{$name}}) Containsʷ(ϟctx context.Context, ϟw ϟapi.StateWatcher, key {{$key}}) bool {
+    if m.Map != nil {
+      {{if or (IsMap $.ValueType) (IsReference $.ValueType) (IsClass $.ValueType)}}
+        v, ok := (*m.Map)[key]
+      {{else}}
+        _, ok := (*m.Map)[key]
+      {{end}}
+      if ϟw != nil {
+        ϟw.OnGet(ϟctx, m, ϟapi.MapIndexFragment{key}, {{Template "Reference" "Type" $.ValueType "Val" "v"}})
+      }
+      return ok
+    }
+    return false
+  }
+
   func (m {{$name}}) Remove(key {{$key}}) {
     if m.Map != nil {
+      delete(*m.Map, key)
+    }
+  }
+
+  func (m {{$name}}) Removeʷ(ϟctx context.Context, ϟw ϟapi.StateWatcher, key {{$key}}) {
+    if m.Map != nil {
+      if ϟw != nil {
+        ϟw.OnSet(ϟctx, m, ϟapi.MapIndexFragment{key},
+          {{Template "Reference" "Type" $.ValueType "Val" "(*m.Map)[key]"}},
+          ϟapi.NilReference{})
+      }
       delete(*m.Map, key)
     }
   }
@@ -305,9 +434,30 @@ import (
     return 0
   }
 
+  func (m {{$name}}) Lenʷ(ϟctx context.Context, ϟw ϟapi.StateWatcher) int {
+    if m.Map != nil {
+      if ϟw != nil {
+        ϟw.OnGet(ϟctx, m, ϟapi.CompleteFragment{}, ϟapi.NilReference{})
+      }
+      return len(*m.Map)
+    }
+    return 0
+  }
+
   // All returns this {{$name}} as a Go map.
   func (m {{$name}}) All() map[{{$key}}]{{$value}} {
     if m.Map != nil {
+      return *m.Map
+    }
+    return nil
+  }
+
+  // All returns this {{$name}} as a Go map.
+  func (m {{$name}}) Allʷ(ϟctx context.Context, ϟw ϟapi.StateWatcher) map[{{$key}}]{{$value}} {
+    if m.Map != nil {
+      if ϟw != nil {
+        ϟw.OnGet(ϟctx, m, ϟapi.CompleteFragment{}, ϟapi.NilReference{})
+      }
       return *m.Map
     }
     return nil
@@ -340,18 +490,69 @@ import (
     return s
   }
 
+  func (m {{$name}}) Keysʷ(ϟctx context.Context, ϟw ϟapi.StateWatcher) []{{$key}} {
+    if m.Map == nil {
+      return nil
+    }
+    if ϟw != nil {
+      ϟw.OnGet(ϟctx, m, ϟapi.CompleteFragment{}, ϟapi.NilReference{})
+    }
+    s := make({{$sorted}}, len(*m.Map))
+    i := 0
+    for k, _ := range *m.Map {
+      s[i] = k
+      i++
+    }
+    sort.Sort(s)
+    return s
+  }
+
   // Clone makes a deep copy of this map.
   func (m {{$name}}) Clone(ϟa arena.Arena, ϟseen ϟapi.CloneContext) {{$name}} {
-    if existing, ok := ϟseen[m.Map]; ok {
-      return {{$name}}{Map: existing.(*map[{{$key}}]{{$value}}), a: ϟa}
+    if existing, ok := ϟseen[m.refID]; ok {
+      return existing.({{$name}})
     }
     out := make(map[{{$key}}]{{$value}}, len(*m.Map))
     ϟseen[m.Map] = &out
+    cloned := {{$name}}{
+      Map: &out,
+      a: ϟa,
+      refID: ϟapi.NewRefID(),
+    }
+    ϟseen[m.refID] = cloned
     for k, v := range *m.Map {
       out[{{Template "Clone" "Type" $.KeyType "Src" "k"}}] = {{Template "Clone" "Type" $.ValueType "Src" "v"}}
     }
-    return {{$name}}{Map: &out, a: ϟa}
+    return cloned
   }
+
+  // Clone makes a deep copy of this map.
+  func (m {{$name}}) Cloneʷ(ϟctx context.Context, ϟw ϟapi.StateWatcher, ϟa arena.Arena, ϟseen ϟapi.CloneContext) {{$name}} {
+    if existing, ok := ϟseen[m.refID]; ok {
+      return existing.({{$name}})
+    }
+    if ϟw != nil {
+      ϟw.OnGet(ϟctx, m, ϟapi.CompleteFragment{}, ϟapi.NilReference{})
+    }
+    out := make(map[{{$key}}]{{$value}}, len(*m.Map))
+    ϟseen[m.Map] = &out
+    cloned := {{$name}}{
+      Map: &out,
+      a: ϟa,
+      refID: ϟapi.NewRefID(),
+    }
+    ϟseen[m.refID] = cloned
+    for k, v := range *m.Map {
+      out[{{Template "Clone" "Type" $.KeyType "Src" "k" "Watch" true}}] =§
+        {{Template "Clone" "Type" $.ValueType "Src" "v" "Watch" true}}
+    }
+    if ϟw != nil {
+      ϟw.OnSet(ϟctx, cloned, ϟapi.CompleteFragment{}, ϟapi.NilReference{}, ϟapi.NilReference{})
+    }
+    return cloned
+  }
+
+  func (m {{$name}}) RefID() ϟapi.RefID { return m.refID }
 {{end}}
 
 
@@ -369,6 +570,7 @@ import (
 
   type {{$name}} struct {
     data *{{$data}}
+    refID ϟapi.RefID
   }
 
   // Nil{{$name}} is a nil-pointer reference.
@@ -396,21 +598,51 @@ import (
   func (c {{$name}}) IsNil() bool { return c.data == nil }
 
   // SetNil nullifies this reference.
-  func (c {{$name}}) SetNil() { c.data = nil }
+  func (c {{$name}}) SetNil() {
+    c.data = nil
+    c.refID = ϟapi.NilRefID
+  }
 
   // Clone makes a deep copy of this reference.
   func (c {{$name}}) Clone(ϟa arena.Arena, ϟseen ϟapi.CloneContext) {{$name}} {
     if c.IsNil() { return Nil{{$name}} }
-    if existing, ok := ϟseen[c.data]; ok {
-      return {{$name}}{data: existing.(*{{$data}})}
+    if existing, ok := ϟseen[c.refID]; ok {
+      return existing.({{$name}})
     }
-    d := &{{$data}}{}
-    ϟseen[c.data] = d
+    cloned := {{$name}}{
+      data: &{{$data}}{},
+      refID: ϟapi.NewRefID(),
+    }
+    ϟseen[c.refID] = cloned
     {{range $f := $.To.Fields}}
       {{$name := $f.Name | GoPrivateName}}
-      d.{{$name}} = c.data.{{Template "Clone" "Type" $f.Type "Src" $name}}
+      cloned.data.{{$name}} = c.data.{{Template "Clone" "Type" $f.Type "Src" $name}}
     {{end}}
-    return {{$name}}{data: d}
+    return cloned
+  }
+
+  // Clone makes a deep copy of this reference.
+  func (c {{$name}}) Cloneʷ(ϟctx context.Context, ϟw ϟapi.StateWatcher, ϟa arena.Arena, ϟseen ϟapi.CloneContext) {{$name}} {
+    if c.IsNil() { return Nil{{$name}} }
+    if existing, ok := ϟseen[c.refID]; ok {
+      return existing.({{$name}})
+    }
+    if ϟw != nil {
+      ϟw.OnGet(ϟctx, c, ϟapi.CompleteFragment{}, ϟapi.NilReference{})
+    }
+    cloned := {{$name}}{
+      data: &{{$data}}{},
+      refID: ϟapi.NewRefID(),
+    }
+    ϟseen[c.refID] = cloned
+    {{range $f := $.To.Fields}}
+      {{$name := $f.Name | GoPrivateName}}
+      cloned.data.{{$name}} = c.data.{{Template "Clone" "Type" $f.Type "Src" $name "Watch" true}}
+    {{end}}
+    if ϟw != nil {
+      ϟw.OnSet(ϟctx, cloned, ϟapi.CompleteFragment{}, ϟapi.NilReference{}, ϟapi.NilReference{})
+    }
+    return cloned
   }
 
   {{if GetAnnotation $.To "resource"}}
@@ -430,16 +662,20 @@ import (
   {{$to := Macro "Go.Type" $.To}}
   func (c {{$name}}) Get() {{$to}} {
     d := *c.data
-    return {{$to}}{data: &d}
+    return {{$to}}{
+      data: &d,
+      refID: ϟapi.NewRefID(),
+    }
   }
 
   func (c {{$name}}) Set(v {{$to}}) {{$name}} {
     *c.data = *v.data
+    c.refID = v.refID
     return c
   }
 
   {{range $f := $.To.Fields}}
-    {{Template "DeclareGetterSetter" "Struct" $name "Prefix" "data" "Name" $f.Name "Type" $f.Type}}
+    {{Template "DeclareGetterSetter" "Struct" $name "Class" $to "Prefix" "data" "Name" $f.Name "Type" $f.Type "Watch" true}}
   {{end}}
 
   // New{{$name}} returns a new {{$name}} reference with the given fields.
@@ -448,12 +684,14 @@ import (
       , {{$f.Name | GoPrivateName}} {{Template "Go.Type" $f}}§
     {{end}}
   ) {{$name}} {
+    ϟdata := &{{$data}}{
+      {{range $f := $.To.Fields}}
+        {{$f.Name | GoPrivateName}}: {{$f.Name | GoPrivateName}},
+      {{end}}
+    }
     return {{$name}}{
-      data: &{{$data}}{
-        {{range $f := $.To.Fields}}
-          {{$f.Name | GoPrivateName}}: {{$f.Name | GoPrivateName}},
-        {{end}}
-      },
+      data: ϟdata,
+      refID: ϟapi.NewRefID(),
     }
   }
 
@@ -469,6 +707,8 @@ import (
       {{end}}
     )
   }
+
+  func (c {{$name}}) RefID() ϟapi.RefID { return c.refID }
 {{end}}
 
 
@@ -546,8 +786,8 @@ import (
   }
 
   // Clone returns a copy of the {{$slice_ty}} in a new memory pool.
-  func (s {{$slice_ty}}) Clone(ϟctx context.Context, ϟc ϟapi.Cmd, ϟg *ϟapi.GlobalState, ϟb *builder.Builder) {{$slice_ty}} {
-    s.OnRead(ϟctx, ϟc, ϟg, ϟb)
+  func (s {{$slice_ty}}) Clone(ϟctx context.Context, ϟc ϟapi.Cmd, ϟg *ϟapi.GlobalState, ϟb *builder.Builder, ϟw ϟapi.StateWatcher) {{$slice_ty}} {
+    s.OnReadʷ(ϟctx, ϟc, ϟg, ϟb, ϟw)
     id, dst := ϟg.Memory.New()
     dst.Write(0, ϟg.Memory.MustGet(s.pool).Slice(s.Range()))
     return {{$slice_ty}}{
@@ -636,8 +876,13 @@ import (
 
     // Read reads and returns all the {{$el_ty}} elements in this {{$slice_ty}}.
     func (s {{$slice_ty}}) Read(ϟctx context.Context, ϟc ϟapi.Cmd, ϟg *ϟapi.GlobalState, ϟb *builder.Builder) ([]{{$el_ty}}, error) {
+      return s.Readʷ(ϟctx, ϟc, ϟg, ϟb, nil)
+    }
+
+    // Read reads and returns all the {{$el_ty}} elements in this {{$slice_ty}}.
+    func (s {{$slice_ty}}) Readʷ(ϟctx context.Context, ϟc ϟapi.Cmd, ϟg *ϟapi.GlobalState, ϟb *builder.Builder, ϟw ϟapi.StateWatcher) ([]{{$el_ty}}, error) {
       ϟa := ϟg.Arena; _ = ϟa
-      s.OnRead(ϟctx, ϟc, ϟg, ϟb)
+      s.OnReadʷ(ϟctx, ϟc, ϟg, ϟb, ϟw)
       out := make([]{{$el_ty}}, s.Count())
       ϟd := s.Decoder(ϟctx, ϟg)
       {{if IsU8 $s.To}}
@@ -655,7 +900,12 @@ import (
 
     // MustRead calls and returns Read, panicing if there was an error.
     func (s {{$slice_ty}}) MustRead(ϟctx context.Context, ϟc ϟapi.Cmd, ϟg *ϟapi.GlobalState, ϟb *builder.Builder) []{{$el_ty}} {
-      vals, err := s.Read(ϟctx, ϟc, ϟg, ϟb)
+      return s.MustReadʷ(ϟctx, ϟc, ϟg, ϟb, nil)
+    }
+
+    // MustRead calls and returns Read, panicing if there was an error.
+    func (s {{$slice_ty}}) MustReadʷ(ϟctx context.Context, ϟc ϟapi.Cmd, ϟg *ϟapi.GlobalState, ϟb *builder.Builder, ϟw ϟapi.StateWatcher) []{{$el_ty}} {
+      vals, err := s.Readʷ(ϟctx, ϟc, ϟg, ϟb, ϟw)
       panicOnError(err)
       return vals
     }
@@ -663,11 +913,17 @@ import (
     // Write copies elements from src to this slice. The number of elements copied is returned
     // which is the minimum of s.count and len(src).
     func (s {{$slice_ty}}) Write(ϟctx context.Context, src []{{$el_ty}}, ϟc ϟapi.Cmd, ϟg *ϟapi.GlobalState, ϟb *builder.Builder) (uint64, error) {
+      return s.Writeʷ(ϟctx, src, ϟc, ϟg, ϟb, nil)
+    }
+
+    // Write copies elements from src to this slice. The number of elements copied is returned
+    // which is the minimum of s.count and len(src).
+    func (s {{$slice_ty}}) Writeʷ(ϟctx context.Context, src []{{$el_ty}}, ϟc ϟapi.Cmd, ϟg *ϟapi.GlobalState, ϟb *builder.Builder, ϟw ϟapi.StateWatcher) (uint64, error) {
       ϟa := ϟg.Arena; _ = ϟa
       count := u64.Min(s.Count(), uint64(len(src)))
       e := s.Slice(0, count).Encoder(ϟg)
       ϟmem.Write(e, src[:count])
-      s.OnWrite(ϟctx, ϟc, ϟg, ϟb)
+      s.OnWriteʷ(ϟctx, ϟc, ϟg, ϟb, ϟw)
       if err := e.Error(); err != nil {
         return 0, err
       }
@@ -676,7 +932,12 @@ import (
 
     // MustWrite calls and returns Write, panicing if there was an error.
     func (s {{$slice_ty}}) MustWrite(ϟctx context.Context, src []{{$el_ty}}, ϟc ϟapi.Cmd, ϟg *ϟapi.GlobalState, ϟb *builder.Builder) uint64 {
-      count, err := s.Write(ϟctx, src, ϟc, ϟg, ϟb)
+      return s.MustWriteʷ(ϟctx, src, ϟc, ϟg, ϟb, nil)
+    }
+
+    // MustWrite calls and returns Write, panicing if there was an error.
+    func (s {{$slice_ty}}) MustWriteʷ(ϟctx context.Context, src []{{$el_ty}}, ϟc ϟapi.Cmd, ϟg *ϟapi.GlobalState, ϟb *builder.Builder, ϟw ϟapi.StateWatcher) uint64 {
+      count, err := s.Writeʷ(ϟctx, src, ϟc, ϟg, ϟb, ϟw)
       panicOnError(err)
       return count
     }
@@ -684,25 +945,37 @@ import (
     // Copy copies elements from src to this slice.
     // The number of elements copied is the minimum of dst.Count and src.Count.
     // The slices of this and dst to the copied elements is returned.
-    func (dst {{$slice_ty}}) Copy(ϟctx context.Context, src {{$slice_ty}}, ϟc ϟapi.Cmd, ϟg *ϟapi.GlobalState, ϟb *builder.Builder) (d, s {{$slice_ty}}) {
+    func (dst {{$slice_ty}}) Copy(ϟctx context.Context, src {{$slice_ty}}, ϟc ϟapi.Cmd, ϟg *ϟapi.GlobalState, ϟb *builder.Builder, ϟw ϟapi.StateWatcher) (d, s {{$slice_ty}}) {
+      return dst.Copyʷ(ϟctx, src, ϟc, ϟg, ϟb, ϟw)
+    }
+
+    // Copy copies elements from src to this slice.
+    // The number of elements copied is the minimum of dst.Count and src.Count.
+    // The slices of this and dst to the copied elements is returned.
+    func (dst {{$slice_ty}}) Copyʷ(ϟctx context.Context, src {{$slice_ty}}, ϟc ϟapi.Cmd, ϟg *ϟapi.GlobalState, ϟb *builder.Builder, ϟw ϟapi.StateWatcher) (d, s {{$slice_ty}}) {
       count := u64.Min(dst.Count(), src.Count())
       dst, src = dst.Slice(0, count), src.Slice(0, count)
     {{if $el_is_ptr}}
       if (dst.Pool() == ϟmem.ApplicationPool) != (src.Pool() == ϟmem.ApplicationPool) {
-        dst.MustWrite(ϟctx, src.MustRead(ϟctx, ϟc, ϟg, ϟb), ϟc, ϟg, ϟb) // Element-wise copy so we can convert u64 <-> {{$ptr_ty}}
+        dst.MustWriteʷ(ϟctx, src.MustReadʷ(ϟctx, ϟc, ϟg, ϟb, ϟw), ϟc, ϟg, ϟb, ϟw) // Element-wise copy so we can convert u64 <-> {{$ptr_ty}}
       } else {
     {{end}}
-      src.OnRead(ϟctx, ϟc, ϟg, ϟb)
+      src.OnReadʷ(ϟctx, ϟc, ϟg, ϟb, ϟw)
       ϟg.Memory.MustGet(dst.Pool()).Write(dst.Base(), ϟg.Memory.MustGet(src.Pool()).Slice(src.Range()))
-      dst.OnWrite(ϟctx, ϟc, ϟg, ϟb)
+      dst.OnWriteʷ(ϟctx, ϟc, ϟg, ϟb, ϟw)
     {{if $el_is_ptr}} } {{end}}
       return dst, src
     }
 
     // Contains returns true if the slice contains the specified value.
     func (s {{$slice_ty}}) Contains(ϟctx context.Context, val {{$el_ty}}, ϟc ϟapi.Cmd, ϟg *ϟapi.GlobalState, ϟb *builder.Builder) bool {
-      for _, e := range s.MustRead(ϟctx, ϟc, ϟg, ϟb) {
-        if {{Template "Go.Equal" "Type" $s.To "LHS" "e" "RHS" "val"}} {
+      return s.Containsʷ(ϟctx, val, ϟc, ϟg, ϟb, nil)
+    }
+
+    // Contains returns true if the slice contains the specified value.
+    func (s {{$slice_ty}}) Containsʷ(ϟctx context.Context, val {{$el_ty}}, ϟc ϟapi.Cmd, ϟg *ϟapi.GlobalState, ϟb *builder.Builder, ϟw ϟapi.StateWatcher) bool {
+      for _, e := range s.MustReadʷ(ϟctx, ϟc, ϟg, ϟb, ϟw) {
+        if {{Template "Equal" "Type" $s.To "LHS" "e" "RHS" "val"}} {
           return true
         }
       }
@@ -713,7 +986,15 @@ import (
 
   // OnRead calls the backing pool's OnRead callback. s is returned so calls can be chained.
   func (s {{$slice_ty}}) OnRead(ϟctx context.Context, ϟc ϟapi.Cmd, ϟg *ϟapi.GlobalState, ϟb *builder.Builder) {{$slice_ty}} {
+    return s.OnReadʷ(ϟctx, ϟc, ϟg, ϟb, nil)
+  }
+
+  // OnRead calls the backing pool's OnRead callback. s is returned so calls can be chained.
+  func (s {{$slice_ty}}) OnReadʷ(ϟctx context.Context, ϟc ϟapi.Cmd, ϟg *ϟapi.GlobalState, ϟb *builder.Builder, ϟw ϟapi.StateWatcher) {{$slice_ty}} {
     ϟl, ϟa := ϟg.MemoryLayout, ϟg.Arena; _, _ = ϟl, ϟa
+    if ϟw != nil {
+      ϟw.OnReadSlice(ϟctx, s)
+    }
     if pool, err := ϟg.Memory.Get(s.Pool()); err == nil {
       if f := pool.OnRead; f != nil {
         f(s.Range())
@@ -762,7 +1043,15 @@ import (
 
   // OnWrite calls the backing pool's OnWrite callback. s is returned so calls can be chained.
   func (s {{$slice_ty}}) OnWrite(ϟctx context.Context, ϟc ϟapi.Cmd, ϟg *ϟapi.GlobalState, ϟb *builder.Builder) {{$slice_ty}} {
+    return s.OnWriteʷ(ϟctx, ϟc, ϟg, ϟb, nil)
+  }
+
+  // OnWrite calls the backing pool's OnWrite callback. s is returned so calls can be chained.
+  func (s {{$slice_ty}}) OnWriteʷ(ϟctx context.Context, ϟc ϟapi.Cmd, ϟg *ϟapi.GlobalState, ϟb *builder.Builder, ϟw ϟapi.StateWatcher) {{$slice_ty}} {
     ϟl, ϟa := ϟg.MemoryLayout, ϟg.Arena; _, _ = ϟl, ϟa
+    if ϟw != nil {
+      ϟw.OnWriteSlice(ϟctx, s)
+    }
     if pool, err := ϟg.Memory.Get(s.Pool()); err == nil {
       if f := pool.OnWrite; f != nil {
         f(s.Range())
@@ -922,8 +1211,13 @@ import (
   {{if not $el_is_void}}
     // Read reads and returns the {{$el_ty}} element at the pointer.
     func (p {{$ptr_ty}}) Read(ϟctx context.Context, ϟc ϟapi.Cmd, ϟg *ϟapi.GlobalState, ϟb *builder.Builder) ({{$el_ty}}, error) {
+      return p.Readʷ(ϟctx, ϟc, ϟg, ϟb, nil)
+    }
+    
+    // Read reads and returns the {{$el_ty}} element at the pointer.
+    func (p {{$ptr_ty}}) Readʷ(ϟctx context.Context, ϟc ϟapi.Cmd, ϟg *ϟapi.GlobalState, ϟb *builder.Builder, ϟw ϟapi.StateWatcher) ({{$el_ty}}, error) {
       ϟa := ϟg.Arena; _ = ϟa
-      vals, err := p.Slice(0, 1, ϟg.MemoryLayout).Read(ϟctx, ϟc, ϟg, ϟb)
+      vals, err := p.Slice(0, 1, ϟg.MemoryLayout).Readʷ(ϟctx, ϟc, ϟg, ϟb, ϟw)
       if err != nil {
         return {{Template "Go.Null" (TypeOf $p.To)}}, err
       }
@@ -932,20 +1226,35 @@ import (
 
     // MustRead calls and returns Read, panicing if there was an error.
     func (p {{$ptr_ty}}) MustRead(ϟctx context.Context, ϟc ϟapi.Cmd, ϟg *ϟapi.GlobalState, ϟb *builder.Builder) {{$el_ty}} {
-      val, err := p.Read(ϟctx, ϟc, ϟg, ϟb)
+      return p.MustReadʷ(ϟctx, ϟc, ϟg, ϟb, nil)
+    }
+
+    // MustRead calls and returns Read, panicing if there was an error.
+    func (p {{$ptr_ty}}) MustReadʷ(ϟctx context.Context, ϟc ϟapi.Cmd, ϟg *ϟapi.GlobalState, ϟb *builder.Builder, ϟw ϟapi.StateWatcher) {{$el_ty}} {
+      val, err := p.Readʷ(ϟctx, ϟc, ϟg, ϟb, ϟw)
       panicOnError(err)
       return val
     }
 
     // Write writes value to the {{$el_ty}} element at the pointer.
     func (p {{$ptr_ty}}) Write(ϟctx context.Context, value {{$el_ty}}, ϟc ϟapi.Cmd, ϟg *ϟapi.GlobalState, ϟb *builder.Builder) error {
-      _, err := p.Slice(0, 1, ϟg.MemoryLayout).Write(ϟctx, []{{$el_ty}}{value}, ϟc, ϟg, ϟb)
+      return p.Writeʷ(ϟctx, value, ϟc, ϟg, ϟb, nil)
+    }
+
+    // Write writes value to the {{$el_ty}} element at the pointer.
+    func (p {{$ptr_ty}}) Writeʷ(ϟctx context.Context, value {{$el_ty}}, ϟc ϟapi.Cmd, ϟg *ϟapi.GlobalState, ϟb *builder.Builder, ϟw ϟapi.StateWatcher) error {
+      _, err := p.Slice(0, 1, ϟg.MemoryLayout).Writeʷ(ϟctx, []{{$el_ty}}{value}, ϟc, ϟg, ϟb, ϟw)
       return err
     }
 
     // MustWrite calls Write, panicing if there was an error.
     func (p {{$ptr_ty}}) MustWrite(ϟctx context.Context, value {{$el_ty}}, ϟc ϟapi.Cmd, ϟg *ϟapi.GlobalState, ϟb *builder.Builder) {
-      panicOnError(p.Write(ϟctx, value, ϟc, ϟg, ϟb))
+      p.MustWriteʷ(ϟctx, value, ϟc, ϟg, ϟb, nil)
+    }
+
+    // MustWrite calls Write, panicing if there was an error.
+    func (p {{$ptr_ty}}) MustWriteʷ(ϟctx context.Context, value {{$el_ty}}, ϟc ϟapi.Cmd, ϟg *ϟapi.GlobalState, ϟb *builder.Builder, ϟw ϟapi.StateWatcher) {
+      panicOnError(p.Writeʷ(ϟctx, value, ϟc, ϟg, ϟb, ϟw))
     }
   {{end}}
 
@@ -1065,6 +1374,7 @@ import (
   type {{$name}} struct {
     data *{{$data}}
     a    arena.Arena
+    refID ϟapi.RefID
     uncompareable
   }
 
@@ -1085,7 +1395,8 @@ import (
   }
 
   {{range $f := $.Fields}}
-    {{Template "DeclareGetterSetter" "Struct" $name "Prefix" "data" "Name" $f.Name "Type" $f.Type}}
+    {{Template "DeclareGetterSetter" "Struct" $name "Prefix" "data" "Name" $f.Name "Type" $f.Type "Watch" true}}
+    {{Template "DeclareFieldID" "Class" $name "Name" $f.Name}}
   {{end}}
 
   // Arena returns the memory arena used to allocate this class.
@@ -1098,12 +1409,14 @@ import (
       , {{$f.Name | GoPrivateName}} {{Template "Go.Type" $f}}§
     {{end}}
   ) {{$name}} {
+    ϟdata := &{{$data}} {
+      {{range $f := $.Fields}}
+        {{$f.Name | GoPrivateName}}: {{$f.Name | GoPrivateName}}, §
+      {{end}}
+    }
     return {{$name}}{
-      data: &{{$data}} {
-        {{range $f := $.Fields}}
-          {{$f.Name | GoPrivateName}}: {{$f.Name | GoPrivateName}}, §
-        {{end}}
-      },
+      data: ϟdata,
+      refID: ϟapi.NewRefID(),
       a: ϟa,
     }
   }
@@ -1140,7 +1453,17 @@ import (
     {{range $f := $.Fields}}
       {{$lhs := print "c.data." ($f.Name | GoPrivateName)}}
       {{$rhs := print "o.data." ($f.Name | GoPrivateName)}}
-      § && {{Template "Go.Equal" "Type" $f.Type "LHS" $lhs "RHS" $rhs}}
+      § && {{Template "Equal" "Type" $f.Type "LHS" $lhs "RHS" $rhs}}
+    {{end}}
+  }
+
+  // Equals returns true if the class fields are equal to those of o.
+  func (c {{$name}}) Equalsʷ(ϟctx context.Context, ϟw ϟapi.StateWatcher, o {{$name}}) bool {
+    return true
+    {{range $f := $.Fields}}
+      {{$lhs := print "c.data." ($f.Name | GoPrivateName)}}
+      {{$rhs := print "o.data." ($f.Name | GoPrivateName)}}
+      § && {{Template "Equal" "Type" $f.Type "LHS" $lhs "RHS" $rhs "Watch" true}}
     {{end}}
   }
 
@@ -1211,7 +1534,7 @@ import (
 
   // Clone makes a deep copy of this class.
   func (c {{$name}}) Clone(ϟa arena.Arena, ϟseen ϟapi.CloneContext) {{$name}} {
-    return {{$name}}{
+    cloned := {{$name}}{
       data: &{{$data}}{
         {{range $f := $.Fields}}
           {{$name := $f.Name | GoPrivateName}}
@@ -1219,8 +1542,33 @@ import (
         {{end}}
       },
       a: ϟa,
+      refID: ϟapi.NewRefID(),
     }
+    return cloned
   }
+
+  // Clone makes a deep copy of this class.
+  func (c {{$name}}) Cloneʷ(ϟctx context.Context, ϟw ϟapi.StateWatcher, ϟa arena.Arena, ϟseen ϟapi.CloneContext) {{$name}} {
+    if ϟw != nil {
+      ϟw.OnGet(ϟctx, c, ϟapi.CompleteFragment{}, ϟapi.NilReference{})
+    }
+    cloned := {{$name}}{
+      data: &{{$data}}{
+        {{range $f := $.Fields}}
+          {{$name := $f.Name | GoPrivateName}}
+          {{$name}}: c.data.{{Template "Clone" "Type" $f.Type "Src" $name "Watch" true}},
+        {{end}}
+      },
+      a: ϟa,
+      refID: ϟapi.NewRefID(),
+    }
+    if ϟw != nil {
+      ϟw.OnSet(ϟctx, cloned, ϟapi.CompleteFragment{}, ϟapi.NilReference{}, ϟapi.NilReference{})
+    }
+    return cloned
+  }
+
+  func (a {{$name}}) RefID() ϟapi.RefID { return a.refID }
 {{end}}
 
 
@@ -1245,6 +1593,7 @@ import (
       {{$p | GoPrivateName}} {{Template "Go.Type" $p}} {{Template "CommandParameterTags" $p}}
     {{end}}
     arena arena.Arena
+    refID ϟapi.RefID
   }
 
   // Arena returns the memory arena used to allocate this command.
@@ -1336,8 +1685,10 @@ import (
 
   {{range $p := $.FullParameters}}
     {{$pname := Macro "Go.Parameter" $p}}
-    {{Template "DeclareGetterSetter" "Struct" $name "Name" $p.Name "Type" $p.Type "PtrMethod" "true"}}¶
+    {{Template "DeclareGetterSetter" "Struct" $name "Name" $p.Name "Type" $p.Type "PtrMethod" "true" "Watch" true}}¶
+    {{Template "DeclareFieldID" "Class" $name "Name" $p.Name}}
   {{end}}
+  {{Template "DeclareFieldID" "Class" $name "Name" "Result"}}
 
   // clone returns a shallow clone of the command. Extras are shared.
   func (ϟc *{{$name}}) clone(ϟa arena.Arena) *{{$name}} {
@@ -1360,6 +1711,8 @@ import (
   func (ϟc *{{$name}}) Clone(ϟa arena.Arena) ϟapi.Cmd {
     return ϟc.clone(ϟa)
   }
+
+  func (ϟc *{{$name}}) RefID() ϟapi.RefID { return ϟc.refID }
 {{end}}
 
 
@@ -1425,11 +1778,13 @@ import (
       {{GoPrivateName $g.Name}} {{Template "Go.Type" $g}}
     {{end}}
     a arena.Arena
+    refID ϟapi.RefID
     CustomState `hidden:"true" nobox:"true"`
   }
 
   {{range $g := $.Globals}}
-    {{Template "DeclareGetterSetter" "Struct" "State" "Name" $g.Name "Type" $g.Type "PtrMethod" "true"}}¶
+    {{Template "DeclareGetterSetter" "Struct" "State" "Name" $g.Name "Type" $g.Type "PtrMethod" "true" "Watch" true}}¶
+    {{Template "DeclareFieldID" "Class" "State" "Name" $g.Name}}
   {{end}}
 
   // Arena returns the memory arena used to allocate the state.
@@ -1439,7 +1794,7 @@ import (
 
   // NewState returns a new, uninitialized state.
   func NewState(ϟa arena.Arena) *State {
-    return &State{a: ϟa}
+    return &State{a: ϟa, refID: ϟapi.NewRefID()}
   }
 
   // Init initializes the state.
@@ -1474,7 +1829,7 @@ import (
 
 	// Clone returns a deep copy of this state object.
   func (g *State) Clone(ϟa arena.Arena) ϟapi.State {
-    out := &State{CustomState: g.CustomState}
+    out := &State{CustomState: g.CustomState, refID: ϟapi.NewRefID()}
     {{if len $.Globals}}
       ϟseen := ϟapi.CloneContext{}
       _ = ϟseen
@@ -1485,6 +1840,8 @@ import (
     {{end}}
     return out
   }
+
+  func (g *State) RefID() ϟapi.RefID { return g.refID }
 {{end}}
 
 
@@ -1679,7 +2036,7 @@ import (
   {{if IsCall $.Expr}}
     {{$call := Unpack $.Expr}}
     {{$args := ForEach $call.Arguments "Go.Read" | JoinWith ", "}}
-    v, _ := {{Template "Go.Subroutine" $call.Target.Function}}(ϟctx, ϟc, ϟi, ϟc.Extras().Observations(), ϟg, GetState(ϟg), ϟc.Thread(), nil, {{$args}})
+    v, _ := {{Template "Go.Subroutine" $call.Target.Function}}(ϟctx, ϟc, ϟi, ϟc.Extras().Observations(), ϟg, GetState(ϟg), ϟc.Thread(), nil, nil, {{$args}})
   {{else}}
     {{Error "%T" $.Expr}}
   {{end}}
@@ -1696,14 +2053,47 @@ import (
   {{$get := GoPublicName $.Name}}
   {{$set := printf "Set%v" $get}}
   {{$field  := print ((Strings "c" $.Prefix) | JoinWith ".") "." (GoPrivateName $.Name) }}
+  {{$fieldID := Macro "FieldID" "Class" $.Class "Name" $.Name}}
+  {{$newRef := Macro "Reference" "Type" $.Type "Val" "v"}}
+  {{$oldRef := Macro "Reference" "Type" $.Type "Val" $field}}
 
-  {{$ty := Underlying $.Type}}
-  {{if $.PtrMethod}}
-    func (c *{{$.Struct}}) {{$get}}() {{$g}} { return {{$field}} }
-    func (c *{{$.Struct}}) {{$set}}(v {{$g}}) { {{$field}} = v }
-  {{else}}
-    func (c {{$.Struct}}) {{$get}}() {{$g}} { return {{$field}} }
-    func (c {{$.Struct}}) {{$set}}(v {{$g}}) { {{$field}} = v }
+  func (c {{if $.PtrMethod}}*{{end}}{{$.Struct}}) {{$get}}() {{$g}} {
+    return {{$field}}
+  }
+
+  func (c {{if $.PtrMethod}}*{{end}}{{$.Struct}}) {{$set}}(v {{$g}}) {
+    {{$field}} = v
+  }
+
+  {{if $.Watch}}
+    func (c {{if $.PtrMethod}}*{{end}}{{$.Struct}}) {{$get}}ʷ(§
+          ϟctx context.Context, ϟw ϟapi.StateWatcher) {{$g}} {
+      v := {{$field}}
+      if ϟw != nil {
+        ϟw.OnGet(ϟctx, c, ϟapi.FieldFragment{§
+          {{if $.Class}}
+            {{Template "FieldID" "Class" $.Class "Name" $.Name}}§
+          {{else}}
+            {{Template "FieldID" "Class" $.Struct "Name" $.Name}}§
+          {{end}}}, §
+          {{$newRef}})
+      }
+      return v
+    }
+
+    func (c {{if $.PtrMethod}}*{{end}}{{$.Struct}}) {{$set}}ʷ(§
+          ϟctx context.Context, ϟw ϟapi.StateWatcher, v {{$g}}) {
+      if ϟw != nil {
+        ϟw.OnSet(ϟctx, c, ϟapi.FieldFragment{§
+          {{if $.Class}}
+            {{Template "FieldID" "Class" $.Class "Name" $.Name}}§
+          {{else}}
+            {{Template "FieldID" "Class" $.Struct "Name" $.Name}}§
+          {{end}}}, §
+          {{$oldRef}}, {{$newRef}})
+      }
+      {{$field}} = v
+    }
   {{end}}
 {{end}}
 
@@ -1731,13 +2121,13 @@ import (
   {{AssertType $.Type "Type"}}
 
   {{     if IsPseudonym     $.Type}}{{Template "Clone" "Type" $.Type.To "Src" $.Src}}
-  {{else if IsStaticArray   $.Type}}{{$.Src}}.Clone(ϟa, ϟseen)
-  {{else if IsMap           $.Type}}{{$.Src}}.Clone(ϟa, ϟseen)
-  {{else if IsClass         $.Type}}{{$.Src}}.Clone(ϟa, ϟseen)
+  {{else if IsStaticArray   $.Type}}{{$.Src}}.Clone{{if $.Watch}}ʷ(ϟctx, ϟw, {{else}}({{end}}ϟa, ϟseen)
+  {{else if IsMap           $.Type}}{{$.Src}}.Clone{{if $.Watch}}ʷ(ϟctx, ϟw, {{else}}({{end}}ϟa, ϟseen)
+  {{else if IsClass         $.Type}}{{$.Src}}.Clone{{if $.Watch}}ʷ(ϟctx, ϟw, {{else}}({{end}}ϟa, ϟseen)
   {{else if IsEnum          $.Type}}{{$.Src}}
   {{else if IsPointer       $.Type}}{{$.Src}}
   {{else if IsSlice         $.Type}}{{$.Src}}
-  {{else if IsReference     $.Type}}{{$.Src}}.Clone(ϟa, ϟseen)
+  {{else if IsReference     $.Type}}{{$.Src}}.Clone{{if $.Watch}}ʷ(ϟctx, ϟw, {{else}}({{end}}ϟa, ϟseen)
   {{else if IsBool          $.Type}}{{$.Src}}
   {{else if IsInt           $.Type}}{{$.Src}}
   {{else if IsUint          $.Type}}{{$.Src}}
@@ -1756,4 +2146,59 @@ import (
   {{else if IsString        $.Type}}{{$.Src}}
   {{else}}{{Error "macro Clone called with unsupported type: %s" $.Name}}
   {{end}}
+{{end}}
+
+
+{{/*
+-------------------------------------------------------------------------------
+  Emits the logic to test whether the two values are equal.
+-------------------------------------------------------------------------------
+*/}}
+{{define "Equal"}}
+  {{AssertType $.Type "Type"}}
+
+  {{$ty := $.Type | Unpack | Underlying}}
+
+  {{if or (IsClass $ty) (IsStaticArray $ty)}}{{$.LHS}}.Equals§
+    {{if $.Watch}}ʷ(ϟctx, ϟw, {{else}}({{end}}{{$.RHS}})
+  {{else}}{{$.LHS}} == {{$.RHS}}
+  {{end}}
+{{end}}
+
+
+{{/*
+-------------------------------------------------------------------------------
+  RefID returns a unique identifier for a reference
+-------------------------------------------------------------------------------
+*/}}
+{{define "Reference"}}
+  {{AssertType $.Type "Type"}}
+
+  {{if or (IsMap $.Type) (IsReference $.Type) (IsClass $.Type) (IsStaticArray $.Type)}}§
+    (ϟapi.Reference)({{$.Val}})
+  {{else}}ϟapi.NilReference{}
+  {{end}}
+{{end}}
+
+
+{{/*
+-------------------------------------------------------------------------------
+  DeclareFieldID emits the Go declaration of the global variable identifying 
+-------------------------------------------------------------------------------
+*/}}
+{{define "DeclareFieldID"}}
+  {{$fieldID := printf "FIELD_%v_%v" $.Class $.Name}}
+  type {{$fieldID}} struct{}
+  func ({{$fieldID}}) ClassName() string { return "{{$.Class}}" }
+  func ({{$fieldID}}) FieldName() string { return "{{$.Name}}" }
+{{end}}
+
+
+{{/*
+-------------------------------------------------------------------------------
+  FieldID returns an identifier for a field in a struct
+-------------------------------------------------------------------------------
+*/}}
+{{define "FieldID"}}
+  FIELD_{{$.Class}}_{{$.Name}}{}
 {{end}}

--- a/gapis/api/templates/go_common.tmpl
+++ b/gapis/api/templates/go_common.tmpl
@@ -523,8 +523,8 @@
   {{else if IsGlobal           $}}{{Template "Go.Global" $}}
   {{else if IsParameter        $}}{{Template "Go.Parameter" $}}
   {{else if IsArrayIndex       $}}{{Template "Go.Read" $.Array}}.Getʷ(ϟctx, ϟw, int({{Template "Go.Read" $.Index}}))
-  {{else if IsMapIndex         $}}{{Template "Go.Read" $.Map}}.Getʷ(ϟctx, ϟw, {{Template "Go.Read" $.Index}})
-  {{else if IsMapContains      $}}{{Template "Go.Read" $.Map}}.Containsʷ(ϟctx, ϟw, {{Template "Go.Read" $.Key}})
+  {{else if IsMapIndex         $}}{{Template "Go.MapIndex" $}}
+  {{else if IsMapContains      $}}{{Template "Go.MapContains" $}}
   {{else if IsLength           $}}{{Template "Go.Type" $.Type}}({{Template "Go.ReadLength" "Type" (TypeOf $.Object) "Value" $.Object}})
   {{else if IsNull             $}}{{Template "Go.Null" $.Type}}
   {{else if IsNew              $}}new {{Template "Go.Type" $.Type}}
@@ -703,7 +703,10 @@
   {{$ty := $.Object | TypeOf | Unpack}}
   {{Template "Go.Read" $.Object}}§
   {{if IsReference $ty}}{{if GetAnnotation $ty.To "resource"}}.OnAccess(ϟg)§{{end}}{{end}}
-  .{{$.Field | GoPublicName}}ʷ(ϟctx, ϟw)
+  .{{$.Field | GoPublicName}}§
+  {{if GetAnnotation $.Field "untracked"}}()
+  {{else}}ʷ(ϟctx, ϟw)
+  {{end}}
 {{end}}
 
 
@@ -715,8 +718,41 @@
 {{define "Go.Global"}}
   {{AssertType $ "Global"}}
 
-  {{if eq $.Name "$Thread"}}ϟt
-  {{else                  }}ϟs.{{$.Name | GoPublicName}}ʷ(ϟctx, ϟw)
+  {{if eq $.Name "$Thread"             }}ϟt
+  {{else if GetAnnotation $ "untracked"}}ϟs.{{$.Name | GoPublicName}}()
+  {{else                               }}ϟs.{{$.Name | GoPublicName}}ʷ(ϟctx, ϟw)
+  {{end}}
+{{end}}
+
+
+{{/*
+-------------------------------------------------------------------------------
+  Emits the logic to execute a map index expression.
+-------------------------------------------------------------------------------
+*/}}
+{{define "Go.MapIndex"}}
+  {{AssertType $ "MapIndex"}}
+
+  {{if Macro "IsUntrackedMap" $.Map}}
+    {{Template "Go.Read" $.Map}}.Get({{Template "Go.Read" $.Index}})
+  {{else}}
+    {{Template "Go.Read" $.Map}}.Getʷ(ϟctx, ϟw, {{Template "Go.Read" $.Index}})
+  {{end}}
+{{end}}
+
+
+{{/*
+-------------------------------------------------------------------------------
+  Emits the logic to execute a map containment expression.
+-------------------------------------------------------------------------------
+*/}}
+{{define "Go.MapContains"}}
+  {{AssertType $ "MapContains"}}
+
+  {{if Macro "IsUntrackedMap" $.Map}}
+    {{Template "Go.Read" $.Map}}.Contains({{Template "Go.Read" $.Key}})
+  {{else}}
+    {{Template "Go.Read" $.Map}}.Containsʷ(ϟctx, ϟw, {{Template "Go.Read" $.Key}})
   {{end}}
 {{end}}
 
@@ -734,7 +770,12 @@
   {{     if IsPseudonym   $ty}}{{Template "Go.ReadLength" "Type" $ty.To "Value" $.Value}}
   {{else if IsSlice       $ty}}{{Template "Go.Read" $.Value}}.Count()
   {{else if IsString      $ty}}len({{Template "Go.Read" $.Value}})
-  {{else if IsMap         $ty}}{{Template "Go.Read" $.Value}}.Lenʷ(ϟctx, ϟw)
+  {{else if IsMap         $ty}}
+    {{if Macro "IsUntrackedMap" $.Value}}
+      {{Template "Go.Read" $.Value}}.Len()
+    {{else}}
+      {{Template "Go.Read" $.Value}}.Lenʷ(ϟctx, ϟw)
+    {{end}}
   {{else                     }}{{Error "macro Go.ReadLength called with unsupported type: %v" $.Type}}
   {{end}}
 {{end}}
@@ -787,5 +828,21 @@
     {{end}}
   {{else}}
     return {{$err}}
+  {{end}}
+{{end}}
+
+{{/*
+-------------------------------------------------------------------------------
+  Emits 1 if $ is map marked with @untrackedMap. This works both for global
+  variables and struct members.
+-------------------------------------------------------------------------------
+*/}}
+{{define "IsUntrackedMap"}}
+  {{/* Global map marked with @untrackedMap */}}
+  {{if GetAnnotation $ "untrackedMap"}}1§
+
+  {{/* Map field marked with @untrackedMap */}}
+  {{else if IsMember $}}
+    {{if GetAnnotation $.Field "untrackedMap"}}1{{end}}
   {{end}}
 {{end}}

--- a/gapis/api/templates/go_common.tmpl
+++ b/gapis/api/templates/go_common.tmpl
@@ -522,9 +522,9 @@
   {{else if IsMember           $}}{{Template "Go.Member" $}}
   {{else if IsGlobal           $}}{{Template "Go.Global" $}}
   {{else if IsParameter        $}}{{Template "Go.Parameter" $}}
-  {{else if IsArrayIndex       $}}{{Template "Go.Read" $.Array}}.Get(int({{Template "Go.Read" $.Index}}))
-  {{else if IsMapIndex         $}}{{Template "Go.Read" $.Map}}.Get({{Template "Go.Read" $.Index}})
-  {{else if IsMapContains      $}}{{Template "Go.Read" $.Map}}.Contains({{Template "Go.Read" $.Key}})
+  {{else if IsArrayIndex       $}}{{Template "Go.Read" $.Array}}.Getʷ(ϟctx, ϟw, int({{Template "Go.Read" $.Index}}))
+  {{else if IsMapIndex         $}}{{Template "Go.Read" $.Map}}.Getʷ(ϟctx, ϟw, {{Template "Go.Read" $.Index}})
+  {{else if IsMapContains      $}}{{Template "Go.Read" $.Map}}.Containsʷ(ϟctx, ϟw, {{Template "Go.Read" $.Key}})
   {{else if IsLength           $}}{{Template "Go.Type" $.Type}}({{Template "Go.ReadLength" "Type" (TypeOf $.Object) "Value" $.Object}})
   {{else if IsNull             $}}{{Template "Go.Null" $.Type}}
   {{else if IsNew              $}}new {{Template "Go.Type" $.Type}}
@@ -532,7 +532,7 @@
   {{else if IsSliceIndex       $}}{{Template "Go.Read" $.Slice  }}.Index({{Template "Go.Read" $.Index}}).{{Macro "Go.MemoryRead"}}[0]
   {{else if IsSliceRange       $}}{{Template "Go.Read" $.Slice  }}.Slice({{Template "Go.Read" $.Range.LHS}}, {{Template "Go.Read" $.Range.RHS}})
   {{else if IsPointerRange     $}}{{Template "Go.Read" $.Pointer}}.Slice({{Template "Go.Read" $.Range.LHS}}, {{Template "Go.Read" $.Range.RHS}}, ϟl)
-  {{else if IsClone            $}}{{Template "Go.Read" $.Slice  }}.Clone(ϟctx, ϟc, ϟg, ϟb)
+  {{else if IsClone            $}}{{Template "Go.Read" $.Slice  }}.Clone(ϟctx, ϟc, ϟg, ϟb, ϟw)
   {{else if IsMake             $}}Make{{Template "Go.Type" $.Type}}({{Template "Go.Read" $.Size}}, ϟg)
   {{else if IsSelect           $}}{{Template "Go.Select" $}}
   {{else if IsArrayInitializer $}}{{Template "Go.ArrayInitializer" $}}
@@ -572,9 +572,9 @@
       observed memory which is undesirable, so instead just perform regular
       (non-replay-builder) read logic.
     */}}
-    MustRead(ϟctx, ϟc, ϟg, nil)
+    MustReadʷ(ϟctx, ϟc, ϟg, nil, ϟw)
   {{else}}
-    MustRead(ϟctx, ϟc, ϟg, ϟb)
+    MustReadʷ(ϟctx, ϟc, ϟg, ϟb, ϟw)
   {{end}}
 {{end}}
 
@@ -591,9 +591,9 @@
   {{if $.Target.Object}}
     {{Template "Go.Read" $.Target.Object}}.{{$.Target.Function.Name}}(ϟctx, {{$args}})
   {{else if $.Target.Function.Extern}}
-    (externs{ϟctx, ϟc, ϟi, ϟg, ϟb}.{{$.Target.Function.Name}}({{$args}}))
+    (externs{ϟctx, ϟc, ϟi, ϟg, ϟb, ϟw}.{{$.Target.Function.Name}}({{$args}}))
   {{else if $.Target.Function.Subroutine}}
-    if ϟerr := {{Template "Go.Subroutine" $.Target.Function}}(ϟctx, ϟc, ϟi, ϟo, ϟg, ϟs, ϟt, ϟb, {{$args}}); ϟerr != nil {
+    if ϟerr := {{Template "Go.Subroutine" $.Target.Function}}(ϟctx, ϟc, ϟi, ϟo, ϟg, ϟs, ϟt, ϟb, ϟw, {{$args}}); ϟerr != nil {
       {{Template "Go.ReturnErr" "ϟerr"}}
     }
   {{else}}
@@ -703,7 +703,7 @@
   {{$ty := $.Object | TypeOf | Unpack}}
   {{Template "Go.Read" $.Object}}§
   {{if IsReference $ty}}{{if GetAnnotation $ty.To "resource"}}.OnAccess(ϟg)§{{end}}{{end}}
-  .{{$.Field | GoPublicName}}()
+  .{{$.Field | GoPublicName}}ʷ(ϟctx, ϟw)
 {{end}}
 
 
@@ -716,7 +716,7 @@
   {{AssertType $ "Global"}}
 
   {{if eq $.Name "$Thread"}}ϟt
-  {{else                  }}ϟs.{{$.Name | GoPublicName}}()
+  {{else                  }}ϟs.{{$.Name | GoPublicName}}ʷ(ϟctx, ϟw)
   {{end}}
 {{end}}
 
@@ -734,7 +734,7 @@
   {{     if IsPseudonym   $ty}}{{Template "Go.ReadLength" "Type" $ty.To "Value" $.Value}}
   {{else if IsSlice       $ty}}{{Template "Go.Read" $.Value}}.Count()
   {{else if IsString      $ty}}len({{Template "Go.Read" $.Value}})
-  {{else if IsMap         $ty}}{{Template "Go.Read" $.Value}}.Len()
+  {{else if IsMap         $ty}}{{Template "Go.Read" $.Value}}.Lenʷ(ϟctx, ϟw)
   {{else                     }}{{Error "macro Go.ReadLength called with unsupported type: %v" $.Type}}
   {{end}}
 {{end}}
@@ -766,23 +766,6 @@
       {{end}}
     }
   }()
-{{end}}
-
-
-{{/*
--------------------------------------------------------------------------------
-  Emits the logic to test whether the two values are equal.
--------------------------------------------------------------------------------
-*/}}
-{{define "Go.Equal"}}
-  {{AssertType $.Type "Type"}}
-
-  {{$ty := $.Type | Unpack | Underlying}}
-
-  {{     if IsClass       $ty}}{{$.LHS}}.Equals({{$.RHS}})
-  {{else if IsStaticArray $ty}}{{$.LHS}}.Equals({{$.RHS}})
-  {{else                     }}{{$.LHS}} == {{$.RHS}}
-  {{end}}
 {{end}}
 
 

--- a/gapis/api/templates/mutate.go.tmpl
+++ b/gapis/api/templates/mutate.go.tmpl
@@ -445,7 +445,8 @@
 
   {
     {{if ne $.IndexIterator.Name "_"}}{{$.IndexIterator.Name}} := int32(0){{end}}
-    for {{$.KeyIterator.Name}}, {{$.ValueIterator.Name}} := range {{Template "Go.Read" $.Map}}.Allʷ(ϟctx, ϟw) {
+    for {{$.KeyIterator.Name}}, {{$.ValueIterator.Name}} := range {{Template "Go.Read" $.Map}}.All§
+      {{if Macro "IsUntrackedMap" $.Map}}(){{else}}ʷ(ϟctx, ϟw){{end}} {
       {{Template "Block" $.Block}}
       {{if ne $.IndexIterator.Name "_"}}{{$.IndexIterator.Name}}++{{end}}
     }
@@ -545,15 +546,21 @@
     {{if ne $.Operator "="}}{{Error "Compound assignments to '_' are not supported (%s)" $.Operator}}{{end}}
     _ = {{Template "Go.Read" $.RHS}}
   {{else}}
-    {{     if IsMember $.LHS}}{{Template "Go.Read" $.LHS.Object}}.Set{{$.LHS.Field | GoPublicName}}ʷ§
-    {{else if IsGlobal $.LHS}}ϟs.Set{{$.LHS.Name | GoPublicName}}ʷ§
+    {{     if IsMember $.LHS}}{{Template "Go.Read" $.LHS.Object}}.Set{{$.LHS.Field | GoPublicName}}§
+      {{if GetAnnotation $.LHS.Field "untracked"}}(§
+      {{else}}ʷ(ϟctx, ϟw, §
+      {{end}}
+    {{else if IsGlobal $.LHS}}ϟs.Set{{$.LHS.Name | GoPublicName}}§
+      {{if GetAnnotation $.LHS "untracked"}}(§
+      {{else}}ʷ(ϟctx, ϟw, §
+      {{end}}
     {{else                  }}{{Error "Unhandled assign to %v" $.LHS}}
     {{end}}
 
     {{if eq $.Operator "="}}
-      (ϟctx, ϟw, {{Template "Go.Read" $.RHS}})
+      {{Template "Go.Read" $.RHS}})
     {{else}}
-      (ϟctx, ϟw, {{Template "Go.Read" $.LHS}} {{$.Operator | TrimRight "="}} {{Template "Go.Read" $.RHS}})
+      {{Template "Go.Read" $.LHS}} {{$.Operator | TrimRight "="}} {{Template "Go.Read" $.RHS}})
     {{end}}
   {{end}}
 {{end}}
@@ -584,7 +591,13 @@
   {{AssertType $ "MapAssign"}}
 
   {{if eq $.Operator "="}}
-    {{Template "Go.Read" $.To.Map}}.Addʷ(ϟctx, ϟw, {{Template "Go.Read" $.To.Index}},{{Template "Go.Read" $.Value}})
+    {{Template "Go.Read" $.To.Map}}.§
+    {{if Macro "IsUntrackedMap" $.To.Map}}
+      Add(§
+    {{else}}§
+      Addʷ(ϟctx, ϟw, §
+    {{end}}
+    {{Template "Go.Read" $.To.Index}},{{Template "Go.Read" $.Value}})
   {{else}}
     {{Error "Unsupported MapAssign operator %s" $.Operator}}
   {{end}}
@@ -599,7 +612,13 @@
 {{define "MapRemove"}}
   {{AssertType $ "MapRemove"}}
 
-  {{Template "Go.Read" $.Map}}.Removeʷ(ϟctx, ϟw, {{Template "Go.Read" $.Key}})
+  {{Template "Go.Read" $.Map}}.§
+  {{if Macro "IsUntrackedMap" $.Map}}
+    Remove(§
+  {{else}}
+    Removeʷ(ϟctx, ϟw, §
+  {{end}}
+  {{Template "Go.Read" $.Key}})
 {{end}}
 
 

--- a/gapis/api/templates/mutate.go.tmpl
+++ b/gapis/api/templates/mutate.go.tmpl
@@ -103,6 +103,7 @@
       ϟs *State, §
       ϟt uint64, §
       ϟb *builder.Builder, §
+      ϟw api.StateWatcher, §
       {{ForEach $.CallParameters "NameAndType" | JoinWith ", "}} §
     ) ({{if not (IsVoid $.Return.Type)}}{{Template "Go.Type" $.Return.Type}}, {{end}}error) {
     ϟl, ϟa := ϟg.MemoryLayout, ϟg.Arena; _, _ = ϟl, ϟa
@@ -148,7 +149,7 @@
       {{end}}
       func (ϟc *{{$name}}) Mutate(§
     {{end}}
-        ϟctx context.Context, ϟi api.CmdID, ϟg *api.GlobalState, ϟb *builder.Builder) error {
+        ϟctx context.Context, ϟi api.CmdID, ϟg *api.GlobalState, ϟb *builder.Builder, ϟw api.StateWatcher) error {
 
       {{if not $r}}ϟb = nil // @no_replay{{end}}
 
@@ -163,8 +164,16 @@
 
       {{Global "CurrentFunction" $}}
 
+      if ϟw != nil {
+        ϟw.OnBeginCmd(ϟctx, ϟi, ϟc)
+        defer ϟw.OnEndCmd(ϟctx, ϟi, ϟc)
+      }
+
       {{/* simulate the call */}}
       ϟo.ApplyReads(ϟg.Memory.ApplicationPool())
+      if ϟo != nil && ϟw != nil {
+        ϟw.OnReadObs(ϟctx, ϟo.Reads)
+      }
       {{Template "Block" $.Block}}
 
       return task.StopReason(ϟctx)
@@ -362,8 +371,8 @@
   {{else if IsIteration    $}}{{Template "Iteration" $}}
   {{else if IsMapIteration $}}{{Template "MapIteration" $}}
   {{else if IsCall         $}}{{Template "Go.Call" $}}
-  {{else if IsRead         $}}{{Template "Go.Read" $.Slice}}.OnRead(ϟctx, ϟc, ϟg, ϟb)
-  {{else if IsWrite        $}}{{Template "Go.Read" $.Slice}}.OnWrite(ϟctx, ϟc, ϟg, ϟb)
+  {{else if IsRead         $}}{{Template "Go.Read" $.Slice}}.OnReadʷ(ϟctx, ϟc, ϟg, ϟb, ϟw)
+  {{else if IsWrite        $}}{{Template "Go.Read" $.Slice}}.OnWriteʷ(ϟctx, ϟc, ϟg, ϟb, ϟw)
   {{else if IsFence        $}}{{Template "Fence" $}}
   {{else if IsBranch       $}}{{Template "Branch" $}}
   {{else if IsSwitch       $}}{{Template "Switch" $}}
@@ -436,7 +445,7 @@
 
   {
     {{if ne $.IndexIterator.Name "_"}}{{$.IndexIterator.Name}} := int32(0){{end}}
-    for {{$.KeyIterator.Name}}, {{$.ValueIterator.Name}} := range {{Template "Go.Read" $.Map}}.All() {
+    for {{$.KeyIterator.Name}}, {{$.ValueIterator.Name}} := range {{Template "Go.Read" $.Map}}.Allʷ(ϟctx, ϟw) {
       {{Template "Block" $.Block}}
       {{if ne $.IndexIterator.Name "_"}}{{$.IndexIterator.Name}}++{{end}}
     }
@@ -452,7 +461,7 @@
 {{define "Copy"}}
   {{AssertType $ "Copy"}}
 
-  {{Template "Go.Read" $.Dst}}.Copy(ϟctx, {{Template "Go.Read" $.Src}}, ϟc, ϟg, ϟb)
+  {{Template "Go.Read" $.Dst}}.Copy(ϟctx, {{Template "Go.Read" $.Src}}, ϟc, ϟg, ϟb, ϟw)
 {{end}}
 
 
@@ -513,7 +522,7 @@
     {{if $call.Target.Function.Subroutine}}
       {{/* Transform: v := sub() -> v, err := sub() */}}
       {{$args := ForEach $call.Arguments "Go.Read" | JoinWith ", "}}
-      {{$.Local.Name}}, ϟerr := {{Template "Go.Subroutine" $call.Target.Function}}(ϟctx, ϟc, ϟi, ϟo, ϟg, ϟs, ϟt, ϟb, {{$args}})
+      {{$.Local.Name}}, ϟerr := {{Template "Go.Subroutine" $call.Target.Function}}(ϟctx, ϟc, ϟi, ϟo, ϟg, ϟs, ϟt, ϟb, ϟw, {{$args}})
       if ϟerr != nil {
         {{Template "Go.ReturnErr" "ϟerr"}}
       }
@@ -536,15 +545,15 @@
     {{if ne $.Operator "="}}{{Error "Compound assignments to '_' are not supported (%s)" $.Operator}}{{end}}
     _ = {{Template "Go.Read" $.RHS}}
   {{else}}
-    {{     if IsMember $.LHS}}{{Template "Go.Read" $.LHS.Object}}.Set{{$.LHS.Field | GoPublicName}}§
-    {{else if IsGlobal $.LHS}}ϟs.Set{{$.LHS.Name | GoPublicName}}§
+    {{     if IsMember $.LHS}}{{Template "Go.Read" $.LHS.Object}}.Set{{$.LHS.Field | GoPublicName}}ʷ§
+    {{else if IsGlobal $.LHS}}ϟs.Set{{$.LHS.Name | GoPublicName}}ʷ§
     {{else                  }}{{Error "Unhandled assign to %v" $.LHS}}
     {{end}}
 
     {{if eq $.Operator "="}}
-      ({{Template "Go.Read" $.RHS}})
+      (ϟctx, ϟw, {{Template "Go.Read" $.RHS}})
     {{else}}
-      ({{Template "Go.Read" $.LHS}} {{$.Operator | TrimRight "="}} {{Template "Go.Read" $.RHS}})
+      (ϟctx, ϟw, {{Template "Go.Read" $.LHS}} {{$.Operator | TrimRight "="}} {{Template "Go.Read" $.RHS}})
     {{end}}
   {{end}}
 {{end}}
@@ -559,7 +568,7 @@
   {{AssertType $ "ArrayAssign"}}
 
   {{if eq $.Operator "="}}
-    {{Template "Go.Read" $.To.Array}}.Set(int({{Template "Go.Read" $.To.Index}}), {{Template "Go.Read" $.Value}})
+    {{Template "Go.Read" $.To.Array}}.Setʷ(ϟctx, ϟw, int({{Template "Go.Read" $.To.Index}}), {{Template "Go.Read" $.Value}})
   {{else}}
     {{Error "Unsupported ArrayAssign operator %s" $.Operator}}
   {{end}}
@@ -575,7 +584,7 @@
   {{AssertType $ "MapAssign"}}
 
   {{if eq $.Operator "="}}
-    {{Template "Go.Read" $.To.Map}}.Add({{Template "Go.Read" $.To.Index}},{{Template "Go.Read" $.Value}})
+    {{Template "Go.Read" $.To.Map}}.Addʷ(ϟctx, ϟw, {{Template "Go.Read" $.To.Index}},{{Template "Go.Read" $.Value}})
   {{else}}
     {{Error "Unsupported MapAssign operator %s" $.Operator}}
   {{end}}
@@ -590,7 +599,7 @@
 {{define "MapRemove"}}
   {{AssertType $ "MapRemove"}}
 
-  {{Template "Go.Read" $.Map}}.Remove({{Template "Go.Read" $.Key}})
+  {{Template "Go.Read" $.Map}}.Removeʷ(ϟctx, ϟw, {{Template "Go.Read" $.Key}})
 {{end}}
 
 
@@ -603,7 +612,7 @@
   {{AssertType $ "SliceAssign"}}
 
   {{if ne $.Operator "="}}{{Error "Compound assignments to pointers are not supported (%s)" $.Operator}}{{end}}
-  {{Template "Go.Read" $.To.Slice}}.Index({{Template "Go.Read" $.To.Index}}).MustWrite(ϟctx, []{{Template "Go.Type" $.To}}{ {{Template "Go.Read" $.Value}} }, ϟc, ϟg, ϟb)
+  {{Template "Go.Read" $.To.Slice}}.Index({{Template "Go.Read" $.To.Index}}).MustWriteʷ(ϟctx, []{{Template "Go.Type" $.To}}{ {{Template "Go.Read" $.Value}} }, ϟc, ϟg, ϟb, ϟw)
 {{end}}
 
 
@@ -636,7 +645,7 @@
         ϟdst, ϟgsrc := {{Template "Go.Read" $.Statement.Dst}}, {{Template "Go.Read" $.Statement.Src}}
         ϟcount := u64.Min(ϟdst.Count(), ϟgsrc.Count())
         ϟdst, ϟgsrc = ϟdst.Slice(0, ϟcount), ϟgsrc.Slice(0, ϟcount)
-        ϟgsrcElems := ϟgsrc.MustRead(ϟctx, ϟc, ϟg, ϟb)
+        ϟgsrcElems := ϟgsrc.MustReadʷ(ϟctx, ϟc, ϟg, ϟb, ϟw)
       {{end}}
 
       {{/* Perform the call */}}
@@ -644,7 +653,7 @@
 
       {{if IsCopy $.Statement}}
         {{/* Apply the fenced-copy write */}}
-        ϟdst.MustWrite(ϟctx, ϟgsrcElems, ϟc, ϟg, ϟb)
+        ϟdst.MustWriteʷ(ϟctx, ϟgsrcElems, ϟc, ϟg, ϟb, ϟw)
       {{end}}
     }
     {{if IsCopy $.Statement}}
@@ -665,6 +674,9 @@
 
   {{/* Merge the observed writes into the application pool */}}
   ϟo.ApplyWrites(ϟg.Memory.ApplicationPool())
+  if ϟo != nil && ϟw != nil {
+    ϟw.OnWriteObs(ϟctx, ϟo.Writes)
+  }
 {{end}}
 
 

--- a/gapis/api/templates/mutate.go.tmpl
+++ b/gapis/api/templates/mutate.go.tmpl
@@ -592,7 +592,9 @@
 
   {{if eq $.Operator "="}}
     {{Template "Go.Read" $.To.Map}}.§
-    {{if Macro "IsUntrackedMap" $.To.Map}}
+    {{if GetAnnotation $.To.Map "handleMap"}}
+      CreateHandleʷ(ϟctx, ϟw, §
+    {{else if Macro "IsUntrackedMap" $.To.Map}}
       Add(§
     {{else}}§
       Addʷ(ϟctx, ϟw, §
@@ -613,7 +615,9 @@
   {{AssertType $ "MapRemove"}}
 
   {{Template "Go.Read" $.Map}}.§
-  {{if Macro "IsUntrackedMap" $.Map}}
+  {{if GetAnnotation $.Map "handleMap"}}
+    DestroyHandleʷ(ϟctx, ϟw, §
+  {{else if Macro "IsUntrackedMap" $.Map}}
     Remove(§
   {{else}}
     Removeʷ(ϟctx, ϟw, §

--- a/gapis/api/test/intrinsics_test.go
+++ b/gapis/api/test/intrinsics_test.go
@@ -33,7 +33,7 @@ func TestClone(t *testing.T) {
 	s := api.NewStateWithEmptyAllocator(device.Little32)
 	cb := CommandBuilder{Thread: 0, Arena: s.Arena}
 	expected := []byte{0x54, 0x33, 0x42, 0x43, 0x46, 0x34, 0x63, 0x24, 0x14, 0x24}
-	api.MutateCmds(ctx, s, nil,
+	api.MutateCmds(ctx, s, nil, nil,
 		cb.CmdClone(p(0x1234), 10).
 			AddRead(memory.Store(ctx, s.MemoryLayout, p(0x1234), expected)),
 	)
@@ -50,7 +50,7 @@ func TestMake(t *testing.T) {
 	cb := CommandBuilder{Thread: 0, Arena: s.Arena}
 	idOfFirstPool, _ := s.Memory.New()
 	assert.For(ctx, "initial NextPoolID").That(idOfFirstPool).Equals(memory.PoolID(1))
-	api.MutateCmds(ctx, s, nil,
+	api.MutateCmds(ctx, s, nil, nil,
 		cb.CmdMake(10),
 	)
 	assert.For(ctx, "buffer count").That(GetState(s).U8s().Size()).Equals(uint64(10))
@@ -65,7 +65,7 @@ func TestCopy(t *testing.T) {
 	s := api.NewStateWithEmptyAllocator(device.Little32)
 	cb := CommandBuilder{Thread: 0, Arena: s.Arena}
 	expected := []byte{0x54, 0x33, 0x42, 0x43, 0x46, 0x34, 0x63, 0x24, 0x14, 0x24}
-	api.MutateCmds(ctx, s, nil,
+	api.MutateCmds(ctx, s, nil, nil,
 		cb.CmdMake(10),
 		cb.CmdCopy(p(0x1234), 10).
 			AddRead(memory.Store(ctx, s.MemoryLayout, p(0x1234), expected)),
@@ -82,7 +82,7 @@ func TestCharsliceToString(t *testing.T) {
 	s := api.NewStateWithEmptyAllocator(device.Little32)
 	cb := CommandBuilder{Thread: 0, Arena: s.Arena}
 	expected := "ħęľĺő ŵōřŀď"
-	api.MutateCmds(ctx, s, nil,
+	api.MutateCmds(ctx, s, nil, nil,
 		cb.CmdCharsliceToString(p(0x1234), uint32(len(expected))).
 			AddRead(memory.Store(ctx, s.MemoryLayout, p(0x1234), expected)),
 	)
@@ -95,7 +95,7 @@ func TestCharptrToString(t *testing.T) {
 	s := api.NewStateWithEmptyAllocator(device.Little32)
 	cb := CommandBuilder{Thread: 0, Arena: s.Arena}
 	expected := "ħęľĺő ŵōřŀď"
-	api.MutateCmds(ctx, s, nil,
+	api.MutateCmds(ctx, s, nil, nil,
 		cb.CmdCharptrToString(p(0x1234)).
 			AddRead(memory.Store(ctx, s.MemoryLayout, p(0x1234), expected)),
 	)
@@ -110,7 +110,7 @@ func TestSliceCasts(t *testing.T) {
 	l := s.MemoryLayout.Clone()
 	l.Integer.Size = 6 // non-multiple of u16
 	s.MemoryLayout = l
-	api.MutateCmds(ctx, s, nil,
+	api.MutateCmds(ctx, s, nil, nil,
 		cb.CmdSliceCasts(p(0x1234), 10),
 	)
 	for _, test := range []struct {

--- a/gapis/api/test/mutate_test.go
+++ b/gapis/api/test/mutate_test.go
@@ -61,7 +61,7 @@ func (test test) check(ctx context.Context, ca, ra *device.MemoryLayout) {
 
 	api.ForeachCmd(ctx, test.cmds, func(ctx context.Context, id api.CmdID, cmd api.Cmd) error {
 		b.BeginCommand(uint64(id), 0)
-		cmd.Mutate(ctx, id, s, b)
+		cmd.Mutate(ctx, id, s, b, nil)
 		b.CommitCommand()
 		return nil
 	})

--- a/gapis/api/test/subroutines_test.go
+++ b/gapis/api/test/subroutines_test.go
@@ -33,7 +33,7 @@ func TestSubAdd(t *testing.T) {
 	defer a.Dispose()
 	cb := CommandBuilder{Thread: 0, Arena: a}
 	s := api.NewStateWithEmptyAllocator(device.Little32)
-	api.MutateCmds(ctx, s, nil, cb.CmdAdd(10, 20))
+	api.MutateCmds(ctx, s, nil, nil, cb.CmdAdd(10, 20))
 	got, err := GetState(s).Ints().Read(ctx, nil, s, nil)
 	expected := []memory.Int{30}
 	if assert.For(ctx, "err").ThatError(err).Succeeded() {

--- a/gapis/api/transform/recorder.go
+++ b/gapis/api/transform/recorder.go
@@ -38,7 +38,7 @@ func (r *Recorder) State() *api.GlobalState {
 // and if the Recorder has a state, mutates this state object.
 func (r *Recorder) MutateAndWrite(ctx context.Context, id api.CmdID, cmd api.Cmd) {
 	if r.S != nil {
-		cmd.Mutate(ctx, id, r.S, nil)
+		cmd.Mutate(ctx, id, r.S, nil, nil)
 	}
 	r.Cmds = append(r.Cmds, cmd)
 	r.CmdsAndIDs = append(r.CmdsAndIDs, CmdAndID{cmd, id})

--- a/gapis/api/transform/transforms.go
+++ b/gapis/api/transform/transforms.go
@@ -93,7 +93,7 @@ func (p TransformWriter) State() *api.GlobalState {
 
 func (p TransformWriter) MutateAndWrite(ctx context.Context, id api.CmdID, cmd api.Cmd) {
 	if config.SeparateMutateStates {
-		cmd.Mutate(ctx, id, p.S, nil /* no builder, just mutate */)
+		cmd.Mutate(ctx, id, p.S, nil, nil /* no builder, no watcher, just mutate */)
 	}
 	p.T.Transform(ctx, id, cmd, p.O)
 }

--- a/gapis/api/vulkan/BUILD.bazel
+++ b/gapis/api/vulkan/BUILD.bazel
@@ -120,6 +120,7 @@ go_library(
         "//gapis/replay/value:go_default_library",
         "//gapis/resolve:go_default_library",
         "//gapis/resolve/dependencygraph:go_default_library",
+        "//gapis/resolve/dependencygraph2:go_default_library",
         "//gapis/resolve/initialcmds:go_default_library",
         "//gapis/service:go_default_library",
         "//gapis/service/path:go_default_library",

--- a/gapis/api/vulkan/api/buffer.api
+++ b/gapis/api/vulkan/api/buffer.api
@@ -50,16 +50,16 @@
 }
 
 @internal class BufferObject {
-  @unused VkDevice                  Device
-  @unused VkBuffer                  VulkanHandle
-  @unused BufferInfo                Info
-  ref!DeviceMemoryObject            Memory
-  VkDeviceSize                      MemoryOffset
-  map!(u64, VkSparseMemoryBind)     SparseMemoryBindings
-  @unused ref!QueueObject           LastBoundQueue
-  @unused ref!VulkanDebugMarkerInfo DebugInfo
-  VkMemoryRequirements              MemoryRequirements
-  ref!DedicatedRequirementsKHR      DedicatedRequirementsKHR
+  @unused VkDevice                   Device
+  @unused VkBuffer                   VulkanHandle
+  @unused BufferInfo                 Info
+  ref!DeviceMemoryObject             Memory
+  VkDeviceSize                       MemoryOffset
+  map!(u64, VkSparseMemoryBind)      SparseMemoryBindings
+  @untracked @unused ref!QueueObject LastBoundQueue
+  @unused ref!VulkanDebugMarkerInfo  DebugInfo
+  VkMemoryRequirements               MemoryRequirements
+  ref!DedicatedRequirementsKHR       DedicatedRequirementsKHR
 }
 
 @threadSafety("system")

--- a/gapis/api/vulkan/api/image.api
+++ b/gapis/api/vulkan/api/image.api
@@ -76,7 +76,7 @@
   ref!DedicatedRequirementsKHR                 DedicatedRequirementsKHR
   // If ever layer/level is set to the same queue, then set it here instead.
   // This can save expensive looping through Aspects/Layers/Levels
-  @unused ref!QueueObject                      LastBoundQueue
+  @untracked @unused ref!QueueObject           LastBoundQueue
 }
 
 @internal class ImageAspect {
@@ -92,10 +92,10 @@
   u32         Height
   @unused u32 Depth
   @spy_disabled
-  @hidden @nobox @internal u8[] Data
-  VkImageLayout                 Layout
-  ref!VkSubresourceLayout       LinearLayout
-  @unused ref!QueueObject       LastBoundQueue
+  @hidden @nobox @internal u8[]      Data
+  VkImageLayout                      Layout
+  ref!VkSubresourceLayout            LinearLayout
+  @untracked @unused ref!QueueObject LastBoundQueue
 }
 
 @internal class SparseBoundImageAspectInfo {

--- a/gapis/api/vulkan/api/query_pool.api
+++ b/gapis/api/vulkan/api/query_pool.api
@@ -54,7 +54,7 @@ enum QueryStatus {
   @unused VkQueryPipelineStatisticFlags PipelineStatistics
   @unused map!(u32, QueryStatus)        Status
   @unused ref!VulkanDebugMarkerInfo     DebugInfo
-  @unused ref!QueueObject               LastBoundQueue
+  @untracked @unused ref!QueueObject    LastBoundQueue
 }
 
 @threadSafety("system")

--- a/gapis/api/vulkan/api/queue.api
+++ b/gapis/api/vulkan/api/queue.api
@@ -190,6 +190,7 @@ cmd VkResult vkQueueSubmit(
 @threadSafety("system")
 @indirect("VkQueue", "VkDevice")
 @threadsafe
+@alive
 cmd VkResult vkQueueWaitIdle(
     VkQueue queue) {
   if !(queue in Queues) { vkErrorInvalidQueue(queue) }

--- a/gapis/api/vulkan/api/queue.api
+++ b/gapis/api/vulkan/api/queue.api
@@ -41,14 +41,14 @@
 ///////////
 
 @internal class QueueObject {
-  @unused VkDevice                       Device
-  @unused u32                            Family
-  @unused u32                            Index
-  @unused VkQueue                        VulkanHandle
-  map!(VkEvent, ref!EventObject)         PendingEvents
-  map!(VkSemaphore, ref!SemaphoreObject) PendingSemaphores
-  @unused ref!VulkanDebugMarkerInfo      DebugInfo
-  dense_map!(u32, ref!CommandReference)  PendingCommands
+  @unused VkDevice                                        Device
+  @unused u32                                             Family
+  @unused u32                                             Index
+  @unused VkQueue                                         VulkanHandle
+  map!(VkEvent, ref!EventObject)                          PendingEvents
+  map!(VkSemaphore, ref!SemaphoreObject)                  PendingSemaphores
+  @unused ref!VulkanDebugMarkerInfo                       DebugInfo
+  @untracked dense_map!(u32, ref!CommandReference)        PendingCommands
 }
 
 @threadSafety("system")

--- a/gapis/api/vulkan/api/queued_command_tracking.api
+++ b/gapis/api/vulkan/api/queued_command_tracking.api
@@ -79,6 +79,7 @@ sub void execPendingCommands(VkQueue queue, bool isRoot) {
         fenceObj := Fences[cmd.SignalFence]
         if fenceObj != null {
           fenceObj.Signaled = true
+          recordFenceSignal(cmd.SignalFence)
         }
       }
       if processSubcommand.b {

--- a/gapis/api/vulkan/api/synchronization.api
+++ b/gapis/api/vulkan/api/synchronization.api
@@ -95,6 +95,7 @@ cmd VkResult vkResetFences(
     f := fences[i]
     if !(f in Fences) { vkErrorInvalidFence(fences[i]) }
     Fences[f].Signaled = false
+    recordFenceReset(f)
   }
   return ?
 }
@@ -122,8 +123,14 @@ cmd VkResult vkWaitForFences(
   if !(device in Devices) { vkErrorInvalidDevice(device) }
   fences := pFences[0:fenceCount]
   for i in (0 .. fenceCount) {
-    if !(fences[i] in Fences) { vkErrorInvalidFence(fences[i]) }
-    _ = fences[i]
+    f := fences[i]
+    if !(f in Fences) { vkErrorInvalidFence(fences[i]) }
+    if Fences[f].Signaled {
+      recordFenceWait(f)
+    } else {
+      // TODO: handle case when signal comes after wait (e.g. in a multi-threaded app)
+      vkErrorInvalidFence(f)
+    }
   }
   return ?
 }
@@ -464,3 +471,7 @@ cmd void vkCmdPipelineBarrier(
 
   AddCommand(commandBuffer, cmd_vkCmdPipelineBarrier, mapPos)
 }
+
+extern void recordFenceSignal(VkFence fence)
+extern void recordFenceWait(VkFence fence)
+extern void recordFenceReset(VkFence fence)

--- a/gapis/api/vulkan/api/util.api
+++ b/gapis/api/vulkan/api/util.api
@@ -348,13 +348,15 @@ sub u32 getDepthElementSize(VkFormat format, bool inBuffer) {
 }
 
 @internal class AllBits {
-  map!(VkImageAspectFlags, dense_map!(u32, VkImageAspectFlagBits)) allBits
+  @untrackedMap @untracked
+  map!(VkImageAspectFlags, ref!unpackedImageAspectFlagBits) allBits
 }
 
-@hidden @serialize
+@hidden @serialize @untracked
 AllBits allBits
 
 @internal class unpackedImageAspectFlagBits {
+  @untrackedMap @untracked
   dense_map!(u32, VkImageAspectFlagBits) Bits
 }
 
@@ -368,10 +370,10 @@ sub dense_map!(u32, VkImageAspectFlagBits) unpackImageAspectFlags(VkImageAspectF
         m.Bits[len(m.Bits)] = as!VkImageAspectFlagBits(1 << as!u32(i))
       }
     }
-    allBits.allBits[flag] = m.Bits
+    allBits.allBits[flag] = m
   }
   
-  return allBits.allBits[flag]
+  return allBits.allBits[flag].Bits
 }
 
 @internal class emptyMap {

--- a/gapis/api/vulkan/draw_call_mesh.go
+++ b/gapis/api/vulkan/draw_call_mesh.go
@@ -185,7 +185,7 @@ func getIndicesData(ctx context.Context, s *api.GlobalState, thread uint64, boun
 		size := uint64(indexCount) * sizeOfIndex
 
 		backingMemoryPieces, err := subGetBufferBoundMemoryPiecesInRange(
-			ctx, nil, api.CmdNoID, nil, s, nil, thread, nil, boundIndexBuffer.BoundBuffer().Buffer(),
+			ctx, nil, api.CmdNoID, nil, s, nil, thread, nil, nil, boundIndexBuffer.BoundBuffer().Buffer(),
 			boundIndexBuffer.BoundBuffer().Offset()+VkDeviceSize(uint64(firstIndex)*sizeOfIndex),
 			VkDeviceSize(size))
 		if err != nil {
@@ -321,7 +321,7 @@ func getVerticesData(ctx context.Context, s *api.GlobalState, thread uint64,
 	sliceSize := uint64(boundVertexBuffer.Range())
 
 	formatElementAndTexelBlockSize, err :=
-		subGetElementAndTexelBlockSize(ctx, nil, api.CmdNoID, nil, s, nil, thread, nil, attribute.Fmt())
+		subGetElementAndTexelBlockSize(ctx, nil, api.CmdNoID, nil, s, nil, thread, nil, nil, attribute.Fmt())
 	if err != nil {
 		return nil, err
 	}
@@ -341,7 +341,7 @@ func getVerticesData(ctx context.Context, s *api.GlobalState, thread uint64,
 	}
 
 	backingMemoryPieces, err := subGetBufferBoundMemoryPiecesInRange(
-		ctx, nil, api.CmdNoID, nil, s, nil, thread, nil, boundVertexBuffer.Buffer(),
+		ctx, nil, api.CmdNoID, nil, s, nil, thread, nil, nil, boundVertexBuffer.Buffer(),
 		boundVertexBuffer.Offset()+VkDeviceSize(offset),
 		VkDeviceSize(fullSize))
 	if err != nil {

--- a/gapis/api/vulkan/extensions/khr_swapchain.api
+++ b/gapis/api/vulkan/extensions/khr_swapchain.api
@@ -242,6 +242,11 @@ cmd VkResult vkAcquireNextImageKHR(
   if (semaphore != as!VkSemaphore(0)) {
     Semaphores[semaphore].Signaled = true
   }
+  if (fence != 0) {
+    if (Fences[fence].Signaled) { vkErrorInvalidFence(fence) }
+    Fences[fence].Signaled = true
+    recordFenceSignal(fence)
+  }
   Swapchains[swapchain].ImagesAcquired[imageIndex] = true
   recordAcquireNextImage(swapchain, imageIndex)
   return ?

--- a/gapis/api/vulkan/extensions/khr_swapchain.api
+++ b/gapis/api/vulkan/extensions/khr_swapchain.api
@@ -237,11 +237,13 @@ cmd VkResult vkAcquireNextImageKHR(
   if !(device in Devices) { vkErrorInvalidDevice(device) }
   if !(swapchain in Swapchains) { vkErrorInvalidSwapchain(swapchain) }
   if pImageIndex == null { vkErrorNullPointer("uint32_t") }
-  _ = pImageIndex[0]
-  pImageIndex[0] = ?
+  imageIndex := ?
+  pImageIndex[0] = imageIndex
   if (semaphore != as!VkSemaphore(0)) {
     Semaphores[semaphore].Signaled = true
   }
+  Swapchains[swapchain].ImagesAcquired[imageIndex] = true
+  recordAcquireNextImage(swapchain, imageIndex)
   return ?
 }
 
@@ -299,6 +301,9 @@ cmd VkResult vkQueuePresentKHR(
         }
       }
     }
+    _ = swapchain.ImagesAcquired[imageIndices[i]]
+    swapchain.ImagesAcquired[imageIndices[i]] = false
+    recordPresentSwapchainImage(swapchains[i], imageIndices[i])
   }
   fence
   if (info.pResults != null) {
@@ -329,5 +334,9 @@ cmd VkResult vkQueuePresentKHR(
   @unused VkPresentModeKHR              PresentMode
   @unused VkBool32                      Clipped
   map!(u32, ref!ImageObject)            SwapchainImages
+  map!(u32, bool)                       ImagesAcquired
   @unused ref!VulkanDebugMarkerInfo     DebugInfo
 }
+
+extern void recordAcquireNextImage(VkSwapchainKHR swapchain, u32 imageIndex)
+extern void recordPresentSwapchainImage(VkSwapchainKHR swapchain, u32 imageIndex)

--- a/gapis/api/vulkan/externs.go
+++ b/gapis/api/vulkan/externs.go
@@ -475,3 +475,23 @@ func (e externs) vkErrInvalidImageSubresource(img VkImage, subresourceType strin
 	issue.Error = fmt.Errorf("Accessing invalid image subresource at Image: %v, %v: %v", uint64(img), subresourceType, value)
 	e.onVkError(issue)
 }
+
+type fenceSignal uint64
+
+func (e externs) recordFenceSignal(fence VkFence) {
+	if e.w != nil {
+		e.w.OpenForwardDependency(e.ctx, fenceSignal(fence))
+	}
+}
+
+func (e externs) recordFenceWait(fence VkFence) {
+	if e.w != nil {
+		e.w.CloseForwardDependency(e.ctx, fenceSignal(fence))
+	}
+}
+
+func (e externs) recordFenceReset(fence VkFence) {
+	if e.w != nil {
+		e.w.DropForwardDependency(e.ctx, fenceSignal(fence))
+	}
+}

--- a/gapis/api/vulkan/externs.go
+++ b/gapis/api/vulkan/externs.go
@@ -34,6 +34,7 @@ type externs struct {
 	cmdID api.CmdID
 	s     *api.GlobalState
 	b     *rb.Builder
+	w     api.StateWatcher
 }
 
 func (e externs) hasDynamicProperty(info VkPipelineDynamicStateCreateInfoᶜᵖ,
@@ -42,8 +43,8 @@ func (e externs) hasDynamicProperty(info VkPipelineDynamicStateCreateInfoᶜᵖ,
 		return false
 	}
 	l := e.s.MemoryLayout
-	dynamicStateInfo := info.Slice(0, 1, l).MustRead(e.ctx, e.cmd, e.s, e.b)[0]
-	states := dynamicStateInfo.PDynamicStates().Slice(0, uint64(dynamicStateInfo.DynamicStateCount()), l).MustRead(e.ctx, e.cmd, e.s, e.b)
+	dynamicStateInfo := info.Slice(0, 1, l).MustReadʷ(e.ctx, e.cmd, e.s, e.b, e.w)[0]
+	states := dynamicStateInfo.PDynamicStates().Slice(0, uint64(dynamicStateInfo.DynamicStateCount()), l).MustReadʷ(e.ctx, e.cmd, e.s, e.b, e.w)
 	for _, s := range states {
 		if s == state {
 			return true
@@ -66,7 +67,7 @@ func (e externs) mapMemory(value Voidᵖᵖ, slice memory.Slice) {
 }
 
 // CallReflectedCommand unpacks the given subcommand and arguments, and calls the method
-func CallReflectedCommand(ctx context.Context, cmd api.Cmd, id api.CmdID, s *api.GlobalState, b *rb.Builder, sub, data interface{}) {
+func CallReflectedCommand(ctx context.Context, cmd api.Cmd, id api.CmdID, s *api.GlobalState, b *rb.Builder, w api.StateWatcher, sub, data interface{}) {
 	reflect.ValueOf(sub).Call([]reflect.Value{
 		reflect.ValueOf(ctx),
 		reflect.ValueOf(cmd),
@@ -76,6 +77,7 @@ func CallReflectedCommand(ctx context.Context, cmd api.Cmd, id api.CmdID, s *api
 		reflect.ValueOf(GetState(s)),
 		reflect.ValueOf(cmd.Thread()),
 		reflect.ValueOf(b),
+		reflect.ValueOf(&w).Elem(),
 		reflect.ValueOf(data),
 	})
 }
@@ -183,7 +185,7 @@ func (e externs) readMappedCoherentMemory(memoryHandle VkDeviceMemory, offsetInM
 	writeRngList := e.s.Memory.ApplicationPool().Slice(absSrcMemRng).ValidRanges()
 	for _, r := range writeRngList {
 		mem.Data().Slice(dstStart+r.Base, dstStart+r.Base+r.Size).
-			Copy(e.ctx, U8ᵖ(mem.MappedLocation()).Slice(srcStart+r.Base, srcStart+r.Base+r.Size, l), e.cmd, e.s, e.b)
+			Copy(e.ctx, U8ᵖ(mem.MappedLocation()).Slice(srcStart+r.Base, srcStart+r.Base+r.Size, l), e.cmd, e.s, e.b, e.w)
 	}
 }
 func (e externs) untrackMappedCoherentMemory(start uint64, size memory.Size) {}
@@ -193,7 +195,7 @@ func (e externs) numberOfPNext(pNext Voidᶜᵖ) uint32 {
 	counter := uint32(0)
 	for pNext != 0 {
 		counter++
-		pNext = Voidᶜᵖᵖ(pNext).Slice(1, 2, l).MustRead(e.ctx, e.cmd, e.s, e.b)[0]
+		pNext = Voidᶜᵖᵖ(pNext).Slice(1, 2, l).MustReadʷ(e.ctx, e.cmd, e.s, e.b, e.w)[0]
 	}
 	return counter
 }
@@ -250,7 +252,7 @@ func bindSparse(ctx context.Context, a api.Cmd, id api.CmdID, s *api.GlobalState
 	st := GetState(s)
 	for buffer, binds := range binds.BufferBinds().All() {
 		if !st.Buffers().Contains(buffer) {
-			subVkErrorInvalidBuffer(ctx, a, id, nil, s, nil, a.Thread(), nil, buffer)
+			subVkErrorInvalidBuffer(ctx, a, id, nil, s, nil, a.Thread(), nil, nil, buffer)
 		}
 		bufObj := st.Buffers().Get(buffer)
 		blockSize := bufObj.MemoryRequirements().Alignment()
@@ -277,7 +279,7 @@ func bindSparse(ctx context.Context, a api.Cmd, id api.CmdID, s *api.GlobalState
 	}
 	for image, binds := range binds.OpaqueImageBinds().All() {
 		if !st.Images().Contains(image) {
-			subVkErrorInvalidImage(ctx, a, id, nil, s, nil, a.Thread(), nil, image)
+			subVkErrorInvalidImage(ctx, a, id, nil, s, nil, a.Thread(), nil, nil, image)
 		}
 		imgObj := st.Images().Get(image)
 		blockSize := imgObj.MemoryRequirements().Alignment()
@@ -304,12 +306,12 @@ func bindSparse(ctx context.Context, a api.Cmd, id api.CmdID, s *api.GlobalState
 	}
 	for image, binds := range binds.ImageBinds().All() {
 		if !st.Images().Contains(image) {
-			subVkErrorInvalidImage(ctx, a, id, nil, s, nil, a.Thread(), nil, image)
+			subVkErrorInvalidImage(ctx, a, id, nil, s, nil, a.Thread(), nil, nil, image)
 		}
 		imgObj := st.Images().Get(image)
 		for _, bind := range binds.SparseImageMemoryBinds().All() {
 			if !imgObj.IsNil() {
-				err := subAddSparseImageMemoryBinding(ctx, a, id, nil, s, nil, a.Thread(), nil, image, bind)
+				err := subAddSparseImageMemoryBinding(ctx, a, id, nil, s, nil, a.Thread(), nil, nil, image, bind)
 				if err != nil {
 					return
 				}

--- a/gapis/api/vulkan/externs.go
+++ b/gapis/api/vulkan/externs.go
@@ -187,6 +187,12 @@ func (e externs) readMappedCoherentMemory(memoryHandle VkDeviceMemory, offsetInM
 		mem.Dataʷ(e.ctx, e.w).Slice(dstStart+r.Base, dstStart+r.Base+r.Size).
 			Copy(e.ctx, U8ᵖ(mem.MappedLocationʷ(e.ctx, e.w)).Slice(srcStart+r.Base, srcStart+r.Base+r.Size, l), e.cmd, e.s, e.b, e.w)
 	}
+	if e.w != nil {
+		dstSlice := mem.Dataʷ(e.ctx, e.w).Slice(dstStart, dstStart+uint64(readSize))
+		srcSlice := U8ᵖ(mem.MappedLocationʷ(e.ctx, e.w)).Slice(srcStart, srcStart+uint64(readSize), l)
+		e.w.OnReadSlice(e.ctx, srcSlice)
+		e.w.OnWriteSlice(e.ctx, dstSlice)
+	}
 }
 func (e externs) untrackMappedCoherentMemory(start uint64, size memory.Size) {}
 

--- a/gapis/api/vulkan/externs.go
+++ b/gapis/api/vulkan/externs.go
@@ -495,3 +495,20 @@ func (e externs) recordFenceReset(fence VkFence) {
 		e.w.DropForwardDependency(e.ctx, fenceSignal(fence))
 	}
 }
+
+type swapchainImage struct {
+	swapchain  VkSwapchainKHR
+	imageIndex uint32
+}
+
+func (e externs) recordAcquireNextImage(swapchain VkSwapchainKHR, imageIndex uint32) {
+	if e.w != nil {
+		e.w.OpenForwardDependency(e.ctx, swapchainImage{swapchain, imageIndex})
+	}
+}
+
+func (e externs) recordPresentSwapchainImage(swapchain VkSwapchainKHR, imageIndex uint32) {
+	if e.w != nil {
+		e.w.CloseForwardDependency(e.ctx, swapchainImage{swapchain, imageIndex})
+	}
+}

--- a/gapis/api/vulkan/externs.go
+++ b/gapis/api/vulkan/externs.go
@@ -44,7 +44,7 @@ func (e externs) hasDynamicProperty(info VkPipelineDynamicStateCreateInfoᶜᵖ,
 	}
 	l := e.s.MemoryLayout
 	dynamicStateInfo := info.Slice(0, 1, l).MustReadʷ(e.ctx, e.cmd, e.s, e.b, e.w)[0]
-	states := dynamicStateInfo.PDynamicStates().Slice(0, uint64(dynamicStateInfo.DynamicStateCount()), l).MustReadʷ(e.ctx, e.cmd, e.s, e.b, e.w)
+	states := dynamicStateInfo.PDynamicStatesʷ(e.ctx, e.w).Slice(0, uint64(dynamicStateInfo.DynamicStateCountʷ(e.ctx, e.w)), l).MustReadʷ(e.ctx, e.cmd, e.s, e.b, e.w)
 	for _, s := range states {
 		if s == state {
 			return true
@@ -88,24 +88,24 @@ func (e externs) resetCmd(commandBuffer VkCommandBuffer) {
 
 func (e externs) notifyPendingCommandAdded(queue VkQueue) {
 	s := GetState(e.s)
-	queueObject := s.Queues().Get(queue)
-	command := queueObject.PendingCommands().Get(uint32(queueObject.PendingCommands().Len() - 1))
-	s.SubCmdIdx[len(s.SubCmdIdx)-1] = uint64(command.CommandIndex())
+	queueObject := s.Queuesʷ(e.ctx, e.w).Getʷ(e.ctx, e.w, queue)
+	command := queueObject.PendingCommandsʷ(e.ctx, e.w).Getʷ(e.ctx, e.w, uint32(queueObject.PendingCommandsʷ(e.ctx, e.w).Lenʷ(e.ctx, e.w)-1))
+	s.SubCmdIdx[len(s.SubCmdIdx)-1] = uint64(command.CommandIndexʷ(e.ctx, e.w))
 	s.queuedCommands[command] = QueuedCommand{
 		submit:          e.cmd,
 		submissionIndex: append([]uint64(nil), s.SubCmdIdx...),
 	}
 
-	queueObject.PendingCommands().Add(uint32(queueObject.PendingCommands().Len()-1), command)
+	queueObject.PendingCommandsʷ(e.ctx, e.w).Addʷ(e.ctx, e.w, uint32(queueObject.PendingCommandsʷ(e.ctx, e.w).Lenʷ(e.ctx, e.w)-1), command)
 }
 
 func (e externs) onCommandAdded(buffer VkCommandBuffer) {
 	o := GetState(e.s)
 	o.initialCommands[buffer] =
 		append(o.initialCommands[buffer], e.cmd)
-	b := o.CommandBuffers().Get(buffer)
+	b := o.CommandBuffersʷ(e.ctx, e.w).Getʷ(e.ctx, e.w, buffer)
 	if o.AddCommand != nil {
-		o.AddCommand(b.CommandReferences().Get(uint32(b.CommandReferences().Len() - 1)))
+		o.AddCommand(b.CommandReferencesʷ(e.ctx, e.w).Getʷ(e.ctx, e.w, uint32(b.CommandReferencesʷ(e.ctx, e.w).Lenʷ(e.ctx, e.w)-1)))
 	}
 }
 
@@ -174,18 +174,18 @@ func (e externs) unmapMemory(slice memory.Slice) {
 func (e externs) trackMappedCoherentMemory(start uint64, size memory.Size) {}
 func (e externs) readMappedCoherentMemory(memoryHandle VkDeviceMemory, offsetInMapped uint64, readSize memory.Size) {
 	l := e.s.MemoryLayout
-	mem := GetState(e.s).DeviceMemories().Get(memoryHandle)
-	mappedOffset := uint64(mem.MappedOffset())
+	mem := GetState(e.s).DeviceMemoriesʷ(e.ctx, e.w).Getʷ(e.ctx, e.w, memoryHandle)
+	mappedOffset := uint64(mem.MappedOffsetʷ(e.ctx, e.w))
 	dstStart := mappedOffset + offsetInMapped
 	srcStart := offsetInMapped
 
-	absSrcStart := mem.MappedLocation().Address() + offsetInMapped
+	absSrcStart := mem.MappedLocationʷ(e.ctx, e.w).Address() + offsetInMapped
 	absSrcMemRng := memory.Range{Base: absSrcStart, Size: uint64(readSize)}
 
 	writeRngList := e.s.Memory.ApplicationPool().Slice(absSrcMemRng).ValidRanges()
 	for _, r := range writeRngList {
-		mem.Data().Slice(dstStart+r.Base, dstStart+r.Base+r.Size).
-			Copy(e.ctx, U8ᵖ(mem.MappedLocation()).Slice(srcStart+r.Base, srcStart+r.Base+r.Size, l), e.cmd, e.s, e.b, e.w)
+		mem.Dataʷ(e.ctx, e.w).Slice(dstStart+r.Base, dstStart+r.Base+r.Size).
+			Copy(e.ctx, U8ᵖ(mem.MappedLocationʷ(e.ctx, e.w)).Slice(srcStart+r.Base, srcStart+r.Base+r.Size, l), e.cmd, e.s, e.b, e.w)
 	}
 }
 func (e externs) untrackMappedCoherentMemory(start uint64, size memory.Size) {}
@@ -214,15 +214,15 @@ func (e externs) popDebugMarker() {
 
 func (e externs) pushRenderPassMarker(rp VkRenderPass) {
 	if GetState(e.s).pushMarkerGroup != nil {
-		rpObj := GetState(e.s).RenderPasses().Get(rp)
+		rpObj := GetState(e.s).RenderPassesʷ(e.ctx, e.w).Getʷ(e.ctx, e.w, rp)
 		var name string
-		if !rpObj.DebugInfo().IsNil() && len(rpObj.DebugInfo().ObjectName()) > 0 {
-			name = rpObj.DebugInfo().ObjectName()
+		if !rpObj.DebugInfoʷ(e.ctx, e.w).IsNil() && len(rpObj.DebugInfoʷ(e.ctx, e.w).ObjectNameʷ(e.ctx, e.w)) > 0 {
+			name = rpObj.DebugInfoʷ(e.ctx, e.w).ObjectNameʷ(e.ctx, e.w)
 		} else {
 			name = fmt.Sprintf("RenderPass: %v", rp)
 		}
 		GetState(e.s).pushMarkerGroup(name, false, RenderPassMarker)
-		if rpObj.SubpassDescriptions().Len() > 1 {
+		if rpObj.SubpassDescriptionsʷ(e.ctx, e.w).Lenʷ(e.ctx, e.w) > 1 {
 			GetState(e.s).pushMarkerGroup("Subpass: 0", false, RenderPassMarker)
 		}
 	}
@@ -244,72 +244,72 @@ func (e externs) popAndPushMarkerForNextSubpass(nextSubpass uint32) {
 	}
 }
 
-func bindSparse(ctx context.Context, a api.Cmd, id api.CmdID, s *api.GlobalState, binds *QueuedSparseBinds) {
+func bindSparse(ctx context.Context, w api.StateWatcher, a api.Cmd, id api.CmdID, s *api.GlobalState, binds *QueuedSparseBinds) {
 	// Do not use the subroutine: subRoundUpTo because the subroutine takes uint32 arguments
 	roundUpTo := func(dividend, divisor VkDeviceSize) VkDeviceSize {
 		return (dividend + divisor - 1) / divisor
 	}
 	st := GetState(s)
-	for buffer, binds := range binds.BufferBinds().All() {
-		if !st.Buffers().Contains(buffer) {
+	for buffer, binds := range binds.BufferBindsʷ(ctx, w).Allʷ(ctx, w) {
+		if !st.Buffersʷ(ctx, w).Containsʷ(ctx, w, buffer) {
 			subVkErrorInvalidBuffer(ctx, a, id, nil, s, nil, a.Thread(), nil, nil, buffer)
 		}
-		bufObj := st.Buffers().Get(buffer)
-		blockSize := bufObj.MemoryRequirements().Alignment()
-		for _, bind := range binds.SparseMemoryBinds().All() {
+		bufObj := st.Buffersʷ(ctx, w).Getʷ(ctx, w, buffer)
+		blockSize := bufObj.MemoryRequirementsʷ(ctx, w).Alignmentʷ(ctx, w)
+		for _, bind := range binds.SparseMemoryBindsʷ(ctx, w).Allʷ(ctx, w) {
 			// TODO: assert bind.Size and bind.MemoryOffset must be multiple times of
 			// block size.
-			numBlocks := roundUpTo(bind.Size(), blockSize)
-			memOffset := bind.MemoryOffset()
-			resOffset := bind.ResourceOffset()
+			numBlocks := roundUpTo(bind.Sizeʷ(ctx, w), blockSize)
+			memOffset := bind.MemoryOffsetʷ(ctx, w)
+			resOffset := bind.ResourceOffsetʷ(ctx, w)
 			for i := VkDeviceSize(0); i < numBlocks; i++ {
-				bufObj.SparseMemoryBindings().Add(
+				bufObj.SparseMemoryBindingsʷ(ctx, w).Addʷ(ctx, w,
 					uint64(resOffset),
 					NewVkSparseMemoryBind(s.Arena, // TODO: Use scratch arena?
-						resOffset,     // resourceOffset
-						blockSize,     // size
-						bind.Memory(), // memory
-						memOffset,     // memoryOffset
-						bind.Flags(),  // flags
+						resOffset,            // resourceOffset
+						blockSize,            // size
+						bind.Memoryʷ(ctx, w), // memory
+						memOffset,            // memoryOffset
+						bind.Flagsʷ(ctx, w),  // flags
 					))
 				memOffset += blockSize
 				resOffset += blockSize
 			}
 		}
 	}
-	for image, binds := range binds.OpaqueImageBinds().All() {
-		if !st.Images().Contains(image) {
+	for image, binds := range binds.OpaqueImageBindsʷ(ctx, w).Allʷ(ctx, w) {
+		if !st.Imagesʷ(ctx, w).Containsʷ(ctx, w, image) {
 			subVkErrorInvalidImage(ctx, a, id, nil, s, nil, a.Thread(), nil, nil, image)
 		}
-		imgObj := st.Images().Get(image)
-		blockSize := imgObj.MemoryRequirements().Alignment()
-		for _, bind := range binds.SparseMemoryBinds().All() {
+		imgObj := st.Imagesʷ(ctx, w).Getʷ(ctx, w, image)
+		blockSize := imgObj.MemoryRequirementsʷ(ctx, w).Alignmentʷ(ctx, w)
+		for _, bind := range binds.SparseMemoryBindsʷ(ctx, w).Allʷ(ctx, w) {
 			// TODO: assert bind.Size and bind.MemoryOffset must be multiple times of
 			// block size.
-			numBlocks := roundUpTo(bind.Size(), blockSize)
-			memOffset := bind.MemoryOffset()
-			resOffset := bind.ResourceOffset()
+			numBlocks := roundUpTo(bind.Sizeʷ(ctx, w), blockSize)
+			memOffset := bind.MemoryOffsetʷ(ctx, w)
+			resOffset := bind.ResourceOffsetʷ(ctx, w)
 			for i := VkDeviceSize(0); i < numBlocks; i++ {
-				imgObj.OpaqueSparseMemoryBindings().Add(
+				imgObj.OpaqueSparseMemoryBindingsʷ(ctx, w).Addʷ(ctx, w,
 					uint64(resOffset),
 					NewVkSparseMemoryBind(s.Arena, // TODO: Use scratch arena?
-						resOffset,     // resourceOffset
-						blockSize,     // size
-						bind.Memory(), // memory
-						memOffset,     // memoryOffset
-						bind.Flags(),  // flags
+						resOffset,            // resourceOffset
+						blockSize,            // size
+						bind.Memoryʷ(ctx, w), // memory
+						memOffset,            // memoryOffset
+						bind.Flagsʷ(ctx, w),  // flags
 					))
 				memOffset += blockSize
 				resOffset += blockSize
 			}
 		}
 	}
-	for image, binds := range binds.ImageBinds().All() {
-		if !st.Images().Contains(image) {
+	for image, binds := range binds.ImageBindsʷ(ctx, w).Allʷ(ctx, w) {
+		if !st.Imagesʷ(ctx, w).Containsʷ(ctx, w, image) {
 			subVkErrorInvalidImage(ctx, a, id, nil, s, nil, a.Thread(), nil, nil, image)
 		}
-		imgObj := st.Images().Get(image)
-		for _, bind := range binds.SparseImageMemoryBinds().All() {
+		imgObj := st.Imagesʷ(ctx, w).Getʷ(ctx, w, image)
+		for _, bind := range binds.SparseImageMemoryBindsʷ(ctx, w).Allʷ(ctx, w) {
 			if !imgObj.IsNil() {
 				err := subAddSparseImageMemoryBinding(ctx, a, id, nil, s, nil, a.Thread(), nil, nil, image, bind)
 				if err != nil {

--- a/gapis/api/vulkan/externs_test.go
+++ b/gapis/api/vulkan/externs_test.go
@@ -37,5 +37,5 @@ func TestCallReflectedCommand(t *testing.T) {
 		memory.Nullptr,
 		VkResult_VK_SUCCESS,
 	)
-	CallReflectedCommand(ctx, cmd, 10, s, nil, subDovkCmdWriteTimestamp, NewVkCmdWriteTimestampArgsʳ(a, 0, 0, 0))
+	CallReflectedCommand(ctx, cmd, 10, s, nil, nil, subDovkCmdWriteTimestamp, NewVkCmdWriteTimestampArgsʳ(a, 0, 0, 0))
 }

--- a/gapis/api/vulkan/find_issues.go
+++ b/gapis/api/vulkan/find_issues.go
@@ -90,7 +90,7 @@ func (t *findIssues) reportTo(r replay.Result) { t.res = append(t.res, r) }
 func (t *findIssues) Transform(ctx context.Context, id api.CmdID, cmd api.Cmd, out transform.Writer) {
 	ctx = log.Enter(ctx, "findIssues")
 
-	mutateErr := cmd.Mutate(ctx, id, t.state, nil /* no builder */)
+	mutateErr := cmd.Mutate(ctx, id, t.state, nil /* no builder */, nil /* no watcher */)
 	if mutateErr != nil {
 		// Ignore since downstream transform layers can only consume valid commands
 		return

--- a/gapis/api/vulkan/footprint_builder.go
+++ b/gapis/api/vulkan/footprint_builder.go
@@ -1253,13 +1253,13 @@ func (vb *FootprintBuilder) visitBlocksInVkSparseImageMemoryBind(ctx context.Con
 
 	gran, found := sparseImageMemoryBindGranularity(ctx, imgObj, bind)
 	if found {
-		width, _ := subGetMipSize(ctx, cmd, id, nil, s, nil, cmd.Thread(), nil, imgObj.Info().Extent().Width(), level)
-		height, _ := subGetMipSize(ctx, cmd, id, nil, s, nil, cmd.Thread(), nil, imgObj.Info().Extent().Height(), level)
-		wb, _ := subRoundUpTo(ctx, cmd, id, nil, s, nil, cmd.Thread(), nil, width, gran.Width())
-		hb, _ := subRoundUpTo(ctx, cmd, id, nil, s, nil, cmd.Thread(), nil, height, gran.Height())
-		xe, _ := subRoundUpTo(ctx, cmd, id, nil, s, nil, cmd.Thread(), nil, bind.Extent().Width(), gran.Width())
-		ye, _ := subRoundUpTo(ctx, cmd, id, nil, s, nil, cmd.Thread(), nil, bind.Extent().Height(), gran.Height())
-		ze, _ := subRoundUpTo(ctx, cmd, id, nil, s, nil, cmd.Thread(), nil, bind.Extent().Depth(), gran.Depth())
+		width, _ := subGetMipSize(ctx, cmd, id, nil, s, nil, cmd.Thread(), nil, nil, imgObj.Info().Extent().Width(), level)
+		height, _ := subGetMipSize(ctx, cmd, id, nil, s, nil, cmd.Thread(), nil, nil, imgObj.Info().Extent().Height(), level)
+		wb, _ := subRoundUpTo(ctx, cmd, id, nil, s, nil, cmd.Thread(), nil, nil, width, gran.Width())
+		hb, _ := subRoundUpTo(ctx, cmd, id, nil, s, nil, cmd.Thread(), nil, nil, height, gran.Height())
+		xe, _ := subRoundUpTo(ctx, cmd, id, nil, s, nil, cmd.Thread(), nil, nil, bind.Extent().Width(), gran.Width())
+		ye, _ := subRoundUpTo(ctx, cmd, id, nil, s, nil, cmd.Thread(), nil, nil, bind.Extent().Height(), gran.Height())
+		ze, _ := subRoundUpTo(ctx, cmd, id, nil, s, nil, cmd.Thread(), nil, nil, bind.Extent().Depth(), gran.Depth())
 		blockSize := uint64(imgObj.MemoryRequirements().Alignment())
 		for zi := uint32(0); zi < ze; zi++ {
 			for yi := uint32(0); yi < ye; yi++ {
@@ -1581,7 +1581,7 @@ func (vb *FootprintBuilder) BuildFootprint(ctx context.Context,
 	}
 
 	// Mutate
-	if err := cmd.Mutate(ctx, id, s, nil); err != nil {
+	if err := cmd.Mutate(ctx, id, s, nil, nil); err != nil {
 		// Continue the footprint building without emitting errors here. It is the
 		// following mutate() calls' responsibility to catch the error.
 		return
@@ -1603,7 +1603,7 @@ func (vb *FootprintBuilder) BuildFootprint(ctx context.Context,
 		modify(ctx, bh, vb.toVkHandle(uint64(cmd.Memory())))
 		memObj := GetState(s).DeviceMemories().Get(cmd.Memory())
 		isCoherent, _ := subIsMemoryCoherent(ctx, cmd, id, nil, s, GetState(s),
-			cmd.Thread(), nil, memObj)
+			cmd.Thread(), nil, nil, memObj)
 		if isCoherent {
 			vb.mappedCoherentMemories[cmd.Memory()] = memObj
 		}
@@ -1624,7 +1624,7 @@ func (vb *FootprintBuilder) BuildFootprint(ctx context.Context,
 			if mem.IsNil() {
 				continue
 			}
-			isCoherent, _ := subIsMemoryCoherent(ctx, cmd, id, nil, s, GetState(s), cmd.Thread(), nil, mem)
+			isCoherent, _ := subIsMemoryCoherent(ctx, cmd, id, nil, s, GetState(s), cmd.Thread(), nil, nil, mem)
 			if isCoherent {
 				if !coherentMemDone {
 					vb.writeCoherentMemoryData(ctx, cmd, bh)
@@ -1686,7 +1686,7 @@ func (vb *FootprintBuilder) BuildFootprint(ctx context.Context,
 		read(ctx, bh, vb.toVkHandle(uint64(cmd.Memory())))
 		offset := uint64(cmd.MemoryOffset())
 		inferredSize, err := subInferImageSize(ctx, cmd, id, nil, s, nil, cmd.Thread(),
-			nil, GetState(s).Images().Get(cmd.Image()))
+			nil, nil, GetState(s).Images().Get(cmd.Image()))
 		if err != nil {
 			log.E(ctx, "FootprintBuilder: Cannot get inferred size of image: %v", cmd.Image())
 			log.E(ctx, "FootprintBuilder: Command %v %v: %v", id, cmd, err)

--- a/gapis/api/vulkan/image_primer.go
+++ b/gapis/api/vulkan/image_primer.go
@@ -313,7 +313,7 @@ func (p *imagePrimer) allocStagingImages(img ImageObjectʳ, aspect VkImageAspect
 	stagingImgs := []ImageObjectʳ{}
 	stagingMems := []DeviceMemoryObjectʳ{}
 
-	srcElementAndTexelInfo, err := subGetElementAndTexelBlockSize(p.sb.ctx, nil, api.CmdNoID, nil, p.sb.oldState, GetState(p.sb.oldState), 0, nil, img.Info().Fmt())
+	srcElementAndTexelInfo, err := subGetElementAndTexelBlockSize(p.sb.ctx, nil, api.CmdNoID, nil, p.sb.oldState, GetState(p.sb.oldState), 0, nil, nil, img.Info().Fmt())
 	if err != nil {
 		return []ImageObjectʳ{}, []DeviceMemoryObjectʳ{}, log.Errf(p.sb.ctx, err, "[Getting element size and texel block info]")
 	}
@@ -323,7 +323,7 @@ func (p *imagePrimer) allocStagingImages(img ImageObjectʳ, aspect VkImageAspect
 	}
 	srcElementSize := srcElementAndTexelInfo.ElementSize()
 	if aspect == VkImageAspectFlagBits_VK_IMAGE_ASPECT_DEPTH_BIT {
-		srcElementSize, err = subGetDepthElementSize(p.sb.ctx, nil, api.CmdNoID, nil, p.sb.oldState, GetState(p.sb.oldState), 0, nil, img.Info().Fmt(), false)
+		srcElementSize, err = subGetDepthElementSize(p.sb.ctx, nil, api.CmdNoID, nil, p.sb.oldState, GetState(p.sb.oldState), 0, nil, nil, img.Info().Fmt(), false)
 		if err != nil {
 			return []ImageObjectʳ{}, []DeviceMemoryObjectʳ{}, log.Errf(p.sb.ctx, err, "[Getting element size for depth aspect] %v", err)
 		}
@@ -342,7 +342,7 @@ func (p *imagePrimer) allocStagingImages(img ImageObjectʳ, aspect VkImageAspect
 	if stagingImgFormat == VkFormat_VK_FORMAT_UNDEFINED {
 		return []ImageObjectʳ{}, []DeviceMemoryObjectʳ{}, log.Errf(p.sb.ctx, nil, "unsupported aspect: %v", aspect)
 	}
-	stagingElementInfo, _ := subGetElementAndTexelBlockSize(p.sb.ctx, nil, api.CmdNoID, nil, p.sb.oldState, GetState(p.sb.oldState), 0, nil, stagingImgFormat)
+	stagingElementInfo, _ := subGetElementAndTexelBlockSize(p.sb.ctx, nil, api.CmdNoID, nil, p.sb.oldState, GetState(p.sb.oldState), 0, nil, nil, stagingImgFormat)
 	stagingElementSize := stagingElementInfo.ElementSize()
 
 	stagingInfo := img.Info().Clone(p.sb.newState.Arena, api.CloneContext{})
@@ -372,7 +372,7 @@ func (p *imagePrimer) allocStagingImages(img ImageObjectʳ, aspect VkImageAspect
 		// Query the memory requirements so validation layers are happy
 		vkGetImageMemoryRequirements(p.sb, dev.VulkanHandle(), stagingImgHandle, MakeVkMemoryRequirements(p.sb.ta))
 
-		stagingImgSize, err := subInferImageSize(p.sb.ctx, nil, api.CmdNoID, nil, p.sb.oldState, GetState(p.sb.oldState), 0, nil, stagingImg)
+		stagingImgSize, err := subInferImageSize(p.sb.ctx, nil, api.CmdNoID, nil, p.sb.oldState, GetState(p.sb.oldState), 0, nil, nil, stagingImg)
 		if err != nil {
 			return []ImageObjectʳ{}, []DeviceMemoryObjectʳ{}, log.Errf(p.sb.ctx, err, "[Getting staging image size]")
 		}
@@ -653,7 +653,7 @@ func (h *ipStoreHandler) store(job *ipStoreJob, queue VkQueue) error {
 	}
 
 	unpackedElementAndTexelBlockSize, _ := subGetElementAndTexelBlockSize(
-		h.sb.ctx, nil, api.CmdNoID, nil, h.sb.oldState, nil, 0, nil, unpackedFmt)
+		h.sb.ctx, nil, api.CmdNoID, nil, h.sb.oldState, nil, 0, nil, nil, unpackedFmt)
 	unpackedElementSize := unpackedElementAndTexelBlockSize.ElementSize()
 
 	// Using multiple texel buffers if necessary
@@ -2878,8 +2878,8 @@ func writeDescriptorSet(sb *stateBuilder, dev VkDevice, descSet VkDescriptorSet,
 }
 
 func walkImageSubresourceRange(sb *stateBuilder, img ImageObjectʳ, rng VkImageSubresourceRange, f func(aspect VkImageAspectFlagBits, layer, level uint32, levelSize byteSizeAndExtent)) {
-	layerCount, _ := subImageSubresourceLayerCount(sb.ctx, nil, api.CmdNoID, nil, sb.oldState, nil, 0, nil, img, rng)
-	levelCount, _ := subImageSubresourceLevelCount(sb.ctx, nil, api.CmdNoID, nil, sb.oldState, nil, 0, nil, img, rng)
+	layerCount, _ := subImageSubresourceLayerCount(sb.ctx, nil, api.CmdNoID, nil, sb.oldState, nil, 0, nil, nil, img, rng)
+	levelCount, _ := subImageSubresourceLevelCount(sb.ctx, nil, api.CmdNoID, nil, sb.oldState, nil, 0, nil, nil, img, rng)
 	for _, aspect := range sb.imageAspectFlagBits(rng.AspectMask()) {
 		for i := uint32(0); i < levelCount; i++ {
 			level := rng.BaseMipLevel() + i

--- a/gapis/api/vulkan/read_framebuffer.go
+++ b/gapis/api/vulkan/read_framebuffer.go
@@ -56,7 +56,7 @@ func (t *readFramebuffer) Transform(ctx context.Context, id api.CmdID, cmd api.C
 	} else {
 		// This is a VkQueuePresent, we need to extract the information out of this,
 		// so that we can correctly display the image.
-		cmd.Mutate(ctx, id, out.State(), nil)
+		cmd.Mutate(ctx, id, out.State(), nil, nil)
 	}
 
 	if r, ok := t.injections[id-api.CmdID(t.numInitialCommands)]; ok {

--- a/gapis/api/vulkan/replay.go
+++ b/gapis/api/vulkan/replay.go
@@ -30,6 +30,7 @@ import (
 	"github.com/google/gapid/gapis/replay"
 	"github.com/google/gapid/gapis/resolve"
 	"github.com/google/gapid/gapis/resolve/dependencygraph"
+	"github.com/google/gapid/gapis/resolve/dependencygraph2"
 	"github.com/google/gapid/gapis/resolve/initialcmds"
 	"github.com/google/gapid/gapis/service"
 )
@@ -129,8 +130,9 @@ type deadCodeEliminationInfo struct {
 }
 
 type dCEInfo struct {
-	ft  *dependencygraph.Footprint
-	dce *dependencygraph.DCE
+	ft     *dependencygraph.Footprint
+	dce    *dependencygraph.DCE
+	newDce *dependencygraph2.DCEBuilder
 }
 
 // color/depth/stencil attachment bit.
@@ -510,15 +512,15 @@ func (a API) Replay(
 	cfg replay.Config,
 	rrs []replay.RequestAndResult,
 	device *device.Instance,
-	capture *capture.Capture,
+	c *capture.Capture,
 	out transform.Writer) error {
-	if a.GetReplayPriority(ctx, device, capture.Header) == 0 {
+	if a.GetReplayPriority(ctx, device, c.Header) == 0 {
 		return log.Errf(ctx, nil, "Cannot replay Vulkan commands on device '%v'", device.Name)
 	}
 
 	optimize := !config.DisableDeadCodeElimination
 
-	cmds := capture.Commands
+	cmds := c.Commands
 
 	transforms := transform.Transforms{}
 	transforms.Add(&makeAttachementReadable{})
@@ -549,19 +551,35 @@ func (a API) Replay(
 			return numInitialCmdWithoutOpt, nil
 		}
 		if opt {
-			// If we have not set up the dependency graph, do it now.
-			if dceInfo.ft == nil {
-				ft, err := dependencygraph.GetFootprint(ctx, intent.Capture)
-				if err != nil {
-					return 0, err
+			if config.NewDeadCodeElimination {
+				if dceInfo.newDce == nil {
+					cfg := dependencygraph2.DependencyGraphConfig{
+						MergeSubCmdNodes:       true,
+						IncludeInitialCommands: true,
+					}
+					graph, err := dependencygraph2.GetDependencyGraph(ctx, capture.Get(ctx), cfg)
+					if err != nil {
+						return 0, fmt.Errorf("Could not build dependency graph for DCE: %v", err)
+					}
+					dceInfo.newDce = dependencygraph2.NewDCEBuilder(graph)
 				}
-				dceInfo.ft = ft
-				dceInfo.dce = dependencygraph.NewDCE(ctx, dceInfo.ft)
+				cmds = []api.Cmd{}
+				return 0, nil
+			} else {
+				// If we have not set up the dependency graph, do it now.
+				if dceInfo.ft == nil {
+					ft, err := dependencygraph.GetFootprint(ctx, intent.Capture)
+					if err != nil {
+						return 0, err
+					}
+					dceInfo.ft = ft
+					dceInfo.dce = dependencygraph.NewDCE(ctx, dceInfo.ft)
+				}
+				cmds = []api.Cmd{}
+				numInitialCmdWithOpt = dceInfo.ft.NumInitialCommands
+				initCmdExpandedWithOpt = true
+				return numInitialCmdWithOpt, nil
 			}
-			cmds = []api.Cmd{}
-			numInitialCmdWithOpt = dceInfo.ft.NumInitialCommands
-			initCmdExpandedWithOpt = true
-			return numInitialCmdWithOpt, nil
 		}
 		// If the capture contains initial state, prepend the commands to build the state.
 		initialCmds, im, _ := initialcmds.InitialCommands(ctx, intent.Capture)
@@ -586,7 +604,7 @@ func (a API) Replay(
 				if err != nil {
 					return err
 				}
-				issues = newFindIssues(ctx, capture, n)
+				issues = newFindIssues(ctx, c, n)
 			}
 			issues.reportTo(rr.Result)
 			optimize = false
@@ -601,7 +619,7 @@ func (a API) Replay(
 				if err != nil {
 					return err
 				}
-				issues = newFindIssues(ctx, capture, n)
+				issues = newFindIssues(ctx, c, n)
 			}
 			issues.reportTo(rr.Result)
 			optimize = false
@@ -631,7 +649,11 @@ func (a API) Replay(
 			}
 
 			if optimize {
-				dceInfo.dce.Request(ctx, api.SubCmdIdx{cmdid})
+				if config.NewDeadCodeElimination {
+					dceInfo.newDce.Request(ctx, api.SubCmdIdx{cmdid})
+				} else {
+					dceInfo.dce.Request(ctx, api.SubCmdIdx{cmdid})
+				}
 			}
 
 			switch cfg.drawMode {
@@ -669,7 +691,11 @@ func (a API) Replay(
 
 	// Use the dead code elimination pass
 	if optimize {
-		transforms.Prepend(dceInfo.dce)
+		if config.NewDeadCodeElimination {
+			transforms.Prepend(dceInfo.newDce)
+		} else {
+			transforms.Prepend(dceInfo.dce)
+		}
 	}
 
 	if wire {
@@ -721,7 +747,7 @@ func (a API) Replay(
 		transforms = newTransforms
 	}
 	if config.LogTransformsToCapture {
-		transforms.Add(transform.NewCaptureLog(ctx, capture, "replay_log.gfxtrace"))
+		transforms.Add(transform.NewCaptureLog(ctx, c, "replay_log.gfxtrace"))
 	}
 	if config.LogMappingsToFile {
 		transforms.Add(replay.NewMappingPrinter(ctx, "mappings.txt"))

--- a/gapis/api/vulkan/replay.go
+++ b/gapis/api/vulkan/replay.go
@@ -272,7 +272,7 @@ func (t *makeAttachementReadable) Transform(ctx context.Context, id api.CmdID, c
 		numDev := e.PPhysicalDeviceCount().Slice(0, 1, l).MustRead(ctx, cmd, s, nil)[0]
 		devSlice := e.PPhysicalDevices().Slice(0, uint64(numDev), l)
 		devs := devSlice.MustRead(ctx, cmd, s, nil)
-		allProps := externs{ctx, cmd, id, s, nil}.fetchPhysicalDeviceProperties(e.Instance(), devSlice)
+		allProps := externs{ctx, cmd, id, s, nil, nil}.fetchPhysicalDeviceProperties(e.Instance(), devSlice)
 		propList := []VkPhysicalDeviceProperties{}
 		for _, dev := range devs {
 			propList = append(propList, allProps.PhyDevToProperties().Get(dev).Clone(s.Arena, api.CloneContext{}))

--- a/gapis/api/vulkan/resources.go
+++ b/gapis/api/vulkan/resources.go
@@ -1180,7 +1180,7 @@ func pipelineResourceData(ctx context.Context,
 				return nil, fmt.Errorf(
 					"Pipeline binding type of %v does not match descriptor set binding type of %v",
 					binding.Type,
-					bindingInfo.BindingType)
+					bindingInfo.BindingType())
 			}
 
 			// Only one of these should be populated

--- a/gapis/api/vulkan/resources.go
+++ b/gapis/api/vulkan/resources.go
@@ -551,13 +551,13 @@ func (t ImageObjectʳ) imageInfo(ctx context.Context, s *api.GlobalState, vkFmt 
 				Bytes:  image.NewID(l.Data().ResourceID(ctx, s)),
 			}
 		}
-		elementAndTexelBlockSize, err := subGetElementAndTexelBlockSize(ctx, nil, api.CmdNoID, nil, s, nil, 0, nil, vkFmt)
+		elementAndTexelBlockSize, err := subGetElementAndTexelBlockSize(ctx, nil, api.CmdNoID, nil, s, nil, 0, nil, nil, vkFmt)
 		if err != nil {
 			log.Errf(ctx, err, "[Trim linear image data for image: %v]", t.VulkanHandle())
 			return nil
 		}
 		texelHeight := elementAndTexelBlockSize.TexelBlockSize().Height()
-		heightInBlocks, _ := subRoundUpTo(ctx, nil, api.CmdNoID, nil, s, nil, 0, nil, l.Height(), texelHeight)
+		heightInBlocks, _ := subRoundUpTo(ctx, nil, api.CmdNoID, nil, s, nil, 0, nil, nil, l.Height(), texelHeight)
 		colorData := make([]uint8, 0, expectedSize)
 		colorRawSize := uint64(format.Size(int(l.Width()), 1, 1))
 		levelData := l.Data().MustRead(ctx, nil, s, nil)
@@ -838,7 +838,7 @@ func (cmd *VkCreateShaderModule) Replace(ctx context.Context, c *capture.Capture
 	ctx = log.Enter(ctx, "VkCreateShaderModule.Replace()")
 	cb := CommandBuilder{Thread: cmd.Thread(), Arena: c.Arena} // TODO: We probably should have a new arena passed in here!
 	state := c.NewState(ctx)
-	cmd.Mutate(ctx, api.CmdNoID, state, nil)
+	cmd.Mutate(ctx, api.CmdNoID, state, nil, nil)
 
 	shader := data.GetShader()
 	var codeSlice interface{}

--- a/gapis/api/vulkan/vulkan.api
+++ b/gapis/api/vulkan/vulkan.api
@@ -276,37 +276,37 @@ enum LastSubmissionType {
 /////////////////////////////
 
 // Dispatchable objects.
-@serialize map!(VkInstance, ref!InstanceObject)             Instances
-@serialize map!(VkPhysicalDevice, ref!PhysicalDeviceObject) PhysicalDevices
-@serialize map!(VkDevice, ref!DeviceObject)                 Devices
-@serialize map!(VkQueue, ref!QueueObject)                   Queues
-@serialize map!(VkCommandBuffer, ref!CommandBufferObject)   CommandBuffers
+@handleMap @serialize map!(VkInstance, ref!InstanceObject)             Instances
+@handleMap @serialize map!(VkPhysicalDevice, ref!PhysicalDeviceObject) PhysicalDevices
+@handleMap @serialize map!(VkDevice, ref!DeviceObject)                 Devices
+@handleMap @serialize map!(VkQueue, ref!QueueObject)                   Queues
+@handleMap @serialize map!(VkCommandBuffer, ref!CommandBufferObject)   CommandBuffers
 // Non-dispatchable objects.
-@serialize map!(VkDeviceMemory, ref!DeviceMemoryObject)                  DeviceMemories
-@serialize map!(VkBuffer, ref!BufferObject)                              Buffers
-@serialize map!(VkBufferView, ref!BufferViewObject)                      BufferViews
-@serialize map!(VkImage, ref!ImageObject)                                Images
-@serialize map!(VkImageView, ref!ImageViewObject)                        ImageViews
-@serialize map!(VkShaderModule, ref!ShaderModuleObject)                  ShaderModules
-@serialize map!(VkPipeline, ref!GraphicsPipelineObject)                  GraphicsPipelines
-@serialize map!(VkPipeline, ref!ComputePipelineObject)                   ComputePipelines
-@serialize map!(VkPipelineLayout, ref!PipelineLayoutObject)              PipelineLayouts
-@serialize map!(VkSampler, ref!SamplerObject)                            Samplers
-@serialize map!(VkDescriptorSet, ref!DescriptorSetObject)                DescriptorSets
-@serialize map!(VkDescriptorSetLayout, ref!DescriptorSetLayoutObject)    DescriptorSetLayouts
-@serialize map!(VkDescriptorPool, ref!DescriptorPoolObject)              DescriptorPools
-@serialize map!(VkFence, ref!FenceObject)                                Fences
-@serialize map!(VkSemaphore, ref!SemaphoreObject)                        Semaphores
-@serialize map!(VkEvent, ref!EventObject)                                Events
-@serialize map!(VkQueryPool, ref!QueryPoolObject)                        QueryPools
-@serialize map!(VkFramebuffer, ref!FramebufferObject)                    Framebuffers
-@serialize map!(VkRenderPass, ref!RenderPassObject)                      RenderPasses
-@serialize map!(VkPipelineCache, ref!PipelineCacheObject)                PipelineCaches
-@serialize map!(VkCommandPool, ref!CommandPoolObject)                    CommandPools
-@serialize map!(VkSurfaceKHR, ref!SurfaceObject)                         Surfaces
-@serialize map!(VkSwapchainKHR, ref!SwapchainObject)                     Swapchains
-@serialize map!(VkDisplayModeKHR, ref!DisplayModeObject)                 DisplayModes
-@serialize map!(VkDebugReportCallbackEXT, ref!DebugReportCallbackObject) DebugReportCallbacks
+@handleMap @serialize map!(VkDeviceMemory, ref!DeviceMemoryObject)                  DeviceMemories
+@handleMap @serialize map!(VkBuffer, ref!BufferObject)                              Buffers
+@handleMap @serialize map!(VkBufferView, ref!BufferViewObject)                      BufferViews
+@handleMap @serialize map!(VkImage, ref!ImageObject)                                Images
+@handleMap @serialize map!(VkImageView, ref!ImageViewObject)                        ImageViews
+@handleMap @serialize map!(VkShaderModule, ref!ShaderModuleObject)                  ShaderModules
+@handleMap @serialize map!(VkPipeline, ref!GraphicsPipelineObject)                  GraphicsPipelines
+@handleMap @serialize map!(VkPipeline, ref!ComputePipelineObject)                   ComputePipelines
+@handleMap @serialize map!(VkPipelineLayout, ref!PipelineLayoutObject)              PipelineLayouts
+@handleMap @serialize map!(VkSampler, ref!SamplerObject)                            Samplers
+@handleMap @serialize map!(VkDescriptorSet, ref!DescriptorSetObject)                DescriptorSets
+@handleMap @serialize map!(VkDescriptorSetLayout, ref!DescriptorSetLayoutObject)    DescriptorSetLayouts
+@handleMap @serialize map!(VkDescriptorPool, ref!DescriptorPoolObject)              DescriptorPools
+@handleMap @serialize map!(VkFence, ref!FenceObject)                                Fences
+@handleMap @serialize map!(VkSemaphore, ref!SemaphoreObject)                        Semaphores
+@handleMap @serialize map!(VkEvent, ref!EventObject)                                Events
+@handleMap @serialize map!(VkQueryPool, ref!QueryPoolObject)                        QueryPools
+@handleMap @serialize map!(VkFramebuffer, ref!FramebufferObject)                    Framebuffers
+@handleMap @serialize map!(VkRenderPass, ref!RenderPassObject)                      RenderPasses
+@handleMap @serialize map!(VkPipelineCache, ref!PipelineCacheObject)                PipelineCaches
+@handleMap @serialize map!(VkCommandPool, ref!CommandPoolObject)                    CommandPools
+@handleMap @serialize map!(VkSurfaceKHR, ref!SurfaceObject)                         Surfaces
+@handleMap @serialize map!(VkSwapchainKHR, ref!SwapchainObject)                     Swapchains
+@handleMap @serialize map!(VkDisplayModeKHR, ref!DisplayModeObject)                 DisplayModes
+@handleMap @serialize map!(VkDebugReportCallbackEXT, ref!DebugReportCallbackObject) DebugReportCallbacks
 // Other state Tracking
 @hidden @serialize map!(VkDevice, VkMemoryRequirements) TransferBufferMemoryRequirements
 @serialize @untracked ref!QueueObject                   LastBoundQueue

--- a/gapis/api/vulkan/vulkan.api
+++ b/gapis/api/vulkan/vulkan.api
@@ -258,6 +258,7 @@ sub ref!ExtensionSet supportedDeviceExtensions() {
 
 @internal class PresentInfo {
   // The number of images presented last present
+  @untracked
   u32 PresentImageCount
   // The images presented in the last present
   map!(u32, ref!ImageObject) PresentImages
@@ -308,10 +309,10 @@ enum LastSubmissionType {
 @serialize map!(VkDebugReportCallbackEXT, ref!DebugReportCallbackObject) DebugReportCallbacks
 // Other state Tracking
 @hidden @serialize map!(VkDevice, VkMemoryRequirements) TransferBufferMemoryRequirements
-@serialize ref!QueueObject                              LastBoundQueue
-@serialize map!(VkQueue, ref!DrawInfo)                  LastDrawInfos
-@serialize map!(VkQueue, ref!ComputeInfo)               LastComputeInfos
-@serialize PresentInfo                                  LastPresentInfo
+@serialize @untracked ref!QueueObject                   LastBoundQueue
+@serialize @untrackedMap map!(VkQueue, ref!DrawInfo)    LastDrawInfos
+@serialize @untrackedMap map!(VkQueue, ref!ComputeInfo) LastComputeInfos
+@serialize @untracked PresentInfo                       LastPresentInfo
 @serialize LastSubmissionType                           LastSubmission
 @hidden @serialize UsedDescriptorSets                   ProcessedDescriptorSets
 

--- a/gapis/api/vulkan/vulkan.go
+++ b/gapis/api/vulkan/vulkan.go
@@ -357,7 +357,7 @@ func (API) ResolveSynchronization(ctx context.Context, d *sync.Data, c *path.Cap
 
 	err = api.ForeachCmd(ctx, cmds, func(ctx context.Context, id api.CmdID, cmd api.Cmd) error {
 		i = id
-		if err := cmd.Mutate(ctx, id, st, nil); err != nil {
+		if err := cmd.Mutate(ctx, id, st, nil, nil); err != nil {
 			return err
 		}
 		return nil
@@ -707,7 +707,7 @@ func (API) MutateSubcommands(ctx context.Context, id api.CmdID, cmd api.Cmd,
 			preSubCmdCb(s, append(api.SubCmdIdx{uint64(id)}, c.SubCmdIdx...), cmd)
 		}
 	}
-	if err := cmd.Mutate(ctx, id, s, nil); err != nil && err == context.Canceled {
+	if err := cmd.Mutate(ctx, id, s, nil, nil); err != nil && err == context.Canceled {
 		return err
 	}
 	return nil

--- a/gapis/api/watcher.go
+++ b/gapis/api/watcher.go
@@ -1,0 +1,114 @@
+// Copyright (C) 2018 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/gapid/gapis/memory"
+)
+
+// StateWatcher provides callbacks to track state effects
+type StateWatcher interface {
+	// OnBeginCmd is called at the beginning of each API call
+	OnBeginCmd(ctx context.Context, cmdID CmdID, cmd Cmd)
+
+	// OnEndCmd is called at the end of each API call
+	OnEndCmd(ctx context.Context, cmdID CmdID, cmd Cmd)
+
+	// OnGet is called when a fragment of state (field, map key, array index) is read
+	OnGet(ctx context.Context, owner Reference, f Fragment, v Reference)
+
+	// OnSet is called when a fragment of state (field, map key, array index) is written
+	OnSet(ctx context.Context, owner Reference, f Fragment, old Reference, new Reference)
+
+	// OnWriteSlice is called when writing to a slice
+	OnWriteSlice(ctx context.Context, s memory.Slice)
+
+	// OnReadSlice is called when reading from a slice
+	OnReadSlice(ctx context.Context, s memory.Slice)
+
+	// OnWriteObs is called when a memory write observations become visible
+	OnWriteObs(ctx context.Context, obs []CmdObservation)
+
+	// OnReadObs is called when a memory read observations become visible
+	OnReadObs(ctx context.Context, obs []CmdObservation)
+
+	// OpenForwardDependency is called to begin a forward dependency.
+	// When `CloseForwardDependency` is called later with the same `dependencyID`,
+	// a dependency is added from the current command node during the
+	// `OpenForwardDependency` to the current command node during the
+	// `CloseForwardDependency` call.
+	// Each `OpenForwardDependency` call should have at most one matching
+	// `CloseForwardDependency` call; additional `CloseForwardDependency`
+	// calls with the same `dependencyID` will **not** result in additional
+	// forward dependencies.
+	OpenForwardDependency(ctx context.Context, dependencyID interface{})
+
+	// CloseForwardDependency is called to end a forward dependency.
+	// See `OpenForwardDependency` for an explanation of forward dependencies.
+	CloseForwardDependency(ctx context.Context, dependencyID interface{})
+}
+
+// Fragment is an interface which marks types which identify pieces of API objects.
+// All of the implementations appear below.
+type Fragment interface {
+	fragment()
+}
+
+// FieldFragment is a Fragment identifying a field member of an API object.
+// This corresponds to API syntax such as `myObj.fieldName`.
+type FieldFragment struct {
+	Field
+}
+
+func (f FieldFragment) Format(s fmt.State, r rune) { fmt.Fprintf(s, ".%s", f.Field.FieldName()) }
+
+func (FieldFragment) fragment() {}
+
+// ArrayIndexFragment is a Fragment identifying an array index.
+// This corresponds to syntax such as `myArray[3]`.
+type ArrayIndexFragment struct {
+	Index int
+}
+
+func (f ArrayIndexFragment) Format(s fmt.State, r rune) { fmt.Fprintf(s, "[%d]", f.Index) }
+
+func (ArrayIndexFragment) fragment() {}
+
+// MapIndexFragment is a Fragment identifying a map index.
+// This corresponds to syntax such as `myMap["foo"]`
+type MapIndexFragment struct {
+	Index interface{}
+}
+
+func (f MapIndexFragment) Format(s fmt.State, r rune) { fmt.Fprintf(s, "[%v]", f.Index) }
+
+func (MapIndexFragment) fragment() {}
+
+// CompleteFragment is a Fragment identifying the entire object (all fields),
+// map (all key/value pairs) or array (all values).
+type CompleteFragment struct{}
+
+func (f CompleteFragment) Format(s fmt.State, r rune) { fmt.Fprintf(s, "[*]") }
+
+func (CompleteFragment) fragment() {}
+
+// Field identifies a field in an API object
+type Field interface {
+	FieldName() string
+	ClassName() string
+}

--- a/gapis/api/watcher.go
+++ b/gapis/api/watcher.go
@@ -61,6 +61,11 @@ type StateWatcher interface {
 	// CloseForwardDependency is called to end a forward dependency.
 	// See `OpenForwardDependency` for an explanation of forward dependencies.
 	CloseForwardDependency(ctx context.Context, dependencyID interface{})
+
+	// DropForwardDependency is called to abandon a previously opened
+	// forward dependency, without actually adding the forward dependency.
+	// See `OpenForwardDependency` for an explanation of forward dependencies.
+	DropForwardDependency(ctx context.Context, dependencyID interface{})
 }
 
 // Fragment is an interface which marks types which identify pieces of API objects.

--- a/gapis/client/client.go
+++ b/gapis/client/client.go
@@ -462,3 +462,17 @@ func (t *traceHandler) Event(evt service.TraceEvent) (*service.StatusResponse, e
 func (t *traceHandler) Dispose() {
 	t.conn.CloseSend()
 }
+
+func (c *client) DCECapture(ctx context.Context, capture *path.Capture, commands []*path.Command) (*path.Capture, error) {
+	res, err := c.client.DCECapture(ctx, &service.DCECaptureRequest{
+		Capture:  capture,
+		Commands: commands,
+	})
+	if err != nil {
+		return nil, err
+	}
+	if err := res.GetError(); err != nil {
+		return nil, err.Get()
+	}
+	return res.GetCapture(), nil
+}

--- a/gapis/config/config.go
+++ b/gapis/config/config.go
@@ -18,7 +18,8 @@ package config
 const (
 	DebugReplay                = false
 	DebugReplayBuilder         = false
-	DisableDeadCodeElimination = true
+	DisableDeadCodeElimination = false
+	NewDeadCodeElimination     = false
 	DebugDeadCodeElimination   = false
 	DebugDependencyGraph       = false
 	LogExtrasInTransforms      = false // Logs all commands' extras together with transforms

--- a/gapis/config/config.go
+++ b/gapis/config/config.go
@@ -18,8 +18,9 @@ package config
 const (
 	DebugReplay                = false
 	DebugReplayBuilder         = false
-	DisableDeadCodeElimination = false
+	DisableDeadCodeElimination = true
 	DebugDeadCodeElimination   = false
+	DebugDependencyGraph       = false
 	LogExtrasInTransforms      = false // Logs all commands' extras together with transforms
 	LogMemoryInExtras          = false // Logs all commands' read/write memory observation together with extras
 	// Logs all mappings at the end of the replay from original trace

--- a/gapis/replay/batch.go
+++ b/gapis/replay/batch.go
@@ -223,7 +223,7 @@ func (w *adapter) State() *api.GlobalState {
 
 func (w *adapter) MutateAndWrite(ctx context.Context, id api.CmdID, cmd api.Cmd) {
 	w.builder.BeginCommand(uint64(id), cmd.Thread())
-	if err := cmd.Mutate(ctx, id, w.state, w.builder); err == nil {
+	if err := cmd.Mutate(ctx, id, w.state, w.builder, nil); err == nil {
 		w.builder.CommitCommand()
 	} else {
 		w.builder.RevertCommand(err)

--- a/gapis/replay/custom.go
+++ b/gapis/replay/custom.go
@@ -32,7 +32,8 @@ type Custom struct {
 	F func(ctx context.Context, s *api.GlobalState, b *builder.Builder) error
 }
 
-func (c Custom) Mutate(ctx context.Context, id api.CmdID, s *api.GlobalState, b *builder.Builder) error {
+func (c Custom) Mutate(ctx context.Context, id api.CmdID, s *api.GlobalState,
+	b *builder.Builder, w api.StateWatcher) error {
 	if b == nil {
 		return nil
 	}

--- a/gapis/replay/custom.go
+++ b/gapis/replay/custom.go
@@ -52,3 +52,4 @@ func (Custom) CmdResult() *api.Property                                         
 func (Custom) CmdFlags(context.Context, api.CmdID, *api.GlobalState) api.CmdFlags { return 0 }
 func (Custom) Extras() *api.CmdExtras                                             { return nil }
 func (cmd Custom) Clone(arena.Arena) api.Cmd                                      { return Custom{cmd.T, cmd.F} }
+func (Custom) Alive() bool                                                        { return false }

--- a/gapis/resolve/command_tree.go
+++ b/gapis/resolve/command_tree.go
@@ -250,7 +250,7 @@ func (r *CommandTreeResolvable) Resolve(ctx context.Context) (interface{}, error
 	// Walk the list of unfiltered commands to build the groups.
 	s := c.NewState(ctx)
 	api.ForeachCmd(ctx, c.Commands, func(ctx context.Context, id api.CmdID, cmd api.Cmd) error {
-		cmd.Mutate(ctx, id, s, nil)
+		cmd.Mutate(ctx, id, s, nil, nil)
 		if filter(id, cmd, s) {
 			for _, g := range groupers {
 				g.Process(ctx, id, cmd, s)
@@ -305,7 +305,7 @@ func (r *CommandTreeResolvable) Resolve(ctx context.Context) (interface{}, error
 	// Now we have all the groups, we finally need to add the filtered commands.
 	s = c.NewState(ctx)
 	api.ForeachCmd(ctx, c.Commands, func(ctx context.Context, id api.CmdID, cmd api.Cmd) error {
-		cmd.Mutate(ctx, id, s, nil)
+		cmd.Mutate(ctx, id, s, nil, nil)
 
 		if !filter(id, cmd, s) {
 			return nil

--- a/gapis/resolve/contexts.go
+++ b/gapis/resolve/contexts.go
@@ -101,7 +101,7 @@ func (r *ContextListResolvable) Resolve(ctx context.Context) (interface{}, error
 
 	s := c.NewState(ctx)
 	err = api.ForeachCmd(ctx, c.Commands, func(ctx context.Context, i api.CmdID, cmd api.Cmd) error {
-		cmd.Mutate(ctx, i, s, nil)
+		cmd.Mutate(ctx, i, s, nil, nil)
 
 		api := cmd.API()
 		if api == nil {

--- a/gapis/resolve/dependencygraph/dependency_graph.go
+++ b/gapis/resolve/dependencygraph/dependency_graph.go
@@ -207,7 +207,7 @@ func (r *DependencyGraphResolvable) Resolve(ctx context.Context) (interface{}, e
 					// dependency info, we still need to mutate it in the new state,
 					// because following commands in other APIs may depends on the
 					// side effect of the current command.
-					if err := cmd.Mutate(ctx, id, s, nil /* builder */); err != nil {
+					if err := cmd.Mutate(ctx, id, s, nil /* builder */, nil /* watcher */); err != nil {
 						log.W(ctx, "Command %v %v: %v", id, cmd, err)
 						g.Behaviours[index].Aborted = true
 					}

--- a/gapis/resolve/dependencygraph/footprint.go
+++ b/gapis/resolve/dependencygraph/footprint.go
@@ -210,7 +210,7 @@ func (r *FootprintResolvable) Resolve(ctx context.Context) (interface{}, error) 
 				// execution footprint info, we still need to mutate it in the new
 				// state, because following commands in other APIs may depends on the
 				// side effect of the this command.
-				if err := cmd.Mutate(ctx, id, s, nil); err != nil {
+				if err := cmd.Mutate(ctx, id, s, nil, nil); err != nil {
 					bh.Aborted = true
 					// Continue the footprint building even if errors are found. It is
 					// following mutate calls, which are to build the replay

--- a/gapis/resolve/dependencygraph2/BUILD.bazel
+++ b/gapis/resolve/dependencygraph2/BUILD.bazel
@@ -1,0 +1,78 @@
+# Copyright (C) 2018 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "dependency_graph.go",
+        "dependency_graph_builder.go",
+        "effect.go",
+        "memory.go",
+        "resolvables.go",
+    ],
+    embed = [":dependencygraph_go_proto"],
+    importpath = "github.com/google/gapid/gapis/resolve/dependencygraph2",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//core/app/benchmark:go_default_library",
+        "//core/log:go_default_library",
+        "//core/math/interval:go_default_library",
+        "//gapis/api:go_default_library",
+        "//gapis/capture:go_default_library",
+        "//gapis/config:go_default_library",
+        "//gapis/database:go_default_library",
+        "//gapis/memory:go_default_library",
+        "//gapis/resolve/initialcmds:go_default_library",
+        "//gapis/service/path:go_default_library",
+    ],
+)
+
+proto_library(
+    name = "dependencygraph_proto",
+    srcs = ["resolvables.proto"],
+    visibility = ["//visibility:public"],
+    deps = ["//gapis/service/path:path_proto"],
+)
+
+go_proto_library(
+    name = "dependencygraph_go_proto",
+    importpath = "github.com/google/gapid/gapis/resolve/dependencygraph2",
+    proto = ":dependencygraph2_proto",
+    visibility = ["//visibility:public"],
+    deps = ["//gapis/service/path:go_default_library"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["dependency_graph_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//core/assert:go_default_library",
+        "//core/memory/arena:go_default_library",
+        "//core/os/device:go_default_library",
+        "//gapis/api:go_default_library",
+        "//gapis/capture:go_default_library",
+        "//gapis/replay/builder:go_default_library",
+    ],
+)
+
+proto_library(
+    name = "dependencygraph2_proto",
+    srcs = ["resolvables.proto"],
+    visibility = ["//visibility:public"],
+    deps = ["//gapis/service/path:path_proto"],
+)

--- a/gapis/resolve/dependencygraph2/BUILD.bazel
+++ b/gapis/resolve/dependencygraph2/BUILD.bazel
@@ -18,6 +18,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "go_default_library",
     srcs = [
+        "dce.go",
         "dependency_graph.go",
         "dependency_graph_builder.go",
         "effect.go",
@@ -31,7 +32,9 @@ go_library(
         "//core/app/benchmark:go_default_library",
         "//core/log:go_default_library",
         "//core/math/interval:go_default_library",
+        "//core/memory/arena:go_default_library",
         "//gapis/api:go_default_library",
+        "//gapis/api/transform:go_default_library",
         "//gapis/capture:go_default_library",
         "//gapis/config:go_default_library",
         "//gapis/database:go_default_library",

--- a/gapis/resolve/dependencygraph2/dce.go
+++ b/gapis/resolve/dependencygraph2/dce.go
@@ -1,0 +1,370 @@
+// Copyright (C) 2018 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dependencygraph2
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/gapid/core/app/benchmark"
+	"github.com/google/gapid/core/log"
+	"github.com/google/gapid/core/memory/arena"
+	"github.com/google/gapid/gapis/api"
+	"github.com/google/gapid/gapis/api/transform"
+	"github.com/google/gapid/gapis/capture"
+	"github.com/google/gapid/gapis/config"
+	"github.com/google/gapid/gapis/service/path"
+)
+
+var (
+	dCE2Counter         = benchmark.Duration("DCE2")
+	dCE2CmdDeadCounter  = benchmark.Integer("DCE2.cmd.dead")
+	dCE2CmdLiveCounter  = benchmark.Integer("DCE2.cmd.live")
+	dCE2DrawDeadCounter = benchmark.Integer("DCE2.draw.dead")
+	dCE2DrawLiveCounter = benchmark.Integer("DCE2.draw.live")
+	dCE2DataDeadCounter = benchmark.Integer("DCE2.data.dead")
+	dCE2DataLiveCounter = benchmark.Integer("DCE2.data.live")
+)
+
+// DCECapture returns a new capture containing only the requested commands and their dependencies.
+func DCECapture(ctx context.Context, name string, p *path.Capture, requestedCmds []*path.Command) (*path.Capture, error) {
+	c, err := capture.ResolveFromPath(ctx, p)
+	if err != nil {
+		return nil, err
+	}
+	ctx = log.Enter(ctx, "DCECapture")
+
+	cfg := DependencyGraphConfig{
+		MergeSubCmdNodes:       true,
+		IncludeInitialCommands: false,
+	}
+	graph, err := GetDependencyGraph(ctx, p, cfg)
+	if err != nil {
+		return nil, fmt.Errorf("Could not build dependency graph for DCE: %v", err)
+	}
+	builder := NewDCEBuilder(graph)
+	for _, cmd := range requestedCmds {
+		id := cmd.Indices[0]
+		log.I(ctx, "Requested (%d) %v\n", id, c.Commands[id])
+		err := builder.Request(ctx, api.SubCmdIdx(cmd.Indices))
+		if err != nil {
+			return nil, err
+		}
+	}
+	builder.Build(ctx)
+
+	return capture.New(ctx, arena.New(), name, c.Header, c.InitialState, builder.LiveCmds())
+}
+
+// DCEBuilder tracks the data necessary to perform dead-command-eliminition on a capture
+type DCEBuilder struct {
+	graph            DependencyGraph
+	requestedNodes   []NodeID
+	isLive           []bool
+	liveCmds         []api.Cmd
+	origCmdIDs       []api.CmdID
+	liveCmdIDs       map[api.CmdID]api.CmdID
+	numLiveInitCmds  int
+	orphanObs        []ObsNode
+	numDead, numLive int
+	deadMem, liveMem uint64
+}
+
+// NewDCEBuilder creates a new DCEBuiler using the specified dependency graph
+func NewDCEBuilder(graph DependencyGraph) *DCEBuilder {
+	b := &DCEBuilder{
+		graph:      graph,
+		isLive:     make([]bool, graph.NumNodes()),
+		liveCmds:   make([]api.Cmd, 0, len(graph.Capture().Commands)),
+		origCmdIDs: make([]api.CmdID, 0, len(graph.Capture().Commands)),
+		liveCmdIDs: make(map[api.CmdID]api.CmdID),
+	}
+	return b
+}
+
+// LiveCmdID maps CmdIDs from the original capture to CmdIDs in within the live commands.
+// If the old CmdID refers to a dead command, the returned command will refer to the next live command; if there is no next live command, api.CmdNoID is returned.
+func (b *DCEBuilder) LiveCmdID(oldCmdID api.CmdID) api.CmdID {
+	liveCmdID, ok := b.liveCmdIDs[oldCmdID]
+	if !ok {
+		return api.CmdNoID
+	}
+	return liveCmdID
+}
+
+// OriginalCmdIDs maps a live CmdID to the CmdID of the corresponding command in the original capture
+func (b *DCEBuilder) OriginalCmdID(liveCmdID api.CmdID) api.CmdID {
+	if liveCmdID.IsReal() {
+		liveCmdID += api.CmdID(b.numLiveInitCmds)
+	} else {
+		liveCmdID = liveCmdID.Real()
+	}
+	return b.origCmdIDs[liveCmdID]
+}
+
+// NumLiveInitiCmds returns the number of live commands which are initial commands.
+// (Initial commands are generated commands to recreate the initial state).
+func (b *DCEBuilder) NumLiveInitCmds() int {
+	return b.numLiveInitCmds
+}
+
+// LiveCmds returns the live commands
+func (b *DCEBuilder) LiveCmds() []api.Cmd {
+	return b.liveCmds
+}
+
+// Build runs the dead-code-elimination.
+// The subcommands specified in cmds are marked alive, along with their transitive dependencies.
+func (b *DCEBuilder) Build(ctx context.Context) error {
+	ctx = log.Enter(ctx, "DCEBuilder.Build")
+
+	t0 := dCE2Counter.Start()
+	// Mark all the transitive dependencies of the live nodes as also being alive.
+	b.markDependencies()
+	dCE2Counter.Stop(t0)
+
+	b.buildLiveCmds(ctx)
+
+	b.LogStats(ctx)
+	if config.DebugDeadCodeElimination {
+		b.printAllCmds(ctx)
+	}
+	return nil
+}
+
+func (b *DCEBuilder) LogStats(ctx context.Context) {
+	numCmd := len(b.graph.Capture().Commands) + b.graph.NumInitialCommands()
+	dCE2CmdDeadCounter.Add(int64(b.numDead))
+	dCE2CmdLiveCounter.Add(int64(b.numLive))
+	dCE2DataDeadCounter.Add(int64(b.deadMem))
+	dCE2DataLiveCounter.Add(int64(b.liveMem))
+	log.I(ctx, "DCE2: dead: %v%% %v cmds %v MB, live: %v%% %v cmds %v MB, time: %v",
+		100*b.numDead/numCmd, b.numDead, b.deadMem/1024/1024,
+		100*b.numLive/numCmd, b.numLive, b.liveMem/1024/1024,
+		dCE2Counter.Get())
+}
+
+// Mark as alive all the transitive dependencies of live nodes.
+// This is just BFS.
+func (b *DCEBuilder) markDependencies() {
+	// TODO: See if a more efficient queue is necessary
+	queue := make([]NodeID, len(b.requestedNodes))
+	copy(queue, b.requestedNodes)
+	for len(queue) > 0 {
+		src := queue[0]
+		queue = queue[1:]
+		b.graph.ForeachDependencyFrom(src, func(tgt NodeID) error {
+			if !b.isLive[tgt] {
+				b.isLive[tgt] = true
+				queue = append(queue, tgt)
+			}
+			return nil
+		})
+	}
+}
+
+func (b *DCEBuilder) printAllCmds(ctx context.Context) {
+	b.graph.ForeachNode(func(nodeID NodeID, node Node) error {
+		alive := b.isLive[nodeID]
+		status := "ALIVE"
+		if !alive {
+			status = "DEAD "
+		}
+		if cmdNode, ok := node.(CmdNode); ok && len(cmdNode.Index) == 1 {
+			cmdID := api.CmdID(cmdNode.Index[0])
+			cmd := b.graph.GetCommand(cmdID)
+			log.D(ctx, "[ %s ] (%v / %v) %v\n", status, cmdID, b.LiveCmdID(cmdID), cmd)
+		} else if obsNode, ok := node.(ObsNode); ok {
+			cmdStatus := "DEAD "
+			if obsNode.CmdID != api.CmdNoID {
+				ownerIdx := api.SubCmdIdx{uint64(obsNode.CmdID)}
+				ownerNodeID := b.graph.GetNodeID(CmdNode{ownerIdx})
+				if b.isLive[ownerNodeID] {
+					cmdStatus = "ALIVE"
+				}
+			}
+			liveCmdID := b.LiveCmdID(obsNode.CmdID)
+			log.D(ctx, "[ %s ] (%v [%s] / %v) Range: %v  Pool: %v  ID: %v\n", status, obsNode.CmdID, cmdStatus, liveCmdID, obsNode.CmdObservation.Range, obsNode.CmdObservation.Pool, obsNode.CmdObservation.ID)
+		}
+		return nil
+	})
+}
+
+// Builds liveCmds, containing the commands marked alive.
+// These commands may be cloned and modified from the commands in the original capture.
+// Live memory observations associated with dead commands are moved to the next live command.
+func (b *DCEBuilder) buildLiveCmds(ctx context.Context) {
+	// Process each node in chronological order
+	// (see DependencyGraph.ForeachNode for clarification).
+	b.graph.ForeachNode(func(nodeID NodeID, node Node) error {
+		alive := b.isLive[nodeID]
+		if cmdNode, ok := node.(CmdNode); ok {
+			if len(cmdNode.Index) > 1 {
+				return nil
+			}
+			cmdID := api.CmdID(cmdNode.Index[0])
+			cmd := b.graph.GetCommand(cmdID)
+			if alive {
+				b.numLive++
+				b.processLiveCmd(ctx, b.graph.Capture().Arena, cmdID, cmd)
+			} else {
+				b.numDead++
+			}
+		} else if obsNode, ok := node.(ObsNode); ok {
+			if alive {
+				b.liveMem += obsNode.CmdObservation.Range.Size
+				b.processLiveObs(ctx, obsNode)
+			} else {
+				b.deadMem += obsNode.CmdObservation.Range.Size
+			}
+		}
+		return nil
+	})
+}
+
+// Process a live command.
+// This involves possibly cloning and modifying the command, and then adding it to liveCmds.
+func (b *DCEBuilder) processLiveCmd(ctx context.Context, a arena.Arena, id api.CmdID, cmd api.Cmd) {
+	// Helper to clone the command if we need to modify it.
+	// Cloning is necessary before any modification because this command is
+	// still used by another capture.
+	// This clones the command at most one time, even if we make multiple modifications.
+	isCloned := false
+	cloneCmd := func() {
+		if !isCloned {
+			isCloned = true
+			cmd = cmd.Clone(a)
+		}
+	}
+
+	// Adjust the command's `Caller`, if necessary
+	if b.LiveCmdID(cmd.Caller()) != cmd.Caller() {
+		cloneCmd()
+		cmd.SetCaller(b.LiveCmdID(cmd.Caller()))
+	}
+
+	// Attach any orphan observations to this command
+	if len(b.orphanObs) > 0 {
+		cloneCmd()
+		b.attachOrphanObs(ctx, id, cmd)
+	}
+
+	// compute the cmdID within the live commands
+	liveCmdID := api.CmdID(len(b.liveCmds))
+	if id.IsReal() {
+		liveCmdID -= api.CmdID(b.numLiveInitCmds)
+	} else {
+		liveCmdID = liveCmdID.Derived()
+		b.numLiveInitCmds++
+	}
+
+	b.liveCmdIDs[id] = liveCmdID
+	b.liveCmds = append(b.liveCmds, cmd)
+	b.origCmdIDs = append(b.origCmdIDs, id)
+}
+
+// Adds the current orphan observations as read observations of the specified command.
+func (b *DCEBuilder) attachOrphanObs(ctx context.Context, id api.CmdID, cmd api.Cmd) {
+	extras := make(api.CmdExtras, len(cmd.Extras().All()))
+	copy(extras, cmd.Extras().All())
+	obs := extras.Observations()
+	oldReads := []api.CmdObservation{}
+	if obs == nil {
+		obs = &api.CmdObservations{
+			Reads: make([]api.CmdObservation, 0, len(b.orphanObs)),
+		}
+		extras.Add(obs)
+	} else {
+		oldReads = obs.Reads
+		oldObs := obs
+		obs = &api.CmdObservations{
+			Reads:  make([]api.CmdObservation, 0, len(b.orphanObs)+len(oldReads)),
+			Writes: make([]api.CmdObservation, len(oldObs.Writes)),
+		}
+		copy(obs.Writes, oldObs.Writes)
+		extras.Replace(oldObs, obs)
+	}
+
+	for _, o := range b.orphanObs {
+		obs.Reads = append(obs.Reads, o.CmdObservation)
+		if config.DebugDeadCodeElimination {
+			cmdObservations := b.graph.GetCommand(o.CmdID).Extras().Observations()
+			var cmdObs api.CmdObservation
+			if o.IsWrite {
+				cmdObs = cmdObservations.Writes[o.Index]
+			} else {
+				cmdObs = cmdObservations.Reads[o.Index]
+			}
+			log.D(ctx, "Adding orphan obs: [%v] %v\n", id, o, cmdObs)
+		}
+	}
+	obs.Reads = append(obs.Reads, oldReads...)
+	*cmd.Extras() = extras
+}
+
+// Process a live memory observation.
+// If this observation is attached to a non-live command, it will be saved into
+// `orphanObs` to be attached to the next live command.
+func (b *DCEBuilder) processLiveObs(ctx context.Context, obs ObsNode) {
+	if obs.CmdID == api.CmdNoID {
+		return
+	}
+	cmdNode := b.graph.GetNodeID(CmdNode{api.SubCmdIdx{uint64(obs.CmdID)}})
+	if !b.isLive[cmdNode] {
+		b.orphanObs = append(b.orphanObs, obs)
+	}
+}
+
+// Request added a requsted command or subcommand, represented by its full
+// command index, to the DCE.
+func (b *DCEBuilder) Request(ctx context.Context, fci api.SubCmdIdx) error {
+	if config.DebugDeadCodeElimination {
+		log.I(ctx, "Requesting [%v] %v", fci[0], b.graph.GetCommand(api.CmdID(fci[0])))
+	}
+	nodeID := b.graph.GetNodeID(CmdNode{fci})
+	if nodeID == NodeNoID {
+		return fmt.Errorf("Requested dependencies of cmd not in graph: %v", fci)
+	}
+	if !b.isLive[nodeID] {
+		b.isLive[nodeID] = true
+		b.requestedNodes = append(b.requestedNodes, nodeID)
+	}
+	return nil
+}
+
+// Transform is to comform the interface of Transformer, but does not accept
+// any input.
+func (*DCEBuilder) Transform(ctx context.Context, id api.CmdID, c api.Cmd, out transform.Writer) {
+	panic(fmt.Errorf("This transform does not accept input commands"))
+}
+
+// Flush is to comform the interface of Transformer. Flush performs DCE, and
+// sends the live commands to the writer
+func (b *DCEBuilder) Flush(ctx context.Context, out transform.Writer) {
+	b.Build(ctx)
+	for i, cmd := range b.LiveCmds() {
+		liveCmdID := api.CmdID(i)
+		if i < b.numLiveInitCmds {
+			liveCmdID = liveCmdID.Derived()
+		} else {
+			liveCmdID -= api.CmdID(b.numLiveInitCmds)
+		}
+		cmdID := b.OriginalCmdID(liveCmdID)
+		if config.DebugDeadCodeElimination {
+			log.I(ctx, "Flushing [%v / %v] %v", cmdID, liveCmdID, cmd)
+		}
+		out.MutateAndWrite(ctx, cmdID, cmd)
+	}
+}

--- a/gapis/resolve/dependencygraph2/dce.go
+++ b/gapis/resolve/dependencygraph2/dce.go
@@ -91,6 +91,15 @@ func NewDCEBuilder(graph DependencyGraph) *DCEBuilder {
 		origCmdIDs: make([]api.CmdID, 0, len(graph.Capture().Commands)),
 		liveCmdIDs: make(map[api.CmdID]api.CmdID),
 	}
+	for i, cmd := range b.graph.Capture().Commands {
+		if cmd.Alive() {
+			nodeID := b.graph.GetNodeID(CmdNode{api.SubCmdIdx{uint64(i)}})
+			if nodeID != NodeNoID && !b.isLive[nodeID] {
+				b.isLive[nodeID] = true
+				b.requestedNodes = append(b.requestedNodes, nodeID)
+			}
+		}
+	}
 	return b
 }
 

--- a/gapis/resolve/dependencygraph2/dependency_graph.go
+++ b/gapis/resolve/dependencygraph2/dependency_graph.go
@@ -1,0 +1,410 @@
+// Copyright (C) 2018 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dependencygraph2
+
+import (
+	"context"
+	"fmt"
+	"math"
+
+	"github.com/google/gapid/gapis/api"
+	"github.com/google/gapid/gapis/capture"
+)
+
+// Node represents a node in the dependency graph, and holds data about the
+// associated command or memory observation.
+type Node interface {
+	dependencyNode()
+}
+
+// CmdNode is a dependency node corresponding to an API call
+type CmdNode struct {
+	Index api.SubCmdIdx
+}
+
+func (CmdNode) dependencyNode() {}
+
+// ObsNode is a dependency node corresponding to a memory observation
+type ObsNode struct {
+	CmdObservation api.CmdObservation
+	CmdID          api.CmdID
+	IsWrite        bool
+	Index          int
+}
+
+func (ObsNode) dependencyNode() {}
+
+// Information about what sort of data to store in a dependency graph
+type DependencyGraphConfig struct {
+	// MergeSubCmdNodes indicates whether the graph should have one node per
+	// command (true), or a separate node for each subcommand (false)
+	MergeSubCmdNodes bool
+
+	// IncludeInitialCommands indicates whether nodes should be created for
+	// the initial (state rebuild) commands
+	IncludeInitialCommands bool
+
+	// ReverseDependencies indicates whether reverse edges should be created
+	ReverseDependencies bool
+}
+
+// NodeID identifies a node in a dependency graph
+type NodeID uint32
+
+const NodeNoID = NodeID(math.MaxUint32)
+
+// DependencyGraph stores the dependencies among api calls and memory observations,
+type DependencyGraph interface {
+
+	// NumNodes returns the number of nodes in the graph
+	NumNodes() int
+
+	// NumDependencies returns the number of dependencies (edges) in the graph
+	NumDependencies() uint64
+
+	// GetNode returns the node data associated with the given NodeID
+	GetNode(NodeID) Node
+
+	// GetNodeID returns the NodeID associated with given node data
+	GetNodeID(Node) NodeID
+
+	// ForeachCmd iterates over all API calls in the graph.
+	// If IncludeInitialCommands is true, this includes the initial commands
+	// which reconstruct the initial state.
+	// CmdIDs for initial commands are:
+	//   CmdID(0).Derived(), CmdID(1).Derived(), ...
+	// Whether or not IncludeInitialCommands is true, the CmdIDs for captured
+	// commands are: 0, 1, 2, ...
+	ForeachCmd(ctx context.Context,
+		cb func(context.Context, api.CmdID, api.Cmd) error) error
+
+	// ForeachNode iterates over all nodes in the graph in chronological order.
+	// I.e., the following order:
+	//   * For each initial command
+	//     * Read observation nodes for this command
+	//     * command node
+	//     * Write observation nodes for this command
+	//   * For each (non-initial) command
+	//     * Read observation nodes for this command
+	//     * command node
+	//     * Write observation nodes for this command
+	ForeachNode(cb func(NodeID, Node) error) error
+
+	// ForeachDependency iterates over all pairs (src, tgt), where src depends on tgt
+	ForeachDependency(cb func(NodeID, NodeID) error) error
+
+	// ForeachDependencyFrom iterates over all the nodes tgt, where src depends on tgt
+	ForeachDependencyFrom(src NodeID, cb func(NodeID) error) error
+
+	// ForeachDependencyTo iterates over all the nodes src, where src depends on tgt.
+	// If Config().ReverseDependencies is false, this will return an error.
+	ForeachDependencyTo(tgt NodeID, cb func(NodeID) error) error
+
+	// Capture returns the capture whose dependencies are stored in this graph
+	Capture() *capture.Capture
+
+	// GetCommand returns the command identified by the given CmdID
+	GetCommand(api.CmdID) api.Cmd
+
+	// NumInitialCommands returns the number of initial commands
+	// (the commands needed to reconstruct the initial state before the
+	// first command in the capture)
+	NumInitialCommands() int
+
+	// Config returns the config used to create this graph
+	Config() DependencyGraphConfig
+}
+
+type obsNodeIDs struct {
+	readNodeIDStart  NodeID
+	writeNodeIDStart NodeID
+}
+
+type dependencyGraph struct {
+	capture           *capture.Capture
+	cmdNodeIDs        *api.SubCmdIdxTrie
+	initMemoryNodeIDs obsNodeIDs
+	initCmdObsNodeIDs []obsNodeIDs
+	cmdObsNodeIDs     []obsNodeIDs
+	initialCommands   []api.Cmd
+	nodes             []Node
+	numDependencies   uint64
+	dependenciesFrom  [][]NodeID
+	dependenciesTo    [][]NodeID
+
+	config DependencyGraphConfig
+}
+
+// newDependencyGraph constructs a new dependency graph
+func newDependencyGraph(ctx context.Context, config DependencyGraphConfig,
+	c *capture.Capture, initialCmds []api.Cmd) *dependencyGraph {
+	g := &dependencyGraph{
+		capture:         c,
+		cmdNodeIDs:      new(api.SubCmdIdxTrie),
+		initialCommands: initialCmds,
+		config:          config,
+	}
+	numCmds := len(initialCmds) + len(c.Commands)
+	numObservations := countObservations(initialCmds) + countObservations(c.Commands)
+	numNodes := numCmds + numObservations
+	g.nodes = make([]Node, 0, numNodes)
+	g.initCmdObsNodeIDs = make([]obsNodeIDs, len(initialCmds))
+	for i, cmd := range initialCmds {
+		g.initCmdObsNodeIDs[i] = g.addCmdNodes(api.CmdID(i).Derived(), cmd.Extras().Observations())
+	}
+	g.cmdObsNodeIDs = make([]obsNodeIDs, len(c.Commands))
+	for i, cmd := range c.Commands {
+		g.cmdObsNodeIDs[i] = g.addCmdNodes(api.CmdID(i), cmd.Extras().Observations())
+	}
+	g.dependenciesFrom = make([][]NodeID, numNodes)
+	return g
+}
+
+// NumNodes returns the number of nodes in the graph
+func (g *dependencyGraph) NumNodes() int {
+	return len(g.nodes)
+}
+
+// NumDependencies returns the number of dependencies (edges) in the graph
+func (g *dependencyGraph) NumDependencies() uint64 {
+	return g.numDependencies
+}
+
+// GetNode returns the node data associated with the given NodeID
+func (g *dependencyGraph) GetNode(nodeID NodeID) Node {
+	if nodeID >= NodeID(len(g.nodes)) {
+		return nil
+	}
+	return g.nodes[nodeID]
+}
+
+// GetNodeID returns the NodeID associated with given node data
+func (g *dependencyGraph) GetNodeID(node Node) NodeID {
+	if cmdNode, ok := node.(CmdNode); ok {
+		index := cmdNode.Index
+		if len(index) == 0 {
+			return NodeNoID
+		}
+		if !g.config.IncludeInitialCommands && !api.CmdID(index[0]).IsReal() {
+			return NodeNoID
+		}
+		if g.config.MergeSubCmdNodes {
+			index = index[:1]
+		}
+		if val := g.cmdNodeIDs.Value(index); val != nil {
+			return val.(NodeID)
+		}
+	} else if obsNode, ok := node.(ObsNode); ok {
+		cmdID := obsNode.CmdID
+		var obsNodeIDs obsNodeIDs
+		if cmdID == api.CmdNoID {
+			obsNodeIDs = g.initMemoryNodeIDs
+		} else if cmdID.IsReal() {
+			obsNodeIDs = g.cmdObsNodeIDs[cmdID]
+		} else {
+			cmdID = cmdID.Real()
+			obsNodeIDs = g.initCmdObsNodeIDs[cmdID]
+		}
+		index := obsNode.Index
+		if obsNode.IsWrite {
+			return obsNodeIDs.writeNodeIDStart + NodeID(index)
+		} else {
+			return obsNodeIDs.readNodeIDStart + NodeID(index)
+		}
+	}
+	return NodeNoID
+}
+
+// ForeachCmd iterates over all API calls in the graph.
+// If IncludeInitialCommands is true, this includes the initial commands
+// which reconstruct the initial state.
+// CmdIDs for initial commands are:
+//   CmdID(0).Derived(), CmdID(1).Derived(), ...
+// Whether or not IncludeInitialCommands is true, the CmdIDs for captured
+// commands are: 0, 1, 2, ...
+func (g *dependencyGraph) ForeachCmd(ctx context.Context, cb func(context.Context, api.CmdID, api.Cmd) error) error {
+	if g.config.IncludeInitialCommands {
+		cbDerived := func(ctx context.Context, cmdID api.CmdID, cmd api.Cmd) error {
+			return cb(ctx, cmdID.Derived(), cmd)
+		}
+		if err := api.ForeachCmd(ctx, g.initialCommands, cbDerived); err != nil {
+			return err
+		}
+	}
+	return api.ForeachCmd(ctx, g.capture.Commands, cb)
+}
+
+// ForeachNode iterates over all nodes in the graph
+func (g *dependencyGraph) ForeachNode(cb func(NodeID, Node) error) error {
+	for i, node := range g.nodes {
+		err := cb(NodeID(i), node)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// ForeachDependency iterates over all pairs (src, tgt), where src depends on tgt
+func (g *dependencyGraph) ForeachDependency(cb func(NodeID, NodeID) error) error {
+	for i, depsFrom := range g.dependenciesFrom {
+		src := NodeID(i)
+		for _, tgt := range depsFrom {
+			err := cb(src, tgt)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// ForeachDependencyFrom iterates over all the nodes tgt, where src depends on tgt
+func (g *dependencyGraph) ForeachDependencyFrom(src NodeID, cb func(NodeID) error) error {
+	for _, tgt := range g.dependenciesFrom[src] {
+		err := cb(tgt)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// ForeachDependencyTo iterates over all the nodes src, where src depends on tgt.
+// If Config().ReverseDependencies is false, this will return an error.
+func (g *dependencyGraph) ForeachDependencyTo(tgt NodeID, cb func(NodeID) error) error {
+	if !g.Config().ReverseDependencies {
+		return fmt.Errorf("ForeachDependencyTo called on dependency graph with reverse dependencies disabled.")
+	}
+	for _, src := range g.dependenciesTo[tgt] {
+		err := cb(src)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Capture returns the capture whose dependencies are stored in this graph
+func (g *dependencyGraph) Capture() *capture.Capture {
+	return g.capture
+}
+
+// GetCommand returns the command identified by the given CmdID
+func (g *dependencyGraph) GetCommand(cmdID api.CmdID) api.Cmd {
+	if cmdID.IsReal() {
+		if cmdID >= api.CmdID(len(g.capture.Commands)) {
+			return nil
+		}
+		return g.capture.Commands[cmdID]
+	} else {
+		cmdID = cmdID.Real()
+		if cmdID >= api.CmdID(len(g.initialCommands)) {
+			return nil
+		}
+		return g.initialCommands[cmdID]
+	}
+}
+
+// InitialCommands returns the initial commands, which
+// reconstruct the initial state before the first command in the capture.
+func (g *dependencyGraph) NumInitialCommands() int {
+	return len(g.initialCommands)
+}
+
+// Config returns the config used to create this graph
+func (g *dependencyGraph) Config() DependencyGraphConfig {
+	return g.config
+}
+
+func (g *dependencyGraph) setDependencies(src NodeID, targets []NodeID) {
+	g.numDependencies -= (uint64)(len(g.dependenciesFrom[src]))
+	g.numDependencies += (uint64)(len(targets))
+	g.dependenciesFrom[src] = targets
+}
+
+func (g *dependencyGraph) addDependency(src, tgt NodeID) {
+	deg := len(g.dependenciesFrom[src])
+	if deg > 0 {
+		last := g.dependenciesFrom[src][deg-1]
+		if last == tgt {
+			return
+		} else if last > tgt {
+			panic(fmt.Errorf("Dependency (%v,%v) added after (%v,%v)", src, tgt, src, g.dependenciesFrom[deg-1]))
+		}
+	}
+	if len(g.dependenciesFrom[src]) == cap(g.dependenciesFrom[src]) {
+		// This should not happen.
+		// addDependency is only called for forward dependencies, and
+		// sufficient capacity should have been allocated for all open
+		// forward dependencies.
+		// Re-allocating the slice could significantly impact performance.
+		// Panic so that we can fix this.
+		panic(fmt.Errorf("AddDependency: No remaining capacity (size %v)\n", len(g.dependenciesFrom[src])))
+	}
+	g.dependenciesFrom[src] = append(g.dependenciesFrom[src], tgt)
+	g.numDependencies++
+}
+
+func (g *dependencyGraph) buildDependenciesTo() {
+	degTo := make([]uint32, len(g.nodes))
+	for _, depsFrom := range g.dependenciesFrom {
+		for _, tgt := range depsFrom {
+			degTo[tgt]++
+		}
+	}
+	g.dependenciesTo = make([][]NodeID, len(g.nodes))
+	for tgt := range g.dependenciesTo {
+		g.dependenciesTo[tgt] = make([]NodeID, 0, degTo[tgt])
+	}
+	for src, depsFrom := range g.dependenciesFrom {
+		for _, tgt := range depsFrom {
+			g.dependenciesTo[tgt] = append(g.dependenciesTo[tgt], NodeID(src))
+		}
+	}
+}
+
+func countObservations(cmds []api.Cmd) int {
+	numObservations := 0
+	for _, cmd := range cmds {
+		observations := cmd.Extras().Observations()
+		if observations != nil {
+			numObservations += len(observations.Reads)
+			numObservations += len(observations.Writes)
+		}
+	}
+	return numObservations
+}
+
+func (g *dependencyGraph) addCmdNodes(cmdID api.CmdID, observations *api.CmdObservations) obsNodeIDs {
+	obsNodeIDs := obsNodeIDs{readNodeIDStart: NodeID(len(g.nodes))}
+	if observations != nil {
+		for i, obs := range observations.Reads {
+			g.nodes = append(g.nodes, ObsNode{obs, cmdID, false, i})
+		}
+	}
+	if cmdID != api.CmdNoID {
+		subCmdIdx := api.SubCmdIdx{uint64(cmdID)}
+		g.cmdNodeIDs.SetValue(subCmdIdx, NodeID(len(g.nodes)))
+		g.nodes = append(g.nodes, CmdNode{subCmdIdx})
+	}
+	obsNodeIDs.writeNodeIDStart = NodeID(len(g.nodes))
+	if observations != nil {
+		for i, obs := range observations.Writes {
+			g.nodes = append(g.nodes, ObsNode{obs, cmdID, true, i})
+		}
+	}
+	return obsNodeIDs
+}

--- a/gapis/resolve/dependencygraph2/dependency_graph_builder.go
+++ b/gapis/resolve/dependencygraph2/dependency_graph_builder.go
@@ -1,0 +1,303 @@
+// Copyright (C) 2018 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dependencygraph2
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+
+	"github.com/google/gapid/core/app/benchmark"
+	"github.com/google/gapid/core/log"
+	"github.com/google/gapid/core/math/interval"
+	"github.com/google/gapid/gapis/api"
+	"github.com/google/gapid/gapis/capture"
+	"github.com/google/gapid/gapis/config"
+	"github.com/google/gapid/gapis/memory"
+)
+
+var (
+	dependencyGraphBuilderCounter = benchmark.Duration("DependencyGraph.Builder")
+)
+
+// The data needed to build a dependency graph by iterating through the commands in a trace
+type dependencyGraphBuilder struct {
+	// graph is the dependency graph being constructed
+	graph *dependencyGraph
+
+	// currentCmdID is the CmdID of the command currently being processed
+	currentCmdID api.CmdID
+
+	// currentCmd is the command currently being processed
+	currentCmd api.Cmd
+
+	// currentNodeID is the NodeID of the dependency graph node corresponding to the currentCmdID
+	currentNodeID NodeID
+
+	// currentDependencyExists[i] is true if currentNodeID depends on node i
+	currentDependencyExists []bool
+
+	// currentDependencies is a slice containing all of the nodes depended on by currentNodeID
+	currentDependencies []NodeID
+
+	// currentSubCmdIdx stores the SubCmdIdx of the latest effect
+	// currentSubCmdIdx api.SubCmdIdx
+
+	// currentCreateCount is a count of how many CreateResource effects are associated with currentNodeID
+	currentCreateCount int
+
+	// fragmentWrites stores all non-overwritten writes to the state, excluding memory writes.
+	// fragmentWrites[ref][frag] gives the latest node to write to the fragment
+	// frag in the object corresponding to ref
+	fragmentWrites map[api.RefID]map[api.Fragment]NodeID
+
+	// memoryWrites stores all non-overwritten writes to memory ranges
+	memoryWrites map[memory.PoolID]*memoryWriteList
+
+	// openForwardDependencies tracks pending forward dependencies, where the
+	// first node has been processed, but the second node has not yet been
+	// processed. The keys are the unique identifier for the forward
+	// dependency.
+	openForwardDependencies map[interface{}]NodeID
+
+	Stats struct {
+		NumCmdNodes     uint64
+		NumObsNodes     uint64
+		NumReads        uint64
+		NumWrites       uint64
+		NumMemoryReads  uint64
+		NumMemoryWrites uint64
+	}
+}
+
+// Build a new dependencyGraphBuilder.
+func newDependencyGraphBuilder(ctx context.Context, config DependencyGraphConfig,
+	c *capture.Capture, initialCmds []api.Cmd) *dependencyGraphBuilder {
+	graph := newDependencyGraph(ctx, config, c, initialCmds)
+	builder := &dependencyGraphBuilder{
+		graph: graph,
+		currentDependencyExists: make([]bool, graph.NumNodes()),
+		currentCmdID:            api.CmdNoID,
+		currentNodeID:           NodeNoID,
+		fragmentWrites:          make(map[api.RefID]map[api.Fragment]NodeID),
+		memoryWrites:            make(map[memory.PoolID]*memoryWriteList),
+		openForwardDependencies: make(map[interface{}]NodeID),
+	}
+	return builder
+}
+
+// BeginCmd is called at the beginning of each API call
+func (b *dependencyGraphBuilder) OnBeginCmd(ctx context.Context, cmdID api.CmdID, cmd api.Cmd) {
+	debug(ctx, "OnBeginCmd [%d] %v", cmdID, cmd)
+	b.currentCmdID = cmdID
+	b.currentCmd = cmd
+	b.currentNodeID = b.graph.GetNodeID(CmdNode{api.SubCmdIdx{uint64(cmdID)}})
+}
+
+// EndCmd is called at the end of each API call
+func (b *dependencyGraphBuilder) OnEndCmd(ctx context.Context, cmdID api.CmdID, cmd api.Cmd) {
+	debug(ctx, "OnEndCmd [%d] %v", cmdID, cmd)
+	if len(b.currentDependencies) > 0 {
+		sortedDeps := make([]NodeID, len(b.currentDependencies), len(b.currentDependencies)+b.currentCreateCount)
+		copy(sortedDeps, b.currentDependencies)
+		b.currentDependencies = b.currentDependencies[:0]
+		for _, tgt := range sortedDeps {
+			b.currentDependencyExists[tgt] = false
+		}
+		b.graph.setDependencies(b.currentNodeID, sortedDeps)
+		b.currentCmdID = api.CmdNoID
+		b.currentCmd = nil
+		b.currentCreateCount = 0
+		b.currentNodeID = NodeNoID
+	}
+}
+
+func (b *dependencyGraphBuilder) OnGet(ctx context.Context, owner api.Reference, frag api.Fragment, valueRef api.Reference) {
+	debug(ctx, "  OnGet (%T %d)%v : %d", owner, owner.RefID(), frag, valueRef.RefID())
+	readEffect := ReadFragmentEffect{b.currentNodeID, frag}
+	writes, ok := b.fragmentWrites[owner.RefID()]
+	if !ok {
+		return
+	}
+	if _, ok := frag.(api.CompleteFragment); ok {
+		for writeFrag, writeNode := range writes {
+			writeEffect := WriteFragmentEffect{writeNode, writeFrag}
+			b.addDependency(writeEffect, readEffect)
+		}
+	} else if writeNode, ok := writes[frag]; ok {
+		writeEffect := WriteFragmentEffect{writeNode, frag}
+		b.addDependency(writeEffect, readEffect)
+	}
+}
+
+func (b *dependencyGraphBuilder) OnSet(ctx context.Context, owner api.Reference, frag api.Fragment, oldValueRef api.Reference, newValueRef api.Reference) {
+	debug(ctx, "  OnSet (%T %d)%v : %d → %d", owner, owner.RefID(), frag, oldValueRef.RefID(), newValueRef.RefID())
+	if _, ok := frag.(api.CompleteFragment); ok {
+		b.fragmentWrites[owner.RefID()] = map[api.Fragment]NodeID{frag: b.currentNodeID}
+	} else if writes, ok := b.fragmentWrites[owner.RefID()]; ok {
+		writes[frag] = b.currentNodeID
+	} else {
+		b.fragmentWrites[owner.RefID()] = map[api.Fragment]NodeID{frag: b.currentNodeID}
+	}
+}
+
+// OnWriteSlice is called when writing to a slice
+func (b *dependencyGraphBuilder) OnWriteSlice(ctx context.Context, slice memory.Slice) {
+	debug(ctx, "  OnWriteSlice: %v", slice)
+	b.addMemoryWrite(WriteMemEffect{b.currentNodeID, slice})
+}
+
+// OnReadSlice is called when reading from a slice
+func (b *dependencyGraphBuilder) OnReadSlice(ctx context.Context, slice memory.Slice) {
+	debug(ctx, "  OnReadSlice: %v", slice)
+	b.addMemoryRead(ReadMemEffect{b.currentNodeID, slice})
+}
+
+// observationSlice constructs a Slice from a CmdObservation
+func observationSlice(obs api.CmdObservation) memory.Slice {
+	return memory.NewSlice(obs.Range.Base, obs.Range.Base, obs.Range.Size, obs.Range.Size, obs.Pool, reflect.TypeOf(memory.Char(0)))
+}
+
+// OnWriteObs is called when a memory write observation becomes visible
+func (b *dependencyGraphBuilder) OnWriteObs(ctx context.Context, obs []api.CmdObservation) {
+	for i, o := range obs {
+		b.addObs(i, o, true)
+	}
+}
+
+// OnReadObs is called when a memory read observation becomes visible
+func (b *dependencyGraphBuilder) OnReadObs(ctx context.Context, obs []api.CmdObservation) {
+	for i, o := range obs {
+		b.addObs(i, o, false)
+	}
+}
+
+// OpenForwardDependency is called to begin a forward dependency.
+// See `StateWatcher.OpenForwardDependency` for an explanation of forward dependencies.
+func (b *dependencyGraphBuilder) OpenForwardDependency(ctx context.Context, dependencyID interface{}) {
+	debug(ctx, "  OpenForwardDependency: %v", dependencyID)
+	if _, ok := b.openForwardDependencies[dependencyID]; ok {
+		log.I(ctx, "OpenForwardDependency: Forward dependency opened multiple times before being closed. DependencyID: %v, close node: %v", dependencyID, b.currentNodeID)
+	} else {
+		b.openForwardDependencies[dependencyID] = b.currentNodeID
+		b.currentCreateCount++
+	}
+}
+
+// CloseForwardDependency is called to end a forward dependency.
+// See `StateWatcher.OpenForwardDependency` for an explanation of forward dependencies.
+func (b *dependencyGraphBuilder) CloseForwardDependency(ctx context.Context, dependencyID interface{}) {
+	debug(ctx, "  CloseForwardDependency: %v", dependencyID)
+	if openNode, ok := b.openForwardDependencies[dependencyID]; ok {
+		delete(b.openForwardDependencies, dependencyID)
+		openEffect := OpenForwardDependencyEffect{openNode, dependencyID}
+		closeEffect := CloseForwardDependencyEffect{b.currentNodeID, dependencyID}
+		b.addDependency(openEffect, closeEffect)
+	} else {
+		log.I(ctx, "CloseForwardDependency: Forward dependency closed before being opened. DependencyID: %v, close node: %v", dependencyID, b.currentNodeID)
+	}
+}
+
+func (b *dependencyGraphBuilder) addMemoryWrite(e WriteMemEffect) {
+	span := interval.U64Span{
+		Start: e.Slice.Base(),
+		End:   e.Slice.Base() + e.Slice.Size(),
+	}
+	if writes, ok := b.memoryWrites[e.Slice.Pool()]; ok {
+		i := interval.Replace(writes, span)
+		(*writes)[i].effect = e
+	} else {
+		b.memoryWrites[e.Slice.Pool()] = &memoryWriteList{memoryWrite{e, span}}
+	}
+}
+
+func (b *dependencyGraphBuilder) addMemoryRead(e ReadMemEffect) {
+	span := interval.U64Span{
+		Start: e.Slice.Base(),
+		End:   e.Slice.Base() + e.Slice.Size(),
+	}
+	if writes, ok := b.memoryWrites[e.Slice.Pool()]; ok {
+		i, c := interval.Intersect(writes, span)
+		for _, w := range (*writes)[i : i+c] {
+			b.addDependency(w.effect, e)
+		}
+	}
+}
+
+func (b *dependencyGraphBuilder) addObs(index int, obs api.CmdObservation, isWrite bool) {
+	obsNode := ObsNode{
+		CmdObservation: obs,
+		CmdID:          b.currentCmdID,
+		IsWrite:        isWrite,
+		Index:          index,
+	}
+	b.addMemoryWrite(WriteMemEffect{b.graph.GetNodeID(obsNode), observationSlice(obs)})
+}
+
+// LogStats logs some interesting stats about the graph construction
+func (b *dependencyGraphBuilder) LogStats(ctx context.Context) {
+	log.I(ctx, "nodes: %v, cmds: %v, obs: %v, edges: %v",
+		b.graph.NumNodes(), b.Stats.NumCmdNodes, b.Stats.NumObsNodes, b.graph.NumDependencies())
+	log.I(ctx, "reads: %v, writes: %v, memReads: %v, memWrites: %v",
+		b.Stats.NumReads, b.Stats.NumWrites, b.Stats.NumMemoryReads, b.Stats.NumMemoryWrites)
+	t := dependencyGraphBuilderCounter.Get()
+	if t != 0 {
+		log.I(ctx, "time: %v", dependencyGraphBuilderCounter.Get())
+	}
+}
+
+func (b *dependencyGraphBuilder) addDependency(write WriteEffect, read ReadEffect) {
+	writeID := write.GetNodeID()
+	readID := read.GetNodeID()
+	if _, ok := write.(ReverseEffect); ok {
+		b.graph.addDependency(writeID, readID)
+		return
+	}
+
+	if readID != b.currentNodeID {
+		panic(fmt.Errorf("Read from node %v; expected %v", readID, b.currentNodeID))
+	}
+	if !b.currentDependencyExists[writeID] {
+		b.currentDependencies = append(b.currentDependencies, writeID)
+		b.currentDependencyExists[writeID] = true
+	}
+}
+
+func BuildDependencyGraph(ctx context.Context, config DependencyGraphConfig,
+	c *capture.Capture, initialCmds []api.Cmd, initialRanges interval.U64RangeList) (DependencyGraph, error) {
+	builder := newDependencyGraphBuilder(ctx, config, c, initialCmds)
+	var state *api.GlobalState
+	if config.IncludeInitialCommands {
+		state = c.NewUninitializedState(ctx, initialRanges)
+	} else {
+		state = c.NewState(ctx)
+	}
+	err := builder.graph.ForeachCmd(ctx, func(ctx context.Context, id api.CmdID, cmd api.Cmd) error {
+		return cmd.Mutate(ctx, id, state, nil, builder)
+	})
+	if err != nil {
+		return nil, err
+	}
+	if config.ReverseDependencies {
+		builder.graph.buildDependenciesTo()
+	}
+	return builder.graph, nil
+}
+
+func debug(ctx context.Context, fmt string, args ...interface{}) {
+	if config.DebugDependencyGraph {
+		log.D(ctx, fmt, args...)
+	}
+}

--- a/gapis/resolve/dependencygraph2/dependency_graph_builder.go
+++ b/gapis/resolve/dependencygraph2/dependency_graph_builder.go
@@ -210,6 +210,14 @@ func (b *dependencyGraphBuilder) CloseForwardDependency(ctx context.Context, dep
 	}
 }
 
+// DropForwardDependency is called to abandon a previously opened
+// forward dependency, without actually adding the forward dependency.
+// See `StateWatcher.OpenForwardDependency` for an explanation of forward dependencies.
+func (b *dependencyGraphBuilder) DropForwardDependency(ctx context.Context, dependencyID interface{}) {
+	debug(ctx, "  DropForwardDependency: %v", dependencyID)
+	delete(b.openForwardDependencies, dependencyID)
+}
+
 func (b *dependencyGraphBuilder) addMemoryWrite(e WriteMemEffect) {
 	span := interval.U64Span{
 		Start: e.Slice.Base(),

--- a/gapis/resolve/dependencygraph2/dependency_graph_test.go
+++ b/gapis/resolve/dependencygraph2/dependency_graph_test.go
@@ -1,0 +1,134 @@
+// Copyright (C) 2018 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dependencygraph2
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/gapid/core/assert"
+	"github.com/google/gapid/core/memory/arena"
+	"github.com/google/gapid/core/os/device"
+	"github.com/google/gapid/gapis/api"
+	"github.com/google/gapid/gapis/capture"
+	"github.com/google/gapid/gapis/replay/builder"
+)
+
+type TestCmd struct{}
+
+func (TestCmd) API() api.API                                                       { return nil }
+func (TestCmd) Caller() api.CmdID                                                  { return 0 }
+func (TestCmd) SetCaller(api.CmdID)                                                {}
+func (TestCmd) Thread() uint64                                                     { return 0 }
+func (TestCmd) SetThread(uint64)                                                   {}
+func (TestCmd) CmdName() string                                                    { return "TestCmd" }
+func (TestCmd) CmdFlags(context.Context, api.CmdID, *api.GlobalState) api.CmdFlags { return 0 }
+func (TestCmd) Extras() *api.CmdExtras                                             { return &api.CmdExtras{} }
+func (TestCmd) Mutate(context.Context, api.CmdID, *api.GlobalState, *builder.Builder, api.StateWatcher) error {
+	return nil
+}
+func (TestCmd) Clone(arena.Arena) api.Cmd { return TestCmd{} }
+func (TestCmd) Alive() bool               { return false }
+func (TestCmd) CmdParams() api.Properties { return api.Properties{} }
+func (TestCmd) CmdResult() *api.Property  { return nil }
+
+type TestRef struct {
+	refID api.RefID
+}
+
+func (ref TestRef) RefID() api.RefID {
+	return ref.refID
+}
+
+func newTestRef() TestRef {
+	return TestRef{api.NewRefID()}
+}
+
+type FIELD_A_B struct{}
+
+func (FIELD_A_B) ClassName() string {
+	return "A"
+}
+func (FIELD_A_B) FieldName() string {
+	return "B"
+}
+
+type FIELD_B_C struct{}
+
+func (FIELD_B_C) ClassName() string {
+	return "B"
+}
+func (FIELD_B_C) FieldName() string {
+	return "C"
+}
+
+func TestBuilder(t *testing.T) {
+	ctx := context.Background()
+	// cmds := make([]api.Cmd, 6)
+	c := &capture.Capture{
+		Name: "test",
+		Header: &capture.Header{
+			ABI: device.LinuxX86_64,
+		},
+		Commands:     []api.Cmd{TestCmd{}, TestCmd{}, TestCmd{}, TestCmd{}, TestCmd{}, TestCmd{}},
+		InitialState: &capture.InitialState{},
+	}
+	b := newDependencyGraphBuilder(ctx, DependencyGraphConfig{}, c, []api.Cmd{})
+	eg := newDependencyGraph(ctx, DependencyGraphConfig{}, c, []api.Cmd{})
+	// root := api.RefID(1)
+	// b.AddRefRoot("R", root)
+	getNodeID := func(cmdID uint64) NodeID {
+		return b.graph.GetNodeID(CmdNode{api.SubCmdIdx{cmdID}})
+	}
+	refA, refB, refC := newTestRef(), newTestRef(), newTestRef()
+	b.OnBeginCmd(ctx, 0, TestCmd{})
+	b.OnSet(ctx, refA, api.FieldFragment{FIELD_A_B{}}, api.NilReference{}, refB)
+	b.OnEndCmd(ctx, 0, TestCmd{})
+	b.OnBeginCmd(ctx, 1, TestCmd{})
+	b.OnSet(ctx, refB, api.FieldFragment{FIELD_B_C{}}, api.NilReference{}, refC)
+	b.OnEndCmd(ctx, 1, TestCmd{})
+
+	b.OnBeginCmd(ctx, 2, TestCmd{})
+	b.OnGet(ctx, refA, api.FieldFragment{FIELD_A_B{}}, refB)
+	b.OnGet(ctx, refB, api.FieldFragment{FIELD_B_C{}}, refC)
+	b.OnEndCmd(ctx, 2, TestCmd{})
+	eg.setDependencies(getNodeID(2), []NodeID{getNodeID(0), getNodeID(1)})
+
+	// eg.Paths = b.graph.Paths
+	assert.To(t).For("Reading struct should depend on writes to fields after last write to struct (0)").That(
+		b.graph).DeepEquals(eg)
+
+	b.OnBeginCmd(ctx, 3, TestCmd{})
+	b.OnGet(ctx, refB, api.FieldFragment{FIELD_B_C{}}, refC)
+	b.OnEndCmd(ctx, 3, TestCmd{})
+	eg.setDependencies(getNodeID(3), []NodeID{getNodeID(1)})
+
+	// eg.Paths = b.graph.Paths
+	assert.To(t).For("Reading field should not depend on write to struct before last write to field").That(
+		b.graph).DeepEquals(eg)
+
+	b.OnBeginCmd(ctx, 4, TestCmd{})
+	b.OnSet(ctx, refA, api.FieldFragment{FIELD_A_B{}}, refB, refB)
+	b.OnEndCmd(ctx, 4, TestCmd{})
+
+	b.OnBeginCmd(ctx, 5, TestCmd{})
+	b.OnGet(ctx, refA, api.FieldFragment{FIELD_A_B{}}, refB)
+	b.OnEndCmd(ctx, 5, TestCmd{})
+	eg.setDependencies(getNodeID(5), []NodeID{getNodeID(4)})
+
+	// eg.Paths = b.graph.Paths
+	assert.To(t).For("Reading field should only depend on write to struct after list write to field").That(
+		b.graph).DeepEquals(eg)
+}

--- a/gapis/resolve/dependencygraph2/effect.go
+++ b/gapis/resolve/dependencygraph2/effect.go
@@ -1,0 +1,166 @@
+// Copyright (C) 2018 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dependencygraph2
+
+import (
+	"github.com/google/gapid/gapis/api"
+	"github.com/google/gapid/gapis/memory"
+)
+
+// Effect is a record of a read or write of a piece of state.
+type Effect interface {
+	// GetNodeID returns the dependency graph node associated with this effect
+	GetNodeID() NodeID
+	effect()
+}
+
+// ReadEffect is a record of a read of a piece of state.
+type ReadEffect interface {
+	Effect
+	readEffect()
+}
+
+// WriteEffect is a record of a write of a piece of state.
+type WriteEffect interface {
+	Effect
+	writeEffect()
+}
+
+// ReverseEffect is a record of an effect whose dependency goes in both directions (read <-> write)
+type ReverseEffect interface {
+	Effect
+	reverseEffect()
+}
+
+type FragmentEffect interface {
+	Effect
+	// GetFragment returns the Fragment which is read or written by this effect
+	GetFragment() api.Fragment
+}
+
+// ReadFragmentEffect is a record of a read of a piece of state in the state graph (as opposed to a memory range)
+type ReadFragmentEffect struct {
+	NodeID   NodeID
+	Fragment api.Fragment
+}
+
+var _ = FragmentEffect(ReadFragmentEffect{})
+var _ = ReadEffect(ReadFragmentEffect{})
+
+// GetNodeID returns the dependency graph node associated with this effect
+func (e ReadFragmentEffect) GetNodeID() NodeID {
+	return e.NodeID
+}
+
+// GetFragment returns the Fragment which is read or written by this effect
+func (e ReadFragmentEffect) GetFragment() api.Fragment {
+	return e.Fragment
+}
+
+func (ReadFragmentEffect) effect()     {}
+func (ReadFragmentEffect) readEffect() {}
+
+// WriteFragmentEffect is a record of a write to a piece of state in the state graph (as opposed to a memory range)
+type WriteFragmentEffect struct {
+	NodeID   NodeID
+	Fragment api.Fragment
+}
+
+var _ = FragmentEffect(WriteFragmentEffect{})
+var _ = WriteEffect(WriteFragmentEffect{})
+
+// GetNodeID returns the dependency graph node associated with this effect
+func (e WriteFragmentEffect) GetNodeID() NodeID {
+	return e.NodeID
+}
+
+// GetFragment returns the Fragment which is read or written by this effect
+func (e WriteFragmentEffect) GetFragment() api.Fragment {
+	return e.Fragment
+}
+
+func (WriteFragmentEffect) effect()      {}
+func (WriteFragmentEffect) writeEffect() {}
+
+// ReadMemEffect is a record of a read of a memory range (either application or device memory)
+type ReadMemEffect struct {
+	NodeID NodeID
+	Slice  memory.Slice
+}
+
+var _ = ReadEffect(ReadMemEffect{})
+
+// GetNodeID returns the dependency graph node associated with this effect
+func (e ReadMemEffect) GetNodeID() NodeID {
+	return e.NodeID
+}
+func (ReadMemEffect) effect()     {}
+func (ReadMemEffect) readEffect() {}
+
+// WriteMemEffect is a record of a write to a memory range (either application or device memory)
+type WriteMemEffect struct {
+	NodeID NodeID
+	Slice  memory.Slice
+}
+
+var _ = WriteEffect(WriteMemEffect{})
+
+// GetNodeID returns the dependency graph node associated with this effect
+func (e WriteMemEffect) GetNodeID() NodeID {
+	return e.NodeID
+}
+func (WriteMemEffect) effect()      {}
+func (WriteMemEffect) writeEffect() {}
+
+// OpenForwardDependencyEffect is a record of the *opening* of a forward dependency.
+// The opening effect must occur before the corresponding *closing* effect
+// (represented by CloseForwardDependencyEffect); the opening node associated
+// with the opening of the foward dependency will depend on the node associated
+// with the closing.
+// E.g. vkAcquireNextImageKHR opens a foward dependency, which is closed by the
+// corresponding vkQueuePresentKHR call.
+type OpenForwardDependencyEffect struct {
+	NodeID       NodeID
+	DependencyID interface{}
+}
+
+var _ = WriteEffect(OpenForwardDependencyEffect{})
+var _ = ReverseEffect(OpenForwardDependencyEffect{})
+
+// GetNodeID returns the dependency graph node associated with this effect
+func (e OpenForwardDependencyEffect) GetNodeID() NodeID {
+	return e.NodeID
+}
+func (OpenForwardDependencyEffect) effect()        {}
+func (OpenForwardDependencyEffect) writeEffect()   {}
+func (OpenForwardDependencyEffect) reverseEffect() {}
+
+// CloseForwardDependencyEffect is a record of the *closing* of a forward dependency.
+// See OpenForwardDependencyEffect above.
+type CloseForwardDependencyEffect struct {
+	NodeID       NodeID
+	DependencyID interface{}
+}
+
+var _ = ReadEffect(CloseForwardDependencyEffect{})
+var _ = ReverseEffect(CloseForwardDependencyEffect{})
+
+// GetNodeID returns the dependency graph node associated with this effect
+func (e CloseForwardDependencyEffect) GetNodeID() NodeID {
+	return e.NodeID
+}
+func (CloseForwardDependencyEffect) effect()        {}
+func (CloseForwardDependencyEffect) readEffect()    {}
+func (CloseForwardDependencyEffect) reverseEffect() {}

--- a/gapis/resolve/dependencygraph2/memory.go
+++ b/gapis/resolve/dependencygraph2/memory.go
@@ -1,0 +1,76 @@
+// Copyright (C) 2018 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dependencygraph2
+
+import (
+	"github.com/google/gapid/core/math/interval"
+)
+
+// memoryWrite stores a WriteMemEffect, together with a memory span affected by that write.
+// The span may be smaller than the whole write.
+type memoryWrite struct {
+	effect WriteMemEffect
+	span   interval.U64Span
+}
+
+// memoryWriteList represents a collection of memory writes, together with the regions of memory affected by each write.
+// memoryWriteList implements the `interval.MutableList` interface, enabling the algorithms in `interval` for efficient queries and updates.
+type memoryWriteList []memoryWrite
+
+// Length returns the number of elements in the list
+// Implements `interval.List.Length`
+func (l *memoryWriteList) Length() int {
+	return len(*l)
+}
+
+// GetSpan returns the span for the element at index in the list
+// Implements `interval.List.GetSpan`
+func (l *memoryWriteList) GetSpan(index int) interval.U64Span {
+	return (*l)[index].span
+}
+
+// SetSpan sets the span for the element at index in the list
+// Implements `interval.MutableList.SetSpan`
+func (l *memoryWriteList) SetSpan(index int, span interval.U64Span) {
+	(*l)[index].span = span
+}
+
+// New creates a new element at the specifed index with the specified span
+// Implements `interval.MutableList.New`
+func (l *memoryWriteList) New(index int, span interval.U64Span) {
+	(*l)[index].span = span
+}
+
+// Copy count list entries
+// Implements `interval.MutableList.Copy`
+func (l *memoryWriteList) Copy(to, from, count int) {
+	copy((*l)[to:to+count], (*l)[from:from+count])
+}
+
+// Resize adjusts the length of the array
+// Implements `interval.MutableList.Resize`
+func (l *memoryWriteList) Resize(length int) {
+	if cap(*l) > length {
+		*l = (*l)[:length]
+	} else {
+		old := *l
+		capacity := cap(*l) * 2
+		if capacity < length {
+			capacity = length
+		}
+		*l = make(memoryWriteList, length, capacity)
+		copy(*l, old)
+	}
+}

--- a/gapis/resolve/dependencygraph2/resolvables.go
+++ b/gapis/resolve/dependencygraph2/resolvables.go
@@ -1,0 +1,58 @@
+// Copyright (C) 2018 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dependencygraph2
+
+import (
+	"context"
+
+	"github.com/google/gapid/core/math/interval"
+	"github.com/google/gapid/gapis/api"
+	"github.com/google/gapid/gapis/capture"
+	"github.com/google/gapid/gapis/database"
+	"github.com/google/gapid/gapis/resolve/initialcmds"
+	"github.com/google/gapid/gapis/service/path"
+)
+
+func GetDependencyGraph(ctx context.Context, c *path.Capture, config DependencyGraphConfig) (DependencyGraph, error) {
+	obj, err := database.Build(ctx, &DependencyGraph2Resolvable{
+		Capture:                c,
+		IncludeInitialCommands: config.IncludeInitialCommands,
+		MergeSubCmdNodes:       config.MergeSubCmdNodes,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return obj.(DependencyGraph), nil
+}
+
+func (r *DependencyGraph2Resolvable) Resolve(ctx context.Context) (interface{}, error) {
+	c, err := capture.ResolveFromPath(ctx, r.Capture)
+	if err != nil {
+		return nil, err
+	}
+	initialCmds := []api.Cmd{}
+	initialRanges := interval.U64RangeList{}
+	if r.IncludeInitialCommands {
+		initialCmds, initialRanges, err = initialcmds.InitialCommands(ctx, r.Capture)
+		if err != nil {
+			return nil, err
+		}
+	}
+	config := DependencyGraphConfig{
+		IncludeInitialCommands: r.IncludeInitialCommands,
+		MergeSubCmdNodes:       r.MergeSubCmdNodes,
+	}
+	return BuildDependencyGraph(ctx, config, c, initialCmds, initialRanges)
+}

--- a/gapis/resolve/dependencygraph2/resolvables.proto
+++ b/gapis/resolve/dependencygraph2/resolvables.proto
@@ -1,0 +1,26 @@
+// Copyright (C) 2018 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package dependencygraph;
+option go_package = "github.com/google/gapid/gapis/resolve/dependencygraph2";
+
+import "gapis/service/path/path.proto";
+
+message DependencyGraph2Resolvable {
+  path.Capture capture = 1;
+  bool includeInitialCommands = 2;
+  bool mergeSubCmdNodes = 3;
+}

--- a/gapis/resolve/events.go
+++ b/gapis/resolve/events.go
@@ -80,7 +80,7 @@ func Events(ctx context.Context, p *path.Events, r *path.ResolveConfig) (*servic
 		return 0
 	}
 	api.ForeachCmd(ctx, c.Commands, func(ctx context.Context, id api.CmdID, cmd api.Cmd) error {
-		cmd.Mutate(ctx, id, s, nil)
+		cmd.Mutate(ctx, id, s, nil, nil)
 
 		// TODO: Add event generation to the API files.
 		if !filter(id, cmd, s) {

--- a/gapis/resolve/memory.go
+++ b/gapis/resolve/memory.go
@@ -57,7 +57,7 @@ func Memory(ctx context.Context, p *path.Memory, rc *path.ResolveConfig) (*servi
 		return nil, err
 	}
 	err = api.ForeachCmd(ctx, cmds[:len(cmds)-1], func(ctx context.Context, id api.CmdID, cmd api.Cmd) error {
-		cmd.Mutate(ctx, id, s, nil)
+		cmd.Mutate(ctx, id, s, nil, nil)
 		return nil
 	})
 	if err != nil {
@@ -82,7 +82,7 @@ func Memory(ctx context.Context, p *path.Memory, rc *path.ResolveConfig) (*servi
 	})
 
 	lastCmd := cmds[len(cmds)-1]
-	api.MutateCmds(ctx, s, nil, lastCmd)
+	api.MutateCmds(ctx, s, nil, nil, lastCmd)
 
 	// Check whether the requested pool was ever created.
 	pool, err := s.Memory.Get(memory.PoolID(p.Pool))

--- a/gapis/resolve/report.go
+++ b/gapis/resolve/report.go
@@ -127,7 +127,7 @@ func (r *ReportResolvable) Resolve(ctx context.Context) (interface{}, error) {
 				messages.ErrTraceAssert(as.Reason)))
 		}
 
-		if err := cmd.Mutate(ctx, id, state, nil /* no builder, just mutate */); err != nil {
+		if err := cmd.Mutate(ctx, id, state, nil /* builder */, nil /* watcher */); err != nil {
 			if !api.IsErrCmdAborted(err) {
 				items = append(items, r.newReportItem(log.Error, uint64(id),
 					messages.ErrInternalError(err.Error())))

--- a/gapis/resolve/resource_data.go
+++ b/gapis/resolve/resource_data.go
@@ -90,7 +90,7 @@ func buildResources(ctx context.Context, p *path.Command) (*ResolvedResources, e
 	}
 
 	api.ForeachCmd(ctx, initialCmds, func(ctx context.Context, id api.CmdID, cmd api.Cmd) error {
-		if err := cmd.Mutate(ctx, id, state, nil); err != nil {
+		if err := cmd.Mutate(ctx, id, state, nil, nil); err != nil {
 			log.W(ctx, "Get resources at %v: Initial cmd [%v]%v - %v", p.Indices, id, cmd, err)
 		}
 		return nil
@@ -98,7 +98,7 @@ func buildResources(ctx context.Context, p *path.Command) (*ResolvedResources, e
 	err = api.ForeachCmd(ctx, cmds, func(ctx context.Context, id api.CmdID, cmd api.Cmd) error {
 		currentCmdResourceCount = 0
 		currentCmdIndex = uint64(id)
-		cmd.Mutate(ctx, id, state, nil)
+		cmd.Mutate(ctx, id, state, nil, nil)
 		return nil
 	})
 	if err != nil {

--- a/gapis/resolve/resources.go
+++ b/gapis/resolve/resources.go
@@ -76,7 +76,7 @@ func (r *ResourcesResolvable) Resolve(ctx context.Context) (interface{}, error) 
 	}
 
 	api.ForeachCmd(ctx, initialCmds, func(ctx context.Context, id api.CmdID, cmd api.Cmd) error {
-		if err := cmd.Mutate(ctx, id, state, nil); err != nil {
+		if err := cmd.Mutate(ctx, id, state, nil, nil); err != nil {
 			log.W(ctx, "Get resources: Initial cmd [%v]%v - %v", id, cmd, err)
 		}
 		return nil
@@ -85,7 +85,7 @@ func (r *ResourcesResolvable) Resolve(ctx context.Context) (interface{}, error) 
 	api.ForeachCmd(ctx, c.Commands, func(ctx context.Context, id api.CmdID, cmd api.Cmd) error {
 		currentCmdResourceCount = 0
 		currentCmdIndex = uint64(id)
-		cmd.Mutate(ctx, id, state, nil)
+		cmd.Mutate(ctx, id, state, nil, nil)
 		return nil
 	})
 

--- a/gapis/resolve/state.go
+++ b/gapis/resolve/state.go
@@ -69,7 +69,7 @@ func (r *GlobalStateResolvable) Resolve(ctx context.Context) (interface{}, error
 	}
 
 	err = api.ForeachCmd(ctx, cmds, func(ctx context.Context, id api.CmdID, cmd api.Cmd) error {
-		cmd.Mutate(ctx, id, s, nil)
+		cmd.Mutate(ctx, id, s, nil, nil)
 		return nil
 	})
 	if err != nil {

--- a/gapis/resolve/stats.go
+++ b/gapis/resolve/stats.go
@@ -126,7 +126,7 @@ func drawCallStats(ctx context.Context, capt *path.Capture, stats *service.Stats
 
 	processCmd := func(idx uint64) error {
 		cmd := cmds[idx]
-		err := cmd.Mutate(ctx, api.CmdID(idx), st, nil)
+		err := cmd.Mutate(ctx, api.CmdID(idx), st, nil, nil)
 		if err != nil {
 			return err
 		}

--- a/gapis/server/BUILD.bazel
+++ b/gapis/server/BUILD.bazel
@@ -44,6 +44,7 @@ go_library(
         "//gapis/replay/devices:go_default_library",
         "//gapis/resolve:go_default_library",
         "//gapis/resolve/dependencygraph:go_default_library",
+        "//gapis/resolve/dependencygraph2:go_default_library",
         "//gapis/service:go_default_library",
         "//gapis/service/path:go_default_library",
         "//gapis/stringtable:go_default_library",

--- a/gapis/server/grpc.go
+++ b/gapis/server/grpc.go
@@ -388,6 +388,15 @@ func (s *grpcServer) ExportReplay(ctx xctx.Context, req *service.ExportReplayReq
 	return &service.ExportReplayResponse{}, nil
 }
 
+func (s *grpcServer) DCECapture(ctx xctx.Context, req *service.DCECaptureRequest) (*service.DCECaptureResponse, error) {
+	defer s.inRPC()()
+	capture, err := s.handler.DCECapture(s.bindCtx(ctx), req.Capture, req.Commands)
+	if err := service.NewError(err); err != nil {
+		return &service.DCECaptureResponse{Res: &service.DCECaptureResponse_Error{Error: err}}, nil
+	}
+	return &service.DCECaptureResponse{Res: &service.DCECaptureResponse_Capture{Capture: capture}}, nil
+}
+
 func (s *grpcServer) GetDevices(ctx xctx.Context, req *service.GetDevicesRequest) (*service.GetDevicesResponse, error) {
 	defer s.inRPC()()
 	devices, err := s.handler.GetDevices(s.bindCtx(ctx))

--- a/gapis/server/server.go
+++ b/gapis/server/server.go
@@ -46,6 +46,7 @@ import (
 	"github.com/google/gapid/gapis/replay/devices"
 	"github.com/google/gapid/gapis/resolve"
 	"github.com/google/gapid/gapis/resolve/dependencygraph"
+	"github.com/google/gapid/gapis/resolve/dependencygraph2"
 	"github.com/google/gapid/gapis/service"
 	"github.com/google/gapid/gapis/service/path"
 	"github.com/google/gapid/gapis/stringtable"
@@ -265,6 +266,19 @@ func (s *server) ExportReplay(ctx context.Context, c *path.Capture, d *path.Devi
 		return fmt.Errorf("Server not configured to allow writing of local files")
 	}
 	return replay.ExportReplay(ctx, c, d, path)
+}
+
+func (s *server) DCECapture(ctx context.Context, p *path.Capture, requested []*path.Command) (*path.Capture, error) {
+	ctx = log.Enter(ctx, "DCECapture")
+	c, err := capture.ResolveFromPath(ctx, p)
+	if err != nil {
+		return nil, err
+	}
+	trimmed, err := dependencygraph2.DCECapture(ctx, c.Name+"_dce", p, requested)
+	if err != nil {
+		return nil, err
+	}
+	return trimmed, nil
 }
 
 func (s *server) GetDevices(ctx context.Context) ([]*path.Device, error) {

--- a/gapis/service/service.go
+++ b/gapis/service/service.go
@@ -81,6 +81,9 @@ type Service interface {
 	// ExportReplay saves replay commands and assets to file.
 	ExportReplay(ctx context.Context, c *path.Capture, d *path.Device, path string) error
 
+	// DCECapture returns a new capture containing only the requested commands and their dependencies.
+	DCECapture(ctx context.Context, capture *path.Capture, commands []*path.Command) (*path.Capture, error)
+
 	// GetDevices returns the full list of replay devices avaliable to the server.
 	// These include local replay devices and any connected Android devices.
 	// This list may change over time, as devices are connected and disconnected.

--- a/gapis/service/service.proto
+++ b/gapis/service/service.proto
@@ -297,6 +297,17 @@ message ExportReplayResponse {
   Error error = 1;
 }
 
+message DCECaptureRequest {
+  path.Capture capture = 1;
+  repeated path.Command commands = 2;
+}
+message DCECaptureResponse {
+  oneof res {
+    path.Capture capture = 1;
+    Error error = 2;
+  }
+}
+
 message GetDevicesRequest {
 }
 message GetDevicesResponse {
@@ -526,6 +537,11 @@ service Gapid {
 
   // ExportReplay saves replay commands and assets to file.
   rpc ExportReplay(ExportReplayRequest) returns (ExportReplayResponse) {
+  }
+
+  // DCECapture returns a new capture containing only the requested commands
+  // and their dependencies.
+  rpc DCECapture(DCECaptureRequest) returns (DCECaptureResponse) {
   }
 
   // GetDevices returns the full list of replay devices avaliable to the server.


### PR DESCRIPTION
This is a new PR for the dependency graph code, updated for all the Gapid changes in the last few months.

The dependency graph code is turned off by default, and generally shouldn't change Gapid's execution. The major exception is that the Go version of the generated Mutate() functions for Vulkan now supports a "watcher", which can enables the dependency graph builder to hook into all the reads/writes. This watcher is generally nil, but nevertheless seems to be causing performance regressions that I'm currently investigating.