### PR TITLE
Vulkan Dependency Graph: Avoid repeated calls to `len` for unchanging maps

### DIFF
--- a/gapis/api/vulkan/api/coherent_memory.api
+++ b/gapis/api/vulkan/api/coherent_memory.api
@@ -65,7 +65,8 @@ sub void readMemoryInBuffer(ref!BufferObject buffer, VkDeviceSize readOffset, Vk
 }
 
 sub void readMemoryInBufferBindings(map!(u32, ref!VkDescriptorBufferInfo) bufferBindings, map!(u32, VkDeviceSize) bufferBindingOffsets) {
-  for i in (0 .. len(bufferBindings)) {
+  n := len(bufferBindings)
+  for i in (0 .. n) {
     bufferBinding := bufferBindings[as!u32(i)]
     if bufferBinding.Buffer != as!VkBuffer(0) {
       if (bufferBinding.Buffer in Buffers) {
@@ -159,7 +160,8 @@ sub void writeMemoryInBuffer(ref!BufferObject buffer, VkDeviceSize offset, VkDev
 }
 
 sub void writeMemoryInBufferBindings(map!(u32, ref!VkDescriptorBufferInfo) bufferBindings, map!(u32, VkDeviceSize) bufferBindingOffsets) {
-  for i in (0 .. len(bufferBindings)) {
+  n := len(bufferBindings)
+  for i in (0 .. n) {
     bufferBinding := bufferBindings[as!u32(i)]
     if bufferBinding.Buffer != as!VkBuffer(0) {
       if (bufferBinding.Buffer in Buffers) {

--- a/gapis/api/vulkan/api/copy_clear_commands.api
+++ b/gapis/api/vulkan/api/copy_clear_commands.api
@@ -227,7 +227,8 @@ sub void dovkCmdCopyImage(ref!vkCmdCopyImageArgs args) {
   dstFormat := dstImageObject.Info.Format
   dstElementAndTexelBlockSize := getElementAndTexelBlockSize(dstFormat)
   dstDepthElementSize := getDepthElementSize(dstFormat, false)
-  for r in (0 .. len(args.Regions)) {
+  n := len(args.Regions)
+  for r in (0 .. n) {
     // TODO: Support KHR_maintenance1 extension, support copying from a 2D array
     // image to slices of a 3D image and vice versa.
     region := args.Regions[as!u32(r)]
@@ -354,7 +355,8 @@ sub void dovkCmdBlitImage(ref!vkCmdBlitImageArgs args) {
   dstFormat := dstImageObject.Info.Format
   dstElementAndTexelBlockSize := getElementAndTexelBlockSize(dstFormat)
   dstDepthElementSize := getDepthElementSize(dstFormat, false)
-  for r in (0 .. len(args.Regions)) {
+  n := len(args.Regions)
+  for r in (0 .. n) {
     // TODO: (qining) Handle the apsect mask
     region := args.Regions[as!u32(r)]
     srcBaseLayer := region.srcSubresource.baseArrayLayer
@@ -516,7 +518,8 @@ sub void dovkCmdCopyBufferToImage(ref!vkCmdCopyBufferToImageArgs args) {
   elementAndTexelBlockSize := getElementAndTexelBlockSize(format)
   depthElementSize := getDepthElementSize(format, true)
   // Iterate through regions
-  for i in (0 .. len(args.Regions)) {
+  n := len(args.Regions)
+  for i in (0 .. n) {
     region := args.Regions[as!u32(i)]
     rowLengthAndImageHeight := getRowLengthAndImageHeight(region)
     rowLength := as!u64(rowLengthAndImageHeight.RowLength / elementAndTexelBlockSize.TexelBlockSize.Width)

--- a/gapis/api/vulkan/api/descriptor.api
+++ b/gapis/api/vulkan/api/descriptor.api
@@ -746,7 +746,8 @@ sub void dovkCmdBindDescriptorSets(ref!vkCmdBindDescriptorSetsArgs args) {
       drawInfo.BufferBindingOffsets
   }
 
-  for i in (0 .. len(args.DescriptorSets)) {
+  numDescSets := len(args.DescriptorSets)
+  for i in (0 .. numDescSets) {
     if args.DescriptorSets[as!u32(i)] in DescriptorSets {
       set := args.DescriptorSets[as!u32(i)]
       setObj := DescriptorSets[set]
@@ -773,7 +774,8 @@ sub void dovkCmdBindDescriptorSets(ref!vkCmdBindDescriptorSetsArgs args) {
         if (j in setObj.Bindings) && (setObj.Bindings[j] != null) {
           desc_binding_buf_offsets := desc_set_buf_offsets[as!u32(j)]
           binding := setObj.Bindings[j]
-          for k in (0 .. len(binding.BufferBinding)) {
+          numBufferBindings := len(binding.BufferBinding)
+          for k in (0 .. numBufferBindings) {
             bufferBinding := binding.BufferBinding[as!u32(k)]
 
             binding_offset := switch binding.BindingType {

--- a/gapis/api/vulkan/api/draw_commands.api
+++ b/gapis/api/vulkan/api/draw_commands.api
@@ -97,7 +97,8 @@ class CmdBindBuffer {
 }
 
 sub void dovkCmdBindVertexBuffers(ref!vkCmdBindVertexBuffersArgs bind) {
-  for i in (0 .. len(bind.Buffers)) {
+  n := len(bind.Buffers)
+  for i in (0 .. n) {
     v := bind.Buffers[as!u32(i)]
     lastDrawInfo().BoundVertexBuffers[as!u32(i) + bind.FirstBinding] = BoundBuffer(
       Buffers[v], bind.Offsets[as!u32(i)],

--- a/gapis/api/vulkan/api/queue.api
+++ b/gapis/api/vulkan/api/queue.api
@@ -144,7 +144,8 @@ cmd VkResult vkQueueSubmit(
           if (as!u32(cb.BeginInfo.Flags) & as!u32(VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT)) != as!u32(0) {
             cb.Recording = TO_BE_RESET
           }
-          for k in (0 .. len(cb.CommandReferences)) {
+          numCmdRefs := len(cb.CommandReferences)
+          for k in (0 .. numCmdRefs) {
             ref := cb.CommandReferences[as!u32(k)]
             LastBoundQueue.PendingCommands[len(LastBoundQueue.PendingCommands)]
             = new!CommandReference(
@@ -161,13 +162,15 @@ cmd VkResult vkQueueSubmit(
             if ref.Type == cmd_vkCmdExecuteCommands {
               enterSubcontext()
               ec := cb.BufferCommands.vkCmdExecuteCommands[ref.MapIndex]
-              for l in (0 .. len(ec.CommandBuffers)) {
+              numCmdBufs := len(ec.CommandBuffers)
+              for l in (0 .. numCmdBufs) {
                 scb := CommandBuffers[ec.CommandBuffers[as!u32(l)]]
                 if scb.Recording != COMPLETED {
                   vkErrorCommandBufferIncomplete(ec.CommandBuffers[as!u32(l)])
                 }
                 enterSubcontext()
-                for c in (0 .. len(scb.CommandReferences)) {
+                numSubCmdRefs := len(scb.CommandReferences)
+                for c in (0 .. numSubCmdRefs) {
                   sref := scb.CommandReferences[as!u32(c)]
                   LastBoundQueue.PendingCommands[len(LastBoundQueue.PendingCommands)]
                   = new!CommandReference(

--- a/gapis/api/vulkan/api/queued_command_tracking.api
+++ b/gapis/api/vulkan/api/queued_command_tracking.api
@@ -48,7 +48,8 @@ sub void execPendingCommands(VkQueue queue, bool isRoot) {
   processSubcommand.b = true
   ProcessedDescriptorSets = UsedDescriptorSets()
 
-  for i in (0 .. len(q.PendingCommands)) {
+  numPendingCmds := len(q.PendingCommands)
+  for i in (0 .. numPendingCmds) {
     cmd := q.PendingCommands[as!u32(i)]
     if ((len(q.PendingEvents) != 0) || (len(q.PendingSemaphores) != 0)) {
       newCmds[len(newCmds)] = cmd
@@ -211,7 +212,8 @@ sub void execPendingCommands(VkQueue queue, bool isRoot) {
   q.PendingCommands = newCmds
 
   resetSubcontext()
-  for i in (0 .. len(signaledQueues)) {
+  numSignaledQueues := len(signaledQueues)
+  for i in (0 .. numSignaledQueues) {
     execPendingCommands(signaledQueues[as!u32(i)], false)
   }
 }

--- a/gapis/api/vulkan/api/renderpass_framebuffer.api
+++ b/gapis/api/vulkan/api/renderpass_framebuffer.api
@@ -244,7 +244,8 @@ sub void dovkCmdBeginRenderPass(ref!vkCmdBeginRenderPassArgs args) {
   lastDrawInfo().RenderPass = RenderPasses[args.RenderPass]
   lastDrawInfo().InRenderPass = true
   attachments := lastDrawInfo().Framebuffer.ImageAttachments
-  for i in (0 .. len(attachments)) {
+  n := len(attachments)
+  for i in (0 .. n) {
     loadImageAttachment(as!u32(i))
   }
   pushRenderPassMarker(args.RenderPass)
@@ -347,7 +348,8 @@ vkCmdEndRenderPassArgs {
 
 sub void dovkCmdEndRenderPass(ref!vkCmdEndRenderPassArgs unused) {
   attachmentDescriptions := lastDrawInfo().RenderPass.AttachmentDescriptions
-  for i in (0 .. len(attachmentDescriptions)) {
+  n := len(attachmentDescriptions)
+  for i in (0 .. n) {
     storeImageAttachment(as!u32(i))
   }
   lastDrawInfo().InRenderPass = false

--- a/gapis/api/vulkan/vulkan.api
+++ b/gapis/api/vulkan/vulkan.api
@@ -346,7 +346,8 @@ sub ref!DrawInfo lastDrawInfo() {
 
 // Clear the recorded descriptor sets in the last draw
 sub void clearLastDrawInfoDescriptorSets() {
-  for i in (0 .. len(lastDrawInfo().DescriptorSets)) {
+  n := len(lastDrawInfo().DescriptorSets)
+  for i in (0 .. n) {
     lastDrawInfo().DescriptorSets[as!u32(i)] = null
   }
 }


### PR DESCRIPTION
This improves performance in building the dependency graph, and seems to be safe because the map should not change over each of these loops.