### PR TITLE
Added a trailing frame-time measurement to the benchmark.

### DIFF
--- a/gapii/cc/spy.h
+++ b/gapii/cc/spy.h
@@ -135,6 +135,7 @@ class Spy : public GlesSpy, public GvrSpy, public VulkanSpy {
   // These keep track of nested frame start/end callbacks.
   int mNestedFrameStart;
   int mNestedFrameEnd;
+  uint64_t mFrameNumber;
 
   std::unordered_map<ContextID, GLenum_Error> mFakeGlError;
   std::unique_ptr<core::AsyncJob> mDeferStartJob;


### PR DESCRIPTION
This allows us to separate loading-time from run-time
in trace-time benchmarking.