### PR TITLE
Mark the entire directroy as +x when trying to set up GAPIR.

### DIFF
--- a/core/os/android/installed_package.go
+++ b/core/os/android/installed_package.go
@@ -210,6 +210,15 @@ func (p *InstalledPackage) FileDir(ctx context.Context) (string, error) {
 	return path, err
 }
 
+// AppDir returns the absolute path of the installed packages files directory.
+func (p *InstalledPackage) AppDir(ctx context.Context) (string, error) {
+	out, err := p.Device.Shell("run-as", p.Name, "pwd").Call(ctx)
+	if err != nil {
+		return "", err
+	}
+	return out, err
+}
+
 // Pid returns the PID of the newest (if pgrep exists) running process belonging to the given package.
 func (p *InstalledPackage) Pid(ctx context.Context) (int, error) {
 	// First, try pgrep.

--- a/gapir/client/session.go
+++ b/gapir/client/session.go
@@ -309,6 +309,16 @@ func (s *session) newADB(ctx context.Context, d adb.Device, abi *device.ABI) err
 	if err != nil {
 		return log.Errf(ctx, err, "Getting gapid.apk files directory")
 	}
+	appDir, err := apk.AppDir(ctx)
+	if err != nil {
+		return log.Errf(ctx, err, "Getting gapid.apk directory")
+	}
+
+	// Ignore the error returned from this. This is best-effort.
+	// See: https://android.googlesource.com/platform/ndk.git/+/ndk-release-r18/ndk-gdb.py#386
+	// for more information.
+	_, _ = d.Shell("run-as", apk.Name, "chmod", "+x", appDir).Call(ctx)
+
 	// Wait for the socket file to be created
 	socketPath := strings.Join([]string{apkDir, socket}, "/")
 	err = task.Retry(ctx, maxCheckSocketFileAttempts, checkSocketFileRetryDelay,


### PR DESCRIPTION
See: https://android.googlesource.com/platform/ndk.git/+/ndk-release-r18/ndk-gdb.py#386
for more information.


Fixes #2387
