### PR TITLE
Move the constants and opcodes out of the volatile memory region.

### DIFF
--- a/cmd/gapir/cc/main.cpp
+++ b/cmd/gapir/cc/main.cpp
@@ -185,7 +185,7 @@ void android_main(struct android_app* app) {
                       "Supported ABIs: %s\n",
                       uri.c_str(), core::supportedABIs());
 
-  auto cache = InMemoryResourceCache::create(memoryManager.getBaseAddress());
+  auto cache = InMemoryResourceCache::create(memoryManager.getTopAddress());
   int idleTimeoutSec = 0;  // No timeout
   std::mutex lock;
   std::unique_ptr<Server> server =
@@ -359,7 +359,7 @@ std::unique_ptr<ResourceCache> createCache(
     const Options::OnDiskCache& onDiskCacheOpts, MemoryManager* memoryManager) {
 #if TARGET_OS == GAPID_OS_LINUX || TARGET_OS == GAPID_OS_OSX
   if (!onDiskCacheOpts.enabled) {
-    return InMemoryResourceCache::create(memoryManager->getBaseAddress());
+    return InMemoryResourceCache::create(memoryManager->getTopAddress());
   }
   auto onDiskCachePath = std::string(onDiskCacheOpts.path);
   bool cleanUpOnDiskCache = onDiskCacheOpts.cleanUp;
@@ -374,14 +374,14 @@ std::unique_ptr<ResourceCache> createCache(
         "No disk cache path specified and no $TMPDIR environment variable "
         "defined for temporary on-disk cache, fallback to use in-memory "
         "cache.");
-    return InMemoryResourceCache::create(memoryManager->getBaseAddress());
+    return InMemoryResourceCache::create(memoryManager->getTopAddress());
   }
   auto onDiskCache =
       OnDiskResourceCache::create(onDiskCachePath, cleanUpOnDiskCache);
   if (onDiskCache == nullptr) {
     GAPID_WARNING(
         "On-disk cache creation failed, fallback to use in-memory cache");
-    return InMemoryResourceCache::create(memoryManager->getBaseAddress());
+    return InMemoryResourceCache::create(memoryManager->getTopAddress());
   }
   GAPID_INFO("On-disk cache created at %s", onDiskCachePath.c_str());
   if (cleanUpOnDiskCache || useTempCacheFolder) {
@@ -427,7 +427,7 @@ std::unique_ptr<ResourceCache> createCache(
   }
 #endif  // TARGET_OS == GAPID_OS_LINUX || TARGET_OS == GAPID_OS_OSX
   // Just use the in-memory cache
-  return InMemoryResourceCache::create(memoryManager->getBaseAddress());
+  return InMemoryResourceCache::create(memoryManager->getTopAddress());
 }
 }  // namespace
 

