### PR TITLE
Vulkan: Fix incorrect traversal of descriptor bindings

### DIFF
--- a/gapis/api/vulkan/api/coherent_memory.api
+++ b/gapis/api/vulkan/api/coherent_memory.api
@@ -109,9 +109,8 @@ sub void readMemoryInImageBindings(map!(u32, ref!VkDescriptorImageInfo) imageBin
 
 sub void readMemoryInDescriptorSet(ref!DescriptorSetObject descriptor_set, map!(u32, map!(u32, VkDeviceSize)) bufferBindingOffsets, bool processImages) {
   if descriptor_set != null {
-    for i in (0 .. len(descriptor_set.Bindings)) {
-      if (descriptor_set.Bindings[as!u32(i)] != null) {
-        binding := descriptor_set.Bindings[as!u32(i)]
+    for _, i, binding in descriptor_set.Bindings {
+      if binding != null {
         switch binding.BindingType {
           case
             VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
@@ -202,9 +201,8 @@ sub void writeMemoryInImageBindings(map!(u32, ref!VkDescriptorImageInfo) imageBi
 
 sub void writeMemoryInDescriptorSet(ref!DescriptorSetObject descriptor_set, map!(u32, map!(u32, VkDeviceSize)) bufferBindingOffsets, bool processImages) {
   if descriptor_set != null {
-    for i in (0 .. len(descriptor_set.Bindings)) {
-      if (descriptor_set.Bindings[as!u32(i)] != null) {
-        binding := descriptor_set.Bindings[as!u32(i)]
+    for _, i, binding in descriptor_set.Bindings {
+      if binding != null {
         switch binding.BindingType {
           case
             VK_DESCRIPTOR_TYPE_STORAGE_BUFFER,

--- a/gapis/api/vulkan/api/descriptor.api
+++ b/gapis/api/vulkan/api/descriptor.api
@@ -759,17 +759,6 @@ sub void dovkCmdBindDescriptorSets(ref!vkCmdBindDescriptorSetsArgs args) {
               }
             }
             desc_binding_buf_offsets[as!u32(k)] = binding_offset
-            if (bufferBinding.Buffer in Buffers) {
-              bufferObject := Buffers[bufferBinding.Buffer]
-              readMemoryInBuffer(bufferObject, binding_offset, bufferBinding.Range)
-            }
-          }
-          for k in (0 .. len(binding.BufferViewBindings)) {
-            buffer_view := binding.BufferViewBindings[as!u32(k)]
-            if (buffer_view != as!VkBufferView(0)) {
-              buffer_view_object := BufferViews[buffer_view]
-              readMemoryInBuffer(buffer_view_object.Buffer, buffer_view_object.Offset, buffer_view_object.Range)
-            }
           }
           desc_set_buf_offsets[as!u32(j)] = desc_binding_buf_offsets
         }


### PR DESCRIPTION
Descriptor bindings are not 'consecutive numbers starting from 0'.
Should use `for _, binding_number, binding in descriptor_set.Bindings`
instead of `for i in (0 .. len(descriptor_set.Bindings))` to traverse
through the maps.

This also allow us to drop the duplicated memory-read for buffers when
binding descriptor sets.