### PR TITLE
Allow partially valid results returned from `find` command when listing files and directories

### DIFF
--- a/cmd/gapir/cc/main.cpp
+++ b/cmd/gapir/cc/main.cpp
@@ -70,12 +70,14 @@ std::vector<uint32_t> memorySizes {
 #if TARGET_OS == GAPID_OS_LINUX || TARGET_OS == GAPID_OS_OSX
 std::string getTempOnDiskCachePath() {
   const char* tmpDir = std::getenv("TMPDIR");
-  struct stat sb;
-  if (!tmpDir && stat("/tmp", &sb) == 0 && S_ISDIR(sb.st_mode)) {
-    tmpDir = "/tmp";
-  } else {
-    GAPID_WARNING("$TMPDIR is null");
-    return "";
+  if (!tmpDir) {
+    struct stat sb;
+    if (stat("/tmp", &sb) == 0 && S_ISDIR(sb.st_mode)) {
+      tmpDir = "/tmp";
+    } else {
+      GAPID_WARNING("$TMPDIR is null and /tmp is not a directory");
+      return "";
+    }
   }
 
   auto t = std::string(tmpDir) + "/gapir-cache.XXXXXX";

--- a/core/os/device/remotessh/commands.go
+++ b/core/os/device/remotessh/commands.go
@@ -321,10 +321,9 @@ func (b binding) ListExecutables(ctx context.Context, inPath string) ([]string, 
 	if inPath == "" {
 		inPath = b.GetURIRoot()
 	}
-	files, err := b.Shell("find", `"`+inPath+`"`, "-mindepth", "1", "-maxdepth", "1", "-type", "f", "-executable", "-printf", `%f\\n`).Call(ctx)
-	if err != nil {
-		return nil, err
-	}
+	// 'find' may partially succeed. Redirect the error messages to /dev/null,
+	// only process the successfully found executables.
+	files, _ := b.Shell("find", `"`+inPath+`"`, "-mindepth", "1", "-maxdepth", "1", "-type", "f", "-executable", "-printf", `%f\\n`, "2>/dev/null").Call(ctx)
 	scanner := bufio.NewScanner(strings.NewReader(files))
 	out := []string{}
 	for scanner.Scan() {
@@ -339,10 +338,9 @@ func (b binding) ListDirectories(ctx context.Context, inPath string) ([]string, 
 	if inPath == "" {
 		inPath = b.GetURIRoot()
 	}
-	dirs, err := b.Shell("find", `"`+inPath+`"`, "-mindepth", "1", "-maxdepth", "1", "-type", "d", "-printf", `%f\\n`).Call(ctx)
-	if err != nil {
-		return nil, err
-	}
+	// 'find' may partially succeed. Redirect the error messages to /dev/null,
+	// only process the successfully found directories.
+	dirs, _ := b.Shell("find", `"`+inPath+`"`, "-mindepth", "1", "-maxdepth", "1", "-type", "d", "-printf", `%f\\n`, "2>/dev/null").Call(ctx)
 	scanner := bufio.NewScanner(strings.NewReader(dirs))
 	out := []string{}
 	for scanner.Scan() {


### PR DESCRIPTION
Sits on top of #2310 

`find` command may partially succeed, in which case we should process
the successfully listed items and ignore the error messages. This CL
redirect the errors generated by `find` to /dev/null to strip away error
messages.