--- a/gapir/cc/context.cpp
+++ b/gapir/cc/context.cpp
@@ -104,9 +104,7 @@ bool Context::initialize() {
 }
 
 void Context::prefetch(ResourceCache* cache) const {
-  auto cacheSize = static_cast<uint32_t>(
-      static_cast<uint8_t*>(mMemoryManager->getVolatileAddress()) -
-      static_cast<uint8_t*>(mMemoryManager->getBaseAddress()));
+  auto cacheSize = static_cast<uint32_t>(mMemoryManager->getFreeSpace());
   cache->resize(cacheSize);
   auto resources = mReplayRequest->getResources();
   if (resources.size() == 0) {

--- a/gapir/cc/in_memory_resource_cache.cpp
+++ b/gapir/cc/in_memory_resource_cache.cpp
@@ -156,14 +156,14 @@ bool InMemoryResourceCache::putCache(const Resource& resource,
 
   // Copy data.
   if (mHead->offset + resource.size <= mBufferSize) {
-    memcpy(mBuffer + mHead->offset, data, resource.size);
+    memcpy(mBuffer - mHead->offset - resource.size, data, resource.size);
   } else {
     // Wraps the end of the buffer
     const uint8_t* dst = reinterpret_cast<const uint8_t*>(data);
     size_t a = mBufferSize - mHead->offset;
     size_t b = resource.size - a;
-    memcpy(mBuffer + mHead->offset, dst, a);
-    memcpy(mBuffer, dst + a, b);
+    memcpy(mBuffer - mBufferSize, dst, a);
+    memcpy(mBuffer - b, dst + a, b);
   }
 
   // Move head on to the next block.
@@ -182,14 +182,14 @@ bool InMemoryResourceCache::loadCache(const Resource& resource, void* data) {
   // Cached resource found. Copy data.
   size_t offset = mCache.find(resource.id)->second;
   if (offset + resource.size <= mBufferSize) {
-    memcpy(data, mBuffer + offset, resource.size);
+    memcpy(data, mBuffer - offset - resource.size, resource.size);
   } else {
     // Wraps the end of the buffer
     uint8_t* dst = reinterpret_cast<uint8_t*>(data);
     size_t a = mBufferSize - offset;
     size_t b = resource.size - a;
-    memcpy(dst, mBuffer + offset, a);
-    memcpy(dst + a, mBuffer, b);
+    memcpy(dst, mBuffer - mBufferSize, a);
+    memcpy(dst + a, mBuffer - b, b);
   }
   return true;
 }

--- a/gapir/cc/in_memory_resource_cache.h
+++ b/gapir/cc/in_memory_resource_cache.h
@@ -105,7 +105,7 @@ class InMemoryResourceCache : public ResourceCache {
   // A map of cached resource identifiers to offsets on mBuffer.
   std::unordered_map<ResourceId, size_t> mCache;
 
-  // The base address and the size of the memory used for caching.
+  // The top address and the size of the memory used for caching.
   // This memory region is owned by the memory manager class, not by the cache
   // itself.
   uint8_t* mBuffer;
@@ -164,11 +164,8 @@ inline void InMemoryResourceCache::free(Block* block) {
 inline void InMemoryResourceCache::foreach_block(
     Block* first, const std::function<void(Block*)>& cb) {
   std::vector<Block*> blocks;
-  blocks.push_back(first);
+  cb(first);
   for (Block* block = first->next; block != first; block = block->next) {
-    blocks.push_back(block);
-  }
-  for (Block* block : blocks) {
     cb(block);
   }
 }

--- a/gapir/cc/in_memory_resource_cache_test.cpp
+++ b/gapir/cc/in_memory_resource_cache_test.cpp
@@ -50,7 +50,7 @@ class ResourceInMemoryCacheTest : public Test {
     mMemoryManager.reset(new MemoryManager(memorySizes));
     mMemoryManager->setVolatileMemory(MEMORY_SIZE - CACHE_SIZE);
 
-    mCache = InMemoryResourceCache::create(mMemoryManager->getBaseAddress());
+    mCache = InMemoryResourceCache::create(mMemoryManager->getTopAddress());
     mMemoryCachedResourceLoader = CachedResourceLoader::create(
         mCache.get(),
         std::unique_ptr<ResourceLoader>(new StrictMock<MockResourceLoader>()));

--- a/gapir/cc/interpreter_test.cpp
+++ b/gapir/cc/interpreter_test.cpp
@@ -109,11 +109,9 @@ TEST_F(InterpreterTest, PushIDouble1) {
 }
 
 TEST_F(InterpreterTest, LoadC) {
-  mMemoryManager->setReplayDataSize(10, 0);
-  uint8_t constantMemory[7] = {0x00, 0x00, 0x12, 0x34, 0x56, 0x78, 0x9a};
-  uint8_t* constantBaseAddress =
-      static_cast<uint8_t*>(mMemoryManager->getConstantAddress());
-  memcpy(constantBaseAddress, &constantMemory, sizeof(constantMemory));
+  uint8_t constantMemory[10] = {0x00, 0x00, 0x12, 0x34, 0x56,
+                                0x78, 0x9a, 0x00, 0x00, 0x00};
+  mMemoryManager->setReplayData(constantMemory, 10, nullptr, 0);
 
   mInterpreter->registerBuiltin(0, 0, CheckTopOfStack<uint16_t>{0x7856});
 
@@ -136,12 +134,10 @@ TEST_F(InterpreterTest, LoadV) {
 }
 
 TEST_F(InterpreterTest, LoadConstantAddress) {
-  mMemoryManager->setReplayDataSize(10, 0);
-  uint8_t constantMemory[7] = {0x00, 0x00, 0x12, 0x34, 0x56, 0x78, 0x9a};
-  uint8_t* constantBaseAddress =
-      static_cast<uint8_t*>(mMemoryManager->getConstantAddress());
-  memcpy(constantBaseAddress, &constantMemory, 7);
+  uint8_t const_memory[10] = {0x00, 0x00, 0x12, 0x34, 0x56,
+                              0x78, 0x9a, 0x00, 0x00, 0x00};
 
+  mMemoryManager->setReplayData(const_memory, 10, nullptr, 0);
   mInterpreter->registerBuiltin(0, 0, CheckTopOfStack<uint16_t>{0x7856});
 
   std::vector<uint32_t> instructions{
@@ -207,11 +203,8 @@ TEST_F(InterpreterTest, Store) {
 }
 
 TEST_F(InterpreterTest, Copy) {
-  mMemoryManager->setReplayDataSize(20, 0);
-  uint8_t constantMemory[10] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
-  uint8_t* constantBaseAddress =
-      static_cast<uint8_t*>(mMemoryManager->getConstantAddress());
-  memcpy(constantBaseAddress, &constantMemory, 10);
+  uint8_t constantMemory[20] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0};
+  mMemoryManager->setReplayData(constantMemory, 20, nullptr, 0);
 
   std::vector<uint32_t> instructions{
       instruction(Interpreter::InstructionCode::PUSH_I,
@@ -307,12 +300,11 @@ TEST_F(InterpreterTest, Add3xFloat) {
 }
 
 TEST_F(InterpreterTest, Strcpy) {
-  mMemoryManager->setReplayDataSize(20, 0);
+  uint8_t const_memory[20] = {};
   const char* constantMemory = "abc";
-  uint8_t* constantBaseAddress =
-      static_cast<uint8_t*>(mMemoryManager->getConstantAddress());
-  memcpy(constantBaseAddress, constantMemory, 4);
+  memcpy(const_memory, constantMemory, 4);
 
+  mMemoryManager->setReplayData(const_memory, 20, nullptr, 0);
   uint8_t* volatileMemory =
       static_cast<uint8_t*>(mMemoryManager->volatileToAbsolute(100));
 
@@ -335,11 +327,10 @@ TEST_F(InterpreterTest, Strcpy) {
 }
 
 TEST_F(InterpreterTest, StrcpyShortBuffer) {
-  mMemoryManager->setReplayDataSize(20, 0);
+  uint8_t const_memory[20] = {};
   const char* constantMemory = "abcdef";
-  uint8_t* constantBaseAddress =
-      static_cast<uint8_t*>(mMemoryManager->getConstantAddress());
-  memcpy(constantBaseAddress, constantMemory, 7);
+  memcpy(const_memory, constantMemory, 7);
+  mMemoryManager->setReplayData(const_memory, 20, nullptr, 0);
 
   uint8_t* volatileMemory =
       static_cast<uint8_t*>(mMemoryManager->volatileToAbsolute(100));

--- a/gapir/cc/memory_manager.cpp
+++ b/gapir/cc/memory_manager.cpp
@@ -24,21 +24,20 @@
 
 //                 mMemory[0]
 //   ┏━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━┓
-//   ┃             ┃        in-memory       ┃
-//   ┃             ┃        resource        ┃
-//   ┃             ┃          cache         ┃
-//   ┃             ┣━━━━━━━━━━━━━━━━━━━━━━━━┨
+//   ┃             ┃                        ┃
+//   ┃             ┃                        ┃
 //   ┃             ┃                        ┃
 //   ┃             ┃         volatile       ┃
 //   ┃   mMemory   ┃          memory        ┃
 //   ┃             ┃                        ┃
-//   ┃             ┣━━━━━━━━━━━━┳━━━━━━━━━━━┨
-//   ┃             ┃            ┃  constant ┃
-//   ┃             ┃   replay   ┃   memory  ┃
-//   ┃             ┃    data    ┣━━━━━━━━━━━┨
-//   ┃             ┃            ┃   opcode  ┃
-//   ┃             ┃            ┃   memory  ┃
-//   ┗━━━━━━━━━━━━━┻━━━━━━━━━━━━┻━━━━━━━━━━━┛
+//   ┃             ┃                        ┨
+//   ┃             ┣━━━━━━━━━━━━━━━━━━━━━━━━┨
+//   ┃             ┃                        ┃
+//   ┃             ┃        in-memory       ┃
+//   ┃             ┃        resource        ┃
+//   ┃             ┃          cache         ┃
+//   ┃             ┃                        ┃
+//   ┗━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━━━━━━━━━━┛
 //                 mMemory[mSize]
 
 namespace gapir {
@@ -49,9 +48,11 @@ namespace {
 const float kDriverOverheadFactor = 0.3f;
 }  // namespace
 
-MemoryManager::MemoryRange::MemoryRange() : base(nullptr), size(0) {}
+template <typename T>
+MemoryManager::MemoryRange<T>::MemoryRange() : base(nullptr), size(0) {}
 
-MemoryManager::MemoryRange::MemoryRange(uint8_t* base, uint32_t size)
+template <typename T>
+MemoryManager::MemoryRange<T>::MemoryRange(T* base, uint32_t size)
     : base(base), size(size) {}
 
 MemoryManager::MemoryManager(const std::vector<uint32_t>& sizeList)
@@ -78,48 +79,15 @@ MemoryManager::MemoryManager(const std::vector<uint32_t>& sizeList)
   }
 
   GAPID_DEBUG("Base address: %p", mMemory.get());
-  setReplayDataSize(0, 0);
   setVolatileMemory(mSize);
 }
 
-bool MemoryManager::setReplayDataSize(uint32_t constantMemorySize,
-                                      uint32_t opcodeMemorySize) {
-  GAPID_DEBUG("MemoryManager::setReplayDataSize(%d, %d)", constantMemorySize,
-              opcodeMemorySize);
-  if (opcodeMemorySize > mSize) {
-    GAPID_ERROR("Opcode memory size: %d larger than total memory size: %d",
-                opcodeMemorySize, mSize);
-    return false;
-  }
-  mOpcodeMemory = {align(mMemory.get() + mSize - opcodeMemorySize),
-                   opcodeMemorySize};
-  GAPID_DEBUG("Opcode range: [%p,%p]", mOpcodeMemory.base,
-              mOpcodeMemory.base + mOpcodeMemory.size - 1);
-
-  if (constantMemorySize > mSize - mOpcodeMemory.size) {
-    GAPID_ERROR(
-        "Constant memory size: %d larger than available memory size: %d",
-        constantMemorySize, mSize - mOpcodeMemory.size);
-    return false;
-  }
-  mConstantMemory = {align(mOpcodeMemory.base - constantMemorySize),
-                     constantMemorySize};
-  GAPID_DEBUG("Constant range: [%p,%p]", mConstantMemory.base,
-              mConstantMemory.base + mConstantMemory.size - 1);
-
-  mReplayData = {mConstantMemory.base,
-                 mConstantMemory.size + mOpcodeMemory.size};
-  GAPID_DEBUG("Replay range: [%p,%p]", mReplayData.base,
-              mReplayData.base + mReplayData.size - 1);
-  return true;
-}
-
 bool MemoryManager::setVolatileMemory(uint32_t size) {
-  if (size > mSize - mReplayData.size) {
+  if (size > mSize) {
     return false;
   }
 
-  mVolatileMemory = {align(mReplayData.base - size), size};
+  mVolatileMemory = {&mMemory[0], size};
   GAPID_DEBUG("Volatile range: [%p,%p]", mVolatileMemory.base,
               mVolatileMemory.base + mVolatileMemory.size - 1);
   return true;
@@ -129,6 +97,16 @@ uint8_t* MemoryManager::align(uint8_t* addr) const {
   uintptr_t x = reinterpret_cast<uintptr_t>(addr);
   x -= x % MemoryManager::kAlignment;
   return reinterpret_cast<uint8_t*>(x);
+}
+
+void MemoryManager::setReplayData(const uint8_t* constantMemoryBase,
+                                  uint32_t constantMemorySize,
+                                  const uint8_t* opcodeMemoryBase,
+                                  uint32_t opcodeMemorySize) {
+  mConstantMemory =
+      MemoryRange<const uint8_t>{constantMemoryBase, constantMemorySize};
+  mOpcodeMemory =
+      MemoryRange<const uint8_t>{opcodeMemoryBase, opcodeMemorySize};
 }
 
 }  // namespace gapir

--- a/gapir/cc/memory_manager_test.cpp
+++ b/gapir/cc/memory_manager_test.cpp
@@ -44,25 +44,13 @@ TEST_F(MemoryManagerTest, ConstantMemoryIsEmptyByDefault) {
 
 TEST_F(MemoryManagerTest, ConstantSizeIsCorrect) {
   // 64 bytes of opcodes, and 192 bytes of constants
-  mMemoryManager->setReplayDataSize(192, 64);
+  mMemoryManager->setReplayData(nullptr, 192, nullptr, 64);
   EXPECT_EQ(192, mMemoryManager->getConstantSize());
   EXPECT_EQ(64, mMemoryManager->getOpcodeSize());
-  EXPECT_EQ((uint8_t*)mMemoryManager->getConstantAddress(),
-            (uint8_t*)mMemoryManager->getOpcodeAddress() - 192);
 }
 
 TEST_F(MemoryManagerTest, DefaultVolatileSizeIsMemorySize) {
   EXPECT_EQ(MEMORY_SIZE, mMemoryManager->getVolatileSize());
-}
-
-TEST_F(MemoryManagerTest, SetReplayDataSize) {
-  EXPECT_TRUE(mMemoryManager->setReplayDataSize(MEMORY_SIZE, 0));
-  EXPECT_FALSE(mMemoryManager->setReplayDataSize(MEMORY_SIZE + 1, 0));
-  EXPECT_TRUE(mMemoryManager->setReplayDataSize(MEMORY_SIZE, 0));
-
-  EXPECT_TRUE(mMemoryManager->setReplayDataSize(0, MEMORY_SIZE));
-  EXPECT_FALSE(mMemoryManager->setReplayDataSize(0, MEMORY_SIZE + 1));
-  EXPECT_TRUE(mMemoryManager->setReplayDataSize(0, MEMORY_SIZE));
 }
 
 TEST_F(MemoryManagerTest, ExplicitVolatileSizeIsUpdated) {
@@ -74,22 +62,19 @@ TEST_F(MemoryManagerTest, ExplicitVolatileSizeIsUpdated) {
 }
 
 TEST_F(MemoryManagerTest, OutOfBoundsVolatileSizeFails) {
-  EXPECT_TRUE(mMemoryManager->setReplayDataSize(MEMORY_SIZE / 2, 0));
-
-  EXPECT_TRUE(mMemoryManager->setVolatileMemory(MEMORY_SIZE / 2));
-  EXPECT_FALSE(mMemoryManager->setVolatileMemory(MEMORY_SIZE / 2 + 1));
-  EXPECT_TRUE(mMemoryManager->setVolatileMemory(MEMORY_SIZE / 2));
+  EXPECT_TRUE(mMemoryManager->setVolatileMemory(MEMORY_SIZE));
+  EXPECT_FALSE(mMemoryManager->setVolatileMemory(MEMORY_SIZE + 1));
+  EXPECT_TRUE(mMemoryManager->setVolatileMemory(MEMORY_SIZE));
 }
 
 TEST_F(MemoryManagerTest, IsConstantAddressWorks) {
-  uint32_t constantMemorySize = 1024;
+  const uint32_t constantMemorySize = 1024;
+  uint8_t const_memory[constantMemorySize] = {};
 
   std::vector<uint8_t> constantMemory(constantMemorySize, 0);
-  mMemoryManager->setReplayDataSize(constantMemorySize, 128);
-  uint8_t* constantBase =
-      static_cast<uint8_t*>(mMemoryManager->getReplayAddress());
-  EXPECT_EQ(mMemoryManager->getReplayAddress(),
-            mMemoryManager->getConstantAddress());
+  mMemoryManager->setReplayData(const_memory, constantMemorySize, nullptr, 0);
+  uint8_t* constantBase = const_cast<uint8_t*>(
+      static_cast<const uint8_t*>(mMemoryManager->getConstantAddress()));
   memcpy(constantBase, &constantMemory.front(), constantMemory.size());
 
   EXPECT_TRUE(mMemoryManager->isConstantAddress(constantBase));
@@ -105,7 +90,6 @@ TEST_F(MemoryManagerTest, IsConstantAddressWorks) {
 TEST_F(MemoryManagerTest, IsVolatileAddressWorks) {
   uint32_t volatileSize = 1024;
 
-  mMemoryManager->setReplayDataSize(512, 0);
   mMemoryManager->setVolatileMemory(volatileSize);
   uint8_t* volatileBase =
       static_cast<uint8_t*>(mMemoryManager->volatileToAbsolute(0));
@@ -129,14 +113,14 @@ TEST_F(MemoryManagerTest, AbsoluteToVolatile) {
 }
 
 TEST_F(MemoryManagerTest, AbsoluteToConstant) {
-  uint32_t constantMemorySize = 1024;
+  const uint32_t constantMemorySize = 1024;
+  uint8_t const_memory[constantMemorySize] = {};
 
   std::vector<uint8_t> constantMemory(constantMemorySize, 0);
-  mMemoryManager->setReplayDataSize(constantMemorySize, 128);
-  uint8_t* constantBase =
-      static_cast<uint8_t*>(mMemoryManager->getReplayAddress());
-  EXPECT_EQ(mMemoryManager->getReplayAddress(),
-            mMemoryManager->getConstantAddress());
+  mMemoryManager->setReplayData(const_memory, constantMemorySize, nullptr, 0);
+  uint8_t* constantBase = const_cast<uint8_t*>(
+      static_cast<const uint8_t*>(mMemoryManager->getConstantAddress()));
+
   memcpy(constantBase, &constantMemory.front(), constantMemory.size());
   EXPECT_EQ(
       10,

--- a/gapir/cc/replay_request.h
+++ b/gapir/cc/replay_request.h
@@ -75,6 +75,10 @@ class ReplayRequest {
 
   // The list of resources (resource id, resource size) used by the replay
   std::vector<Resource> mResources;
+
+  // This is the payload provided by the server.
+  // mConstnatMemory/mInstructionList point into this payload.
+  std::unique_ptr<ReplayService::Payload> mPayload;
 };
 
 }  // namespace gapir

--- a/gapir/cc/stack_test.cpp
+++ b/gapir/cc/stack_test.cpp
@@ -36,9 +36,12 @@ class StackTest : public ::testing::Test {
     std::vector<uint32_t> memorySizes = {MEMORY_SIZE};
     mMemoryManager.reset(new MemoryManager(memorySizes));
     mStack.reset(new Stack(STACK_CAPACITY, mMemoryManager.get()));
-    mMemoryManager->setReplayDataSize(CONSTANT_SIZE, 0);
+
+    mMemoryManager->setReplayData(const_memory, constantMemorySize, nullptr, 0);
   }
 
+  static const uint32_t constantMemorySize = 1024;
+  uint8_t const_memory[constantMemorySize] = {};
   std::unique_ptr<MemoryManager> mMemoryManager;
   std::unique_ptr<Stack> mStack;
 };

--- a/gapir/client/connection.go
+++ b/gapir/client/connection.go
@@ -135,7 +135,7 @@ func (c *Connection) SendResources(ctx context.Context, resources []byte) error 
 		},
 	}
 	if err := c.stream.Send(&resReq); err != nil {
-		return log.Err(ctx, err, "Sneding resources")
+		return log.Err(ctx, err, "Sending resources")
 	}
 	return nil
 }


### PR DESCRIPTION
This is a prerequisite for some upcomming replay changes to
allow us to pre-warm the VM.