### PR TITLE
Vulkan: Drop VkDestroyXXX and VkFreeXXX commands that refer to not tracked handles

### DIFF
--- a/gapis/api/vulkan/README.md
+++ b/gapis/api/vulkan/README.md
@@ -14,6 +14,23 @@ If tracing from the command line this can be done with
 When using the GUI, this can be acheived by unchecking
 `Trace from Beginning`
 
+### Invalid VkDestoryXXX and VkFreeXXX Commands Due to Mid-Execution Capture
+When using Mid-Execution capture, it is possible that at the time of
+capturing, an object's dependee has been destroyed but the object itself is
+still there, such objects will **NOT** be rebuilt for replay and the
+`VkDestroyXXX` referring to such object will be **dropped** for replay, also
+`VkFreeXXX` commands referring to such objects will be **modified** or
+**dropped** to not freeing those not-rebuilt objects.
+
+For example: A `VkImage` might have been destroyed when a
+Mid-Execution capture starts, but the `VkImageView` handles that were created
+with the destroyed `VkImage` might still be there. In such cases, those
+`VkImageView` handles are invalid and will not be created during replay, also
+the `VkFramebuffer` handles that depend on those `VkImageView` handles will
+not be created during replay too. `VkDestroyImageView` and `VkDestroyFramebuffer`
+commands that refer to those `VkImageView` and `VkFramebuffer` handles will be
+dropped, so won't be called during replay.
+
 ## Subcommands
 When visualizing the tree of Commands, every VkQueueSubmit is expanded into
 a list of the commands that are run during that submission. From there you can

--- a/gapis/api/vulkan/state_rebuilder.go
+++ b/gapis/api/vulkan/state_rebuilder.go
@@ -2493,6 +2493,7 @@ func (sb *stateBuilder) createImageView(iv ImageViewObjectʳ) {
 		!GetState(sb.newState).Images().Contains(iv.Image().VulkanHandle()) {
 		// If the image that this image view points to has been deleted,
 		// then don't even re-create the image view
+		log.W(sb.ctx, "The image of image view %v is invalid, image view %v will not be created", iv.VulkanHandle(), iv.VulkanHandle())
 		return
 	}
 
@@ -2518,6 +2519,7 @@ func (sb *stateBuilder) createBufferView(bv BufferViewObjectʳ) {
 	if !GetState(sb.newState).Buffers().Contains(bv.Buffer().VulkanHandle()) {
 		// If the image that this image view points to has been deleted,
 		// then don't even re-create the image view
+		log.W(sb.ctx, "The buffer of buffer view %v is invalid, buffer view %v will not be created", bv.VulkanHandle(), bv.VulkanHandle())
 		return
 	}
 


### PR DESCRIPTION
For replay, if a Vulkan handle is not tracked, do not call VkDestroyXXX
or VkFreeXXX commands upon it.