### PR TITLE
Fix typo in descriptor api.

### DIFF
--- a/gapis/api/vulkan/api/descriptor.api
+++ b/gapis/api/vulkan/api/descriptor.api
@@ -746,7 +746,7 @@ sub void dovkCmdBindDescriptorSets(ref!vkCmdBindDescriptorSetsArgs args) {
             // If the offset has changed, then we may have to reprocess this
             // descriptor set.
             if hasBeenRead.b {
-              if !(as!u32(j) in existingOffsets[as!u32(i)]) {
+              if !(as!u32(j) in existingOffsets) {
                 hasBeenRead.b = false
               } else if !(as!u32(k) in existingOffsets[as!u32(j)]) {
                 hasBeenRead.b = false


### PR DESCRIPTION
This was small typo, it turns out to not have had much
semantic meaning, since the next like will also catch the
same condition.