### PR TITLE
ODR: Query the driver for the format/type for glReadPixels.

### DIFF
--- a/gapis/api/gles/BUILD.bazel
+++ b/gapis/api/gles/BUILD.bazel
@@ -130,6 +130,7 @@ go_library(
         "//gapis/messages:go_default_library",
         "//gapis/replay:go_default_library",
         "//gapis/replay/builder:go_default_library",
+        "//gapis/replay/protocol:go_default_library",
         "//gapis/replay/value:go_default_library",
         "//gapis/resolve:go_default_library",
         "//gapis/resolve/dependencygraph:go_default_library",

--- a/gapis/api/gles/tweaker.go
+++ b/gapis/api/gles/tweaker.go
@@ -340,6 +340,14 @@ func (t *tweaker) glBindFramebuffer_Read(ctx context.Context, id FramebufferId) 
 	}
 }
 
+// glBindFramebuffer_ReadToBoth binds the currently bound READ_FRAMEBUFFER to GL_FRAMEBUFFER.
+func (t *tweaker) glBindFramebuffer_ReadToBoth(ctx context.Context) {
+	d, r := t.c.Bound().DrawFramebuffer().GetID(), t.c.Bound().ReadFramebuffer().GetID()
+	t.doAndUndo(ctx,
+		t.cb.GlBindFramebuffer(GLenum_GL_FRAMEBUFFER, r),
+		t.cb.GlBindFramebuffer(GLenum_GL_DRAW_FRAMEBUFFER, d))
+}
+
 func (t *tweaker) glReadBuffer(ctx context.Context, id GLenum) {
 	fb := t.c.Bound().ReadFramebuffer()
 	if o := fb.ReadBuffer(); o != id {


### PR DESCRIPTION
The GLES spec requires glReadPixels to be able to return the data in one of three formats (see section 4.3.2 of the GLES 3.0 spec):

  1. for normalized, unsigned and signed integer formats, simply in their base RGBA format (e.g. RGBA8, RGBA32I and RGBA32UI).
  2. in an implementation chosen format that can be queried from the bound draw framebuffer.
  3. RGBA/UNSIGNED_INT_2_10_10_10_REV if the internal format is RGB10_A2.

Since 1 plus 3 is too restrictive and doesn't even support float formats, we need to use 2. With this change, the replay VM instructions are augmented to query the framebuffer for the supported format and type, which is then used when reading the pixels. The format and type are then also posted back along with the pixel data.

The whole thing is complicated due to driver issues, where the querying of the format and type is flawed and returns the format of the framebuffer bound by `GL_FRAMEBUFFER` instead of `GL_DRAW_FRAMEBUFFER` and also ignores the requested attachment of `glReadBuffer`.