### PR TITLE
Fix Compressed Texture Compat

### DIFF
--- a/gapis/api/gles/compat.go
+++ b/gapis/api/gles/compat.go
@@ -108,7 +108,7 @@ func getFeatures(ctx context.Context, version string, ext extensions) (features,
 		vertexHalfFloatOES:        ext.get("GL_OES_vertex_half_float"),
 		eglImageExternal:          ext.get("GL_OES_EGL_image_external"),
 		textureMultisample:        ext.get("ARB_texture_multisample"),
-		compressedTextureFormats:  getSupportedCompressedTextureFormats(ext),
+		compressedTextureFormats:  getSupportedCompressedTextureFormats(v, ext),
 		supportGenerateMipmapHint: v.IsES,
 	}
 

--- a/gapis/api/gles/texture_compat.go
+++ b/gapis/api/gles/texture_compat.go
@@ -120,6 +120,14 @@ func (tc *textureCompat) convertFormat(
 	id api.CmdID,
 	cmd api.Cmd) {
 
+	// Compressed formats are replaced by RGBA8
+	// TODO: What about SRGB?
+	if internalformat != nil && isCompressedFormat(internalformat.get()) {
+		if _, supported := tc.f.compressedTextureFormats[internalformat.get()]; !supported {
+			internalformat.set(GLenum_GL_RGBA8)
+		}
+	}
+
 	if tc.v.IsES {
 		return
 	}
@@ -165,14 +173,6 @@ func (tc *textureCompat) convertFormat(
 		case GLenum_GL_RGB10_A2UI: // Not supported in GL 3.2
 			internalformat.set(GLenum_GL_RGBA16UI)
 		case GLenum_GL_STENCIL_INDEX8: // TODO: not supported on desktop.
-		}
-
-		// Compressed formats are replaced by RGBA8
-		// TODO: What about SRGB?
-		if isCompressedFormat(internalformat.get()) {
-			if _, supported := tc.f.compressedTextureFormats[internalformat.get()]; !supported {
-				internalformat.set(GLenum_GL_RGBA8)
-			}
 		}
 	}
 

--- a/gapis/api/gles/texture_compat.go
+++ b/gapis/api/gles/texture_compat.go
@@ -323,14 +323,27 @@ func decompressTexSubImage2D(ctx context.Context, i api.CmdID, a *GlCompressedTe
 
 // getSupportedCompressedTextureFormats returns the set of supported compressed
 // texture formats for a given extension list.
-func getSupportedCompressedTextureFormats(extensions extensions) map[GLenum]struct{} {
+func getSupportedCompressedTextureFormats(v *Version, extensions extensions) map[GLenum]struct{} {
 	supported := map[GLenum]struct{}{}
 	for extension := range extensions {
 		for _, format := range getExtensionTextureFormats(extension) {
 			supported[format] = struct{}{}
 		}
 	}
+	if v.AtLeastES(3, 0) || v.AtLeastGL(4, 3) {
+		supported[GLenum_GL_COMPRESSED_R11_EAC] = struct{}{}
+		supported[GLenum_GL_COMPRESSED_SIGNED_R11_EAC] = struct{}{}
+		supported[GLenum_GL_COMPRESSED_RG11_EAC] = struct{}{}
+		supported[GLenum_GL_COMPRESSED_SIGNED_RG11_EAC] = struct{}{}
+		supported[GLenum_GL_COMPRESSED_RGB8_ETC2] = struct{}{}
+		supported[GLenum_GL_COMPRESSED_SRGB8_ETC2] = struct{}{}
+		supported[GLenum_GL_COMPRESSED_RGB8_PUNCHTHROUGH_ALPHA1_ETC2] = struct{}{}
+		supported[GLenum_GL_COMPRESSED_SRGB8_PUNCHTHROUGH_ALPHA1_ETC2] = struct{}{}
+		supported[GLenum_GL_COMPRESSED_RGBA8_ETC2_EAC] = struct{}{}
+		supported[GLenum_GL_COMPRESSED_SRGB8_ALPHA8_ETC2_EAC] = struct{}{}
+	}
 	return supported
+
 }
 
 // getExtensionTextureFormats returns the list of compressed texture formats


### PR DESCRIPTION
 1) Check compressed texture format in ODR.
  In `compat.go` compressed texture commands check whether the replay target supports the requested compressed format. However, commands that can be used for both uncompressed and compressed textures, such as `glTexStorage2d`, did not in the case of ODR.
 2) Add spec required compressed formats to compat.
 The GLES 3.0 and OpenGL 4.3 specs require some compressed formats to be implemented, so we can assume they are present on the specific versions.