### PR TITLE
Update to Vulkan IsTrivialTerminator for the last command.

### DIFF
--- a/gapis/api/vulkan/vulkan.go
+++ b/gapis/api/vulkan/vulkan.go
@@ -659,6 +659,7 @@ func (API) IsTrivialTerminator(ctx context.Context, p *path.Capture, after api.S
 				}
 			}
 		}
+		return true, nil
 	}
 	return false, nil
 }


### PR DESCRIPTION
Removes un-necessary state mutation when talking about
the last command.