### PR TITLE
External Images Fixes and Support for On Device Replay

### DIFF
--- a/core/vulkan/vk_virtual_swapchain/cc/BUILD.bazel
+++ b/core/vulkan/vk_virtual_swapchain/cc/BUILD.bazel
@@ -37,7 +37,7 @@ cc_library(
         # Android
         "//conditions:default": [
             "-ldl",
-            "-lm"
+            "-lm",
         ],
     }),
     visibility = ["//visibility:public"],

--- a/gapir/cc/android/gles_renderer.cpp
+++ b/gapir/cc/android/gles_renderer.cpp
@@ -21,6 +21,7 @@
 #include "core/cc/log.h"
 
 #include <EGL/egl.h>
+#include <EGL/eglext.h>
 
 namespace gapir {
 namespace {
@@ -34,6 +35,7 @@ class GlesRendererImpl : public GlesRenderer {
   virtual void setBackbuffer(Backbuffer backbuffer) override;
   virtual void bind(bool resetViewportScissor) override;
   virtual void unbind() override;
+  virtual void* createExternalImage(uint32_t texture) override;
   virtual const char* name() override;
   virtual const char* extensions() override;
   virtual const char* vendor() override;
@@ -195,6 +197,12 @@ void GlesRendererImpl::bind(bool resetViewportScissor) {
 void GlesRendererImpl::unbind() {
   eglMakeCurrent(mDisplay, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT);
   EGL_CHECK_ERROR("Failed to release EGL context");
+}
+
+void* GlesRendererImpl::createExternalImage(uint32_t texture) {
+  return mApi.mFunctionStubs.eglCreateImageKHR(
+      mDisplay, mContext, EGL_GL_TEXTURE_2D_KHR,
+      (EGLClientBuffer)(uint64_t)texture, nullptr);
 }
 
 const char* GlesRendererImpl::name() {

--- a/gapir/cc/context.cpp
+++ b/gapir/cc/context.cpp
@@ -326,6 +326,37 @@ void Context::registerCallbacks(Interpreter* interpreter) {
       });
 
   interpreter->registerBuiltin(
+      Gles::INDEX, Builtins::ReplayCreateExternalImage,
+      [this](uint32_t label, Stack* stack, bool pushReturn) {
+        uint32_t texId = stack->pop<uint32_t>();
+        uint32_t ctxId = stack->pop<uint32_t>();
+
+        if (!stack->isValid()) {
+          GAPID_WARNING(
+              "[%u]Error during calling function replayCreateExternalImage",
+              label);
+          return false;
+        }
+
+        auto renderer = mGlesRenderers[ctxId];
+        if (renderer == nullptr) {
+          GAPID_WARNING(
+              "[%u]replayCreateExternalImage called with unknown renderer "
+              "%" PRIu32,
+              label, ctxId);
+          return false;
+        }
+
+        GAPID_INFO("[%u]replayCreateExternalImage(%d, %d)", label, ctxId,
+                   texId);
+        auto result = renderer->createExternalImage(texId);
+        if (pushReturn) {
+          stack->push(result);
+        }
+        return true;
+      });
+
+  interpreter->registerBuiltin(
       Vulkan::INDEX, Builtins::ReplayCreateVkInstance,
       [this, interpreter](uint32_t label, Stack* stack, bool pushReturn) {
         GAPID_DEBUG("[%u]replayCreateVkInstance()", label);

--- a/gapir/cc/gles_renderer.h
+++ b/gapir/cc/gles_renderer.h
@@ -73,6 +73,9 @@ class GlesRenderer : public Renderer {
   virtual const char* version() = 0;
 
   virtual bool isValid() { return true; }
+
+  // Creates an external image backed by the given texture.
+  virtual void* createExternalImage(uint32_t texture) { return nullptr; }
 };
 
 inline GlesRenderer::Backbuffer::Format::Format()

--- a/gapis/api/gles/api/egl.api
+++ b/gapis/api/gles/api/egl.api
@@ -17,7 +17,7 @@ type void* EGLClientBuffer
 type void* EGLConfig
 type void* EGLContext
 type void* EGLDisplay
-@replay_custom_value type void* EGLImageKHR
+@replay_remap @replay_custom_value type void* EGLImageKHR
 type s32   EGLint
 type int   EGLNativeDisplayType
 type void* EGLNativePixmapType

--- a/gapis/api/gles/api/egl.api
+++ b/gapis/api/gles/api/egl.api
@@ -403,7 +403,7 @@ cmd EGLBoolean eglWaitNative(EGLint engine) {
 
 @if(Extension.EGL_KHR_image_base)
 @doc("https://www.khronos.org/registry/egl/extensions/KHR/EGL_KHR_image_base.txt", Extension.EGL_KHR_image_base)
-@no_replay
+@custom @no_replay
 cmd EGLImageKHR eglCreateImageKHR(EGLDisplay      display,
                                   EGLContext      context,
                                   EGLenum         target,

--- a/gapis/api/gles/api/egl.api
+++ b/gapis/api/gles/api/egl.api
@@ -17,7 +17,7 @@ type void* EGLClientBuffer
 type void* EGLConfig
 type void* EGLContext
 type void* EGLDisplay
-type void* EGLImageKHR
+@replay_custom_value type void* EGLImageKHR
 type s32   EGLint
 type int   EGLNativeDisplayType
 type void* EGLNativePixmapType
@@ -25,9 +25,6 @@ type void* EGLNativeWindowType
 type void* EGLSurface
 type void* EGLSyncKHR
 type u64   EGLTimeKHR
-
-@replay_custom_value
-type void* GLeglImageOES
 
 sub EGLint[] CloneAttribList(const EGLint* attrib_list) {
   // TODO: Replace with proper loop control flow

--- a/gapis/api/gles/api/extensions.api
+++ b/gapis/api/gles/api/extensions.api
@@ -623,7 +623,7 @@ cmd void glDrawRangeElementsBaseVertexOES(GLenum         mode,
 
 @if(Extension.GL_OES_EGL_image)
 @doc("https://www.khronos.org/registry/gles/extensions/OES/OES_EGL_image.txt", Extension.GL_OES_EGL_image)
-cmd void glEGLImageTargetRenderbufferStorageOES(GLenum target, GLeglImageOES image) {
+cmd void glEGLImageTargetRenderbufferStorageOES(GLenum target, EGLImageKHR image) {
 
 }
 
@@ -631,7 +631,7 @@ cmd void glEGLImageTargetRenderbufferStorageOES(GLenum target, GLeglImageOES ima
 @doc("https://www.khronos.org/registry/gles/extensions/OES/OES_EGL_image.txt", Extension.GL_OES_EGL_image)
 @doc("https://www.khronos.org/registry/gles/extensions/EXT/EXT_EGL_image_array.txt", Extension.GL_EXT_EGL_image_array)
 @doc("https://www.khronos.org/registry/gles/extensions/OES/OES_EGL_image_external.txt", Extension.GL_OES_EGL_image_external)
-cmd void glEGLImageTargetTexture2DOES(GLenum target, GLeglImageOES image) {
+cmd void glEGLImageTargetTexture2DOES(GLenum target, EGLImageKHR image) {
   switch (target) {
     @if(Extension.GL_OES_EGL_image)
     case GL_TEXTURE_2D: {}
@@ -644,7 +644,7 @@ cmd void glEGLImageTargetTexture2DOES(GLenum target, GLeglImageOES image) {
   }
   eglImage := EGLImages[as!EGLImageKHR(image)]
   if eglImage == null {
-    glErrorInvalidOperation_ObjectDoesNotExist!GLeglImageOES(image)
+    glErrorInvalidOperation_ObjectDoesNotExist!EGLImageKHR(image)
   }
   t := GetBoundTextureOrErrorInvalidEnum(target)
 

--- a/gapis/api/gles/compat.go
+++ b/gapis/api/gles/compat.go
@@ -155,17 +155,6 @@ func compat(ctx context.Context, device *device.Instance, onError onCompatError)
 	bufferCompat := newBufferCompat(int(glDev.UniformBufferAlignment))
 	eglContextHandle := map[Contextʳ]EGLContext{}
 
-	nextTextureID := TextureId(0xffff0000)
-	newTexture := func(i api.CmdID, cb CommandBuilder, out transform.Writer) TextureId {
-		s := out.State()
-		id := nextTextureID
-		tmp := s.AllocDataOrPanic(ctx, id)
-		defer tmp.Free()
-		out.MutateAndWrite(ctx, i.Derived(), cb.GlGenTextures(1, tmp.Ptr()).AddWrite(tmp.Data()))
-		nextTextureID--
-		return id
-	}
-
 	// Definitions of Vertex Arrays backed by client memory.
 	// We postpone the write of the command until draw call.
 	clientVAs := map[VertexAttributeArrayʳ]*GlVertexAttribPointer{}
@@ -1096,71 +1085,44 @@ func compat(ctx context.Context, device *device.Instance, onError onCompatError)
 					out.MutateAndWrite(ctx, id, cmd)
 					return
 				}
-				// Create GL texture as compat replacement of the EGL image (on first use)
-				switch eglImage.Target() {
-				case EGLenum_EGL_GL_TEXTURE_2D:
-					{
-						// Already a GL texture - either specified by the user, or we already translated it.
-					}
-				case EGLenum_EGL_NATIVE_BUFFER_ANDROID:
-					{
-						// We do not have any kind of native buffers available during replay.
-						// Instead, create a new texture in this context, and point the EGLImage to it.
 
-						imgs := eglImage.Images()
-						img := imgs.Get(0)
-						sizedFormat := img.SizedFormat() // Might be RGB565 which is not supported on desktop
-						sizedFormatProp := &glenumProperty{func() GLenum { return sizedFormat }, func(f GLenum) { sizedFormat = f }}
+				target := cmd.Target()
+				imgs := eglImage.Images()
+				img := imgs.Get(0)
+				sizedFormat := img.SizedFormat() // Might be RGB565 which is not supported on desktop
+				sizedFormatProp := &glenumProperty{func() GLenum { return sizedFormat }, func(f GLenum) { sizedFormat = f }}
 
-						texID := newTexture(id, cb, out)
-						t := newTweaker(out, dID, cb)
-						target := cmd.Target()
-						switch target {
-						case GLenum_GL_TEXTURE_2D, GLenum_GL_TEXTURE_EXTERNAL_OES:
-							target = GLenum_GL_TEXTURE_2D
-							t.glBindTexture_2D(ctx, texID)
+				t := newTweaker(out, dID, cb)
+				defer t.revert(ctx)
+				t.GlBindBuffer_PixelUnpackBuffer(ctx, 0)
 
-							textureCompat.convertFormat(ctx, GLenum_GL_TEXTURE_2D, sizedFormatProp, nil, nil, out, id, cmd)
-							out.MutateAndWrite(ctx, dID, cb.GlTexImage2D(GLenum_GL_TEXTURE_2D, 0, GLint(sizedFormat), img.Width(), img.Height(), 0, img.DataFormat(), img.DataType(), memory.Nullptr))
-						case GLenum_GL_TEXTURE_2D_ARRAY:
-							t.glBindTexture_2DArray(ctx, texID)
-							textureCompat.convertFormat(ctx, GLenum_GL_TEXTURE_2D_ARRAY, sizedFormatProp, nil, nil, out, id, cmd)
-							out.MutateAndWrite(ctx, dID, cb.GlTexImage3D(GLenum_GL_TEXTURE_2D_ARRAY, 0, GLint(sizedFormat), img.Width(), img.Height(), GLsizei(imgs.Len()), 0, img.DataFormat(), img.DataType(), memory.Nullptr))
-						default:
-							onError(ctx, id, cmd, fmt.Errorf("Unexpected GlEGLImageTargetTexture2DOES target: %v", target))
+				switch target {
+				case GLenum_GL_TEXTURE_2D, GLenum_GL_TEXTURE_EXTERNAL_OES:
+					// First time this texture is sync'ed. Initilize it.
+					if c.Bound().TextureUnit().Binding2d().Image().IsNil() {
+						textureCompat.convertFormat(ctx, GLenum_GL_TEXTURE_2D, sizedFormatProp, nil, nil, out, id, cmd)
+						out.MutateAndWrite(ctx, dID, cb.GlTexImage2D(GLenum_GL_TEXTURE_2D, 0, GLint(sizedFormat), img.Width(), img.Height(), 0, img.DataFormat(), img.DataType(), memory.Nullptr))
+						// External textures use GL_LINEAR as the default and only allow GL_LINEAR or GL_NEAREST.
+						if c.Bound().TextureUnit().Binding2d().MinFilter() == GLenum_GL_NEAREST_MIPMAP_LINEAR {
+							out.MutateAndWrite(ctx, dID, cb.GlTexParameteri(GLenum_GL_TEXTURE_2D, GLenum_GL_TEXTURE_MIN_FILTER, GLint(GLenum_GL_LINEAR)))
 						}
-						// Set the default filtering modes applicable to external images.
-						// This is important as the default (mipmap) mode would result in incomplete texture.
-						// TODO: Ensure that different contexts can set different modes at the same time.
-						out.MutateAndWrite(ctx, dID, cb.GlTexParameteri(target, GLenum_GL_TEXTURE_MIN_FILTER, GLint(GLenum_GL_LINEAR)))
-						out.MutateAndWrite(ctx, dID, cb.GlTexParameteri(target, GLenum_GL_TEXTURE_MAG_FILTER, GLint(GLenum_GL_LINEAR)))
-
-						out.MutateAndWrite(ctx, dID, cb.Custom(func(ctx context.Context, s *api.GlobalState, b *builder.Builder) error {
-							eglImage.SetContext(eglContextHandle[c])
-							eglImage.SetTarget(EGLenum_EGL_GL_TEXTURE_2D)
-							eglImage.SetBuffer(EGLClientBuffer(texID))
-							return nil
-						}))
-						t.revert(ctx)
+					}
+				case GLenum_GL_TEXTURE_2D_ARRAY:
+					// First time this texture is sync'ed. Initilize it.
+					if c.Bound().TextureUnit().Binding2dArray().Image().IsNil() {
+						textureCompat.convertFormat(ctx, GLenum_GL_TEXTURE_2D_ARRAY, sizedFormatProp, nil, nil, out, id, cmd)
+						out.MutateAndWrite(ctx, dID, cb.GlTexImage3D(GLenum_GL_TEXTURE_2D_ARRAY, 0, GLint(sizedFormat), img.Width(), img.Height(), GLsizei(imgs.Len()), 0, img.DataFormat(), img.DataType(), memory.Nullptr))
+						// External textures use GL_LINEAR as the default and only allow GL_LINEAR or GL_NEAREST.
+						if c.Bound().TextureUnit().Binding2dArray().MinFilter() == GLenum_GL_NEAREST_MIPMAP_LINEAR {
+							out.MutateAndWrite(ctx, dID, cb.GlTexParameteri(GLenum_GL_TEXTURE_2D_ARRAY, GLenum_GL_TEXTURE_MIN_FILTER, GLint(GLenum_GL_LINEAR)))
+						}
 					}
 				default:
-					onError(ctx, id, cmd, fmt.Errorf("Unknown EGLImage target: %v", eglImage.Target()))
+					onError(ctx, id, cmd, fmt.Errorf("Unexpected GlEGLImageTargetTexture2DOES target: %v", target))
 				}
-
-				cmd := cmd.clone(s.Arena)
-				convertTexTarget(cmd)
-				out.MutateAndWrite(ctx, dID, cb.Custom(func(ctx context.Context, s *api.GlobalState, b *builder.Builder) error {
-					return cmd.Mutate(ctx, id, s, nil, nil) // do not call, just mutate
-				}))
-
-				// Rebind the currently bound 2D texture.  This might seem like a no-op, however,
-				// the remapping layer will use the ID of the EGL image replacement texture now.
-				out.MutateAndWrite(ctx, dID, cb.GlBindTexture(GLenum_GL_TEXTURE_2D, c.Bound().TextureUnit().Binding2d().ID()))
 
 				// Update the content if we made a snapshot.
 				if e := FindEGLImageData(cmd.Extras()); e != nil {
-					t := newTweaker(out, dID, cb)
-					defer t.revert(ctx)
 					t.setUnpackStorage(ctx, NewPixelStorageState(s.Arena,
 						0, // ImageHeight
 						0, // SkipImages

--- a/gapis/api/gles/custom_replay.go
+++ b/gapis/api/gles/custom_replay.go
@@ -79,20 +79,6 @@ func (i ShaderId) remap(cmd api.Cmd, s *api.GlobalState) (key interface{}, remap
 func (i TextureId) remap(cmd api.Cmd, s *api.GlobalState) (key interface{}, remap bool) {
 	ctx := GetContext(s, cmd.Thread())
 	if !ctx.IsNil() && i != 0 {
-		if tex := ctx.Objects().Textures().Get(i); !tex.IsNil() {
-			_, isDeleteCmd := cmd.(*GlDeleteTextures)
-			if eglImage := tex.EGLImage(); !eglImage.IsNil() && !isDeleteCmd {
-				// Ignore this texture and use the data that EGLImage points to.
-				// (unless it is a delete command - we do not want kill the shared data)
-				ctx := GetState(s).EGLContexts().Get(eglImage.Context())
-				isTex2D := eglImage.Target() == EGLenum_EGL_GL_TEXTURE_2D
-				i := TextureId(eglImage.Buffer().Address())
-				if !ctx.IsNil() && isTex2D && ctx.Objects().Textures().Contains(i) {
-					return objectKey{ctx.Objects().Textures(), i}, true
-				}
-				panic(fmt.Errorf("Can not find EGL image target: %v", eglImage))
-			}
-		}
 		key, remap = objectKey{ctx.Objects().Textures(), i}, true
 	}
 	return

--- a/gapis/api/gles/custom_replay.go
+++ b/gapis/api/gles/custom_replay.go
@@ -235,7 +235,7 @@ func (i BufferDataPointer) value(b *builder.Builder, cmd api.Cmd, s *api.GlobalS
 	return value.ObservedPointer(i)
 }
 
-func (i GLeglImageOES) value(b *builder.Builder, cmd api.Cmd, s *api.GlobalState) value.Value {
+func (i EGLImageKHR) value(b *builder.Builder, cmd api.Cmd, s *api.GlobalState) value.Value {
 	return value.AbsolutePointer(i)
 }
 

--- a/gapis/api/gles/custom_replay.go
+++ b/gapis/api/gles/custom_replay.go
@@ -127,6 +127,13 @@ func (i GLsync) remap(cmd api.Cmd, s *api.GlobalState) (key interface{}, remap b
 	return
 }
 
+func (i EGLImageKHR) remap(cmd api.Cmd, s *api.GlobalState) (key interface{}, remap bool) {
+	if !i.IsNullptr() {
+		key, remap = objectKey{GetState(s).EGLImages(), i}, true
+	}
+	return
+}
+
 func (i GLsync) value(b *builder.Builder, cmd api.Cmd, s *api.GlobalState) value.Value {
 	return value.AbsolutePointer(i)
 }

--- a/gapis/api/gles/state_builder.go
+++ b/gapis/api/gles/state_builder.go
@@ -415,7 +415,7 @@ func (sb *stateBuilder) eglImage(ctx context.Context, img EGLImageʳ) {
 	attribs := img.AttribList().MustRead(ctx, nil, sb.oldState, nil)
 	cmd := cb.EglCreateImageKHR(img.Display(), img.Context(), img.Target(), img.Buffer(), sb.readsData(ctx, attribs), img.ID())
 	if extra := img.Extra(); !extra.IsNil() {
-		cmd.Extras().Add(extra)
+		cmd.Extras().Add(extra.Get().Clone(cb.Arena, sb.cloneCtx))
 	}
 	write(ctx, cmd)
 }

--- a/gapis/api/gles/synthetic.api
+++ b/gapis/api/gles/synthetic.api
@@ -33,6 +33,11 @@ cmd void replayChangeBackbuffer(u32     rendererID,
                                 GLenum  backbuffer_depth_fmt,
                                 GLenum  backbuffer_stencil_fmt) { }
 
+// replayCreateExternalImage creates a texture base EGL external image. This command
+// is only valid if the replay target is GLES.
+@synthetic
+cmd EGLImageKHR replayCreateExternalImage(u32 rendererID, TextureId texture) { return ? }
+
 @synthetic
 cmd void startTimer(u8 index) { }
 

--- a/gapis/api/gles/tweaker.go
+++ b/gapis/api/gles/tweaker.go
@@ -324,6 +324,14 @@ func (t *tweaker) GlBindBuffer_ElementArrayBuffer(ctx context.Context, id Buffer
 	}
 }
 
+func (t *tweaker) GlBindBuffer_PixelUnpackBuffer(ctx context.Context, id BufferId) {
+	if o := t.c.Bound().PixelUnpackBuffer().GetID(); o != id {
+		t.doAndUndo(ctx,
+			t.cb.GlBindBuffer(GLenum_GL_PIXEL_UNPACK_BUFFER, id),
+			t.cb.GlBindBuffer(GLenum_GL_PIXEL_UNPACK_BUFFER, o))
+	}
+}
+
 func (t *tweaker) glBindFramebuffer_Draw(ctx context.Context, id FramebufferId) {
 	if o := t.c.Bound().DrawFramebuffer().GetID(); o != id {
 		t.doAndUndo(ctx,


### PR DESCRIPTION
Fixes a dependency graph bug for external images backed by GL textures.
Adds support for external images in ODR:

Since we don't fudge the shaders for ODR, shaders using external samplers will expect external textures. Therefore, we cannot use the desktop handling of external textures, which coerces them to regular textures. Instead, we need to create EGLImages and map them to the external textures, the same as the application did. However, since we won't have the native buffers anymore, we convert all EGLImages to be backed by GL textures. Since no context needs to be bound when creating an EGLImage, but we need one to create backing texture, the creation of the texture and EGLImage is delayed until the sync point, where a context is bound.

Introduces a new synthetic replay command to create an external image. This is needed, because the `eglCreateImageKHR` needs the display and context pointer, which are not exposed to gapis. Also adds a custom mutate to `eglCreateImageKHR` command, which augments the mutate by replacing the command with the synthetic one on replay.

Fixes #2279