### PR TITLE
Only take the slow-path in MutationCmdsFor if we really have to.

### DIFF
--- a/gapis/api/gvr/gvr.go
+++ b/gapis/api/gvr/gvr.go
@@ -143,6 +143,11 @@ func (API) FlattenSubcommandIdx(idx api.SubCmdIdx, data *sync.Data, unused bool)
 	return api.CmdID(0), false
 }
 
+// IsTrivialTerminator returns true if the terminator is just stopping at the given index
+func (API) IsTrivialTerminator(ctx context.Context, p *path.Capture, command api.SubCmdIdx) (bool, error) {
+	return true, nil
+}
+
 // RecoverMidExecutionCommand returns a virtual command, used to describe the
 // a subcommand that was created before the start of the trace
 // GVR has no subcommands of this type, so this should never be called


### PR DESCRIPTION
This saves us a bunch of performance since for the most part
we never have to hit the slow-path. This is especially
true for GLES.