### PR TITLE
Add profile command to query timestamps when replay the trace

### DIFF
--- a/cmd/gapit/BUILD.bazel
+++ b/cmd/gapit/BUILD.bazel
@@ -40,6 +40,7 @@ go_library(
         "stats.go",
         "stresstest.go",
         "sxs_video.go",
+        "profile.go",
         "trace.go",
         "trim.go",
         "unpack.go",

--- a/cmd/gapit/flags.go
+++ b/cmd/gapit/flags.go
@@ -329,4 +329,9 @@ type (
 		CommandFilterFlags
 		CaptureFileFlags
 	}
+	GetTimestampsFlags struct {
+		Gapis GapisFlags
+		Gapir GapirFlags
+		Out   string `help:"output file to save the profiling result"`
+	}
 )

--- a/cmd/gapit/profile.go
+++ b/cmd/gapit/profile.go
@@ -1,0 +1,110 @@
+// Copyright (C) 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"encoding/csv"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/google/gapid/core/app"
+	"github.com/google/gapid/core/log"
+	"github.com/google/gapid/gapis/service"
+	"github.com/google/gapid/gapis/service/path"
+)
+
+type profileVerb struct{ GetTimestampsFlags }
+
+func init() {
+	verb := &profileVerb{}
+	app.AddVerb(&app.Verb{
+		Name:      "profile",
+		ShortHelp: "Profile a replay to get the time of executing the commands.",
+		Action:    verb,
+	})
+}
+
+func (verb *profileVerb) Run(ctx context.Context, flags flag.FlagSet) error {
+	if flags.NArg() != 1 {
+		app.Usage(ctx, "Exactly one gfx trace file expected, got %d", flags.NArg())
+		return nil
+	}
+	capture, err := filepath.Abs(flags.Arg(0))
+	if err != nil {
+		log.Errf(ctx, err, "Could not find capture file: %v", flags.Arg(0))
+	}
+
+	client, err := getGapis(ctx, verb.Gapis, verb.Gapir)
+	if err != nil {
+		return log.Err(ctx, err, "Failed to connect to the GAPIS server")
+	}
+	defer client.Close()
+
+	capturePath, err := client.LoadCapture(ctx, capture)
+	if err != nil {
+		return log.Err(ctx, err, "Failed to load the capture file")
+	}
+
+	device, err := getDevice(ctx, client, capturePath, verb.Gapir)
+	if err != nil {
+		return err
+	}
+
+	var out io.Writer = os.Stdout
+	if verb.Out != "" {
+		f, err := os.OpenFile(verb.Out, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0644)
+		if err != nil {
+			return log.Err(ctx, err, "Failed to open report output file")
+		}
+		defer f.Close()
+		out = f
+	}
+
+	boxedRes, err := client.GetTimestamps(ctx, capturePath, device)
+	if err != nil {
+		return log.Err(ctx, err, "Failed to get the timestamps")
+	}
+	res := boxedRes.(*service.GetTimestampsResponse)
+
+	reportWriter := csv.NewWriter(out)
+	defer reportWriter.Flush()
+
+	header := []string{"BeginCmd", "EndCmd", "Time(ns)"}
+	if err = reportWriter.Write(header); err != nil {
+		log.Err(ctx, err, "Failed to write header")
+	}
+
+	cmdToString := func(cmd *path.Command) string {
+		return strings.Trim(strings.Join(strings.Fields(fmt.Sprint(cmd.Indices)), "."), "[]")
+	}
+
+	if ts := res.GetTimestamps(); ts != nil {
+		for _, t := range ts.Timestamps {
+			begin := cmdToString(t.Begin)
+			end := cmdToString(t.End)
+			record := []string{begin, end, fmt.Sprint(t.Time)}
+			if err := reportWriter.Write(record); err != nil {
+				log.Err(ctx, err, "Failed to write record")
+			}
+		}
+	}
+
+	return nil
+}

