### PR TITLE
gapir/cc: Fix tests.

### DIFF
--- a/gapir/cc/in_memory_resource_cache_test.cpp
+++ b/gapir/cc/in_memory_resource_cache_test.cpp
@@ -101,7 +101,7 @@ class ResourceInMemoryCacheTest : public Test {
     auto res_data = createResourcesData(resources);
     EXPECT_CALL(*mFallbackLoader, fetch(_, _))
         .With(Args<0, 1>(ElementsAreArray(resources)))
-        .WillOnce(Return(ByMove(std::move(createResources(res_data)))))
+        .WillOnce(Return(ByMove(createResources(res_data))))
         .RetiresOnSaturation();
     EXPECT_TRUE(mMemoryCachedResourceLoader->load(
         resources.data(), resources.size(), got.data(), size));
@@ -143,8 +143,8 @@ TEST_F(ResourceInMemoryCacheTest, Prefetch) {
 
   EXPECT_CALL(*mFallbackLoader, fetch(_, _))
       .With(Args<0, 1>(ElementsAre(A, B, C, D)))
-      .WillOnce(Return(ByMove(
-          std::move(createResources(createResourcesData({A, B, C, D}))))));
+      .WillOnce(
+          Return(ByMove(createResources(createResourcesData({A, B, C, D})))));
 
   Resource resources[] = {A, B, C, D, E};
   mCache->resize(TEMP_SIZE);
@@ -191,8 +191,7 @@ TEST_F(ResourceInMemoryCacheTest, PrefetchPartialCacheHit) {
   std::vector<Resource> resources{A, B, C, D};
   EXPECT_CALL(*mFallbackLoader, fetch(_, _))
       .With(Args<0, 1>(ElementsAre(B, D)))
-      .WillOnce(Return(
-          ByMove(std::move(createResources(createResourcesData({B, D}))))));
+      .WillOnce(Return(ByMove(createResources(createResourcesData({B, D})))));
   EXPECT_TRUE(
       mMemoryCachedResourceLoader->load(resources.data(), 4, mTemp, TEMP_SIZE));
   // ┏━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━┓
@@ -218,8 +217,7 @@ TEST_F(ResourceInMemoryCacheTest, PrefetchPartialCacheHitWithWrapped) {
   Resource resources[] = {B, C, D};
   EXPECT_CALL(*mFallbackLoader, fetch(_, _))
       .With(Args<0, 1>(ElementsAre(C)))
-      .WillOnce(
-          Return(ByMove(std::move(createResources(createResourcesData({C}))))));
+      .WillOnce(Return(ByMove(createResources(createResourcesData({C})))));
   mMemoryCachedResourceLoader->load(resources, 3, mTemp, TEMP_SIZE);
   // ┏━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┓
   // ┃ offset:  64 ┃ offset: 576 ┃ offset: 768 ┃ offset:  832 ┃
@@ -356,8 +354,7 @@ TEST_F(ResourceInMemoryCacheTest, CachingLogic) {
     Resource resources[] = {A1, B1, C1, D1, E1};
     EXPECT_CALL(*mFallbackLoader, fetch(_, _))
         .With(Args<0, 1>(ElementsAre(E1)))
-        .WillOnce(Return(
-            ByMove(std::move(createResources(createResourcesData({E1}))))));
+        .WillOnce(Return(ByMove(createResources(createResourcesData({E1})))));
     mMemoryCachedResourceLoader->load(resources, 5, mTemp, TEMP_SIZE);
     expectCacheHit({A1, B1, C1, D1, E1});
   }
@@ -384,8 +381,8 @@ TEST_F(ResourceInMemoryCacheTest, CachingLogic) {
     Resource resources[] = {A1, C2, D2};
     EXPECT_CALL(*mFallbackLoader, fetch(_, _))
         .With(Args<0, 1>(ElementsAre(A1, D2)))
-        .WillOnce(Return(
-            ByMove(std::move(createResources(createResourcesData({A1, D2}))))));
+        .WillOnce(
+            Return(ByMove(createResources(createResourcesData({A1, D2})))));
     mMemoryCachedResourceLoader->load(resources, 3, mTemp, TEMP_SIZE);
   }
   // ┏━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━┓
@@ -411,8 +408,8 @@ TEST_F(ResourceInMemoryCacheTest, PrefecthOverrun) {
   std::vector<Resource> resources1{A1, B1, C1, D1, E1};
   EXPECT_CALL(*mFallbackLoader, fetch(_, _))
       .With(Args<0, 1>(ElementsAre(A1, B1, C1, D1, E1)))
-      .WillOnce(Return(
-          ByMove(std::move(createResources(createResourcesData(resources1))))));
+      .WillOnce(
+          Return(ByMove(createResources(createResourcesData(resources1)))));
   mMemoryCachedResourceLoader->load(resources1.data(), 5, mTemp, TEMP_SIZE);
 
   // ┏━━━━━━┳━━━━━━┳━━━━━━┳━━━━━━┳━━━━━━┳━━━━━━┳━━━━━━┳━━━━━━┓

--- a/gapir/cc/replay_request_test.cpp
+++ b/gapir/cc/replay_request_test.cpp
@@ -18,7 +18,6 @@
 #include "memory_manager.h"
 #include "mock_replay_service.h"
 #include "mock_resource_loader.h"
-#include "replay_connection.h"
 #include "test_utilities.h"
 
 #include <gmock/gmock.h>

--- a/test/integration/gles/replay/gles_test.go
+++ b/test/integration/gles/replay/gles_test.go
@@ -268,6 +268,7 @@ func TestResizeRenderer(t *testing.T) {
 	)
 
 	b.ResizeBackbuffer(64, 64)
+	b.Add(b.CB.GlViewport(0, 0, 64, 64))
 	b.ClearColor(0, 0, 1, 1)
 	triangle := b.Add(b.CB.GlDrawArrays(gles.GLenum_GL_TRIANGLES, 0, 3).AddRead(triangleVerticesR.Data()))
 	c := buildAndMaybeExportCapture(ctx, b, "resize-renderer")


### PR DESCRIPTION
`error: moving a temporary object prevents copy elision [-Werror,-Wpessimizing-move]`