### PR TITLE
gapis/resolve/dependencygraph: Bind a replay device.

### DIFF
--- a/core/vulkan/vk_virtual_swapchain/cc/BUILD.bazel
+++ b/core/vulkan/vk_virtual_swapchain/cc/BUILD.bazel
@@ -37,7 +37,7 @@ cc_library(
         # Android
         "//conditions:default": [
             "-ldl",
-            "-lm"
+            "-lm",
         ],
     }),
     visibility = ["//visibility:public"],

--- a/gapis/resolve/command_tree.go
+++ b/gapis/resolve/command_tree.go
@@ -180,7 +180,7 @@ func CommandTreeNodeForCommand(ctx context.Context, p *path.CommandTreeNodeForCo
 // Resolve implements the database.Resolver interface.
 func (r *CommandTreeResolvable) Resolve(ctx context.Context) (interface{}, error) {
 	p := r.Path
-	ctx = setupContext(ctx, p.Capture, r.Config)
+	ctx = SetupContext(ctx, p.Capture, r.Config)
 
 	c, err := capture.Resolve(ctx)
 	if err != nil {

--- a/gapis/resolve/contexts.go
+++ b/gapis/resolve/contexts.go
@@ -83,7 +83,7 @@ type Named interface {
 
 // Resolve implements the database.Resolver interface.
 func (r *ContextListResolvable) Resolve(ctx context.Context) (interface{}, error) {
-	ctx = setupContext(ctx, r.Capture, r.Config)
+	ctx = SetupContext(ctx, r.Capture, r.Config)
 
 	c, err := capture.Resolve(ctx)
 	if err != nil {

--- a/gapis/resolve/dependencygraph/BUILD.bazel
+++ b/gapis/resolve/dependencygraph/BUILD.bazel
@@ -37,6 +37,7 @@ go_library(
         "//gapis/config:go_default_library",
         "//gapis/database:go_default_library",
         "//gapis/replay:go_default_library",
+        "//gapis/resolve:go_default_library",
         "//gapis/resolve/initialcmds:go_default_library",
         "//gapis/service/path:go_default_library",
     ],

--- a/gapis/resolve/dependencygraph/footprint.go
+++ b/gapis/resolve/dependencygraph/footprint.go
@@ -23,6 +23,7 @@ import (
 	"github.com/google/gapid/gapis/api"
 	"github.com/google/gapid/gapis/capture"
 	"github.com/google/gapid/gapis/database"
+	"github.com/google/gapid/gapis/resolve"
 	"github.com/google/gapid/gapis/resolve/initialcmds"
 	"github.com/google/gapid/gapis/service/path"
 )
@@ -174,10 +175,13 @@ func GetFootprint(ctx context.Context, c *path.Capture) (*Footprint, error) {
 
 // Resolve implements the database.Resolver interface.
 func (r *FootprintResolvable) Resolve(ctx context.Context) (interface{}, error) {
-	c, err := capture.ResolveFromPath(ctx, r.Capture)
+	ctx = resolve.SetupContext(ctx, r.Capture, r.Config)
+
+	c, err := capture.Resolve(ctx)
 	if err != nil {
 		return nil, err
 	}
+
 	cmds := c.Commands
 	// If the capture contains initial state, prepend the commands to build the state.
 	initialCmds, ranges, err := initialcmds.InitialCommands(ctx, r.Capture)

--- a/gapis/resolve/dependencygraph/resolvables.proto
+++ b/gapis/resolve/dependencygraph/resolvables.proto
@@ -21,10 +21,10 @@ import "gapis/service/path/path.proto";
 
 message DependencyGraphResolvable {
   path.Capture capture = 1;
-  path.Device device = 2;
+  path.ResolveConfig config = 2;
 }
 
 message FootprintResolvable {
   path.Capture capture = 1;
-  path.Device device = 2;
+  path.ResolveConfig config = 2;
 }

--- a/gapis/resolve/framebuffer_attachment_data.go
+++ b/gapis/resolve/framebuffer_attachment_data.go
@@ -27,7 +27,7 @@ import (
 // Resolve implements the database.Resolver interface.
 func (r *FramebufferAttachmentBytesResolvable) Resolve(ctx context.Context) (interface{}, error) {
 	c := path.FindCapture(r.After)
-	ctx = setupContext(ctx, c, r.Config)
+	ctx = SetupContext(ctx, c, r.Config)
 
 	intent := replay.Intent{
 		Device:  r.ReplaySettings.Device,

--- a/gapis/resolve/framebuffer_changes.go
+++ b/gapis/resolve/framebuffer_changes.go
@@ -62,7 +62,7 @@ const errNoAPI = fault.Const("Command has no API")
 
 // Resolve implements the database.Resolver interface.
 func (r *FramebufferChangesResolvable) Resolve(ctx context.Context) (interface{}, error) {
-	ctx = setupContext(ctx, r.Capture, r.Config)
+	ctx = SetupContext(ctx, r.Capture, r.Config)
 
 	c, err := capture.Resolve(ctx)
 	if err != nil {

--- a/gapis/resolve/get.go
+++ b/gapis/resolve/get.go
@@ -29,6 +29,6 @@ func Get(ctx context.Context, p *path.Any, r *path.ResolveConfig) (interface{}, 
 // Resolve implements the database.Resolver interface.
 func (r *GetResolvable) Resolve(ctx context.Context) (interface{}, error) {
 	c := path.FindCapture(r.Path.Node())
-	ctx = setupContext(ctx, c, r.Config)
+	ctx = SetupContext(ctx, c, r.Config)
 	return ResolveService(ctx, r.Path.Node(), r.Config)
 }

--- a/gapis/resolve/memory.go
+++ b/gapis/resolve/memory.go
@@ -30,7 +30,7 @@ import (
 
 // Memory resolves and returns the memory from the path p.
 func Memory(ctx context.Context, p *path.Memory, rc *path.ResolveConfig) (*service.Memory, error) {
-	ctx = setupContext(ctx, path.FindCapture(p), rc)
+	ctx = SetupContext(ctx, path.FindCapture(p), rc)
 
 	cmdIdx := p.After.Indices[0]
 	fullCmdIdx := p.After.Indices

--- a/gapis/resolve/report.go
+++ b/gapis/resolve/report.go
@@ -51,7 +51,7 @@ func (r *ReportResolvable) newReportItem(s log.Severity, c uint64, m *stringtabl
 
 // Resolve implements the database.Resolver interface.
 func (r *ReportResolvable) Resolve(ctx context.Context) (interface{}, error) {
-	ctx = setupContext(ctx, r.Path.Capture, r.Config)
+	ctx = SetupContext(ctx, r.Path.Capture, r.Config)
 
 	c, err := capture.Resolve(ctx)
 	if err != nil {

--- a/gapis/resolve/resolve.go
+++ b/gapis/resolve/resolve.go
@@ -424,7 +424,8 @@ func convert(val reflect.Value, ty reflect.Type) (reflect.Value, bool) {
 	return val, false
 }
 
-func setupContext(ctx context.Context, c *path.Capture, r *path.ResolveConfig) context.Context {
+// SetupContext binds the capture and a replay device to the returned context.
+func SetupContext(ctx context.Context, c *path.Capture, r *path.ResolveConfig) context.Context {
 	if c != nil {
 		ctx = capture.Put(ctx, c)
 	}

--- a/gapis/resolve/resource_data.go
+++ b/gapis/resolve/resource_data.go
@@ -39,7 +39,7 @@ type ResolvedResources struct {
 // Resolve builds a ResolvedResources object for all of the resources
 // at the path r.After
 func (r *AllResourceDataResolvable) Resolve(ctx context.Context) (interface{}, error) {
-	ctx = setupContext(ctx, r.After.Capture, r.Config)
+	ctx = SetupContext(ctx, r.After.Capture, r.Config)
 
 	resources, err := buildResources(ctx, r.After)
 

--- a/gapis/resolve/resources.go
+++ b/gapis/resolve/resources.go
@@ -39,7 +39,7 @@ func Resources(ctx context.Context, c *path.Capture, r *path.ResolveConfig) (*se
 
 // Resolve implements the database.Resolver interface.
 func (r *ResourcesResolvable) Resolve(ctx context.Context) (interface{}, error) {
-	ctx = setupContext(ctx, r.Capture, r.Config)
+	ctx = SetupContext(ctx, r.Capture, r.Config)
 
 	c, err := capture.Resolve(ctx)
 	if err != nil {

--- a/gapis/resolve/set.go
+++ b/gapis/resolve/set.go
@@ -43,7 +43,7 @@ func Set(ctx context.Context, p *path.Any, v interface{}, r *path.ResolveConfig)
 
 // Resolve implements the database.Resolver interface.
 func (r *SetResolvable) Resolve(ctx context.Context) (interface{}, error) {
-	ctx = setupContext(ctx, path.FindCapture(r.Path.Node()), r.Config)
+	ctx = SetupContext(ctx, path.FindCapture(r.Path.Node()), r.Config)
 
 	a := arena.New()
 

--- a/gapis/resolve/state.go
+++ b/gapis/resolve/state.go
@@ -44,7 +44,7 @@ func State(ctx context.Context, p *path.State, r *path.ResolveConfig) (interface
 
 // Resolve implements the database.Resolver interface.
 func (r *GlobalStateResolvable) Resolve(ctx context.Context) (interface{}, error) {
-	ctx = setupContext(ctx, r.Path.After.Capture, r.Config)
+	ctx = SetupContext(ctx, r.Path.After.Capture, r.Config)
 
 	cmdIdx := r.Path.After.Indices[0]
 	allCmds, err := Cmds(ctx, r.Path.After.Capture)
@@ -80,7 +80,7 @@ func (r *GlobalStateResolvable) Resolve(ctx context.Context) (interface{}, error
 
 // Resolve implements the database.Resolver interface.
 func (r *StateResolvable) Resolve(ctx context.Context) (interface{}, error) {
-	ctx = setupContext(ctx, r.Path.After.Capture, r.Config)
+	ctx = SetupContext(ctx, r.Path.After.Capture, r.Config)
 	obj, _, _, err := state(ctx, r.Path, r.Config)
 	return obj, err
 }


### PR DESCRIPTION
Fixes a whole bunch of warnings in GLES externs about not having a replay device bound.

Fixes #2278