### PR TITLE
Gapis: Cmd.Clone() now returns Cmd; clone() returns specific cmd type.

### DIFF
--- a/gapis/api/cmd.go
+++ b/gapis/api/cmd.go
@@ -18,6 +18,7 @@ import (
 	"context"
 
 	"github.com/google/gapid/core/fault"
+	"github.com/google/gapid/core/memory/arena"
 	"github.com/google/gapid/gapis/replay/builder"
 )
 
@@ -58,6 +59,9 @@ type Cmd interface {
 	// Mutate mutates the State using the command. If the builder argument is
 	// not nil then it will call the replay function on the builder.
 	Mutate(context.Context, CmdID, *GlobalState, *builder.Builder) error
+
+	// Clone makes a shallow copy of this command.
+	Clone(arena.Arena) Cmd
 }
 
 const (

--- a/gapis/api/gles/compat.go
+++ b/gapis/api/gles/compat.go
@@ -209,7 +209,7 @@ func compat(ctx context.Context, device *device.Instance, onError onCompatError)
 			// TODO(dsrbecky): This might make some commands valid for replay which were invalid on trace.
 			scs := FindStaticContextState(s.Arena, cmd.Extras())
 			if !scs.IsNil() && !version.IsES && scs.Constants().MajorVersion() < 3 {
-				clone := cmd.Clone(s.Arena)
+				clone := cmd.clone(s.Arena)
 				clone.Extras().MustClone(cmd.Extras().All()...)
 				for _, e := range clone.Extras().All() {
 					if cs, ok := e.(*StaticContextState); ok {
@@ -290,7 +290,7 @@ func compat(ctx context.Context, device *device.Instance, onError onCompatError)
 
 		case *GlBindTexture:
 			{
-				cmd := cmd.Clone(s.Arena)
+				cmd := cmd.clone(s.Arena)
 				if cmd.Texture() != 0 && !c.Objects().GeneratedNames().Textures().Get(cmd.Texture()) {
 					// glGenTextures() was not used to generate the texture. Legal in GLES 2.
 					tmp := s.AllocDataOrPanic(ctx, cmd.Texture())
@@ -540,7 +540,7 @@ func compat(ctx context.Context, device *device.Instance, onError onCompatError)
 		// TODO: Handle glTextureStorage family of functions - those use direct state access, not the bound texture.
 		case *GlTexStorage1DEXT:
 			{
-				cmd := cmd.Clone(s.Arena)
+				cmd := cmd.clone(s.Arena)
 				internalFormat := &glenumProperty{cmd.Internalformat, cmd.SetInternalformat}
 				textureCompat.convertFormat(ctx, cmd.Target(), internalFormat, nil, nil, out, id, cmd)
 				if !version.IsES { // Strip suffix on desktop.
@@ -553,7 +553,7 @@ func compat(ctx context.Context, device *device.Instance, onError onCompatError)
 			}
 		case *GlTexStorage2D:
 			{
-				cmd := cmd.Clone(s.Arena)
+				cmd := cmd.clone(s.Arena)
 				internalFormat := &glenumProperty{cmd.Internalformat, cmd.SetInternalformat}
 				textureCompat.convertFormat(ctx, cmd.Target(), internalFormat, nil, nil, out, id, cmd)
 				out.MutateAndWrite(ctx, id, cmd)
@@ -561,7 +561,7 @@ func compat(ctx context.Context, device *device.Instance, onError onCompatError)
 			}
 		case *GlTexStorage2DEXT:
 			{
-				cmd := cmd.Clone(s.Arena)
+				cmd := cmd.clone(s.Arena)
 				internalFormat := &glenumProperty{cmd.Internalformat, cmd.SetInternalformat}
 				textureCompat.convertFormat(ctx, cmd.Target(), internalFormat, nil, nil, out, id, cmd)
 				if !version.IsES { // Strip suffix on desktop.
@@ -575,7 +575,7 @@ func compat(ctx context.Context, device *device.Instance, onError onCompatError)
 		case *GlTexStorage2DMultisample:
 			if version.IsES || version.AtLeastGL(4, 3) {
 				// glTexStorage2DMultisample is supported by replay device.
-				cmd := cmd.Clone(s.Arena)
+				cmd := cmd.clone(s.Arena)
 				internalFormat := &glenumProperty{cmd.Internalformat, cmd.SetInternalformat}
 				textureCompat.convertFormat(ctx, cmd.Target(), internalFormat, nil, nil, out, id, cmd)
 				out.MutateAndWrite(ctx, id, cmd)
@@ -590,7 +590,7 @@ func compat(ctx context.Context, device *device.Instance, onError onCompatError)
 			return
 		case *GlTexStorage3D:
 			{
-				cmd := cmd.Clone(s.Arena)
+				cmd := cmd.clone(s.Arena)
 				internalFormat := &glenumProperty{cmd.Internalformat, cmd.SetInternalformat}
 				textureCompat.convertFormat(ctx, cmd.Target(), internalFormat, nil, nil, out, id, cmd)
 				out.MutateAndWrite(ctx, id, cmd)
@@ -598,7 +598,7 @@ func compat(ctx context.Context, device *device.Instance, onError onCompatError)
 			}
 		case *GlTexStorage3DEXT:
 			{
-				cmd := cmd.Clone(s.Arena)
+				cmd := cmd.clone(s.Arena)
 				internalFormat := &glenumProperty{cmd.Internalformat, cmd.SetInternalformat}
 				textureCompat.convertFormat(ctx, cmd.Target(), internalFormat, nil, nil, out, id, cmd)
 				if !version.IsES { // Strip suffix on desktop.
@@ -611,7 +611,7 @@ func compat(ctx context.Context, device *device.Instance, onError onCompatError)
 			}
 		case *GlTexStorage3DMultisample:
 			{
-				cmd := cmd.Clone(s.Arena)
+				cmd := cmd.clone(s.Arena)
 				internalFormat := &glenumProperty{cmd.Internalformat, cmd.SetInternalformat}
 				textureCompat.convertFormat(ctx, cmd.Target(), internalFormat, nil, nil, out, id, cmd)
 				out.MutateAndWrite(ctx, id, cmd)
@@ -619,7 +619,7 @@ func compat(ctx context.Context, device *device.Instance, onError onCompatError)
 			}
 		case *GlTexStorage3DMultisampleOES:
 			{
-				cmd := cmd.Clone(s.Arena)
+				cmd := cmd.clone(s.Arena)
 				internalFormat := &glenumProperty{cmd.Internalformat, cmd.SetInternalformat}
 				textureCompat.convertFormat(ctx, cmd.Target(), internalFormat, nil, nil, out, id, cmd)
 				if !version.IsES { // Strip suffix on desktop.
@@ -632,7 +632,7 @@ func compat(ctx context.Context, device *device.Instance, onError onCompatError)
 			}
 		case *GlTexImage2D:
 			{
-				cmd := cmd.Clone(s.Arena)
+				cmd := cmd.clone(s.Arena)
 				internalFormat := &glenumProperty{
 					func() GLenum { return GLenum(cmd.Internalformat()) },
 					func(fmt GLenum) { cmd.SetInternalformat(GLint(fmt)) },
@@ -645,7 +645,7 @@ func compat(ctx context.Context, device *device.Instance, onError onCompatError)
 			}
 		case *GlTexImage3D:
 			{
-				cmd := cmd.Clone(s.Arena)
+				cmd := cmd.clone(s.Arena)
 				internalFormat := &glenumProperty{
 					func() GLenum { return GLenum(cmd.Internalformat()) },
 					func(fmt GLenum) { cmd.SetInternalformat(GLint(fmt)) },
@@ -658,7 +658,7 @@ func compat(ctx context.Context, device *device.Instance, onError onCompatError)
 			}
 		case *GlTexImage3DOES:
 			{
-				cmd := cmd.Clone(s.Arena)
+				cmd := cmd.clone(s.Arena)
 				internalFormat := &glenumProperty{cmd.Internalformat, cmd.SetInternalformat}
 				fmt := &glenumProperty{cmd.Fmt, cmd.SetFmt}
 				ty := &glenumProperty{cmd.Type, cmd.SetType}
@@ -675,7 +675,7 @@ func compat(ctx context.Context, device *device.Instance, onError onCompatError)
 			}
 		case *GlTexSubImage2D:
 			{
-				cmd := cmd.Clone(s.Arena)
+				cmd := cmd.clone(s.Arena)
 				fmt := &glenumProperty{cmd.Fmt, cmd.SetFmt}
 				ty := &glenumProperty{cmd.Type, cmd.SetType}
 				textureCompat.convertFormat(ctx, cmd.Target(), nil, fmt, ty, out, id, cmd)
@@ -684,7 +684,7 @@ func compat(ctx context.Context, device *device.Instance, onError onCompatError)
 			}
 		case *GlTexSubImage3D:
 			{
-				cmd := cmd.Clone(s.Arena)
+				cmd := cmd.clone(s.Arena)
 				fmt := &glenumProperty{cmd.Fmt, cmd.SetFmt}
 				ty := &glenumProperty{cmd.Type, cmd.SetType}
 				textureCompat.convertFormat(ctx, cmd.Target(), nil, fmt, ty, out, id, cmd)
@@ -693,7 +693,7 @@ func compat(ctx context.Context, device *device.Instance, onError onCompatError)
 			}
 		case *GlTexSubImage3DOES:
 			{
-				cmd := cmd.Clone(s.Arena)
+				cmd := cmd.clone(s.Arena)
 				fmt := &glenumProperty{cmd.Fmt, cmd.SetFmt}
 				ty := &glenumProperty{cmd.Type, cmd.SetType}
 				textureCompat.convertFormat(ctx, cmd.Target(), nil, fmt, ty, out, id, cmd)
@@ -709,7 +709,7 @@ func compat(ctx context.Context, device *device.Instance, onError onCompatError)
 			}
 		case *GlCopyTexImage2D:
 			{
-				cmd := cmd.Clone(s.Arena)
+				cmd := cmd.clone(s.Arena)
 				internalFormat := &glenumProperty{cmd.Internalformat, cmd.SetInternalformat}
 				textureCompat.convertFormat(ctx, cmd.Target(), internalFormat, nil, nil, out, id, cmd)
 				out.MutateAndWrite(ctx, id, cmd)
@@ -718,7 +718,7 @@ func compat(ctx context.Context, device *device.Instance, onError onCompatError)
 
 		case *GlTexParameterIivOES:
 			{
-				cmd := cmd.Clone(s.Arena)
+				cmd := cmd.clone(s.Arena)
 				convertTexTarget(cmd)
 				out.MutateAndWrite(ctx, id, cmd)
 				textureCompat.postTexParameter(ctx, cmd.Target(), cmd.Pname(), out, id, cmd)
@@ -726,7 +726,7 @@ func compat(ctx context.Context, device *device.Instance, onError onCompatError)
 			}
 		case *GlTexParameterIuivOES:
 			{
-				cmd := cmd.Clone(s.Arena)
+				cmd := cmd.clone(s.Arena)
 				convertTexTarget(cmd)
 				out.MutateAndWrite(ctx, id, cmd)
 				textureCompat.postTexParameter(ctx, cmd.Target(), cmd.Pname(), out, id, cmd)
@@ -734,7 +734,7 @@ func compat(ctx context.Context, device *device.Instance, onError onCompatError)
 			}
 		case *GlTexParameterIiv:
 			{
-				cmd := cmd.Clone(s.Arena)
+				cmd := cmd.clone(s.Arena)
 				convertTexTarget(cmd)
 				out.MutateAndWrite(ctx, id, cmd)
 				textureCompat.postTexParameter(ctx, cmd.Target(), cmd.Pname(), out, id, cmd)
@@ -742,7 +742,7 @@ func compat(ctx context.Context, device *device.Instance, onError onCompatError)
 			}
 		case *GlTexParameterIuiv:
 			{
-				cmd := cmd.Clone(s.Arena)
+				cmd := cmd.clone(s.Arena)
 				convertTexTarget(cmd)
 				out.MutateAndWrite(ctx, id, cmd)
 				textureCompat.postTexParameter(ctx, cmd.Target(), cmd.Pname(), out, id, cmd)
@@ -750,7 +750,7 @@ func compat(ctx context.Context, device *device.Instance, onError onCompatError)
 			}
 		case *GlTexParameterf:
 			{
-				cmd := cmd.Clone(s.Arena)
+				cmd := cmd.clone(s.Arena)
 				convertTexTarget(cmd)
 				out.MutateAndWrite(ctx, id, cmd)
 				textureCompat.postTexParameter(ctx, cmd.Target(), cmd.Parameter(), out, id, cmd)
@@ -758,7 +758,7 @@ func compat(ctx context.Context, device *device.Instance, onError onCompatError)
 			}
 		case *GlTexParameterfv:
 			{
-				cmd := cmd.Clone(s.Arena)
+				cmd := cmd.clone(s.Arena)
 				convertTexTarget(cmd)
 				out.MutateAndWrite(ctx, id, cmd)
 				textureCompat.postTexParameter(ctx, cmd.Target(), cmd.Pname(), out, id, cmd)
@@ -766,7 +766,7 @@ func compat(ctx context.Context, device *device.Instance, onError onCompatError)
 			}
 		case *GlTexParameteri:
 			{
-				cmd := cmd.Clone(s.Arena)
+				cmd := cmd.clone(s.Arena)
 				convertTexTarget(cmd)
 				out.MutateAndWrite(ctx, id, cmd)
 				textureCompat.postTexParameter(ctx, cmd.Target(), cmd.Parameter(), out, id, cmd)
@@ -774,7 +774,7 @@ func compat(ctx context.Context, device *device.Instance, onError onCompatError)
 			}
 		case *GlTexParameteriv:
 			{
-				cmd := cmd.Clone(s.Arena)
+				cmd := cmd.clone(s.Arena)
 				convertTexTarget(cmd)
 				out.MutateAndWrite(ctx, id, cmd)
 				textureCompat.postTexParameter(ctx, cmd.Target(), cmd.Pname(), out, id, cmd)
@@ -782,7 +782,7 @@ func compat(ctx context.Context, device *device.Instance, onError onCompatError)
 			}
 		case *GlTexParameterIivEXT:
 			{
-				cmd := cmd.Clone(s.Arena)
+				cmd := cmd.clone(s.Arena)
 				convertTexTarget(cmd)
 				out.MutateAndWrite(ctx, id, cmd)
 				textureCompat.postTexParameter(ctx, cmd.Target(), cmd.Pname(), out, id, cmd)
@@ -790,7 +790,7 @@ func compat(ctx context.Context, device *device.Instance, onError onCompatError)
 			}
 		case *GlTexParameterIuivEXT:
 			{
-				cmd := cmd.Clone(s.Arena)
+				cmd := cmd.clone(s.Arena)
 				convertTexTarget(cmd)
 				out.MutateAndWrite(ctx, id, cmd)
 				textureCompat.postTexParameter(ctx, cmd.Target(), cmd.Pname(), out, id, cmd)
@@ -1147,7 +1147,7 @@ func compat(ctx context.Context, device *device.Instance, onError onCompatError)
 					onError(ctx, id, cmd, fmt.Errorf("Unknown EGLImage target: %v", eglImage.Target()))
 				}
 
-				cmd := cmd.Clone(s.Arena)
+				cmd := cmd.clone(s.Arena)
 				convertTexTarget(cmd)
 				out.MutateAndWrite(ctx, dID, cb.Custom(func(ctx context.Context, s *api.GlobalState, b *builder.Builder) error {
 					return cmd.Mutate(ctx, id, s, nil) // do not call, just mutate

--- a/gapis/api/gles/compat_client.go
+++ b/gapis/api/gles/compat_client.go
@@ -220,7 +220,7 @@ func moveClientVBsToVAs(
 		arr := va.VertexAttributeArrays().Get(l)
 		if arr.Enabled() == GLboolean_GL_TRUE {
 			if glVAP, ok := clientVAs[arr]; ok {
-				glVAP := glVAP.Clone(s.Arena)
+				glVAP := glVAP.clone(s.Arena)
 				i := interval.IndexOf(&rngs, glVAP.Data().Address())
 				t.GlBindBuffer_ArrayBuffer(ctx, ids[i])
 				// The glVertexAttribPointer call may have come from a different thread

--- a/gapis/api/templates/api.go.tmpl
+++ b/gapis/api/templates/api.go.tmpl
@@ -1339,8 +1339,8 @@ import (
     {{Template "DeclareGetterSetter" "Struct" $name "Name" $p.Name "Type" $p.Type "PtrMethod" "true"}}¶
   {{end}}
 
-  // Clone returns a shallow clone of the command. Extras are shared.
-  func (ϟc *{{$name}}) Clone(ϟa arena.Arena) *{{$name}} {
+  // clone returns a shallow clone of the command. Extras are shared.
+  func (ϟc *{{$name}}) clone(ϟa arena.Arena) *{{$name}} {
     out := &{{$name}}{
       extras: ϟc.extras,
       caller: ϟc.caller,
@@ -1355,6 +1355,10 @@ import (
       {{end}}
     {{end}}
     return out
+  }
+
+  func (ϟc *{{$name}}) Clone(ϟa arena.Arena) ϟapi.Cmd {
+    return ϟc.clone(ϟa)
   }
 {{end}}
 

--- a/gapis/api/vulkan/replay.go
+++ b/gapis/api/vulkan/replay.go
@@ -452,7 +452,7 @@ func newDisplayToSurface() *DisplayToSurface {
 func (t *DisplayToSurface) Transform(ctx context.Context, id api.CmdID, cmd api.Cmd, out transform.Writer) {
 	switch c := cmd.(type) {
 	case *VkCreateSwapchainKHR:
-		newCmd := c.Clone(out.State().Arena)
+		newCmd := c.clone(out.State().Arena)
 		newCmd.extras = api.CmdExtras{}
 		// Add an extra to indicate to custom_replay to add a flag to
 		// the virtual swapchain pNext

--- a/gapis/replay/BUILD.bazel
+++ b/gapis/replay/BUILD.bazel
@@ -40,6 +40,7 @@ go_library(
         "//core/data/id:go_default_library",
         "//core/image:go_default_library",
         "//core/log:go_default_library",
+        "//core/memory/arena:go_default_library",
         "//core/os/device:go_default_library",
         "//core/os/device/bind:go_default_library",
         "//gapir/client:go_default_library",

--- a/gapis/replay/custom.go
+++ b/gapis/replay/custom.go
@@ -17,6 +17,7 @@ package replay
 import (
 	"context"
 
+	"github.com/google/gapid/core/memory/arena"
 	"github.com/google/gapid/gapis/api"
 	"github.com/google/gapid/gapis/replay/builder"
 )
@@ -49,3 +50,4 @@ func (Custom) CmdParams() api.Properties                                        
 func (Custom) CmdResult() *api.Property                                           { return nil }
 func (Custom) CmdFlags(context.Context, api.CmdID, *api.GlobalState) api.CmdFlags { return 0 }
 func (Custom) Extras() *api.CmdExtras                                             { return nil }
+func (cmd Custom) Clone(arena.Arena) api.Cmd                                      { return Custom{cmd.T, cmd.F} }


### PR DESCRIPTION
Used by dependency graph PR