### PR TITLE
 gles/read_framebuffer: correctly resolve multisample with MRT

### DIFF
--- a/gapis/api/gles/api/framebuffer.api
+++ b/gapis/api/gles/api/framebuffer.api
@@ -521,8 +521,44 @@ cmd void glDrawBuffers(GLsizei n, const GLenum* bufs) {
 
 sub void DrawBuffers(GLsizei n, const GLenum* buffers) {
   ctx := GetContext()
+
+  CheckCountGE!GLsizei(n, 0)
+  CheckLE!GLsizei(n, as!GLsizei(ctx.Constants.MaxDrawBuffers))
+
   b := buffers[0:n]
   framebuffer := GetBoundFramebufferOrErrorInvalidEnum(GL_DRAW_FRAMEBUFFER)
+
+  // For the default framebuffer
+  if (framebuffer.ID == 0) && (n != 1) {
+    glErrorInvalidOperation()
+  }
+
+  for i in (0 .. as!GLint(n)) {
+    switch (b[i]) {
+      case GL_NONE: {
+        // Always accepted.
+      }
+      case GL_BACK: {
+        // Only accepted for the default framebuffer.
+        if (framebuffer.ID != 0) {
+          glErrorInvalidOperation()
+        }
+      }
+      case GL_COLOR_ATTACHMENT0, GL_COLOR_ATTACHMENT1, GL_COLOR_ATTACHMENT10, GL_COLOR_ATTACHMENT11,
+          GL_COLOR_ATTACHMENT12, GL_COLOR_ATTACHMENT13, GL_COLOR_ATTACHMENT14, GL_COLOR_ATTACHMENT15,
+          GL_COLOR_ATTACHMENT2, GL_COLOR_ATTACHMENT3, GL_COLOR_ATTACHMENT4, GL_COLOR_ATTACHMENT5,
+          GL_COLOR_ATTACHMENT6, GL_COLOR_ATTACHMENT7, GL_COLOR_ATTACHMENT8, GL_COLOR_ATTACHMENT9: {
+        // Not valid for the default framebuffer.
+        if (framebuffer.ID == 0) {
+          glErrorInvalidOperation()
+        }
+      }
+      default: {
+        glErrorInvalidEnum(b[i])
+      }
+    }
+  }
+
   for i in (0 .. as!GLint(n)) {
     framebuffer.DrawBuffer[i] = b[i]
   }

--- a/gapis/api/gles/read_framebuffer.go
+++ b/gapis/api/gles/read_framebuffer.go
@@ -219,6 +219,12 @@ func postFBData(ctx context.Context,
 		renderbufferID := t.glGenRenderbuffer(ctx)
 		t.glBindRenderbuffer(ctx, renderbufferID)
 
+		if hasColor {
+			// Blit defaults to color attachment 0. attaching there avoids
+			// having to setup the read/draw buffer mappings.
+			attachment = GLenum_GL_COLOR_ATTACHMENT0
+		}
+
 		mutateAndWriteEach(ctx, out, dID,
 			cb.GlRenderbufferStorage(GLenum_GL_RENDERBUFFER, fbai.format, GLsizei(inW), GLsizei(inH)),
 			cb.GlFramebufferRenderbuffer(GLenum_GL_DRAW_FRAMEBUFFER, attachment, GLenum_GL_RENDERBUFFER, renderbufferID),
@@ -226,6 +232,7 @@ func postFBData(ctx context.Context,
 		)
 
 		t.glBindFramebuffer_Read(ctx, framebufferID)
+		t.glReadBuffer(ctx, attachment)
 	}
 
 	if hasColor && (inW != outW || inH != outH) {
@@ -235,6 +242,10 @@ func postFBData(ctx context.Context,
 		t.glBindFramebuffer_Draw(ctx, framebufferID)
 		renderbufferID := t.glGenRenderbuffer(ctx)
 		t.glBindRenderbuffer(ctx, renderbufferID)
+
+		// Blit defaults to color attachment 0. Attaching there avoids having to
+		// setup the read/draw buffer mappings.
+		attachment = GLenum_GL_COLOR_ATTACHMENT0
 
 		mutateAndWriteEach(ctx, out, dID,
 			cb.GlRenderbufferStorage(GLenum_GL_RENDERBUFFER, fbai.format, GLsizei(outW), GLsizei(outH)),


### PR DESCRIPTION
hen blitting color, `glBlitFramebuffers` blits the attachment of `glReadBuffer` to each of the attachments specified via `glDrawBuffers`. By default `glDrawBuffers` is only `GL_COLOR_ATTACHMENT0`. Since we didn't touch the default, but would bind to other color attachments depending on what was requested, we would end up blitting to nowhere and return garbage data. Thus, by forcing the attachment to be `GL_COLOR_ATTACHMENT0`, we can avoid having to setup the `glDrawBuffers` on the temporary framebuffer.

The same was true when doing GPU resizing.