### PR TITLE
 Add framebuffer postback to export_replay.

### DIFF
--- a/cmd/gapit/flags.go
+++ b/cmd/gapit/flags.go
@@ -111,9 +111,11 @@ type (
 		CommandFilterFlags
 	}
 	ExportReplayFlags struct {
-		Gapis GapisFlags
-		Gapir GapirFlags
-		Out   string `help:"output directory for commands and assets"`
+		Gapis        GapisFlags
+		Gapir        GapirFlags
+		Out          string `help:"output directory for commands and assets"`
+		OutputFrames bool   `help:"generate trace that output frames(disable diagnostics)"`
+		CommandFilterFlags
 	}
 	VideoFlags struct {
 		Gapis GapisFlags

--- a/gapir/cc/replay_archive.h
+++ b/gapir/cc/replay_archive.h
@@ -24,8 +24,10 @@ namespace gapir {
 // ReplayArchive implements ReplayConnection for exported replays.
 class ReplayArchive : public ReplayConnection {
  public:
-  ReplayArchive(const std::string& fileprefix)
-      : ReplayConnection(nullptr), mFileprefix(fileprefix) {}
+  ReplayArchive(const std::string& fileprefix, const std::string& postbackDir)
+      : ReplayConnection(nullptr),
+        mFileprefix(fileprefix),
+        mPostbackDir(postbackDir) {}
   // Read payload from disk.
   virtual std::unique_ptr<Payload> getPayload() override;
 
@@ -44,6 +46,7 @@ class ReplayArchive : public ReplayConnection {
 
  private:
   std::string mFileprefix;
+  std::string mPostbackDir;
 };
 
 }  // namespace gapir

--- a/gapis/api/gles/replay.go
+++ b/gapis/api/gles/replay.go
@@ -276,7 +276,7 @@ func (a API) Replay(
 func (a API) QueryIssues(
 	ctx context.Context,
 	intent replay.Intent,
-	mgr *replay.Manager,
+	mgr replay.Manager,
 	displayToSurface bool,
 	hints *service.UsageHints) ([]replay.Issue, error) {
 
@@ -291,7 +291,7 @@ func (a API) QueryIssues(
 func (a API) QueryFramebufferAttachment(
 	ctx context.Context,
 	intent replay.Intent,
-	mgr *replay.Manager,
+	mgr replay.Manager,
 	after []uint64,
 	width, height uint32,
 	attachment api.FramebufferAttachment,

--- a/gapis/api/gvr/gvr.go
+++ b/gapis/api/gvr/gvr.go
@@ -58,7 +58,7 @@ func (API) RebuildState(ctx context.Context, g *api.GlobalState) ([]api.Cmd, int
 func (API) QueryFramebufferAttachment(
 	ctx context.Context,
 	intent replay.Intent,
-	mgr *replay.Manager,
+	mgr replay.Manager,
 	after []uint64,
 	width, height uint32,
 	attachment api.FramebufferAttachment,

--- a/gapis/api/vulkan/replay.go
+++ b/gapis/api/vulkan/replay.go
@@ -502,10 +502,6 @@ type issuesRequest struct {
 	displayToSurface bool
 }
 
-// exportReplayRequest requests full trace to be produced.
-type exportReplayRequest struct {
-}
-
 func (a API) Replay(
 	ctx context.Context,
 	intent replay.Intent,
@@ -611,18 +607,6 @@ func (a API) Replay(
 			if req.displayToSurface {
 				doDisplayToSurface = true
 			}
-
-		case exportReplayRequest:
-			// TODO: Implement a transform specifically for export replay
-			if issues == nil {
-				n, err := expandCommands(false)
-				if err != nil {
-					return err
-				}
-				issues = newFindIssues(ctx, c, n)
-			}
-			issues.reportTo(rr.Result)
-			optimize = false
 
 		case framebufferRequest:
 
@@ -809,6 +793,9 @@ func (a API) QueryFramebufferAttachment(
 	if err != nil {
 		return nil, err
 	}
+	if _, ok := mgr.(replay.Exporter); ok {
+		return nil, nil
+	}
 	return res.(*image.Data), nil
 }
 
@@ -824,10 +811,8 @@ func (a API) QueryIssues(
 	if err != nil {
 		return nil, err
 	}
+	if _, ok := mgr.(replay.Exporter); ok {
+		return nil, nil
+	}
 	return res.([]replay.Issue), nil
-}
-
-// ExportReplayRequest returns request type for standalone replay.
-func (a API) ExportReplayRequest() replay.Request {
-	return exportReplayRequest{}
 }

--- a/gapis/api/vulkan/replay.go
+++ b/gapis/api/vulkan/replay.go
@@ -760,7 +760,7 @@ func (a API) Replay(
 func (a API) QueryFramebufferAttachment(
 	ctx context.Context,
 	intent replay.Intent,
-	mgr *replay.Manager,
+	mgr replay.Manager,
 	after []uint64,
 	width, height uint32,
 	attachment api.FramebufferAttachment,
@@ -815,7 +815,7 @@ func (a API) QueryFramebufferAttachment(
 func (a API) QueryIssues(
 	ctx context.Context,
 	intent replay.Intent,
-	mgr *replay.Manager,
+	mgr replay.Manager,
 	displayToSurface bool,
 	hints *service.UsageHints) ([]replay.Issue, error) {
 

--- a/gapis/client/client.go
+++ b/gapis/client/client.go
@@ -283,11 +283,12 @@ func (c *client) SaveCapture(ctx context.Context, capture *path.Capture, path st
 	return nil
 }
 
-func (c *client) ExportReplay(ctx context.Context, capture *path.Capture, device *path.Device, path string) error {
+func (c *client) ExportReplay(ctx context.Context, capture *path.Capture, device *path.Device, path string, opts *service.ExportReplayOptions) error {
 	res, err := c.client.ExportReplay(ctx, &service.ExportReplayRequest{
 		Capture: capture,
 		Path:    path,
 		Device:  device,
+		Options: opts,
 	})
 	if err != nil {
 		return err

--- a/gapis/replay/BUILD.bazel
+++ b/gapis/replay/BUILD.bazel
@@ -34,7 +34,6 @@ go_library(
         "//core/app/analytics:go_default_library",
         "//core/app/benchmark:go_default_library",
         "//core/app/status:go_default_library",
-        "//core/archive:go_default_library",
         "//core/context/keys:go_default_library",
         "//core/data/binary:go_default_library",
         "//core/data/id:go_default_library",
@@ -48,7 +47,6 @@ go_library(
         "//gapis/api/transform:go_default_library",
         "//gapis/capture:go_default_library",
         "//gapis/config:go_default_library",
-        "//gapis/database:go_default_library",
         "//gapis/memory:go_default_library",
         "//gapis/replay/builder:go_default_library",
         "//gapis/replay/executor:go_default_library",
@@ -56,6 +54,5 @@ go_library(
         "//gapis/resolve/initialcmds:go_default_library",
         "//gapis/service:go_default_library",
         "//gapis/service/path:go_default_library",
-        "@com_github_golang_protobuf//proto:go_default_library",
     ],
 )

--- a/gapis/replay/batch.go
+++ b/gapis/replay/batch.go
@@ -53,7 +53,7 @@ func findABI(ml *device.MemoryLayout, abis []*device.ABI) *device.ABI {
 	return nil
 }
 
-func (m *Manager) batch(ctx context.Context, e []scheduler.Executable, b scheduler.Batch) {
+func (m *manager) batch(ctx context.Context, e []scheduler.Executable, b scheduler.Batch) {
 	batch := b.Key.(batchKey)
 
 	ctx = PutDevice(ctx, path.NewDevice(batch.device))
@@ -100,7 +100,7 @@ func (m *Manager) batch(ctx context.Context, e []scheduler.Executable, b schedul
 	}
 }
 
-func (m *Manager) execute(
+func (m *manager) execute(
 	ctx context.Context,
 	d bind.Device,
 	deviceID, captureID id.ID,

--- a/gapis/replay/context.go
+++ b/gapis/replay/context.go
@@ -26,18 +26,18 @@ type contextMgrKeyTy string
 const contextMgrKey = contextMgrKeyTy("replayMgrID")
 
 // PutManager attaches a manager to a Context.
-func PutManager(ctx context.Context, m *Manager) context.Context {
+func PutManager(ctx context.Context, m Manager) context.Context {
 	return keys.WithValue(ctx, contextMgrKey, m)
 }
 
 // GetManager retrieves the manager from a context previously annotated by
 // PutManager.
-func GetManager(ctx context.Context) *Manager {
+func GetManager(ctx context.Context) Manager {
 	val := ctx.Value(contextMgrKey)
 	if val == nil {
 		panic(string(contextMgrKey + " not present"))
 	}
-	return val.(*Manager)
+	return val.(Manager)
 }
 
 type contextDeviceKeyTy string

--- a/gapis/replay/interfaces.go
+++ b/gapis/replay/interfaces.go
@@ -43,7 +43,7 @@ type QueryIssues interface {
 	QueryIssues(
 		ctx context.Context,
 		intent Intent,
-		mgr *Manager,
+		mgr Manager,
 		displayToSurface bool,
 		hints *service.UsageHints) ([]Issue, error)
 }
@@ -55,7 +55,7 @@ type QueryFramebufferAttachment interface {
 	QueryFramebufferAttachment(
 		ctx context.Context,
 		intent Intent,
-		mgr *Manager,
+		mgr Manager,
 		after []uint64,
 		width, height uint32,
 		attachment api.FramebufferAttachment,

--- a/gapis/replay/manager.go
+++ b/gapis/replay/manager.go
@@ -37,7 +37,10 @@ const (
 	defaultBatchDelay    = time.Millisecond * 100
 )
 
+// Manager executes replay requests.
 type Manager interface {
+	// Replay requests that req is to be performed on the device described by
+	// intent, using the capture described by intent.
 	Replay(
 		ctx context.Context,
 		intent Intent,

--- a/gapis/server/BUILD.bazel
+++ b/gapis/server/BUILD.bazel
@@ -17,6 +17,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = [
+        "export_replay.go",
         "grpc.go",
         "server.go",
     ],
@@ -30,7 +31,9 @@ go_library(
         "//core/app/crash:go_default_library",
         "//core/app/crash/reporting:go_default_library",
         "//core/app/status:go_default_library",
+        "//core/archive:go_default_library",
         "//core/context/keys:go_default_library",
+        "//core/data/id:go_default_library",
         "//core/event/task:go_default_library",
         "//core/log:go_default_library",
         "//core/log/log_pb:go_default_library",
@@ -39,6 +42,7 @@ go_library(
         "//gapis/api:go_default_library",
         "//gapis/api/all:go_default_library",
         "//gapis/capture:go_default_library",
+        "//gapis/database:go_default_library",
         "//gapis/messages:go_default_library",
         "//gapis/replay:go_default_library",
         "//gapis/replay/devices:go_default_library",
@@ -50,6 +54,7 @@ go_library(
         "//gapis/stringtable:go_default_library",
         "//gapis/trace:go_default_library",
         "//gapis/trace/tracer:go_default_library",
+        "@com_github_golang_protobuf//proto:go_default_library",
         "@com_github_google_go_github//github:go_default_library",
         "@org_golang_google_grpc//:go_default_library",
         "@org_golang_x_net//context:go_default_library",

--- a/gapis/server/export_replay.go
+++ b/gapis/server/export_replay.go
@@ -1,0 +1,156 @@
+// Copyright (C) 2018 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package server implements the rpc gpu debugger service, queriable by the
+// clients, along with some helpers exposed via an http listener.
+package server
+
+import (
+	"context"
+	"io/ioutil"
+	"os"
+	gopath "path"
+
+	"github.com/golang/protobuf/proto"
+	"github.com/google/gapid/core/archive"
+	"github.com/google/gapid/core/data/id"
+	"github.com/google/gapid/core/log"
+	"github.com/google/gapid/gapis/capture"
+	"github.com/google/gapid/gapis/database"
+	"github.com/google/gapid/gapis/replay"
+	"github.com/google/gapid/gapis/resolve"
+	"github.com/google/gapid/gapis/service"
+	"github.com/google/gapid/gapis/service/path"
+)
+
+func exportReplay(ctx context.Context, c *path.Capture, d *path.Device, out string, opts *service.ExportReplayOptions) error {
+	if d == nil {
+		return log.Errf(ctx, nil, "Unable to produce replay on unknown device.")
+	}
+
+	cap, err := capture.ResolveFromPath(ctx, c)
+	intent := replay.Intent{d, c}
+
+	var queries []func(mgr replay.Manager) error
+	switch {
+	case opts.Report != nil && len(opts.GetFramebufferAttachmentRequests) > 0:
+		return log.Errf(ctx, nil, "Report and Framebuffer requests are not compatible.")
+	case opts.GetFramebufferAttachmentRequests != nil:
+		r := &path.ResolveConfig{ReplayDevice: d}
+		changes, err := resolve.FramebufferChanges(ctx, c, r)
+		if err != nil {
+			return err
+		}
+
+		for _, req := range opts.GetFramebufferAttachmentRequests {
+			req := req
+			fbInfo, err := changes.Get(ctx, req.After, req.Attachment)
+			if err != nil {
+				return err
+			}
+
+			for _, a := range cap.APIs {
+				a, ok := a.(replay.QueryFramebufferAttachment)
+				if !ok {
+					continue
+				}
+				queries = append(queries, func(mgr replay.Manager) error {
+					_, err := a.QueryFramebufferAttachment(
+						ctx,                   // context.Context
+						intent,                // Intent
+						mgr,                   // Manager
+						req.After.Indices,     // after []uint64
+						fbInfo.Width,          // width uint32
+						fbInfo.Height,         // height uint32
+						req.Attachment,        // api.FramebufferAttachment
+						fbInfo.Index,          // uint32
+						req.Settings.DrawMode, // service.DrawMode
+						true,  // disableReplayOptimization bool
+						false, // displayToSurface bool
+						nil,   // hints *service.UsageHints
+					)
+					return err
+				})
+			}
+		}
+	case opts.Report != nil:
+		// TODO(hysw): Add a simple replay request that output commands as
+		// captured. For now, if there are no frame query, force an issue query.
+		// Since otherwise the trace will not be generated.
+		fallthrough
+	default:
+		for _, a := range cap.APIs {
+			a, ok := a.(replay.QueryIssues)
+			if !ok {
+				continue
+			}
+			queries = append(queries, func(mgr replay.Manager) error {
+				_, err := a.QueryIssues(ctx, intent, mgr, false, nil)
+				return err
+			})
+		}
+	}
+
+	exporter := replay.NewExporter()
+
+	errs := make(chan error, len(queries))
+	for _, q := range queries {
+		q := q
+		go func() {
+			errs <- q(exporter)
+		}()
+	}
+
+	payload, err := exporter.Export(ctx, len(queries))
+	if err != nil {
+		return err
+	}
+
+	for range queries {
+		err := <-errs
+		if err != nil {
+			// TODO(hysw): Ignore error for now, since empty postback will upset some
+			// of the postback handlers.
+		}
+	}
+
+	err = os.MkdirAll(out, os.ModePerm)
+	if err != nil {
+		return log.Errf(ctx, err, "Failed to create output directory: %v", out)
+	}
+
+	payloadBytes, err := proto.Marshal(payload)
+	if err != nil {
+		return log.Errf(ctx, err, "Failed to serialize replay payload.")
+	}
+	err = ioutil.WriteFile(gopath.Join(out, "payload.bin"), payloadBytes, 0644)
+
+	ar := archive.New(gopath.Join(out, "resources"))
+	defer ar.Dispose()
+
+	db := database.Get(ctx)
+	for _, ri := range payload.Resources {
+		rID, err := id.Parse(ri.Id)
+		if err != nil {
+			return log.Errf(ctx, err, "Failed to parse resource id: %v", ri.Id)
+		}
+		obj, err := db.Resolve(ctx, rID)
+		if err != nil {
+			return log.Errf(ctx, err, "Failed to parse resource id: %v", ri.Id)
+		}
+		ar.Write(ri.Id, obj.([]byte))
+	}
+
+	return nil
+}

--- a/gapis/server/grpc.go
+++ b/gapis/server/grpc.go
@@ -381,7 +381,7 @@ func (s *grpcServer) SaveCapture(ctx xctx.Context, req *service.SaveCaptureReque
 
 func (s *grpcServer) ExportReplay(ctx xctx.Context, req *service.ExportReplayRequest) (*service.ExportReplayResponse, error) {
 	defer s.inRPC()()
-	err := s.handler.ExportReplay(s.bindCtx(ctx), req.Capture, req.Device, req.Path)
+	err := s.handler.ExportReplay(s.bindCtx(ctx), req.Capture, req.Device, req.Path, req.Options)
 	if err := service.NewError(err); err != nil {
 		return &service.ExportReplayResponse{Error: err}, nil
 	}

--- a/gapis/server/server.go
+++ b/gapis/server/server.go
@@ -42,7 +42,6 @@ import (
 	"github.com/google/gapid/gapis/api"
 	"github.com/google/gapid/gapis/capture"
 	"github.com/google/gapid/gapis/messages"
-	"github.com/google/gapid/gapis/replay"
 	"github.com/google/gapid/gapis/replay/devices"
 	"github.com/google/gapid/gapis/resolve"
 	"github.com/google/gapid/gapis/resolve/dependencygraph"
@@ -259,13 +258,14 @@ func (s *server) SaveCapture(ctx context.Context, c *path.Capture, path string) 
 	defer f.Close()
 	return capture.Export(ctx, c, f)
 }
-
-func (s *server) ExportReplay(ctx context.Context, c *path.Capture, d *path.Device, path string) error {
+func (s *server) ExportReplay(ctx context.Context, c *path.Capture, d *path.Device, out string, opts *service.ExportReplayOptions) error {
+	ctx = status.Start(ctx, "RPC ExportReplay")
+	defer status.Finish(ctx)
 	ctx = log.Enter(ctx, "ExportReplay")
 	if !s.enableLocalFiles {
 		return fmt.Errorf("Server not configured to allow writing of local files")
 	}
-	return replay.ExportReplay(ctx, c, d, path)
+	return exportReplay(ctx, c, d, out, opts)
 }
 
 func (s *server) DCECapture(ctx context.Context, p *path.Capture, requested []*path.Command) (*path.Capture, error) {

--- a/gapis/service/service.go
+++ b/gapis/service/service.go
@@ -79,7 +79,7 @@ type Service interface {
 	SaveCapture(ctx context.Context, c *path.Capture, path string) error
 
 	// ExportReplay saves replay commands and assets to file.
-	ExportReplay(ctx context.Context, c *path.Capture, d *path.Device, path string) error
+	ExportReplay(ctx context.Context, c *path.Capture, d *path.Device, path string, opts *ExportReplayOptions) error
 
 	// DCECapture returns a new capture containing only the requested commands and their dependencies.
 	DCECapture(ctx context.Context, capture *path.Capture, commands []*path.Command) (*path.Capture, error)

--- a/gapis/service/service.proto
+++ b/gapis/service/service.proto
@@ -288,11 +288,19 @@ message SaveCaptureResponse {
   Error error = 1;
 }
 
+message ExportReplayOptions {
+  path.Report report = 1;
+  repeated GetFramebufferAttachmentRequest get_framebuffer_attachment_requests =
+      2;
+}
+
 message ExportReplayRequest {
   path.Capture capture = 1;
   string path = 2;
   path.Device device = 3;
+  ExportReplayOptions options = 4;
 }
+
 message ExportReplayResponse {
   Error error = 1;
 }


### PR DESCRIPTION
Usage:
Add `--outputframes=true` to `gapit export_replay` to include framebuffer postback in the exported trace.
Add `--postback-dir ${dir}` to `gapir` to store the framebuffer postback.