### PR TITLE
Update poolSlice to not actualy store the data in the database.

### DIFF
--- a/gapis/memory/pool.go
+++ b/gapis/memory/pool.go
@@ -253,11 +253,16 @@ func (m poolSlice) Get(ctx context.Context, offset uint64, dst []byte) error {
 }
 
 func (m poolSlice) ResourceID(ctx context.Context) (id.ID, error) {
-	bytes := make([]byte, m.Size())
-	if err := m.Get(ctx, 0, bytes); err != nil {
-		return id.ID{}, err
+	callcount := 0
+	getBytes := func() ([]byte, error) {
+		callcount++
+		bytes := make([]byte, m.Size())
+		if err := m.Get(ctx, 0, bytes); err != nil {
+			return []byte{}, err
+		}
+		return bytes, nil
 	}
-	return database.Store(ctx, bytes)
+	return database.Store(ctx, getBytes)
 }
 
 func (m poolSlice) Slice(rng Range) Data {

--- a/gapis/server/server.go
+++ b/gapis/server/server.go
@@ -236,10 +236,12 @@ func (s *server) LoadCapture(ctx context.Context, path string) (*path.Capture, e
 	if _, err = capture.ResolveFromPath(ctx, p); err != nil {
 		return nil, err
 	}
+
 	// Pre-resolve the dependency graph.
+	newCtx := keys.Clone(context.Background(), ctx)
 	crash.Go(func() {
-		newCtx := keys.Clone(context.Background(), ctx)
-		_, err = dependencygraph.GetFootprint(newCtx, p)
+		cctx := status.PutTask(newCtx, nil)
+		_, err = dependencygraph.GetFootprint(cctx, p)
 		if err != nil {
 			log.E(newCtx, "Error resolve dependency graph: %v", err)
 		}


### PR DESCRIPTION
This allows us to manually query it when we want. This ends up
saving a lot of memory in certain circumstances where we
are using a lot of pool slices.