### PR TITLE
Allow `gapit screenshot` to create multiple screenshots in one go

### DIFF
--- a/cmd/apic/BUILD.bazel
+++ b/cmd/apic/BUILD.bazel
@@ -29,7 +29,6 @@ go_library(
     visibility = ["//visibility:private"],
     deps = [
         "//core/app:go_default_library",
-        "//core/app/flags:go_default_library",
         "//core/log:go_default_library",
         "//core/os/device:go_default_library",
         "//core/os/file:go_default_library",

--- a/cmd/apic/template.go
+++ b/cmd/apic/template.go
@@ -26,7 +26,6 @@ import (
 	"github.com/google/gapid/gapil/resolver"
 
 	"github.com/google/gapid/core/app"
-	"github.com/google/gapid/core/app/flags"
 	"github.com/google/gapid/core/log"
 	"github.com/google/gapid/core/os/file"
 	"github.com/google/gapid/gapil/template"
@@ -46,7 +45,7 @@ type templateVerb struct {
 	Dir        string        `help:"The output directory"`
 	Tracer     string        `help:"The template function trace expression"`
 	Gopath     string        `help:"the go path to use when looking up packages"`
-	GlobalList flags.Strings `help:"A global value setting for the template"`
+	GlobalList []string      `help:"A global value setting for the template"`
 	Search     file.PathList `help:"The set of paths to search for includes"`
 }
 
@@ -76,7 +75,7 @@ func (v *templateVerb) Run(ctx context.Context, flags flag.FlagSet) error {
 		Dir:     v.Dir,
 		APIFile: api.Name(),
 		Loader:  ioutil.ReadFile,
-		Globals: v.GlobalList.Strings(),
+		Globals: v.GlobalList,
 		Tracer:  v.Tracer,
 	}
 	f, err := template.NewFunctions(ctx, api, mappings, options)

--- a/cmd/gapit/flags.go
+++ b/cmd/gapit/flags.go
@@ -253,7 +253,8 @@ type (
 		Gapis      GapisFlags
 		Gapir      GapirFlags
 		At         []flags.U64Slice `help:"command/subcommand index for the screenshot (repeatable)"`
-		Frame      []int64          `help:"frame index for the screenshot (repeatable). Empty for last"`
+		Frame      []int            `help:"frame index for the screenshot (repeatable). Empty for last"`
+		Draws      bool             `help:"create a screenshot of every draw call in the requested frame(s) (only honored if using -frame)"`
 		Out        string           `help:"output image file (default 'screenshot.png')"`
 		NoOpt      bool             `help:"disables optimization of the replay stream"`
 		Attachment string           `help:"the attachment to show (0-3 for color, d for depth, s for stencil)"`

--- a/cmd/gapit/flags.go
+++ b/cmd/gapit/flags.go
@@ -252,12 +252,12 @@ type (
 	ScreenshotFlags struct {
 		Gapis      GapisFlags
 		Gapir      GapirFlags
-		At         flags.U64Slice `help:"command/subcommand index for the screenshot"`
-		Frame      int64          `help:"frame index for the screenshot. Empty for last"`
-		Out        string         `help:"output image file (default 'screenshot.png')"`
-		NoOpt      bool           `help:"disables optimization of the replay stream"`
-		Attachment string         `help:"the attachment to show (0-3 for color, d for depth, s for stencil)"`
-		Overdraw   bool           `help:"renders the overdraw instead of the color framebuffer"`
+		At         []flags.U64Slice `help:"command/subcommand index for the screenshot (repeatable)"`
+		Frame      []int64          `help:"frame index for the screenshot (repeatable). Empty for last"`
+		Out        string           `help:"output image file (default 'screenshot.png')"`
+		NoOpt      bool             `help:"disables optimization of the replay stream"`
+		Attachment string           `help:"the attachment to show (0-3 for color, d for depth, s for stencil)"`
+		Overdraw   bool             `help:"renders the overdraw instead of the color framebuffer"`
 		Max        struct {
 			Overdraw int `help:"the amount of overdraw to map to white in the output"`
 		}

--- a/core/app/flags/BUILD.bazel
+++ b/core/app/flags/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
         "choices.go",
         "doc.go",
         "flags.go",
+        "repeated.go",
         "strings.go",
     ],
     importpath = "github.com/google/gapid/core/app/flags",
@@ -29,7 +30,10 @@ go_library(
 go_test(
     name = "go_default_test",
     size = "small",
-    srcs = ["choices_test.go"],
+    srcs = [
+        "choices_test.go",
+        "repeated_test.go",
+    ],
     embed = [":go_default_library"],
     deps = ["//core/assert:go_default_library"],
 )

--- a/core/app/flags/repeated.go
+++ b/core/app/flags/repeated.go
@@ -1,0 +1,79 @@
+// Copyright (C) 2018 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package flags
+
+import (
+	"flag"
+	"fmt"
+	"reflect"
+	"strings"
+	"time"
+)
+
+type repeated struct {
+	value  reflect.Value
+	single reflect.Value
+	parser flag.Value
+}
+
+const (
+	dummyFlag = "dummy"
+)
+
+func newRepeatedFlag(value reflect.Value) flag.Value {
+	fs := flag.NewFlagSet("", flag.ContinueOnError)
+
+	single := reflect.New(value.Type().Elem())
+	switch s := single.Interface().(type) {
+	case *bool:
+		fs.BoolVar(s, dummyFlag, *s, "")
+	case *int:
+		fs.IntVar(s, dummyFlag, *s, "")
+	case *int64:
+		fs.Int64Var(s, dummyFlag, *s, "")
+	case *uint:
+		fs.UintVar(s, dummyFlag, *s, "")
+	case *uint64:
+		fs.Uint64Var(s, dummyFlag, *s, "")
+	case *float64:
+		fs.Float64Var(s, dummyFlag, *s, "")
+	case *string:
+		fs.StringVar(s, dummyFlag, *s, "")
+	case *time.Duration:
+		fs.DurationVar(s, dummyFlag, *s, "")
+	case flag.Value:
+		fs.Var(s, dummyFlag, "")
+	default:
+		panic(fmt.Sprintf("Unhandled flag type: %v", single.Type()))
+	}
+
+	return &repeated{value, single, fs.Lookup(dummyFlag).Value}
+}
+
+func (f *repeated) String() string {
+	strs := make([]string, f.value.Len())
+	for i := 0; i < len(strs); i++ {
+		strs[i] = f.value.Index(i).String()
+	}
+	return strings.Join(strs, ":")
+}
+
+func (f *repeated) Set(value string) error {
+	if err := f.parser.Set(value); err != nil {
+		return err
+	}
+	f.value.Set(reflect.Append(f.value, f.single.Elem()))
+	return nil
+}

--- a/core/app/flags/repeated_test.go
+++ b/core/app/flags/repeated_test.go
@@ -1,0 +1,108 @@
+// Copyright (C) 2018 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package flags_test
+
+import (
+	"io/ioutil"
+	"testing"
+
+	"github.com/google/gapid/core/app/flags"
+	"github.com/google/gapid/core/assert"
+)
+
+type MyFlag string
+
+func (f *MyFlag) String() string     { return string(*f) }
+func (f *MyFlag) Set(v string) error { *f = MyFlag(v); return nil }
+
+type MyFlags struct {
+	Str    string
+	Bools  []bool
+	Strs   []string
+	Ints   []int
+	Uints  []uint
+	Floats []float64
+	Mine   []MyFlag
+}
+
+var (
+	args1 = []string{
+		"-str", "foo",
+		"-bools", "true",
+		"-strs", "one",
+		"-ints", "1",
+		"-uints", "2",
+		"-floats", "3.5",
+		"-mine", "yours",
+	}
+	args2 = []string{
+		"-str", "bar",
+		"-bools", "true", "-bools", "false",
+		"-strs", "one", "-strs", "two",
+		"-ints", "1", "-ints", "4",
+		"-uints", "2", "-uints", "5",
+		"-floats", "3.5", "-floats", "6.7",
+		"-mine", "yours", "-mine", "ours",
+	}
+	args3 = []string{
+		"-str", "baz",
+		"-bools", "true", "-bools", "false", "-bools", "false",
+		"-strs", "one", "-strs", "two", "-strs", "three",
+		"-ints", "1", "-ints", "4", "-ints", "7",
+		"-uints", "2", "-uints", "5", "-uints", "8",
+		"-floats", "3.5", "-floats", "6.7", "-floats", "9.2",
+		"-mine", "yours", "-mine", "ours", "-mine", "theirs",
+	}
+)
+
+func b(v ...bool) []bool       { return v }
+func s(v ...string) []string   { return v }
+func i(v ...int) []int         { return v }
+func u(v ...uint) []uint       { return v }
+func f(v ...float64) []float64 { return v }
+func m(v ...string) (r []MyFlag) {
+	for _, s := range v {
+		r = append(r, MyFlag(s))
+	}
+	return
+}
+
+func TestRepeatedParsing(t *testing.T) {
+	assert := assert.To(t)
+
+	for _, cs := range []struct {
+		args []string
+		exp  MyFlags
+	}{
+		{args1, MyFlags{"foo", b(true), s("one"), i(1), u(2), f(3.5), m("yours")}},
+		{args2, MyFlags{"bar", b(true, false), s("one", "two"), i(1, 4), u(2, 5), f(3.5, 6.7), m("yours", "ours")}},
+		{args3, MyFlags{"baz", b(true, false, false), s("one", "two", "three"), i(1, 4, 7), u(2, 5, 8), f(3.5, 6.7, 9.2), m("yours", "ours", "theirs")}},
+	} {
+		verb := &struct{ MyFlags }{}
+		flags := flags.Set{}
+		flags.Raw.Usage = func() {}
+		flags.Raw.SetOutput(ioutil.Discard)
+		flags.Bind("", verb, "")
+		err := flags.Raw.Parse(cs.args)
+		assert.For("err").ThatError(err).Succeeded()
+		assert.For("str").ThatString(verb.Str).Equals(cs.exp.Str)
+		assert.For("bools").ThatSlice(verb.Bools).Equals(cs.exp.Bools)
+		assert.For("strs").ThatSlice(verb.Strs).Equals(cs.exp.Strs)
+		assert.For("ints").ThatSlice(verb.Ints).Equals(cs.exp.Ints)
+		assert.For("uints").ThatSlice(verb.Uints).Equals(cs.exp.Uints)
+		assert.For("floats").ThatSlice(verb.Floats).Equals(cs.exp.Floats)
+		assert.For("mine").ThatSlice(verb.Mine).Equals(cs.exp.Mine)
+	}
+}

--- a/core/app/flags/strings.go
+++ b/core/app/flags/strings.go
@@ -16,19 +16,7 @@ package flags
 
 import (
 	"net/url"
-	"strings"
 )
-
-// Strings implements flag.Value for lists of strings.
-type Strings []string
-
-func (f *Strings) String() string    { return strings.Join(f.Strings(), ":") }
-func (f *Strings) Strings() []string { return ([]string)(*f) }
-
-func (f *Strings) Set(value string) error {
-	*f = append(*f, value)
-	return nil
-}
 
 // URL implements flag.Value for a url.URL flag.
 type URL struct {


### PR DESCRIPTION
Makes the `--at` and `--frame` flags repeatable and adds a `--draws` flag to request a screenshot of every draw call.