### PR TITLE
Query the SDK version for Android devices.

### DIFF
--- a/core/os/android/adb/commands.go
+++ b/core/os/android/adb/commands.go
@@ -92,9 +92,9 @@ func (b *binding) InstallAPK(ctx context.Context, path string, reinstall bool, g
 	if reinstall {
 		args = append(args, "-r")
 	}
-	if grantPermissions && b.Instance().GetConfiguration().GetOS().GetMajorVersion() >= 6 {
-		// Starting with Android 6.0, permissions are not granted by default
-		// during installation. Before Android 6.0, the flag did not exist.
+	if grantPermissions && b.Instance().GetConfiguration().GetOS().GetAPIVersion() >= 23 {
+		// Starting with API 23, permissions are not granted by default
+		// during installation. Before API 23, the flag did not exist.
 		args = append(args, "-g")
 	}
 	args = append(args, path)
@@ -145,8 +145,8 @@ func (b *binding) StartActivityForDebug(ctx context.Context, a android.ActivityA
 // StartService launches the specified service action.
 func (b *binding) StartService(ctx context.Context, a android.ServiceAction, extras ...android.ActionExtra) error {
 	cmd := "start-foreground-service"
-	if b.Instance().GetConfiguration().GetOS().GetMajorVersion() < 8 {
-		// "am start-foreground-service" was added in 8.0 (API 26).
+	if b.Instance().GetConfiguration().GetOS().GetAPIVersion() < 26 {
+		// "am start-foreground-service" was added in API 26.
 		cmd = "startservice"
 	}
 	args := append([]string{

--- a/core/os/android/adb/device.go
+++ b/core/os/android/adb/device.go
@@ -17,6 +17,7 @@ package adb
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -132,6 +133,12 @@ func newDevice(ctx context.Context, serial string, status bind.Status) (*binding
 		var major, minor, point int32
 		fmt.Sscanf(version, "%d.%d.%d", &major, &minor, &point)
 		d.To.Configuration.OS = device.AndroidOS(major, minor, point)
+	}
+
+	// Collect the API version
+	if version, err := d.SystemProperty(ctx, "ro.build.version.sdk"); err == nil {
+		v, _ := strconv.Atoi(version)
+		d.To.Configuration.OS.APIVersion = int32(v)
 	}
 
 	if description, err := d.SystemProperty(ctx, "ro.build.description"); err == nil {

--- a/core/os/device/device.proto
+++ b/core/os/device/device.proto
@@ -120,6 +120,8 @@ message OS {
   int32 minor_version = 5;
   // The point version of the OS.
   int32 point_version = 6;
+  // The API version of the OS.
+  int32 API_version = 7;
 }
 
 // CPU represents a specific central processing unit product.


### PR DESCRIPTION
The `ro.build.version.release` property does not actually have a defined format and can be any string. Make version decisions on the SDK version, rather than the release name.