### PR TITLE
Most gapit verbs can now take a capture ID instead of a gfxtrace file.

### DIFF
--- a/cmd/gapit/BUILD.bazel
+++ b/cmd/gapit/BUILD.bazel
@@ -54,6 +54,7 @@ go_library(
         "//core/app/flags:go_default_library",
         "//core/app/status:go_default_library",
         "//core/data/endian:go_default_library",
+        "//core/data/id:go_default_library",
         "//core/data/pack:go_default_library",
         "//core/data/protoutil:go_default_library",
         "//core/event/task:go_default_library",

--- a/cmd/gapit/dump.go
+++ b/cmd/gapit/dump.go
@@ -19,7 +19,6 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"path/filepath"
 
 	"github.com/google/gapid/core/app"
 	"github.com/google/gapid/core/log"
@@ -43,22 +42,11 @@ func (verb *dumpVerb) Run(ctx context.Context, flags flag.FlagSet) error {
 		return nil
 	}
 
-	client, err := getGapis(ctx, verb.Gapis, verb.Gapir)
+	client, cp, err := getGapisAndLoadCapture(ctx, verb.Gapis, verb.Gapir, flags.Arg(0), verb.CaptureFileFlags)
 	if err != nil {
-		return log.Err(ctx, err, "Failed to connect to the GAPIS server")
+		return err
 	}
 	defer client.Close()
-
-	filepath, err := filepath.Abs(flags.Arg(0))
-	ctx = log.V{"filepath": filepath}.Bind(ctx)
-	if err != nil {
-		return log.Err(ctx, err, "Could not find capture file")
-	}
-
-	cp, err := client.LoadCapture(ctx, filepath)
-	if err != nil {
-		return log.Err(ctx, err, "Failed to load the capture file")
-	}
 
 	boxedCapture, err := client.Get(ctx, cp.Path(), nil)
 	if err != nil {

--- a/cmd/gapit/dump_pipeline.go
+++ b/cmd/gapit/dump_pipeline.go
@@ -19,7 +19,6 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	"path/filepath"
 	"strconv"
 	"strings"
 	"text/tabwriter"
@@ -51,22 +50,11 @@ func (verb *pipeVerb) Run(ctx context.Context, flags flag.FlagSet) error {
 		return nil
 	}
 
-	client, err := getGapis(ctx, verb.Gapis, GapirFlags{})
+	client, c, err := getGapisAndLoadCapture(ctx, verb.Gapis, GapirFlags{}, flags.Arg(0), verb.CaptureFileFlags)
 	if err != nil {
-		return log.Err(ctx, err, "Failed to connect to the GAPIS server")
+		return err
 	}
 	defer client.Close()
-
-	filepath, err := filepath.Abs(flags.Arg(0))
-	ctx = log.V{"filepath": filepath}.Bind(ctx)
-	if err != nil {
-		return log.Err(ctx, err, "Could not find capture file")
-	}
-
-	c, err := client.LoadCapture(ctx, filepath)
-	if err != nil {
-		return log.Err(ctx, err, "Failed to load the capture file")
-	}
 
 	if len(verb.At) == 0 {
 		boxedCapture, err := client.Get(ctx, c.Path(), nil)

--- a/cmd/gapit/dump_shaders.go
+++ b/cmd/gapit/dump_shaders.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"flag"
 	"os"
-	"path/filepath"
 
 	"github.com/google/gapid/core/app"
 	"github.com/google/gapid/core/log"
@@ -48,21 +47,11 @@ func (verb *dumpShadersVerb) Run(ctx context.Context, flags flag.FlagSet) error 
 		return nil
 	}
 
-	filepath, err := filepath.Abs(flags.Arg(0))
+	client, capture, err := getGapisAndLoadCapture(ctx, verb.Gapis, verb.Gapir, flags.Arg(0), verb.CaptureFileFlags)
 	if err != nil {
-		return log.Errf(ctx, err, "Could not find capture file '%s'", flags.Arg(0))
-	}
-
-	client, err := getGapis(ctx, verb.Gapis, verb.Gapir)
-	if err != nil {
-		return log.Err(ctx, err, "Failed to connect to the GAPIS server")
+		return err
 	}
 	defer client.Close()
-
-	capture, err := client.LoadCapture(ctx, filepath)
-	if err != nil {
-		return log.Errf(ctx, err, "Failed to load the capture file '%v'", filepath)
-	}
 
 	boxedResources, err := client.Get(ctx, capture.Resources().Path(), nil)
 	if err != nil {

--- a/cmd/gapit/export_replay.go
+++ b/cmd/gapit/export_replay.go
@@ -17,7 +17,6 @@ package main
 import (
 	"context"
 	"flag"
-	"path/filepath"
 
 	"github.com/google/gapid/core/app"
 	"github.com/google/gapid/core/log"
@@ -45,21 +44,11 @@ func (verb *exportReplayVerb) Run(ctx context.Context, flags flag.FlagSet) error
 		return nil
 	}
 
-	capture, err := filepath.Abs(flags.Arg(0))
+	client, capturePath, err := getGapisAndLoadCapture(ctx, verb.Gapis, verb.Gapir, flags.Arg(0), verb.CaptureFileFlags)
 	if err != nil {
-		log.Errf(ctx, err, "Could not find capture file: %v", flags.Arg(0))
-	}
-
-	client, err := getGapis(ctx, verb.Gapis, verb.Gapir)
-	if err != nil {
-		return log.Err(ctx, err, "Failed to connect to the GAPIS server")
+		return err
 	}
 	defer client.Close()
-
-	capturePath, err := client.LoadCapture(ctx, capture)
-	if err != nil {
-		return log.Err(ctx, err, "Failed to load the capture file")
-	}
 
 	var device *path.Device
 	if !verb.OriginalDevice {
@@ -91,7 +80,7 @@ func (verb *exportReplayVerb) Run(ctx context.Context, flags flag.FlagSet) error
 		for _, e := range eofEvents {
 			fbreqs = append(fbreqs, &service.GetFramebufferAttachmentRequest{
 				ReplaySettings: &service.ReplaySettings{
-					Device: device,
+					Device:                    device,
 					DisableReplayOptimization: true,
 				},
 				After:      e.Command,

--- a/cmd/gapit/export_replay.go
+++ b/cmd/gapit/export_replay.go
@@ -80,7 +80,7 @@ func (verb *exportReplayVerb) Run(ctx context.Context, flags flag.FlagSet) error
 		for _, e := range eofEvents {
 			fbreqs = append(fbreqs, &service.GetFramebufferAttachmentRequest{
 				ReplaySettings: &service.ReplaySettings{
-					Device:                    device,
+					Device: device,
 					DisableReplayOptimization: true,
 				},
 				After:      e.Command,

--- a/cmd/gapit/flags.go
+++ b/cmd/gapit/flags.go
@@ -68,6 +68,9 @@ func (v PackagesOutput) String() string {
 }
 
 type (
+	CaptureFileFlags struct {
+		CaptureID bool `help:"if true then interpret the capture file argument as a capture ID that is already loaded in gapis"`
+	}
 	CommandFilterFlags struct {
 		Context int `help:"Filter to the i'th context."`
 	}
@@ -81,7 +84,7 @@ type (
 		Os     string            `help:"Os of the device to trace on."`
 		Env    flags.StringSlice `help:"List of environment variables to set, X=Y"`
 		Ssh    struct {
-			Config string `help: "The ssh config to use for finding remote devices"`
+			Config string `help:"The ssh config to use for finding remote devices"`
 		}
 	}
 	DevicesFlags struct {
@@ -111,6 +114,7 @@ type (
 		Out              string `help:"output report path"`
 		DisplayToSurface bool   `help:"display the frames rendered in the replay back to the surface"`
 		CommandFilterFlags
+		CaptureFileFlags
 	}
 	ExportReplayFlags struct {
 		Gapis          GapisFlags
@@ -119,6 +123,7 @@ type (
 		Out            string `help:"output directory for commands and assets"`
 		OutputFrames   bool   `help:"generate trace that output frames(disable diagnostics)"`
 		CommandFilterFlags
+		CaptureFileFlags
 	}
 	VideoFlags struct {
 		Gapis GapisFlags
@@ -139,17 +144,20 @@ type (
 		}
 		NoOpt bool `help:"disables optimization of the replay stream"`
 		CommandFilterFlags
+		CaptureFileFlags
 	}
 	DumpShadersFlags struct {
 		Gapis GapisFlags
 		Gapir GapirFlags
 		At    int `help:"command index to dump the resources after"`
+		CaptureFileFlags
 	}
 	DumpFBOFlags struct {
 		Gapis GapisFlags
 		Gapir GapirFlags
 		Out   string `help:"output framebuffer directory path"`
 		CommandFilterFlags
+		CaptureFileFlags
 	}
 	DumpFlags struct {
 		Gapis          GapisFlags
@@ -158,6 +166,7 @@ type (
 		ShowDeviceInfo bool `help:"if true then show originating device information."`
 		ShowABIInfo    bool `help:"if true then show information of the ABI used for the trace."`
 		Observations   ObservationFlags
+		CaptureFileFlags
 	}
 	CommandsFlags struct {
 		Gapis                  GapisFlags
@@ -184,17 +193,21 @@ type (
 		At                   int    `help:"command index to replace the resource(s) at"`
 		UpdateResourceBinary string `help:"shaders only. binary to run for every shader; consumes resource data from standard input and writes to standard output"`
 		OutputTraceFile      string `help:"file name for the updated trace"`
+		SkipOutput           bool   `help:"skip writing the modified trace to a file"`
+		CaptureFileFlags
 	}
 	StateFlags struct {
 		Gapis  GapisFlags
 		Gapir  GapirFlags
 		At     flags.U64Slice    `help:"command/subcommand index to get the state after. Empty for last"`
-		Depth  int               `help: "How many nodes deep should the state tree be displayed. -1 for all"`
-		Filter flags.StringSlice `help: "Which path through the tree should we filter to, default All"`
+		Depth  int               `help:"How many nodes deep should the state tree be displayed. -1 for all"`
+		Filter flags.StringSlice `help:"Which path through the tree should we filter to, default All"`
+		CaptureFileFlags
 	}
 	StressTestFlags struct {
 		Gapis GapisFlags
 		Gapir GapirFlags
+		CaptureFileFlags
 	}
 	TraceFlags struct {
 		DeviceFlags
@@ -275,6 +288,7 @@ type (
 		}
 		DisplayToSurface bool `help:"display the frames rendered in the replay back to the surface"`
 		CommandFilterFlags
+		CaptureFileFlags
 	}
 	UnpackFlags struct {
 		Verbose bool `help:"if true, then output will not be truncated"`
@@ -285,10 +299,12 @@ type (
 			Start int `help:"frame to start stats from"`
 			Count int `help:"number of frames after Start to process: -1 for all frames"`
 		}
+		CaptureFileFlags
 	}
 	MemoryFlags struct {
 		Gapis GapisFlags
 		At    flags.U64Slice `help:"command/subcommand index to get the memory after. Empty for last"`
+		CaptureFileFlags
 	}
 	PipelineFlags struct {
 		Gapis GapisFlags
@@ -297,6 +313,7 @@ type (
 			Shaders bool `help:"print the disassembled shaders along with the bound descriptor values"`
 		}
 		Compute bool `help:"print out the most recently bound compute pipeline instead of graphics pipeline"`
+		CaptureFileFlags
 	}
 	TrimFlags struct {
 		Gapis         GapisFlags
@@ -309,5 +326,6 @@ type (
 		}
 		Out string `help:"gfxtrace file to save the trimmed capture"`
 		CommandFilterFlags
+		CaptureFileFlags
 	}
 )

--- a/cmd/gapit/replace_resource.go
+++ b/cmd/gapit/replace_resource.go
@@ -63,21 +63,11 @@ func (verb *replaceResourceVerb) Run(ctx context.Context, flags flag.FlagSet) er
 		return nil
 	}
 
-	captureFilepath, err := filepath.Abs(flags.Arg(0))
+	client, capture, err := getGapisAndLoadCapture(ctx, verb.Gapis, verb.Gapir, flags.Arg(0), verb.CaptureFileFlags)
 	if err != nil {
-		return log.Errf(ctx, err, "Could not find capture file '%s'", flags.Arg(0))
-	}
-
-	client, err := getGapis(ctx, verb.Gapis, verb.Gapir)
-	if err != nil {
-		return log.Err(ctx, err, "Failed to connect to the GAPIS server")
+		return err
 	}
 	defer client.Close()
-
-	capture, err := client.LoadCapture(ctx, captureFilepath)
-	if err != nil {
-		return log.Errf(ctx, err, "Failed to load the capture file '%v'", captureFilepath)
-	}
 
 	boxedResources, err := client.Get(ctx, capture.Resources().Path(), nil)
 	if err != nil {
@@ -152,10 +142,22 @@ func (verb *replaceResourceVerb) Run(ctx context.Context, flags flag.FlagSet) er
 		return log.Errf(ctx, err, "Could not update resource data: %v", resourcePath)
 	}
 	newCapture := path.FindCapture(newResourcePath.Node())
-	newCaptureFilepath, err := filepath.Abs(verb.OutputTraceFile)
-	err = client.SaveCapture(ctx, newCapture, newCaptureFilepath)
+	log.I(ctx, "New capture id: %s", newCapture.ID)
 
-	log.I(ctx, "Capture written to: %v", newCaptureFilepath)
+	if verb.SkipOutput {
+		log.I(ctx, "Skipped writing new capture to file.")
+	} else {
+		newCaptureFilepath, err := filepath.Abs(verb.OutputTraceFile)
+		if err != nil {
+			return log.Errf(ctx, err, "Could not handle capture file path '%s'", newCaptureFilepath)
+		}
+		err = client.SaveCapture(ctx, newCapture, newCaptureFilepath)
+		if err != nil {
+			return log.Errf(ctx, err, "Failed to write capture to: '%s'", newCaptureFilepath)
+		}
+		log.I(ctx, "Capture written to: '%s'", newCaptureFilepath)
+	}
+
 	return nil
 }
 

--- a/cmd/gapit/report.go
+++ b/cmd/gapit/report.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path/filepath"
 
 	"github.com/google/gapid/core/app"
 	"github.com/google/gapid/core/log"
@@ -51,14 +50,9 @@ func (verb *reportVerb) Run(ctx context.Context, flags flag.FlagSet) error {
 		return nil
 	}
 
-	capture, err := filepath.Abs(flags.Arg(0))
+	client, capturePath, err := getGapisAndLoadCapture(ctx, verb.Gapis, verb.Gapir, flags.Arg(0), verb.CaptureFileFlags)
 	if err != nil {
-		log.Errf(ctx, err, "Could not find capture file: %v", flags.Arg(0))
-	}
-
-	client, err := getGapis(ctx, verb.Gapis, verb.Gapir)
-	if err != nil {
-		return log.Err(ctx, err, "Failed to connect to the GAPIS server")
+		return err
 	}
 	defer client.Close()
 
@@ -74,11 +68,6 @@ func (verb *reportVerb) Run(ctx context.Context, flags flag.FlagSet) error {
 		if err != nil {
 			return log.Err(ctx, err, "Failed get string table")
 		}
-	}
-
-	capturePath, err := client.LoadCapture(ctx, capture)
-	if err != nil {
-		return log.Err(ctx, err, "Failed to load the capture file")
 	}
 
 	device, err := getDevice(ctx, client, capturePath, verb.Gapir)

--- a/cmd/gapit/screenshot.go
+++ b/cmd/gapit/screenshot.go
@@ -146,7 +146,7 @@ func (verb *screenshotVerb) getSingleFrame(ctx context.Context, cmd *path.Comman
 	}
 	iip, err := client.GetFramebufferAttachment(ctx,
 		&service.ReplaySettings{
-			Device:                    device,
+			Device: device,
 			DisableReplayOptimization: verb.NoOpt,
 			DisplayToSurface:          verb.DisplayToSurface,
 		},

--- a/cmd/gapit/state.go
+++ b/cmd/gapit/state.go
@@ -19,7 +19,6 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	"path/filepath"
 
 	"github.com/google/gapid/core/app"
 	"github.com/google/gapid/core/app/flags"
@@ -54,22 +53,11 @@ func (verb *stateVerb) Run(ctx context.Context, flags flag.FlagSet) error {
 		return nil
 	}
 
-	client, err := getGapis(ctx, verb.Gapis, verb.Gapir)
+	client, c, err := getGapisAndLoadCapture(ctx, verb.Gapis, verb.Gapir, flags.Arg(0), verb.CaptureFileFlags)
 	if err != nil {
-		return log.Err(ctx, err, "Failed to connect to the GAPIS server")
+		return err
 	}
 	defer client.Close()
-
-	filepath, err := filepath.Abs(flags.Arg(0))
-	ctx = log.V{"filepath": filepath}.Bind(ctx)
-	if err != nil {
-		return log.Err(ctx, err, "Could not find capture file")
-	}
-
-	c, err := client.LoadCapture(ctx, filepath)
-	if err != nil {
-		return log.Err(ctx, err, "Failed to load the capture file")
-	}
 
 	if len(verb.At) == 0 {
 		boxedCapture, err := client.Get(ctx, c.Path(), nil)

--- a/cmd/gapit/stresstest.go
+++ b/cmd/gapit/stresstest.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"flag"
 	"math/rand"
-	"path/filepath"
 	"sync"
 	"time"
 
@@ -47,22 +46,11 @@ func (verb *stresstestVerb) Run(ctx context.Context, flags flag.FlagSet) error {
 		return nil
 	}
 
-	client, err := getGapis(ctx, verb.Gapis, verb.Gapir)
+	client, c, err := getGapisAndLoadCapture(ctx, verb.Gapis, verb.Gapir, flags.Arg(0), verb.CaptureFileFlags)
 	if err != nil {
-		return log.Err(ctx, err, "Failed to connect to the GAPIS server")
+		return err
 	}
 	defer client.Close()
-
-	filepath, err := filepath.Abs(flags.Arg(0))
-	ctx = log.V{"filepath": filepath}.Bind(ctx)
-	if err != nil {
-		return log.Err(ctx, err, "Could not find capture file")
-	}
-
-	c, err := client.LoadCapture(ctx, filepath)
-	if err != nil {
-		return log.Err(ctx, err, "Failed to load the capture file")
-	}
 
 	boxedCapture, err := client.Get(ctx, c.Path(), nil)
 	if err != nil {

--- a/cmd/gapit/trim.go
+++ b/cmd/gapit/trim.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"flag"
 	"io/ioutil"
-	"path/filepath"
 
 	"github.com/google/gapid/core/app"
 	"github.com/google/gapid/core/log"
@@ -45,21 +44,11 @@ func (verb *trimVerb) Run(ctx context.Context, flags flag.FlagSet) error {
 		return nil
 	}
 
-	filepath, err := filepath.Abs(flags.Arg(0))
+	client, capture, err := getGapisAndLoadCapture(ctx, verb.Gapis, verb.Gapir, flags.Arg(0), verb.CaptureFileFlags)
 	if err != nil {
-		return log.Errf(ctx, err, "Finding file: %v", flags.Arg(0))
-	}
-
-	client, err := getGapis(ctx, verb.Gapis, verb.Gapir)
-	if err != nil {
-		return log.Err(ctx, err, "Failed to connect to the GAPIS server")
+		return err
 	}
 	defer client.Close()
-
-	capture, err := client.LoadCapture(ctx, filepath)
-	if err != nil {
-		return log.Errf(ctx, err, "LoadCapture(%v)", filepath)
-	}
 
 	eofEvents, err := verb.eofEvents(ctx, capture, client)
 	if err != nil {

--- a/cmd/gapit/video.go
+++ b/cmd/gapit/video.go
@@ -333,7 +333,7 @@ func getFrame(ctx context.Context, maxWidth, maxHeight int, cmd *path.Command, d
 	ctx = log.V{"cmd": cmd.Indices}.Bind(ctx)
 	settings := &service.RenderSettings{MaxWidth: uint32(maxWidth), MaxHeight: uint32(maxHeight)}
 	iip, err := client.GetFramebufferAttachment(ctx, &service.ReplaySettings{
-		Device:                    device,
+		Device: device,
 		DisableReplayOptimization: noOpt,
 	}, cmd, api.FramebufferAttachment_Color0, settings, nil)
 	if err != nil {


### PR DESCRIPTION
I would like to be able to pass a capture ID and a gapis-port to `gapit screenshot` so that it will take a screenshot of some capture that is already loaded. This avoids me having to wait 5 mins per screenshot to load the capture; instead, I can load it once from disk and then refer to it later via its capture ID. I would also like to modify (i.e. create mutated versions of) captures in gapis without writing them to disk, so this PR will be useful in this scenario.

Slightly weird: since the capture file is a positional/non-flag argument, I am attempting to parse it as a hex string (capture ID) and, if that fails, treating it as a file as before. If you have a filename that happens to be a hex string, you could use e.g. "./0000FFFFF". Could alternatively use a flag and then expect no positional args.