### PR TITLE
Vulkan: Fix framebuffer and querypool creation for initial state

### DIFF
--- a/gapis/api/vulkan/scratch_resources.go
+++ b/gapis/api/vulkan/scratch_resources.go
@@ -16,7 +16,6 @@ package vulkan
 
 import (
 	"github.com/google/gapid/core/data/id"
-	"github.com/google/gapid/core/log"
 	"github.com/google/gapid/gapis/database"
 	"github.com/google/gapid/gapis/memory"
 )
@@ -221,6 +220,9 @@ func (qr *queueFamilyScratchResources) bindAndFillBuffers(totalAllocationSize ui
 		deviceMemory = qr.getDeviceMemory()
 		allocated = qr.allocated
 		usingTempMem = false
+		if totalAllocationSize == uint64(0) || len(buffers) == 0 {
+			return deviceMemory, usingTempMem
+		}
 	}
 	atData := sb.MustReserve(totalAllocationSize)
 	ptrAtData := sb.newState.AllocDataOrPanic(sb.ctx, NewVoidᵖ(atData.Ptr()))
@@ -380,9 +382,6 @@ func (sb *stateBuilder) newScratchTaskOnQueue(queue VkQueue) *scratchTask {
 // callbacks to the after-execution callback queue.
 func (t *scratchTask) commit() error {
 	sb := t.sb
-	if t.totalAllocationSize == uint64(0) {
-		return log.Err(sb.ctx, nil, "Nil or empty scratch buffer session")
-	}
 	res := sb.getQueueFamilyScratchResources(t.queue)
 	if mem, isTemp := res.bindAndFillBuffers(t.totalAllocationSize, t.buffers); isTemp {
 		// The fixed size scratch buffer is not large enough for the allocation,

--- a/gapis/api/vulkan/state_rebuilder.go
+++ b/gapis/api/vulkan/state_rebuilder.go
@@ -2584,7 +2584,7 @@ func (sb *stateBuilder) createDescriptorPoolAndAllocateDescriptorSets(dp Descrip
 func (sb *stateBuilder) createFramebuffer(fb FramebufferObjectʳ) {
 	var temporaryRenderPass RenderPassObjectʳ
 	for _, v := range fb.ImageAttachments().All() {
-		if !GetState(sb.oldState).ImageViews().Contains(v.VulkanHandle()) {
+		if !GetState(sb.newState).ImageViews().Contains(v.VulkanHandle()) {
 			log.W(sb.ctx, "Image View %v is invalid, framebuffer %v will not be created", v.VulkanHandle(), fb.VulkanHandle())
 			return
 		}


### PR DESCRIPTION
1. Framebuffer creation should depend on the image views in the new
state not the old state
2. ScratchTask should allow tasks with no new memory allocation, this
bug prevents the querypool state to be recovered correctly.