### PR TITLE
Make the Go garbage-collector more aggressive.

### DIFF
--- a/core/app/run.go
+++ b/core/app/run.go
@@ -18,6 +18,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"runtime/debug"
 	"sync"
 	"syscall"
 	"time"
@@ -112,6 +113,10 @@ func (v VersionSpec) Format(f fmt.State, c rune) {
 func init() {
 	Name = file.Abs(os.Args[0]).Basename()
 	Flags.Log = logDefaults()
+	// TODO(awoloszyn): Figure out why object churn is soo bad, and try to
+	//                  minimize it.
+	//                  At that point we can remove this.
+	debug.SetGCPercent(40)
 }
 
 // getArgs preprocesses the command line arguments to


### PR DESCRIPTION
This will make the go GC more aggressive in collecting
objects, this provides a significant reduction in
our peak memory usage, and prevents some OOM cases.

The performance implications of this are fairly minimal,
(<5%) but the memory savings are sigificant (25-30% reduction
of peak memory usage)