### PR TITLE
Fix tests broken by #2231

### DIFF
--- a/gapis/api/gles/compat_test.go
+++ b/gapis/api/gles/compat_test.go
@@ -53,7 +53,7 @@ func TestGlVertexAttribPointerCompatTest(t *testing.T) {
 
 	h := &capture.Header{ABI: device.AndroidARMv7a}
 	ml := h.ABI.MemoryLayout
-	capturePath, err := capture.New(ctx, a, "test", h, []api.Cmd{})
+	capturePath, err := capture.New(ctx, a, "test", h, nil, []api.Cmd{})
 	if err != nil {
 		panic(err)
 	}

--- a/gapis/api/gles/dead_code_elimination_test.go
+++ b/gapis/api/gles/dead_code_elimination_test.go
@@ -225,7 +225,7 @@ func TestDeadCommandRemoval(t *testing.T) {
 		cmds := append(prologue, testCmds...)
 
 		h := &capture.Header{ABI: device.WindowsX86_64}
-		capturePath, err := capture.New(ctx, a, name, h, cmds)
+		capturePath, err := capture.New(ctx, a, name, h, nil, cmds)
 		if err != nil {
 			panic(err)
 		}

--- a/gapis/capture/capture.go
+++ b/gapis/capture/capture.go
@@ -92,11 +92,13 @@ func init() {
 // The new capture is stored in the database.
 func New(ctx context.Context, a arena.Arena, name string, header *Header, initialState *InitialState, cmds []api.Cmd) (*path.Capture, error) {
 	b := newBuilder(a)
-	for _, state := range initialState.APIs {
-		b.addInitialState(ctx, state)
-	}
-	for _, mem := range initialState.Memory {
-		b.addInitialMemory(ctx, mem)
+	if initialState != nil {
+		for _, state := range initialState.APIs {
+			b.addInitialState(ctx, state)
+		}
+		for _, mem := range initialState.Memory {
+			b.addInitialMemory(ctx, mem)
+		}
 	}
 	for _, cmd := range cmds {
 		b.addCmd(ctx, cmd)

--- a/gapis/capture/capture_test.go
+++ b/gapis/capture/capture_test.go
@@ -33,7 +33,7 @@ func TestCaptureExportImport(t *testing.T) {
 	ctx = database.Put(ctx, database.NewInMemory(ctx))
 	header := &capture.Header{ABI: device.WindowsX86_64}
 	cmds := []api.Cmd{test.Cmds.A, test.Cmds.B}
-	p, err := capture.New(ctx, arena.New(), "test", header, cmds)
+	p, err := capture.New(ctx, arena.New(), "test", header, nil, cmds)
 	if !assert.For(ctx, "capture.New").ThatError(err).Succeeded() {
 		return
 	}

--- a/gapis/resolve/get_set_test.go
+++ b/gapis/resolve/get_set_test.go
@@ -42,7 +42,7 @@ func newPathTest(ctx context.Context) *path.Capture {
 		cb.CmdTypeMix(1, 15, 25, 35, 45, 55, 65, 75, 85, 95, 105, false, test.Voidᵖ(0x87654321), 3),
 		cb.PrimeState(test.U8ᵖ(0x89abcdef)),
 	}
-	p, err := capture.New(ctx, a, "test", h, cmds)
+	p, err := capture.New(ctx, a, "test", h, nil, cmds)
 	if err != nil {
 		log.F(ctx, true, "Couldn't create capture: %v", err)
 	}

--- a/gapis/resolve/state_tree_test.go
+++ b/gapis/resolve/state_tree_test.go
@@ -197,7 +197,7 @@ func TestStateTreeNode(t *testing.T) {
 	ctx := log.Testing(t)
 	ctx = database.Put(ctx, database.NewInMemory(ctx))
 	header := capture.Header{ABI: device.AndroidARM64v8a}
-	c, err := capture.New(ctx, arena.New(), "test-capture", &header, []api.Cmd{})
+	c, err := capture.New(ctx, arena.New(), "test-capture", &header, nil, []api.Cmd{})
 	if err != nil {
 		panic(err)
 	}

--- a/test/integration/gles/snippets/builder.go
+++ b/test/integration/gles/snippets/builder.go
@@ -73,7 +73,7 @@ func (b *Builder) Capture(ctx context.Context, name string) *path.Capture {
 		Device: b.device,
 		ABI:    b.abi,
 	}
-	out, err := capture.New(ctx, b.CB.Arena, name, h, b.Cmds)
+	out, err := capture.New(ctx, b.CB.Arena, name, h, nil, b.Cmds)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
A friendly reminder that tests can be run with:

`bazel test tests`