### PR TITLE
Force the GAPID apk to be debuggable.

### DIFF
--- a/gapidapk/android/apk/AndroidManifest.xml.in
+++ b/gapidapk/android/apk/AndroidManifest.xml.in
@@ -24,6 +24,7 @@
         android:icon="@drawable/logo"
         android:label="GAPID - ${name}"
         android:supportsRtl="true"
+        android:debuggable="true"
         >
         <activity android:name="android.app.NativeActivity"
                   android:label="GAPID - ${name}">


### PR DESCRIPTION
We need this to be the case to force run-as to behave.