### PR TITLE
Add resource.created field.

### DIFF
--- a/gapis/resolve/resources.go
+++ b/gapis/resolve/resources.go
@@ -64,6 +64,7 @@ func (r *ResourcesResolvable) Resolve(ctx context.Context) (interface{}, error) 
 			resource: r,
 			id:       genResourceID(currentCmdIndex, currentCmdResourceCount),
 			accesses: []uint64{currentCmdIndex},
+			created:  currentCmdIndex,
 		})
 	}
 	state.OnResourceAccessed = func(r api.Resource) {
@@ -129,6 +130,7 @@ type trackedResource struct {
 	name     string
 	accesses []uint64
 	deleted  uint64
+	created  uint64
 }
 
 func (r trackedResource) asService(p *path.Capture) *service.Resource {
@@ -145,6 +147,7 @@ func (r trackedResource) asService(p *path.Capture) *service.Resource {
 	if r.deleted > 0 {
 		out.Deleted = p.Command(r.deleted)
 	}
+	out.Created = p.Command(r.created)
 	return out
 }
 

--- a/gapis/service/service.proto
+++ b/gapis/service/service.proto
@@ -849,6 +849,8 @@ message Resource {
   repeated path.Command accesses = 5;
   // The command at which this resource was deleted/destroyed.
   path.Command deleted = 6;
+  // The command at which this resource was created.
+  path.Command created = 7;
 }
 
 // Context represents a single rendering context in the capture.


### PR DESCRIPTION
We already have resource.deleted, which gives the command index at which the resource was deleted.