### PR TITLE
 Handle `port:<pipename>:<abi>` URLs for Android tracing.

### DIFF
--- a/cmd/gapit/flags.go
+++ b/cmd/gapit/flags.go
@@ -250,6 +250,7 @@ type (
 		Local struct {
 			Port int `help:"connect to an application already running on the server using this port"`
 		}
+		PipeName string `help:"The name of the pipe to connect/listen to."`
 	}
 	BenchmarkFlags struct {
 		DeviceFlags

--- a/cmd/gapit/trace.go
+++ b/cmd/gapit/trace.go
@@ -176,6 +176,7 @@ func (verb *traceVerb) Run(ctx context.Context, flags flag.FlagSet) error {
 		RecordTraceTimes:      verb.Record.TraceTimes,
 		ClearCache:            verb.Clear.Cache,
 		ServerLocalSavePath:   out,
+		PipeName:              verb.PipeName,
 	}
 
 	if uri != "" {

--- a/core/java/jdwp/coder.go
+++ b/core/java/jdwp/coder.go
@@ -130,6 +130,8 @@ func (c *Connection) encode(w binary.Writer, v reflect.Value) error {
 			w.Float32(float32(v.Float()))
 		case reflect.Float64:
 			w.Float64(v.Float())
+		case reflect.Bool:
+			w.Bool(v.Bool())
 		case reflect.Struct:
 			for i, count := 0, v.NumField(); i < count; i++ {
 				c.encode(w, v.Field(i))

--- a/gapii/cc/spy.cpp
+++ b/gapii/cc/spy.cpp
@@ -137,7 +137,12 @@ Spy::Spy()
   // Use a "localabstract" pipe on Android to prevent depending on the traced
   // application having the INTERNET permission set, required for opening and
   // listening on a TCP socket.
-  mConnection = ConnectionStream::listenPipe("gapii", true);
+  std::string pipe = "gapii";
+  char* envPipe = getenv("GAPII_PIPE_NAME");
+  if (envPipe != nullptr) {
+    pipe = envPipe;
+  }
+  mConnection = ConnectionStream::listenPipe(pipe.c_str(), true);
 #else   // TARGET_OS
   mConnection = ConnectionStream::listenSocket("127.0.0.1", "9286");
 #endif  // TARGET_OS

--- a/gapii/client/adb.go
+++ b/gapii/client/adb.go
@@ -105,7 +105,11 @@ func Start(ctx context.Context, p *android.InstalledPackage, a *android.Activity
 	ctx = log.V{"port": port}.Bind(ctx)
 
 	log.I(ctx, "Forwarding")
-	if err := d.Forward(ctx, adb.TCPPort(port), adb.NamedAbstractSocket("gapii")); err != nil {
+	pipe := "gapii"
+	if o.PipeName != "" {
+		pipe = o.PipeName
+	}
+	if err := d.Forward(ctx, adb.TCPPort(port), adb.NamedAbstractSocket(pipe)); err != nil {
 		return nil, log.Err(ctx, err, "Setting up port forwarding for gapii")
 	}
 

--- a/gapii/client/adb.go
+++ b/gapii/client/adb.go
@@ -167,6 +167,40 @@ func Start(ctx context.Context, p *android.InstalledPackage, a *android.Activity
 	return process, nil
 }
 
+// Connect connects to an app that is already setup to trace. This is similar to
+// Start(...), except that it skips some steps as it is assumed that the loading
+// of libgapii is done manually and the app is waiting for a connection from the
+// host.
+func Connect(ctx context.Context, d adb.Device, abi *device.ABI, pipe string, o Options) (*Process, error) {
+	port, err := adb.LocalFreeTCPPort()
+	if err != nil {
+		return nil, log.Err(ctx, err, "Finding free port for gapii")
+	}
+	ctx = log.V{"port": port}.Bind(ctx)
+
+	log.I(ctx, "Checking gapid.apk is installed")
+	apk, err := gapidapk.EnsureInstalled(ctx, d, abi)
+	if err != nil {
+		return nil, log.Err(ctx, err, "Installing gapid.apk")
+	}
+
+	log.I(ctx, "Forwarding")
+	if err := d.Forward(ctx, adb.TCPPort(port), adb.NamedAbstractSocket(pipe)); err != nil {
+		return nil, log.Err(ctx, err, "Setting up port forwarding for gapii")
+	}
+
+	process := &Process{
+		Port:    int(port),
+		Device:  d,
+		Options: o,
+	}
+	interceptorPath := apk.LibInterceptorPath(abi)
+	if err := process.connect(ctx, 0, interceptorPath); err != nil {
+		return nil, err
+	}
+	return process, nil
+}
+
 // reserveVulkanDevice reserves the given device for starting Vulkan trace and
 // set the implicit Vulkan layers property to let the Vulkan loader loads
 // VkGraphicsSpy layer. It returns the mutex which reserves the device and error.

--- a/gapii/client/capture.go
+++ b/gapii/client/capture.go
@@ -82,6 +82,8 @@ type Options struct {
 	Flags Flags
 	// Additional flags to pass to am start
 	AdditionalFlags string
+	// The name of the pipe to connect/listen to.
+	PipeName string
 }
 
 const sizeGap = 1024 * 1024 * 5

--- a/gapii/client/jdwp_loader.go
+++ b/gapii/client/jdwp_loader.go
@@ -301,6 +301,11 @@ func (p *Process) loadAndConnectViaJDWP(
 		gapiiPath := gapidAPK.LibGAPIIPath(abi)
 		ctx = log.V{"gapii.so": gapiiPath, "process abi": abi.Name}.Bind(ctx)
 
+		if p.Options.PipeName != "" {
+			// Set the GAPID_PIPE_NAME environment variable.
+			j.Class("libcore.io.Libcore").Field("os").Call("setenv", "GAPII_PIPE_NAME", p.Options.PipeName, true)
+		}
+
 		// Load the library.
 		log.D(ctx, "Loading GAPII library...")
 		j.Class("java.lang.System").Call("load", gapiiPath)

--- a/gapis/server/server.go
+++ b/gapis/server/server.go
@@ -534,6 +534,7 @@ func optionsToTraceOptions(opts *service.TraceOptions) tracer.TraceOptions {
 		NoBuffer:              opts.NoBuffer,
 		HideUnknownExtensions: opts.HideUnknownExtensions,
 		StoreTimestamps:       opts.RecordTraceTimes,
+		PipeName:              opts.PipeName,
 	}
 }
 

--- a/gapis/service/service.proto
+++ b/gapis/service/service.proto
@@ -1045,6 +1045,8 @@ message TraceOptions {
   bool record_trace_times = 20;
   // Where should we save the capture file.
   string server_local_save_path = 21;
+  // Name of the pipe to connect/listen to.
+  string pipe_name = 22;
 }
 
 enum TraceEvent {

--- a/gapis/trace/android/BUILD.bazel
+++ b/gapis/trace/android/BUILD.bazel
@@ -24,6 +24,7 @@ go_library(
         "//core/os/android:go_default_library",
         "//core/os/android/adb:go_default_library",
         "//core/os/android/apk:go_default_library",
+        "//core/os/device:go_default_library",
         "//core/os/device/bind:go_default_library",
         "//gapidapk:go_default_library",
         "//gapidapk/pkginfo:go_default_library",

--- a/gapis/trace/tracer/tracer.go
+++ b/gapis/trace/tracer/tracer.go
@@ -56,6 +56,7 @@ type TraceOptions struct {
 	WriteFile         string   // Where should we write the output
 	AdditionalFlags   string   // Additional flags to pass to the application
 	CWD               string   // What directory the application use as a CWD
+	PipeName          string   // The name of the pipe to connect/listen to.
 
 	Duration              float32 // How many seconds should we trace
 	ObserveFrameFrequency uint32  // How frequently should we do frame observations
@@ -147,5 +148,6 @@ func (o TraceOptions) GapiiOptions() gapii.Options {
 		apis,
 		flags,
 		o.AdditionalFlags,
+		o.PipeName,
 	}
 }


### PR DESCRIPTION
A URL of this pattern indicates tracing an Android app that is assumed to be already setup for tracing (i.e. have libgapii loaded) and is waiting for a connection from the host.