### PR TITLE
Vulkan Dependency Graph: Ensure `vkEndCommandBuffer` depends on `vkBeginCommandBuffer`

### DIFF
--- a/gapii/cc/vulkan_inlines.inc
+++ b/gapii/cc/vulkan_inlines.inc
@@ -47,6 +47,10 @@ inline void VulkanSpy::vkErrCommandBufferIncomplete(CallObserver*, VkCommandBuff
     GAPID_WARNING("Error: Executing command buffer %zu was not in the COMPLETED state", cmdbuf)
 }
 
+inline void VulkanSpy::vkErrCommandBufferNotRecording(CallObserver*, VkCommandBuffer cmdbuf) {
+    GAPID_WARNING("Error: Executing command buffer %zu was not in the RECORDING state", cmdbuf)
+}
+
 inline void VulkanSpy::vkErrInvalidImageLayout(CallObserver*, VkImage img, uint32_t aspect, uint32_t layer, uint32_t level, uint32_t layout, uint32_t expectedLayout) {
     GAPID_WARNING("Error: Image subresource at Image: %" PRIu64 ", AspectBit: %" PRIu32 ", Layer: %" PRIu32 ", Level: %" PRIu32 " was in layout %" PRIu32 ", but was expected to be in layout %" PRIu32,
         img, aspect, layer, level, layout, expectedLayout);

--- a/gapis/api/vulkan/api/command_buffer_control.api
+++ b/gapis/api/vulkan/api/command_buffer_control.api
@@ -421,7 +421,9 @@ cmd VkResult vkEndCommandBuffer(
     vkErrorInvalidCommandBuffer(commandBuffer)
   } else {
     buff := CommandBuffers[commandBuffer]
-    _ = buff.Recording
+    if (buff.Recording != RECORDING) {
+      vkErrorCommandBufferNotRecording(commandBuffer)
+    }
     buff.Recording = COMPLETED
   }
   return ?

--- a/gapis/api/vulkan/api/command_buffer_control.api
+++ b/gapis/api/vulkan/api/command_buffer_control.api
@@ -421,6 +421,7 @@ cmd VkResult vkEndCommandBuffer(
     vkErrorInvalidCommandBuffer(commandBuffer)
   } else {
     buff := CommandBuffers[commandBuffer]
+    _ = buff.Recording
     buff.Recording = COMPLETED
   }
   return ?

--- a/gapis/api/vulkan/errors.api
+++ b/gapis/api/vulkan/errors.api
@@ -46,6 +46,7 @@ extern void vkErrExpectNVDedicatedlyAllocatedHandle(string handleType, u64 handl
 extern void vkErrInvalidDescriptorArrayElement(u64 set, u32 binding, u32 arrayIndex)
 extern void vkErrInvalidDescriptorBindingType(VkDescriptorSet set, u32 binding, VkDescriptorType layoutType, VkDescriptorType updateType)
 extern void vkErrCommandBufferIncomplete(VkCommandBuffer cmdbuf)
+extern void vkErrCommandBufferNotRecording(VkCommandBuffer cmdbuf)
 extern void vkErrInvalidImageLayout(VkImage img, u32 aspect, u32 layer, u32 level, VkImageLayout layout, VkImageLayout expectedLayout)
 extern void vkErrInvalidImageSubresource(VkImage img, string subresourceType, u32 value)
 
@@ -73,6 +74,10 @@ sub void vkErrorInvalidCommandBuffer(VkCommandBuffer cmdbuf) {
 
 sub void vkErrorCommandBufferIncomplete(VkCommandBuffer cmdbuf) {
   vkErrCommandBufferIncomplete(cmdbuf)
+}
+
+sub void vkErrorCommandBufferNotRecording(VkCommandBuffer cmdbuf) {
+  vkErrCommandBufferNotRecording(cmdbuf)
 }
 
 sub void vkErrorInvalidDeviceMemory(VkDeviceMemory mem) {

--- a/gapis/api/vulkan/externs.go
+++ b/gapis/api/vulkan/externs.go
@@ -466,6 +466,14 @@ func (e externs) vkErrCommandBufferIncomplete(cmdbuf VkCommandBuffer) {
 	e.onVkError(issue)
 }
 
+func (e externs) vkErrCommandBufferNotRecording(cmdbuf VkCommandBuffer) {
+	var issue replay.Issue
+	issue.Command = e.cmdID
+	issue.Severity = service.Severity_ErrorLevel
+	issue.Error = fmt.Errorf("Executing command buffer %v was not in the RECORDING state", cmdbuf)
+	e.onVkError(issue)
+}
+
 func (e externs) vkErrInvalidImageLayout(img VkImage, aspect, layer, level uint32, layout VkImageLayout, expectedLayout VkImageLayout) {
 	var issue replay.Issue
 	issue.Command = e.cmdID


### PR DESCRIPTION
This explicit read of `buff.Recording` makes `vkEndCommandBuffer` depend on `vkBeginCommandBuffer`'s setting of `buff.Recording`.