--- a/cmd/gapit/profile.go
+++ b/cmd/gapit/profile.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2017 Google Inc.
+// Copyright (C) 2018 Google Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -99,7 +99,7 @@ func (verb *profileVerb) Run(ctx context.Context, flags flag.FlagSet) error {
 		for _, t := range ts.Timestamps {
 			begin := cmdToString(t.Begin)
 			end := cmdToString(t.End)
-			record := []string{begin, end, fmt.Sprint(t.Time)}
+			record := []string{begin, end, fmt.Sprint(t.TimeInNanoseconds)}
 			if err := reportWriter.Write(record); err != nil {
 				log.Err(ctx, err, "Failed to write record")
 			}

--- a/gapis/api/vulkan/BUILD.bazel
+++ b/gapis/api/vulkan/BUILD.bazel
@@ -63,6 +63,7 @@ go_library(
         "draw_call_mesh.go",
         "externs.go",
         "find_issues.go",
+        "query_timestamps.go",
         "footprint_builder.go",
         "image_primer.go",
         "image_primer_shaders.go",

--- a/gapis/api/vulkan/api/query_pool.api
+++ b/gapis/api/vulkan/api/query_pool.api
@@ -116,6 +116,7 @@ cmd void vkDestroyQueryPool(
 // hangs depending on the state of the query pool
 // TODO(awoloszyn): Work out all of the cases where this
 // may cause hangs, and fix it for replay.
+// Currently(12/11/2018) comments out for getting timestamps out.
 cmd VkResult vkGetQueryPoolResults(
     VkDevice           device,
     VkQueryPool        queryPool,

--- a/gapis/api/vulkan/api/query_pool.api
+++ b/gapis/api/vulkan/api/query_pool.api
@@ -110,7 +110,7 @@ cmd void vkDestroyQueryPool(
 @threadSafety("system")
 @indirect("VkDevice")
 @threadsafe
-@no_replay
+//@no_replay
 // GetQueryPoolResults has no semantic impact
 // on replay, so avoid replaying it. It can cause
 // hangs depending on the state of the query pool

--- a/gapis/api/vulkan/api/query_pool.api
+++ b/gapis/api/vulkan/api/query_pool.api
@@ -110,13 +110,6 @@ cmd void vkDestroyQueryPool(
 @threadSafety("system")
 @indirect("VkDevice")
 @threadsafe
-//@no_replay
-// GetQueryPoolResults has no semantic impact
-// on replay, so avoid replaying it. It can cause
-// hangs depending on the state of the query pool
-// TODO(awoloszyn): Work out all of the cases where this
-// may cause hangs, and fix it for replay.
-// Currently(12/11/2018) comments out for getting timestamps out.
 cmd VkResult vkGetQueryPoolResults(
     VkDevice           device,
     VkQueryPool        queryPool,

--- a/gapis/api/vulkan/query_timestamps.go
+++ b/gapis/api/vulkan/query_timestamps.go
@@ -1,0 +1,437 @@
+// Copyright (C) 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vulkan
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/gapid/core/data/binary"
+	"github.com/google/gapid/core/log"
+	"github.com/google/gapid/gapis/api"
+	"github.com/google/gapid/gapis/api/transform"
+	"github.com/google/gapid/gapis/capture"
+	"github.com/google/gapid/gapis/memory"
+	"github.com/google/gapid/gapis/replay"
+	"github.com/google/gapid/gapis/replay/builder"
+	"github.com/google/gapid/gapis/replay/value"
+	"github.com/google/gapid/gapis/service/path"
+)
+
+type queryTimestamps struct {
+	commandPool     VkCommandPool
+	queryPool       VkQueryPool
+	queryPoolSize   uint32
+	device          VkDevice
+	timestampPeriod float32
+	replayResult    []replay.Result
+	timestamps      []replay.Timestamps
+	allocated       []*api.AllocResult
+	resultIndex     uint32
+}
+
+const queryPoolSize = 256
+
+func newQueryTimestamps(ctx context.Context, c *capture.Capture, numInitialCmds int) *queryTimestamps {
+	transform := &queryTimestamps{
+		queryPoolSize: queryPoolSize,
+	}
+	return transform
+}
+
+func (t *queryTimestamps) mustAllocData(ctx context.Context, s *api.GlobalState, v ...interface{}) api.AllocResult {
+	res := s.AllocDataOrPanic(ctx, v...)
+	t.allocated = append(t.allocated, &res)
+	return res
+}
+
+func (t *queryTimestamps) reportTo(r replay.Result) { t.replayResult = append(t.replayResult, r) }
+
+func (t *queryTimestamps) createQueryPoolIfNeeded(ctx context.Context,
+	cb CommandBuilder,
+	out transform.Writer,
+	numQuery uint32) {
+	s := out.State()
+
+	if GetState(s).QueryPools().Contains(t.queryPool) {
+		if numQuery <= t.queryPoolSize {
+			return
+		}
+		// Destroy old query pool.
+		newCmd := cb.VkDestroyQueryPool(
+			t.device,
+			t.queryPool,
+			memory.Nullptr)
+		out.MutateAndWrite(ctx, api.CmdNoID, newCmd)
+		// Increase the size of pool to 1.5 times of previous size every time.
+		t.queryPoolSize = t.queryPoolSize * 3 / 2
+	}
+
+	log.I(ctx, "Create query pool of size %d", t.queryPoolSize)
+
+	queryPool := VkQueryPool(newUnusedID(false, func(id uint64) bool {
+		return GetState(s).QueryPools().Contains(VkQueryPool(id))
+	}))
+
+	queryPoolHandleData := t.mustAllocData(ctx, s, queryPool)
+	queryPoolCreateInfo := t.mustAllocData(ctx, s, NewVkQueryPoolCreateInfo(s.Arena,
+		VkStructureType_VK_STRUCTURE_TYPE_QUERY_POOL_CREATE_INFO, // sType
+		0,                                   // pNext
+		0,                                   // flags
+		VkQueryType_VK_QUERY_TYPE_TIMESTAMP, // queryType
+		t.queryPoolSize,                     // queryCount
+		0,                                   // pipelineStatistics
+	))
+
+	newCmd := cb.VkCreateQueryPool(
+		t.device,
+		queryPoolCreateInfo.Ptr(),
+		memory.Nullptr,
+		queryPoolHandleData.Ptr(),
+		VkResult_VK_SUCCESS)
+
+	newCmd.AddRead(queryPoolCreateInfo.Data()).AddWrite(queryPoolHandleData.Data())
+	t.queryPool = queryPool
+	out.MutateAndWrite(ctx, api.CmdNoID, newCmd)
+}
+
+func (t *queryTimestamps) createComandpoolIfNeeded(ctx context.Context,
+	cb CommandBuilder,
+	out transform.Writer,
+	queueFamilyIndex uint32) {
+	s := out.State()
+
+	if GetState(s).CommandPools().Contains(VkCommandPool(t.commandPool)) {
+		return
+	}
+
+	commandPoolID := VkCommandPool(newUnusedID(false,
+		func(x uint64) bool {
+			ok := GetState(s).CommandPools().Contains(VkCommandPool(x))
+			return ok
+		}))
+	commandPoolCreateInfo := NewVkCommandPoolCreateInfo(s.Arena,
+		VkStructureType_VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO,                                 // sType
+		NewVoidᶜᵖ(memory.Nullptr),                                                                  // pNext
+		VkCommandPoolCreateFlags(VkCommandPoolCreateFlagBits_VK_COMMAND_POOL_CREATE_TRANSIENT_BIT), // flags
+		queueFamilyIndex, // queueFamilyIndex
+	)
+	commandPoolCreateInfoData := t.mustAllocData(ctx, s, commandPoolCreateInfo)
+	commandPoolData := t.mustAllocData(ctx, s, commandPoolID)
+
+	newCmd := cb.VkCreateCommandPool(
+		t.device,
+		commandPoolCreateInfoData.Ptr(),
+		memory.Nullptr,
+		commandPoolData.Ptr(),
+		VkResult_VK_SUCCESS,
+	).AddRead(
+		commandPoolCreateInfoData.Data(),
+	).AddWrite(
+		commandPoolData.Data(),
+	)
+	out.MutateAndWrite(ctx, api.CmdNoID, newCmd)
+
+	t.commandPool = commandPoolID
+}
+
+func (t *queryTimestamps) generateQueryCommand(ctx context.Context,
+	cb CommandBuilder,
+	out transform.Writer,
+	query uint32) VkCommandBuffer {
+
+	s := out.State()
+	commandBufferAllocateInfo := NewVkCommandBufferAllocateInfo(s.Arena,
+		VkStructureType_VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO, // sType
+		NewVoidᶜᵖ(memory.Nullptr),                                      // pNext
+		t.commandPool,                                                  // commandPool
+		VkCommandBufferLevel_VK_COMMAND_BUFFER_LEVEL_PRIMARY,           // level
+		1, // commandBufferCount
+	)
+	commandBufferAllocateInfoData := t.mustAllocData(ctx, s, commandBufferAllocateInfo)
+	commandBufferID := VkCommandBuffer(newUnusedID(true,
+		func(x uint64) bool {
+			ok := GetState(s).CommandBuffers().Contains(VkCommandBuffer(x))
+			return ok
+		}))
+	commandBufferData := t.mustAllocData(ctx, s, commandBufferID)
+
+	beginCommandBufferInfo := NewVkCommandBufferBeginInfo(s.Arena,
+		VkStructureType_VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO, // sType
+		0, // pNext
+		VkCommandBufferUsageFlags(VkCommandBufferUsageFlagBits_VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT), // flags
+		0, // pInheritanceInfo
+	)
+	beginCommandBufferInfoData := t.mustAllocData(ctx, s, beginCommandBufferInfo)
+
+	writeEach(ctx, out,
+		cb.VkAllocateCommandBuffers(
+			t.device,
+			commandBufferAllocateInfoData.Ptr(),
+			commandBufferData.Ptr(),
+			VkResult_VK_SUCCESS,
+		).AddRead(
+			commandBufferAllocateInfoData.Data(),
+		).AddWrite(
+			commandBufferData.Data(),
+		),
+		cb.VkBeginCommandBuffer(
+			commandBufferID,
+			beginCommandBufferInfoData.Ptr(),
+			VkResult_VK_SUCCESS,
+		).AddRead(
+			beginCommandBufferInfoData.Data(),
+		),
+		cb.VkCmdResetQueryPool(commandBufferID, t.queryPool, query, 1),
+		cb.VkCmdWriteTimestamp(commandBufferID,
+			VkPipelineStageFlagBits_VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT,
+			t.queryPool,
+			query),
+		cb.VkEndCommandBuffer(
+			commandBufferID,
+			VkResult_VK_SUCCESS,
+		),
+	)
+
+	return commandBufferID
+}
+
+func (t *queryTimestamps) rewriteQueueSubmit(ctx context.Context,
+	cb CommandBuilder,
+	out transform.Writer,
+	id api.CmdID,
+	cmd *VkQueueSubmit) {
+
+	s := out.State()
+	l := s.MemoryLayout
+	reads := []api.AllocResult{}
+	allocAndRead := func(v ...interface{}) api.AllocResult {
+		res := t.mustAllocData(ctx, s, v)
+		reads = append(reads, res)
+		return res
+	}
+
+	cmd.Extras().Observations().ApplyReads(s.Memory.ApplicationPool())
+	submitCount := cmd.SubmitCount()
+	submitInfos := cmd.pSubmits.Slice(0, uint64(submitCount), s.MemoryLayout).MustRead(ctx, cmd, s, nil)
+	newSubmitInfos := make([]VkSubmitInfo, submitCount)
+	query := uint32(0)
+	for i := uint32(0); i < submitCount; i++ {
+		si := submitInfos[i]
+		waitSemPtr := memory.Nullptr
+		waitDstStagePtr := memory.Nullptr
+		if count := uint64(si.WaitSemaphoreCount()); count > 0 {
+			waitSemPtr = allocAndRead(si.PWaitSemaphores().
+				Slice(0, count, l).
+				MustRead(ctx, cmd, s, nil)).Ptr()
+			waitDstStagePtr = allocAndRead(si.PWaitDstStageMask().
+				Slice(0, count, l).
+				MustRead(ctx, cmd, s, nil)).Ptr()
+		}
+
+		signalSemPtr := memory.Nullptr
+		if count := uint64(si.SignalSemaphoreCount()); count > 0 {
+			signalSemPtr = allocAndRead(si.PSignalSemaphores().
+				Slice(0, count, l).
+				MustRead(ctx, cmd, s, nil)).Ptr()
+		}
+
+		cmdBuffers := si.PCommandBuffers().Slice(0, uint64(si.CommandBufferCount()), s.MemoryLayout).MustRead(ctx, cmd, s, nil)
+		cmdCount := si.CommandBufferCount()
+		newCmdCount := cmdCount*2 + 1
+
+		commandbuffer := t.generateQueryCommand(ctx,
+			cb,
+			out,
+			query)
+		newCmdBUffers := make([]VkCommandBuffer, newCmdCount)
+		newCmdBUffers[0] = commandbuffer
+		for j := uint32(0); j < cmdCount; j++ {
+			buf := cmdBuffers[j]
+			newCmdBUffers[j*2+1] = buf
+
+			query++
+			commandbuffer = t.generateQueryCommand(ctx,
+				cb,
+				out,
+				query)
+			newCmdBUffers[j*2+2] = commandbuffer
+
+			begin := &path.Command{
+				Indices: []uint64{uint64(id), uint64(i), uint64(j), 0},
+			}
+			c, ok := GetState(s).CommandBuffers().Lookup(buf)
+			if !ok {
+				fmt.Errorf("Invalid command buffer %v", buf)
+			}
+			n := c.CommandReferences().Len()
+			end := &path.Command{
+				Indices: []uint64{uint64(id), uint64(i), uint64(j), uint64(n - 1)},
+			}
+			t.timestamps = append(t.timestamps, replay.Timestamps{Begin: begin, End: end})
+		}
+
+		cmdBufferPtr := allocAndRead(newCmdBUffers).Ptr()
+		newSubmitInfos[i] = NewVkSubmitInfo(s.Arena,
+			VkStructureType_VK_STRUCTURE_TYPE_SUBMIT_INFO,
+			0,                            // pNext
+			si.WaitSemaphoreCount(),      // waitSemaphoreCount
+			NewVkSemaphoreᶜᵖ(waitSemPtr), // pWaitSemaphores
+			NewVkPipelineStageFlagsᶜᵖ(waitDstStagePtr), // pWaitDstStageMask
+			newCmdCount,                        // commandBufferCount
+			NewVkCommandBufferᶜᵖ(cmdBufferPtr), // pCommandBuffers
+			si.SignalSemaphoreCount(),          // signalSemaphoreCount
+			NewVkSemaphoreᶜᵖ(signalSemPtr),     // pSignalSemaphores
+		)
+	}
+
+	submitInfoPtr := allocAndRead(newSubmitInfos).Ptr()
+
+	newCmd := cb.VkQueueSubmit(
+		cmd.Queue(),
+		cmd.SubmitCount(),
+		submitInfoPtr,
+		cmd.Fence(),
+		VkResult_VK_SUCCESS,
+	)
+
+	for _, read := range reads {
+		newCmd.AddRead(read.Data())
+	}
+	out.MutateAndWrite(ctx, id, newCmd)
+}
+
+func (t *queryTimestamps) Transform(ctx context.Context, id api.CmdID, cmd api.Cmd, out transform.Writer) {
+	s := out.State()
+	cb := CommandBuilder{Thread: cmd.Thread(), Arena: s.Arena}
+
+	defer func() {
+		for _, d := range t.allocated {
+			d.Free()
+		}
+	}()
+
+	switch cmd := cmd.(type) {
+	case *VkGetPhysicalDeviceProperties:
+		cmd.Extras().Observations().ApplyWrites(s.Memory.ApplicationPool())
+		out.MutateAndWrite(ctx, id, cmd)
+		info := cmd.pProperties.MustRead(ctx, cmd, s, nil)
+		t.timestampPeriod = info.Limits().TimestampPeriod()
+		log.I(ctx, "TimestampPeriod is %v", t.timestampPeriod)
+
+	case *VkCreateDevice:
+		out.MutateAndWrite(ctx, id, cmd)
+		cmd.Extras().Observations().ApplyWrites(s.Memory.ApplicationPool())
+		t.device = cmd.pDevice.MustRead(ctx, cmd, s, nil)
+
+	case *VkQueueSubmit:
+		cmd.Extras().Observations().ApplyReads(s.Memory.ApplicationPool())
+		queue := cmd.Queue()
+		queueFamilyIndex := GetState(s).Queues().Get(queue).Family()
+		submitCount := cmd.SubmitCount()
+		submitInfos := cmd.pSubmits.Slice(0, uint64(submitCount), s.MemoryLayout).MustRead(ctx, cmd, s, nil)
+		cmdBufferCount := uint32(0)
+		for i := uint32(0); i < submitCount; i++ {
+			si := submitInfos[i]
+			cmdBufferCount += si.CommandBufferCount()
+		}
+		queryCount := cmdBufferCount * 2
+
+		t.createComandpoolIfNeeded(ctx, cb, out, queueFamilyIndex)
+		t.createQueryPoolIfNeeded(ctx, cb, out, queryCount)
+		t.rewriteQueueSubmit(ctx, cb, out, id, cmd)
+
+		waitCmd := cb.VkQueueWaitIdle(queue, VkResult_VK_SUCCESS)
+		out.MutateAndWrite(ctx, id, waitCmd)
+
+		// Get result back.
+		buflen := uint64(queryCount * 8)
+		tmp := s.AllocOrPanic(ctx, buflen)
+		flags := VkQueryResultFlags(VkQueryResultFlagBits_VK_QUERY_RESULT_64_BIT | VkQueryResultFlagBits_VK_QUERY_RESULT_WAIT_BIT)
+		newCmd := cb.VkGetQueryPoolResults(
+			t.device,
+			t.queryPool,
+			0,
+			queryCount,
+			memory.Size(buflen),
+			tmp.Ptr(),
+			8,
+			flags,
+			VkResult_VK_SUCCESS)
+
+		out.MutateAndWrite(ctx, api.CmdNoID, newCmd)
+
+		out.MutateAndWrite(ctx, api.CmdNoID, cb.Custom(func(ctx context.Context, s *api.GlobalState, b *builder.Builder) error {
+			b.ReserveMemory(tmp.Range())
+			b.Post(value.ObservedPointer(tmp.Address()), buflen, func(r binary.Reader, err error) {
+				if err != nil {
+					log.I(ctx, "b post get err %v", err)
+					return
+				}
+
+				tStart := r.Uint64()
+				for i := uint32(1); i < queryCount; i++ {
+					tEnd := r.Uint64()
+					t.timestamps[t.resultIndex].Time = uint64(float32(tEnd-tStart) * t.timestampPeriod)
+					t.resultIndex++
+					tStart = tEnd
+				}
+
+			})
+			return nil
+		}))
+
+		tmp.Free()
+
+	case *VkDestroyCommandPool:
+		cmd.Extras().Observations().ApplyReads(s.Memory.ApplicationPool())
+		writeEach(ctx, out,
+			cb.VkDestroyCommandPool(
+				t.device,
+				t.commandPool,
+				memory.Nullptr),
+			cb.VkDestroyQueryPool(
+				t.device,
+				t.queryPool,
+				memory.Nullptr))
+
+		out.MutateAndWrite(ctx, id, cmd)
+	default:
+		out.MutateAndWrite(ctx, id, cmd)
+	}
+}
+
+func (t *queryTimestamps) Flush(ctx context.Context, out transform.Writer) {
+	s := out.State()
+	cb := CommandBuilder{Thread: 0, Arena: s.Arena}
+	out.MutateAndWrite(ctx, api.CmdNoID, cb.Custom(func(ctx context.Context, s *api.GlobalState, b *builder.Builder) error {
+		code := uint32(0xbeefcace)
+		b.Push(value.U32(code))
+		b.Post(b.Buffer(1), 4, func(r binary.Reader, err error) {
+			for _, res := range t.replayResult {
+				res.Do(func() (interface{}, error) {
+					if err != nil {
+						return nil, log.Err(ctx, err, "Flush did not get expected EOS code: '%v'")
+					}
+					if r.Uint32() != code {
+						return nil, log.Err(ctx, nil, "Flush did not get expected EOS code")
+					}
+					return t.timestamps, nil
+				})
+			}
+		})
+		return nil
+	}))
+}

--- a/gapis/api/vulkan/query_timestamps.go
+++ b/gapis/api/vulkan/query_timestamps.go
@@ -419,14 +419,10 @@ func (t *queryTimestamps) GetQueryResults(ctx context.Context,
 				t.timestamps = append(t.timestamps, record.timestamp)
 				queryPoolInfo.readIndex++
 			}
-			// Reset the results array after store the results in the final result list t.timestamps
-			queryPoolInfo.results = []timestampRecord{}
-			queryPoolInfo.readIndex = 0
-			queryPoolInfo.writeIndex = 0
 		})
 		return nil
 	}))
-
+	queryPoolInfo.writeIndex = 0
 	tmp.Free()
 }
 

