### PR TITLE
Gapis: Preload new dependency graph or old footprint based on config

### DIFF
--- a/gapis/server/BUILD.bazel
+++ b/gapis/server/BUILD.bazel
@@ -44,6 +44,7 @@ go_library(
         "//gapis/api:go_default_library",
         "//gapis/api/all:go_default_library",
         "//gapis/capture:go_default_library",
+        "//gapis/config:go_default_library",
         "//gapis/database:go_default_library",
         "//gapis/messages:go_default_library",
         "//gapis/replay:go_default_library",


### PR DESCRIPTION
This change ensures that gapis obeys the config flags (`DisableDeadCodeElimination` and `NewDeadCodeElimination`) when pre-loading the dependency graph.