### PR TITLE
Various GLES state reconstruction fixes

### DIFF
--- a/core/memory/arena/BUILD.bazel
+++ b/core/memory/arena/BUILD.bazel
@@ -24,6 +24,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//core/context/keys:go_default_library",
+        "//core/data/compare:go_default_library",
     ],
 )
 

--- a/core/memory/arena/arena.go
+++ b/core/memory/arena/arena.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"unsafe"
 
+	"github.com/google/gapid/core/data/compare"
+
 	"github.com/google/gapid/core/context/keys"
 )
 
@@ -215,4 +217,10 @@ func (r *Reader) Read(dst unsafe.Pointer, size int) {
 		*dst = *src
 	}
 	r.Offset += size
+}
+
+func init() {
+	// Don't compare arenas.
+	compare.Register(func(c compare.Comparator, a, b Arena) {
+	})
 }

--- a/gapii/cc/spy.cpp
+++ b/gapii/cc/spy.cpp
@@ -417,13 +417,11 @@ gapil::Ref<DynamicContextState> GlesSpy::GetEGLDynamicContextState(
         display, context);
   }
 
-  bool resetViewportScissor = true;
   bool preserveBuffersOnSwap = swapBehavior == EGL_BUFFER_PRESERVED;
 
   auto out = gapil::Ref<DynamicContextState>::create(
       arena(), width, height, backbufferColorFmt, backbufferDepthFmt,
-      backbufferStencilFmt, resetViewportScissor, preserveBuffersOnSwap, r, g,
-      b, a, d, s);
+      backbufferStencilFmt, preserveBuffersOnSwap, r, g, b, a, d, s);
 
   // Store the DynamicContextState as an extra.
   observer->encode(*out.get());

--- a/gapil/runtime/cc/maker.h
+++ b/gapil/runtime/cc/maker.h
@@ -67,6 +67,14 @@ struct Maker<const void*, true> {
   static inline void inplace_new(void** ptr, core::Arena* a) { *ptr = nullptr; }
 };
 
+// Special case for bool, because std::is_constructible<bool, core::Arena*>
+// is true, but without an arg, we want it to return false.
+template <>
+struct Maker<bool, true> {
+  static inline bool make(core::Arena* a) { return false; }
+  static inline void inplace_new(bool* ptr, core::Arena* a) { *ptr = false; }
+};
+
 // make returns a T constructed by the list of args.
 // If T has a core::Arena* as the first constructor parameter then a is
 // prepended to the list of arguments.

