### PR TITLE
Avoid querying GLES 3.0 features in 2.0.

### DIFF
--- a/core/os/device/deviceinfo/cc/gl.cpp
+++ b/core/os/device/deviceinfo/cc/gl.cpp
@@ -48,12 +48,6 @@ void glDriver(device::OpenGLDriver* driver) {
   GAPID_ASSERT(glGetError != nullptr);
   GAPID_ASSERT(glGetString != nullptr);
 
-  glGetIntegerv(GL_UNIFORM_BUFFER_OFFSET_ALIGNMENT, &uniformbufferalignment);
-  glGetIntegerv(GL_MAX_TRANSFORM_FEEDBACK_SEPARATE_ATTRIBS,
-                &maxtransformfeedbackseparateattribs);
-  glGetIntegerv(GL_MAX_TRANSFORM_FEEDBACK_INTERLEAVED_COMPONENTS,
-                &maxtransformfeedbackinterleavedcomponents);
-
   glGetError();  // Clear error state.
   glGetIntegerv(GL_MAJOR_VERSION, &major_version);
   glGetIntegerv(GL_MINOR_VERSION, &minor_version);
@@ -67,6 +61,12 @@ void glDriver(device::OpenGLDriver* driver) {
   if (major_version >= 3) {
     GAPID_ASSERT(glGetIntegerv != nullptr);
     GAPID_ASSERT(glGetStringi != nullptr);
+
+    glGetIntegerv(GL_UNIFORM_BUFFER_OFFSET_ALIGNMENT, &uniformbufferalignment);
+    glGetIntegerv(GL_MAX_TRANSFORM_FEEDBACK_SEPARATE_ATTRIBS,
+                  &maxtransformfeedbackseparateattribs);
+    glGetIntegerv(GL_MAX_TRANSFORM_FEEDBACK_INTERLEAVED_COMPONENTS,
+                  &maxtransformfeedbackinterleavedcomponents);
 
     int32_t c = 0;
     glGetIntegerv(GL_NUM_EXTENSIONS, &c);

--- a/gapii/cc/gles_extras.cpp
+++ b/gapii/cc/gles_extras.cpp
@@ -60,8 +60,10 @@ static void GetProgramReflectionInfo_GLES20(GlesSpy* spy,
   int32_t maxLength = 0;
   maxLength = std::max(maxLength, getProgramiv(GL_ACTIVE_ATTRIBUTE_MAX_LENGTH));
   maxLength = std::max(maxLength, getProgramiv(GL_ACTIVE_UNIFORM_MAX_LENGTH));
-  maxLength = std::max(maxLength,
-                       getProgramiv(GL_ACTIVE_UNIFORM_BLOCK_MAX_NAME_LENGTH));
+  if (gles30) {
+    maxLength = std::max(maxLength,
+                         getProgramiv(GL_ACTIVE_UNIFORM_BLOCK_MAX_NAME_LENGTH));
+  }
   maxLength += 16;  // extra space for appending of array suffix
   std::vector<char> buffer(maxLength);
 


### PR DESCRIPTION
These cause avoidable GL errors.