### PR TITLE
Track resource deletion.

### DIFF
--- a/gapic/src/main/com/google/gapid/util/Paths.java
+++ b/gapic/src/main/com/google/gapid/util/Paths.java
@@ -345,14 +345,18 @@ public class Paths {
         .build();
   }
 
+  public static boolean isNull(Path.Command c) {
+    return (c == null) || (c.getIndicesCount() == 0);
+  }
+
   /**
    * Compares a and b, returning -1 if a comes before b, 1 if b comes before a and 0 if they
    * are equal.
    */
   public static int compare(Path.Command a, Path.Command b) {
-    if (a == null) {
-      return (b == null) ? 0 : -1;
-    } else if (b == null) {
+    if (isNull(a)) {
+      return isNull(b) ? 0 : -1;
+    } else if (isNull(b)) {
       return 1;
     }
 

--- a/gapic/src/main/com/google/gapid/views/ShaderView.java
+++ b/gapic/src/main/com/google/gapid/views/ShaderView.java
@@ -412,7 +412,7 @@ public class ShaderView extends Composite
               }
             });
             resources.stream()
-                .map(Data::new)
+                .map(r -> new Data(r.resource))
                 .forEach(shaders::add);
           }
           lastUpdateContainedAllShaders = resources.complete;

--- a/gapil/semantic/expression.go
+++ b/gapil/semantic/expression.go
@@ -157,6 +157,11 @@ func (*Member) isExpression() {}
 // ExpressionType implements Expression returning the type of the field.
 func (m *Member) ExpressionType() Type { return m.Field.Type }
 
