### PR TITLE
Add create index to resource handle string.

### DIFF
--- a/gapis/resolve/resources.go
+++ b/gapis/resolve/resources.go
@@ -136,7 +136,7 @@ type trackedResource struct {
 func (r trackedResource) asService(p *path.Capture) *service.Resource {
 	out := &service.Resource{
 		ID:       path.NewID(r.id),
-		Handle:   r.resource.ResourceHandle(),
+		Handle:   r.resource.ResourceHandle() + fmt.Sprintf("<%d>", r.created),
 		Label:    r.resource.ResourceLabel(),
 		Order:    r.resource.Order(),
 		Accesses: make([]*path.Command, len(r.accesses)),


### PR DESCRIPTION
This ensures all shaders etc. are accessible in the UI and via gapit dump_resources/replace_resource. 