--- a/gapis/api/vulkan/replay.go
+++ b/gapis/api/vulkan/replay.go
@@ -834,7 +834,6 @@ func (a API) Replay(
 				}
 				timestamps = newQueryTimestamps(ctx, c, n)
 			}
-			log.I(ctx, "replay result is %v", rr.Result)
 			timestamps.reportTo(rr.Result)
 			optimize = false
 		case framebufferRequest:
@@ -920,7 +919,6 @@ func (a API) Replay(
 	}
 
 	if issues != nil {
-		// transforms.Add(newQueryTimestamps(ctx, c))
 		transforms.Add(issues) // Issue reporting required.
 	} else {
 		if timestamps != nil {
@@ -1056,12 +1054,7 @@ func (a API) QueryTimestamps(
 	ctx context.Context,
 	intent replay.Intent,
 	mgr replay.Manager,
-	hints *service.UsageHints) ([]replay.Timestamps, error) {
-
-	_, err := resolve.SyncData(ctx, intent.Capture)
-	if err != nil {
-		return nil, err
-	}
+	hints *service.UsageHints) ([]replay.Timestamp, error) {
 
 	c, r := timestampsConfig{}, timestampsRequest{}
 	res, err := mgr.Replay(ctx, intent, c, r, a, hints)
@@ -1071,5 +1064,5 @@ func (a API) QueryTimestamps(
 	if _, ok := mgr.(replay.Exporter); ok {
 		return nil, nil
 	}
-	return res.([]replay.Timestamps), nil
+	return res.([]replay.Timestamp), nil
 }

--- a/gapis/api/vulkan/replay.go
+++ b/gapis/api/vulkan/replay.go
@@ -40,6 +40,7 @@ var (
 	_ = replay.QueryIssues(API{})
 	_ = replay.QueryFramebufferAttachment(API{})
 	_ = replay.Support(API{})
+	_ = replay.QueryTimestamps(API{})
 )
 
 // GetReplayPriority returns a uint32 representing the preference for
@@ -711,6 +712,12 @@ type issuesRequest struct {
 	displayToSurface bool
 }
 
+type timestampsConfig struct {
+}
+
+type timestampsRequest struct {
+}
+
 func (a API) Replay(
 	ctx context.Context,
 	intent replay.Intent,
@@ -735,6 +742,8 @@ func (a API) Replay(
 	injector := &transform.Injector{}
 	// Gathers and reports any issues found.
 	var issues *findIssues
+
+	var timestamps *queryTimestamps
 
 	earlyTerminator, err := NewVulkanTerminator(ctx, intent.Capture)
 	if err != nil {
@@ -817,7 +826,17 @@ func (a API) Replay(
 			if req.displayToSurface {
 				doDisplayToSurface = true
 			}
-
+		case timestampsRequest:
+			if timestamps == nil {
+				n, err := expandCommands(false)
+				if err != nil {
+					return err
+				}
+				timestamps = newQueryTimestamps(ctx, c, n)
+			}
+			log.I(ctx, "replay result is %v", rr.Result)
+			timestamps.reportTo(rr.Result)
+			optimize = false
 		case framebufferRequest:
 
 			cfg := cfg.(drawConfig)
@@ -901,9 +920,15 @@ func (a API) Replay(
 	}
 
 	if issues != nil {
+		// transforms.Add(newQueryTimestamps(ctx, c))
 		transforms.Add(issues) // Issue reporting required.
 	} else {
-		transforms.Add(earlyTerminator)
+		if timestamps != nil {
+			transforms.Add(timestamps)
+		} else {
+			transforms.Add(earlyTerminator)
+		}
+
 	}
 
 	if overdraw != nil {
@@ -1025,4 +1050,26 @@ func (a API) QueryIssues(
 		return nil, nil
 	}
 	return res.([]replay.Issue), nil
+}
+
+func (a API) QueryTimestamps(
+	ctx context.Context,
+	intent replay.Intent,
+	mgr replay.Manager,
+	hints *service.UsageHints) ([]replay.Timestamps, error) {
+
+	_, err := resolve.SyncData(ctx, intent.Capture)
+	if err != nil {
+		return nil, err
+	}
+
+	c, r := timestampsConfig{}, timestampsRequest{}
+	res, err := mgr.Replay(ctx, intent, c, r, a, hints)
+	if err != nil {
+		return nil, err
+	}
+	if _, ok := mgr.(replay.Exporter); ok {
+		return nil, nil
+	}
+	return res.([]replay.Timestamps), nil
 }

--- a/gapis/client/client.go
+++ b/gapis/client/client.go
@@ -473,3 +473,14 @@ func (c *client) UpdateSettings(ctx context.Context, req *service.UpdateSettings
 	}
 	return nil
 }
+
+func (c *client) GetTimestamps(ctx context.Context, capture *path.Capture, device *path.Device) (interface{}, error) {
+	res, err := c.client.GetTimestamps(ctx, &service.GetTimestampsRequest{
+		Capture: capture,
+		Device:  device,
+	})
+	if err != nil {
+		return "", err
+	}
+	return res, nil
+}

--- a/gapis/replay/BUILD.bazel
+++ b/gapis/replay/BUILD.bazel
@@ -27,6 +27,7 @@ go_library(
         "manager.go",
         "mapping_printer.go",
         "replay.go",
+        "timestamps.go",
     ],
     importpath = "github.com/google/gapid/gapis/replay",
     visibility = ["//visibility:public"],

--- a/gapis/replay/interfaces.go
+++ b/gapis/replay/interfaces.go
@@ -50,6 +50,8 @@ type QueryIssues interface {
 		hints *service.UsageHints) ([]Issue, error)
 }
 
+// QueryTimestamps is the interface implemented by types that can
+// return the timestamps of the execution of commands
 type QueryTimestamps interface {
 	QueryTimestamps(
 		ctx context.Context,

--- a/gapis/replay/interfaces.go
+++ b/gapis/replay/interfaces.go
@@ -16,6 +16,7 @@ package replay
 
 import (
 	"context"
+	"time"
 
 	"github.com/google/gapid/core/image"
 	"github.com/google/gapid/core/os/device"
@@ -54,7 +55,7 @@ type QueryTimestamps interface {
 		ctx context.Context,
 		intent Intent,
 		mgr Manager,
-		hints *service.UsageHints) ([]Timestamps, error)
+		hints *service.UsageHints) ([]Timestamp, error)
 }
 
 // QueryFramebufferAttachment is the interface implemented by types that can
@@ -82,8 +83,12 @@ type Issue struct {
 	Error    error            // The issue's error.
 }
 
-type Timestamps struct {
+// Timestamp represents an execution time measurement between the two commands specified.
+type Timestamp struct {
+	// The path of the command which begins the time measurement.
 	Begin *path.Command
-	End   *path.Command
-	Time  uint64
+	// The path of the command which ends the time measurement.
+	End *path.Command
+	// The duration in nanoseconds between the two commands specified.
+	Time time.Duration
 }

--- a/gapis/replay/interfaces.go
+++ b/gapis/replay/interfaces.go
@@ -22,6 +22,7 @@ import (
 	"github.com/google/gapid/gapis/api"
 	"github.com/google/gapid/gapis/capture"
 	"github.com/google/gapid/gapis/service"
+	"github.com/google/gapid/gapis/service/path"
 )
 
 // Support is the optional interface implemented by APIs that can describe
@@ -48,6 +49,14 @@ type QueryIssues interface {
 		hints *service.UsageHints) ([]Issue, error)
 }
 
+type QueryTimestamps interface {
+	QueryTimestamps(
+		ctx context.Context,
+		intent Intent,
+		mgr Manager,
+		hints *service.UsageHints) ([]Timestamps, error)
+}
+
 // QueryFramebufferAttachment is the interface implemented by types that can
 // return the content of a framebuffer attachment at a particular point in a
 // capture.
@@ -71,4 +80,10 @@ type Issue struct {
 	Command  api.CmdID        // The command that reported the issue.
 	Severity service.Severity // The severity of the issue.
 	Error    error            // The issue's error.
+}
+
+type Timestamps struct {
+	Begin *path.Command
+	End   *path.Command
+	Time  uint64
 }

--- a/gapis/replay/timestamps.go
+++ b/gapis/replay/timestamps.go
@@ -1,0 +1,74 @@
+// Copyright (C) 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package replay
+
+import (
+	"context"
+
+	"github.com/google/gapid/core/log"
+	"github.com/google/gapid/gapis/capture"
+	"github.com/google/gapid/gapis/service"
+	"github.com/google/gapid/gapis/service/path"
+)
+
+// GetTimestamps replays the trace and return the start and end timestamps for each commandbuffers
+func GetTimestamps(ctx context.Context, capturePath *path.Capture, device *path.Device) (*service.GetTimestampsResponse, error) {
+	c, err := capture.ResolveFromPath(ctx, capturePath)
+	if err != nil {
+		return nil, err
+	}
+
+	ts := []Timestamps{}
+	if device != nil {
+		intent := Intent{
+			Capture: capturePath,
+			Device:  device,
+		}
+
+		mgr := GetManager(ctx)
+		hints := &service.UsageHints{Background: true}
+		for _, a := range c.APIs {
+			if qi, ok := a.(QueryTimestamps); ok {
+				ts, err = qi.QueryTimestamps(ctx, intent, mgr, hints)
+				if err != nil {
+					log.E(ctx, "Query timestamps failed.")
+					continue
+				}
+			}
+		}
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	var timestamps service.Timestamps
+	for _, t := range ts {
+		item := &service.TimestampsItem{
+			Begin: t.Begin,
+			End:   t.End,
+			Time:  t.Time,
+		}
+		timestamps.Timestamps = append(timestamps.Timestamps, item)
+	}
+
+	res := service.GetTimestampsResponse{
+		Res: &service.GetTimestampsResponse_Timestamps{
+			Timestamps: &timestamps,
+		},
+	}
+
+	return &res, nil
+}

--- a/gapis/replay/timestamps.go
+++ b/gapis/replay/timestamps.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2017 Google Inc.
+// Copyright (C) 2018 Google Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -30,7 +30,7 @@ func GetTimestamps(ctx context.Context, capturePath *path.Capture, device *path.
 		return nil, err
 	}
 
-	ts := []Timestamps{}
+	ts := []Timestamp{}
 	if device != nil {
 		intent := Intent{
 			Capture: capturePath,
@@ -57,9 +57,9 @@ func GetTimestamps(ctx context.Context, capturePath *path.Capture, device *path.
 	var timestamps service.Timestamps
 	for _, t := range ts {
 		item := &service.TimestampsItem{
-			Begin: t.Begin,
-			End:   t.End,
-			Time:  t.Time,
+			Begin:             t.Begin,
+			End:               t.End,
+			TimeInNanoseconds: uint64(t.Time),
 		}
 		timestamps.Timestamps = append(timestamps.Timestamps, item)
 	}

--- a/gapis/server/grpc.go
+++ b/gapis/server/grpc.go
@@ -536,3 +536,12 @@ func (s *grpcServer) Trace(conn service.Gapid_TraceServer) error {
 	}
 	return nil
 }
+
+func (s *grpcServer) GetTimestamps(ctx xctx.Context, req *service.GetTimestampsRequest) (*service.GetTimestampsResponse, error) {
+	defer s.inRPC()()
+	data, err := s.handler.GetTimestamps(s.bindCtx(ctx), req.Capture, req.Device)
+	if err := service.NewError(err); err != nil {
+		return &service.GetTimestampsResponse{Res: &service.GetTimestampsResponse_Error{Error: err}}, nil
+	}
+	return data.(*service.GetTimestampsResponse), nil
+}

--- a/gapis/server/server.go
+++ b/gapis/server/server.go
@@ -44,6 +44,7 @@ import (
 	"github.com/google/gapid/gapis/api"
 	"github.com/google/gapid/gapis/capture"
 	"github.com/google/gapid/gapis/messages"
+	"github.com/google/gapid/gapis/replay"
 	"github.com/google/gapid/gapis/replay/devices"
 	"github.com/google/gapid/gapis/resolve"
 	"github.com/google/gapid/gapis/resolve/dependencygraph"
@@ -677,4 +678,11 @@ func (s *server) UpdateSettings(ctx context.Context, settings *service.UpdateSet
 		adb.ADB = file.Abs(settings.Adb)
 	}
 	return nil
+}
+
+func (s *server) GetTimestamps(ctx context.Context, c *path.Capture, d *path.Device) (interface{}, error) {
+	ctx = status.Start(ctx, "RPC GetTimestamps")
+	defer status.Finish(ctx)
+	ctx = log.Enter(ctx, "GetTimestamps")
+	return replay.GetTimestamps(ctx, c, d)
 }

--- a/gapis/service/service.go
+++ b/gapis/service/service.go
@@ -161,6 +161,8 @@ type Service interface {
 
 	// Update the environment settings.
 	UpdateSettings(ctx context.Context, req *UpdateSettingsRequest) error
+
+	GetTimestamps(ctx context.Context, c *path.Capture, d *path.Device) (interface{}, error)
 }
 
 type TraceHandler interface {

--- a/gapis/service/service.proto
+++ b/gapis/service/service.proto
@@ -630,6 +630,11 @@ service Gapid {
   // GetProfile returns the pprof profile with the given name.
   rpc GetProfile(GetProfileRequest) returns (GetProfileResponse) {
   }
+
+  // GetTimestamps returns the timestamps of the begin and end of execution of a
+  // command buffer.
+  rpc GetTimestamps(GetTimestampsRequest) returns (GetTimestampsResponse) {
+  }
 }
 
 message Error {
@@ -1112,4 +1117,26 @@ message DeviceAPITraceConfiguration {
   bool can_disable_pcs = 2;
   // Does this API support MEC.
   FeatureStatus mid_execution_capture_support = 3;
+}
+
+message GetTimestampsRequest {
+  path.Capture capture = 1;
+  path.Device device = 2;
+}
+
+message TimestampsItem {
+  path.Command begin = 1;
+  path.Command end = 2;
+  uint64 time = 3;
+}
+
+message Timestamps {
+  repeated TimestampsItem timestamps = 1;
+}
+
+message GetTimestampsResponse {
+  oneof res {
+    Timestamps timestamps = 1;
+    Error error = 2;
+  }
 }

--- a/gapis/service/service.proto
+++ b/gapis/service/service.proto
@@ -1119,21 +1119,33 @@ message DeviceAPITraceConfiguration {
   FeatureStatus mid_execution_capture_support = 3;
 }
 
+// GetTimestampsRequest is the request send to server to get the timestamps for
+// the commands in the capture.
 message GetTimestampsRequest {
   path.Capture capture = 1;
   path.Device device = 2;
 }
 
-message TimestampsItem {
-  path.Command begin = 1;
-  path.Command end = 2;
-  uint64 time = 3;
-}
-
+// Timestamps describes the durations of commands execution, each of which
+// is specified in a TimestampsItem message.
 message Timestamps {
   repeated TimestampsItem timestamps = 1;
 }
 
+// TimestampsItem represents one entry in a Timestamps report.
+// It describes the duratoin of execution time between the two commands
+// specified by "begin" and "end" fields.
+message TimestampsItem {
+  // The path of the command which begins the time measurement.
+  path.Command begin = 1;
+  // The path of the command which ends the time measurement.
+  path.Command end = 2;
+  // The duration in nanoseconds between the two commands specified.
+  uint64 time_in_nanoseconds = 3;
+}
+
+// GetTimestampsResponse is the response message server sends back which contains
+// the time duratoins for the commands when replay the trace.
 message GetTimestampsResponse {
   oneof res {
     Timestamps timestamps = 1;


### PR DESCRIPTION
Add `profile` command to query timestamps when replay the trace. The results will be saved to a CSV file specified by the `-out` flag if provided, or print out to the stdout. 