+// GetAnnotation returns the annotation with the matching name, if present.
+func (m *Member) GetAnnotation(name string) *Annotation {
+	return m.Field.GetAnnotation(name)
+}
+
 // MessageValue is an expression that produces a localized message
 type MessageValue struct {
 	AST       *ast.Class          // the underlying syntax node this was built from

--- a/gapis/api/gles/gles.api
+++ b/gapis/api/gles/gles.api
@@ -455,22 +455,22 @@ class DefaultObjects {
 // Objects which are never shared between contexts.
 @internal
 class Objects {
-  GeneratedObjectNames                             GeneratedNames
-  DefaultObjects                                   Default
-  map!(BufferId, ref!Buffer)                       Buffers
-  map!(FramebufferId, ref!Framebuffer)             Framebuffers
-  map!(ImageUnitId, ref!ImageUnit)                 ImageUnits
-  map!(PipelineId, ref!Pipeline)                   Pipelines
-  map!(ProgramId, ref!Program)                     Programs
-  map!(QueryId, ref!Query)                         Queries
-  map!(RenderbufferId, ref!Renderbuffer)           Renderbuffers
-  map!(SamplerId, ref!Sampler)                     Samplers
-  map!(ShaderId, ref!Shader)                       Shaders
-  map!(GLsync, ref!SyncObject)                     SyncObjects
-  map!(TextureUnitId, ref!TextureUnit)             TextureUnits
-  map!(TextureId, ref!Texture)                     Textures
-  map!(TransformFeedbackId, ref!TransformFeedback) TransformFeedbacks
-  map!(VertexArrayId, ref!VertexArray)             VertexArrays
+  GeneratedObjectNames                                        GeneratedNames
+  DefaultObjects                                              Default
+  @handleMap map!(BufferId, ref!Buffer)                       Buffers
+  @handleMap map!(FramebufferId, ref!Framebuffer)             Framebuffers
+  @handleMap map!(ImageUnitId, ref!ImageUnit)                 ImageUnits
+  @handleMap map!(PipelineId, ref!Pipeline)                   Pipelines
+  @handleMap map!(ProgramId, ref!Program)                     Programs
+  @handleMap map!(QueryId, ref!Query)                         Queries
+  @handleMap map!(RenderbufferId, ref!Renderbuffer)           Renderbuffers
+  @handleMap map!(SamplerId, ref!Sampler)                     Samplers
+  @handleMap map!(ShaderId, ref!Shader)                       Shaders
+  @handleMap map!(GLsync, ref!SyncObject)                     SyncObjects
+  @handleMap map!(TextureUnitId, ref!TextureUnit)             TextureUnits
+  @handleMap map!(TextureId, ref!Texture)                     Textures
+  @handleMap map!(TransformFeedbackId, ref!TransformFeedback) TransformFeedbacks
+  @handleMap map!(VertexArrayId, ref!VertexArray)             VertexArrays
 }
 
 @internal

--- a/gapis/api/state.go
+++ b/gapis/api/state.go
@@ -58,6 +58,9 @@ type GlobalState struct {
 	// OnResourceAccessed is called when a resource is used.
 	OnResourceAccessed func(Resource)
 
+	// OnResourceDestroyed is called when a resource is destroyed.
+	OnResourceDestroyed func(Resource)
+
 	// OnError is called when the command does not conform to the API.
 	OnError func(err interface{})
 

--- a/gapis/api/templates/api.go.tmpl
+++ b/gapis/api/templates/api.go.tmpl
@@ -388,7 +388,7 @@ import (
     return m
   }
 
-  func (m {{$name}}) CreateHandleʷ(ϟctx context.Context, ϟw ϟapi.StateWatcher, key {{$key}}, val {{$value}}) {{$name}} {
+  func (m {{$name}}) CreateHandleʷ(ϟctx context.Context, ϟw ϟapi.StateWatcher, ϟg *ϟapi.GlobalState, key {{$key}}, val {{$value}}) {{$name}} {
     if ϟw != nil {
       ϟw.OnSet(ϟctx, m, ϟapi.MapIndexFragment{key},
         {{Template "Reference" "Type" $.ValueType "Val" "(*m.Map)[key]"}},
@@ -398,6 +398,10 @@ import (
       }
     }
     (*m.Map)[key] = val
+
+    {{if IsReference $.ValueType}}{{if GetAnnotation $.ValueType.To "resource"}}
+      val.OnCreate(ϟg)
+    {{end}}{{end}}
     return m
   }
 
@@ -674,9 +678,8 @@ import (
 
   {{if GetAnnotation $.To "resource"}}
     // OnCreate should be called immediately after the {{$name}} resource is created.
-    func (c {{$name}}) OnCreate(ϟg *ϟapi.GlobalState) {{$name}} {
+    func (c {{$name}}) OnCreate(ϟg *ϟapi.GlobalState) {
       if f := ϟg.OnResourceCreated; c.IsResource() && f != nil { f(c) }
-      return c
     }
 
     // OnAccess should be called each time the {{$name}} resource is used.

--- a/gapis/api/templates/api.go.tmpl
+++ b/gapis/api/templates/api.go.tmpl
@@ -405,7 +405,7 @@ import (
     return m
   }
 
-  func (m {{$name}}) DestroyHandleʷ(ϟctx context.Context, ϟw ϟapi.StateWatcher, key {{$key}}) {
+  func (m {{$name}}) DestroyHandleʷ(ϟctx context.Context, ϟw ϟapi.StateWatcher, ϟg *ϟapi.GlobalState, key {{$key}}) {
     if m.Map != nil {
       if ϟw != nil {
         ϟw.OnSet(ϟctx, m, ϟapi.MapIndexFragment{key},
@@ -415,6 +415,11 @@ import (
           ϟw.CloseForwardDependency(ϟctx, key)
         }
       }
+      {{if IsReference $.ValueType}}{{if GetAnnotation $.ValueType.To "resource"}}
+      if v, ok := (*m.Map)[key]; ok {
+        v.OnDestroy(ϟg)
+      }
+      {{end}}{{end}}
       delete(*m.Map, key)
     }
   }
@@ -686,6 +691,11 @@ import (
     func (c {{$name}}) OnAccess(ϟg *ϟapi.GlobalState) {{$name}} {
       if f := ϟg.OnResourceAccessed; c.IsResource() && f != nil { f(c) }
       return c
+    }
+
+    // OnDestroy should be called immediately after the {{$name}} resource is destroyed.
+    func (c {{$name}}) OnDestroy(ϟg *ϟapi.GlobalState) {
+      if f := ϟg.OnResourceDestroyed; c.IsResource() && f != nil { f(c) }
     }
   {{end}}
 

--- a/gapis/api/templates/go_common.tmpl
+++ b/gapis/api/templates/go_common.tmpl
@@ -684,11 +684,7 @@
 {{define "Go.Create"}}
   {{AssertType $ "Create"}}
 
-  {{if GetAnnotation $.Initializer.Class "resource"}}
-    New{{Template "Go.Type" $.Type}}{{Template "Go.ClassInitializer" $.Initializer}}.OnCreate(ϟg)
-  {{else}}
-    New{{Template "Go.Type" $.Type}}{{Template "Go.ClassInitializer" $.Initializer}}
-  {{end}}
+  New{{Template "Go.Type" $.Type}}{{Template "Go.ClassInitializer" $.Initializer}}
 {{end}}
 
 

--- a/gapis/api/templates/mutate.go.tmpl
+++ b/gapis/api/templates/mutate.go.tmpl
@@ -570,7 +570,7 @@
   {{if eq $.Operator "="}}
     {{Template "Go.Read" $.To.Map}}.§
     {{if GetAnnotation $.To.Map "handleMap"}}
-      CreateHandleʷ(ϟctx, ϟw, §
+      CreateHandleʷ(ϟctx, ϟw, ϟg, §
     {{else if Macro "IsUntrackedMap" $.To.Map}}
       Add(§
     {{else}}§

--- a/gapis/api/templates/mutate.go.tmpl
+++ b/gapis/api/templates/mutate.go.tmpl
@@ -593,7 +593,7 @@
 
   {{Template "Go.Read" $.Map}}.§
   {{if GetAnnotation $.Map "handleMap"}}
-    DestroyHandleʷ(ϟctx, ϟw, §
+    DestroyHandleʷ(ϟctx, ϟw, ϟg, §
   {{else if Macro "IsUntrackedMap" $.Map}}
     Remove(§
   {{else}}

--- a/gapis/service/service.proto
+++ b/gapis/service/service.proto
@@ -847,6 +847,8 @@ message Resource {
   uint64 order = 4;
   // The list of command indices where the resource was used.
   repeated path.Command accesses = 5;
+  // The command at which this resource was deleted/destroyed.
+  path.Command deleted = 6;
 }
 
 // Context represents a single rendering context in the capture.


### PR DESCRIPTION
We already have an OnCreate callback on resources. This change adds an OnDestroy callback. It is implemented by extending the `Create/DestroyHandle` functions on `@handleMap` maps and thus requires resources to be stored in a `@handleMap` map, which they currently are.

Fixes the issue where GLES MEC traces would show two copies of each shader resource in the UI, due to how programs are handled in the state reconstruction.

Allows the user to filter deleted textures in the texture view.