--- a/gapis/api/BUILD.bazel
+++ b/gapis/api/BUILD.bazel
@@ -53,6 +53,7 @@ go_library(
         "//core/app/status:go_default_library",
         "//core/context/keys:go_default_library",
         "//core/data/binary:go_default_library",
+        "//core/data/compare:go_default_library",
         "//core/data/deep:go_default_library",
         "//core/data/endian:go_default_library",
         "//core/data/generic:go_default_library",

--- a/gapis/api/gles/api/egl.api
+++ b/gapis/api/gles/api/egl.api
@@ -282,8 +282,10 @@ cmd EGLBoolean eglMakeCurrent(EGLDisplay display,
     SetContext(ctx)
     if !ctx.Other.Initialized {
       ApplyStaticContextState(ctx, GetEGLStaticContextState(display, context))
+      ApplyDynamicContextState(ctx, GetEGLDynamicContextState(display, draw, context), true)
+    } else {
+      ApplyDynamicContextState(ctx, GetEGLDynamicContextState(display, draw, context), false)
     }
-    ApplyDynamicContextState(ctx, GetEGLDynamicContextState(display, draw, context))
   } else {
     dynamicState := GetEGLDynamicContextState(display, draw, context)
     staticState := GetEGLStaticContextState(display, context)
@@ -300,7 +302,7 @@ cmd EGLBoolean eglMakeCurrent(EGLDisplay display,
       // ApplyDynamicContextState() so SetContext() must be set before these
       // calls.
       ApplyStaticContextState(ctx, staticState)
-      ApplyDynamicContextState(ctx, dynamicState)
+      ApplyDynamicContextState(ctx, dynamicState, false)
     } else {
       // TODO: onEGLError(EGL_BAD_CONTEXT)
       _ = newMsg(SEVERITY_ERROR, new!ERR_CONTEXT_DOES_NOT_EXIST(id: as!u64(context)))

--- a/gapis/api/gles/api/extras.api
+++ b/gapis/api/gles/api/extras.api
@@ -30,7 +30,6 @@ class DynamicContextState {
   GLenum  BackbufferColorFmt
   GLenum  BackbufferDepthFmt
   GLenum  BackbufferStencilFmt
-  bool    ResetViewportScissor
   bool    PreserveBuffersOnSwap
   // TODO: Currently unused
   @unused GLuint RedSize

--- a/gapis/api/gles/custom_replay.go
+++ b/gapis/api/gles/custom_replay.go
@@ -285,7 +285,6 @@ func (ω *EglMakeCurrent) Mutate(ctx context.Context, id api.CmdID, s *api.Globa
 			return err
 		}
 	}
-	resetViewportScissor := false
 	if cs := FindDynamicContextState(s.Arena, ω.Extras()); !cs.IsNil() {
 		cmd := cb.ReplayChangeBackbuffer(
 			ctxID,
@@ -298,9 +297,8 @@ func (ω *EglMakeCurrent) Mutate(ctx context.Context, id api.CmdID, s *api.Globa
 		if err := cmd.Mutate(ctx, id, s, b, nil); err != nil {
 			return err
 		}
-		resetViewportScissor = cs.ResetViewportScissor()
 	}
-	if err := cb.ReplayBindRenderer(ctxID, resetViewportScissor).Mutate(ctx, id, s, b, nil); err != nil {
+	if err := cb.ReplayBindRenderer(ctxID, false).Mutate(ctx, id, s, b, nil); err != nil {
 		return err
 	}
 	return nil

--- a/gapis/api/gles/gles.api
+++ b/gapis/api/gles/gles.api
@@ -740,7 +740,7 @@ sub void ApplyStaticContextState(ref!Context ctx, ref!StaticContextState staticS
   }
 }
 
-sub void ApplyDynamicContextState(ref!Context ctx, ref!DynamicContextState dynamicState) {
+sub void ApplyDynamicContextState(ref!Context ctx, ref!DynamicContextState dynamicState, bool resetViewportScissor) {
   if (dynamicState != null) {
     backbuffer := ctx.Objects.Framebuffers[0]
 
@@ -762,7 +762,7 @@ sub void ApplyDynamicContextState(ref!Context ctx, ref!DynamicContextState dynam
       SizedFormat: dynamicState.BackbufferStencilFmt,
     )
 
-    if dynamicState.ResetViewportScissor {
+    if resetViewportScissor {
       ctx.Pixel.Scissor.Box.Width = dynamicState.BackbufferWidth
       ctx.Pixel.Scissor.Box.Height = dynamicState.BackbufferHeight
       ctx.Rasterization.Viewport.Width = dynamicState.BackbufferWidth

--- a/gapis/api/gles/helpers.go
+++ b/gapis/api/gles/helpers.go
@@ -224,8 +224,7 @@ func NewDynamicContextStateForTest(a arena.Arena, width, height int, preserveBuf
 		GLenum_GL_RGB565,            //   BackbufferColorFmt
 		GLenum_GL_DEPTH_COMPONENT16, //   BackbufferDepthFmt
 		GLenum_GL_STENCIL_INDEX8,    //   BackbufferStencilFmt
-		true, //     ResetViewportScissor
-		preserveBuffersOnSwap, //     PreserveBuffersOnSwap
+		preserveBuffersOnSwap,       //     PreserveBuffersOnSwap
 		0, // RedSize
 		0, // GreenSize
 		0, // BlueSize

--- a/gapis/api/reference.go
+++ b/gapis/api/reference.go
@@ -16,6 +16,8 @@ package api
 
 import (
 	"sync/atomic"
+
+	"github.com/google/gapid/core/data/compare"
 )
 
 // RefID is a type used to identify instances of the reference types used in the API models.
@@ -44,4 +46,10 @@ type NilReference struct{}
 
 func (NilReference) RefID() RefID {
 	return NilRefID
+}
+
+func init() {
+	// Don't compare RefIDs.
+	compare.Register(func(c compare.Comparator, a, b RefID) {
+	})
 }


### PR DESCRIPTION
Fixes to make the state comparison quieter:
 - Don't compare arenas
 - Don't compare RefIDs
 - Fix the slice comparison to actually work
 - Fix the recreation of programs to use the same IDs as during trace
 - Correctly record what extensions the trace device supported (fixing c++ bool-map default values)
 - Fix handling of resetting the scissor and viewport