### PR TITLE
MEC Depth Fixes

### DIFF
--- a/gapii/cc/gles_mid_execution.cpp
+++ b/gapii/cc/gles_mid_execution.cpp
@@ -697,13 +697,18 @@ ImageData Reader::ReadTexture(const texture& tex, index idx, uint32_t format) {
       break;
     case GL_DEPTH24_STENCIL8:
     case GL_DEPTH32F_STENCIL8:
-      GAPID_WARNING("MEC: Reading of stencil data is not yet supported");
-      // Fall through to depth
+      GAPID_WARNING("MEC: Reading of depth stencil data is not yet supported");
+      break;
     case GL_DEPTH_COMPONENT16:
     case GL_DEPTH_COMPONENT24:
-    case GL_DEPTH_COMPONENT32F:
-      return ReadTextureViaDrawQuad(tex, idx, GL_R32F, "depth",
-                                    GL_DEPTH_COMPONENT, GL_RED);
+    case GL_DEPTH_COMPONENT32:
+    case GL_DEPTH_COMPONENT32F: {
+      ImageData r = ReadTextureViaDrawQuad(tex, idx, GL_R32F, "depth",
+                                           GL_DEPTH_COMPONENT, GL_RED);
+      // Override the internal format to the format of the data.
+      r.sizedFormat = GL_DEPTH_COMPONENT32F;
+      return r;
+    }
     /* alpha and luminance */
     case GL_ALPHA8_EXT:
       return ReadTextureViaDrawQuad(tex, idx, GL_R8, "alpha", GL_ALPHA,

--- a/gapis/api/gles/read_framebuffer.go
+++ b/gapis/api/gles/read_framebuffer.go
@@ -322,7 +322,7 @@ func getReadPixelsFormat(version *Version, uf GLenum, ty GLenum) (GLenum, GLenum
 		switch uf {
 		case GLenum_GL_RED_INTEGER, GLenum_GL_RG_INTEGER, GLenum_GL_RGB_INTEGER, GLenum_GL_RGBA_INTEGER:
 			uf = GLenum_GL_RGBA_INTEGER
-		case GLenum_GL_DEPTH_COMPONENT:
+		case GLenum_GL_DEPTH_COMPONENT, GLenum_GL_DEPTH_STENCIL:
 			return GLenum_GL_RED, GLenum_GL_FLOAT, GLenum_GL_DEPTH_COMPONENT
 		default:
 			uf = GLenum_GL_RGBA


### PR DESCRIPTION
Fix MEC reading of depth textures
 - Don't attempt to read `DEPTH_STENCIL` textures as just depth, since
   the resulting data cannot be used to initialize it in the replay
   anyways.
 - Override the internal format of the depth texture to be that of the
   read data, so that the initialization on replay is valid.

ODR: Fix reading depth data of depth stencil buffers