### PR TITLE
Vulkan: Track dependencies among query commands

### DIFF
--- a/gapii/cc/vulkan_extras.cpp
+++ b/gapii/cc/vulkan_extras.cpp
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include <bitset>
 #include "gapii/cc/vulkan_layer_extras.h"
 #include "gapii/cc/vulkan_spy.h"
 
@@ -499,6 +500,9 @@ void VulkanSpy::popDebugMarker(CallObserver*) {}
 void VulkanSpy::pushRenderPassMarker(CallObserver*, VkRenderPass) {}
 void VulkanSpy::popRenderPassMarker(CallObserver*) {}
 void VulkanSpy::popAndPushMarkerForNextSubpass(CallObserver*, uint32_t) {}
+uint32_t VulkanSpy::onesCount(CallObserver*, uint32_t x) {
+  return std::bitset<32>(x).count();
+}
 
 gapil::Ref<PhysicalDevicesAndProperties>
 VulkanSpy::fetchPhysicalDeviceProperties(CallObserver* observer,

--- a/gapii/cc/vulkan_inlines.inc
+++ b/gapii/cc/vulkan_inlines.inc
@@ -51,6 +51,22 @@ inline void VulkanSpy::vkErrCommandBufferNotRecording(CallObserver*, VkCommandBu
     GAPID_WARNING("Error: Executing command buffer %zu was not in the RECORDING state", cmdbuf)
 }
 
+inline void VulkanSpy::vkErrQueryOutOfRange(CallObserver*, VkQueryPool queryPool, uint32_t query) {
+    GAPID_WARNING("Error: Query %" PRIu32 " in QueryPool %" PRIu64 " was out of range", query, queryPool)
+}
+
+inline void VulkanSpy::vkErrQueryUninitialized(CallObserver*, VkQueryPool queryPool, uint32_t query) {
+    GAPID_WARNING("Error: Query %" PRIu32 " in QueryPool %" PRIu64 " was uninitialized", query, queryPool)
+}
+
+inline void VulkanSpy::vkErrQueryNotInactive(CallObserver*, VkQueryPool queryPool, uint32_t query) {
+    GAPID_WARNING("Error: Query %" PRIu32 " in QueryPool %" PRIu64 " was not in the INACTIVE state", query, queryPool)
+}
+
+inline void VulkanSpy::vkErrQueryNotActive(CallObserver*, VkQueryPool queryPool, uint32_t query) {
+    GAPID_WARNING("Error: Query %" PRIu32 " in QueryPool %" PRIu64 " was not in the ACTIVE state", query, queryPool)
+}
+
 inline void VulkanSpy::vkErrInvalidImageLayout(CallObserver*, VkImage img, uint32_t aspect, uint32_t layer, uint32_t level, uint32_t layout, uint32_t expectedLayout) {
     GAPID_WARNING("Error: Image subresource at Image: %" PRIu64 ", AspectBit: %" PRIu32 ", Layer: %" PRIu32 ", Level: %" PRIu32 " was in layout %" PRIu32 ", but was expected to be in layout %" PRIu32,
         img, aspect, layer, level, layout, expectedLayout);

--- a/gapis/api/vulkan/api/query_pool.api
+++ b/gapis/api/vulkan/api/query_pool.api
@@ -41,9 +41,10 @@
 //////////////////////////
 
 enum QueryStatus {
-  QUERY_STATUS_INACTIVE = 0
-  QUERY_STATUS_ACTIVE   = 1
-  QUERY_STATUS_COMPLETE = 2
+  QUERY_STATUS_INACTIVE      = 0
+  QUERY_STATUS_ACTIVE        = 1
+  QUERY_STATUS_COMPLETE      = 2
+  QUERY_STATUS_UNINITIALIZED = 4
 }
 
 @internal class QueryPoolObject {
@@ -87,7 +88,7 @@ cmd VkResult vkCreateQueryPool(
     QueryCount:          info.queryCount,
     PipelineStatistics:  info.pipelineStatistics)
   for i in (0 .. info.queryCount) {
-    pool.Status[i] = QUERY_STATUS_INACTIVE
+    pool.Status[i] = QUERY_STATUS_UNINITIALIZED
   }
 
   QueryPools[handle] = pool
@@ -121,7 +122,29 @@ cmd VkResult vkGetQueryPoolResults(
     VkQueryResultFlags flags) {
   if !(device in Devices) { vkErrorInvalidDevice(device) }
   if !(queryPool in QueryPools) { vkErrorInvalidQueryPool(queryPool) }
-  write(as!u8*(pData)[0:dataSize])
+
+  pool := QueryPools[queryPool]
+  dstIntSize := switch (as!u32(flags) & as!u32(VK_QUERY_RESULT_64_BIT)) != 0 {
+    case true: as!VkDeviceSize(8)
+    case false: as!VkDeviceSize(4)
+  }
+  resultCount := getResultCount(pool)
+  dstCount := switch (as!u32(flags) & as!u32(VK_QUERY_RESULT_WITH_AVAILABILITY_BIT)) != 0 {
+    case true: resultCount + 1
+    case false: resultCount
+  }
+  dstSize := dstIntSize * as!VkDeviceSize(dstCount)
+  for i in (0 .. queryCount) {
+    dstOffset := as!VkDeviceSize(i) * stride
+    write(pData[dstOffset:dstOffset + dstSize])
+
+    query := i + firstQuery
+    if !(query < pool.QueryCount) { vkErrorQueryOutOfRange(queryPool, query) }
+    if pool.Status[query] == QUERY_STATUS_UNINITIALIZED {
+      vkErrorQueryUninitialized(queryPool, query)
+    }
+  }
+
   return ?
 }
 
@@ -136,8 +159,13 @@ cmd VkResult vkGetQueryPoolResults(
 }
 
 sub void dovkCmdBeginQuery(ref!vkCmdBeginQueryArgs args) {
+  if !(args.QueryPool in QueryPools) { vkErrorInvalidQueryPool(args.QueryPool) }
   pool := QueryPools[args.QueryPool]
   if pool != null {
+    if !(args.Query < pool.QueryCount) { vkErrorQueryOutOfRange(args.QueryPool, args.Query) }
+    if pool.Status[args.Query] != QUERY_STATUS_INACTIVE {
+      vkErrorQueryNotInactive(args.QueryPool, args.Query)
+    }
     pool.Status[args.Query] = QUERY_STATUS_ACTIVE
     pool.LastBoundQueue = LastBoundQueue
   }
@@ -173,8 +201,13 @@ vkCmdEndQueryArgs {
 }
 
 sub void dovkCmdEndQuery(ref!vkCmdEndQueryArgs args) {
+  if !(args.QueryPool in QueryPools) { vkErrorInvalidQueryPool(args.QueryPool) }
   pool := QueryPools[args.QueryPool]
   if pool != null {
+    if !(args.Query < pool.QueryCount) { vkErrorQueryOutOfRange(args.QueryPool, args.Query) }
+    if pool.Status[args.Query] != QUERY_STATUS_ACTIVE {
+      vkErrorQueryNotActive(args.QueryPool, args.Query)
+    }
     pool.Status[args.Query] = QUERY_STATUS_COMPLETE
     pool.LastBoundQueue = LastBoundQueue
   }
@@ -210,9 +243,12 @@ vkCmdResetQueryPoolArgs {
 }
 
 sub void dovkCmdResetQueryPool(ref!vkCmdResetQueryPoolArgs args) {
+  if !(args.QueryPool in QueryPools) { vkErrorInvalidQueryPool(args.QueryPool) }
   pool := QueryPools[args.QueryPool]
   if pool != null {
     for i in (0 .. args.QueryCount) {
+      query := args.FirstQuery + i
+      if !(query < pool.QueryCount) { vkErrorQueryOutOfRange(args.QueryPool, query) }
       pool.Status[args.FirstQuery + i] = QUERY_STATUS_INACTIVE
     }
     pool.LastBoundQueue = LastBoundQueue
@@ -249,8 +285,15 @@ cmd void vkCmdResetQueryPool(
 }
 
 sub void dovkCmdWriteTimestamp(ref!vkCmdWriteTimestampArgs args) {
+  if !(args.QueryPool in QueryPools) { vkErrorInvalidQueryPool(args.QueryPool) }
   pool := QueryPools[args.QueryPool]
   if pool != null {
+    if !(args.Query < pool.QueryCount) { vkErrorQueryOutOfRange(args.QueryPool, args.Query) }
+    if pool.Status[args.Query] != QUERY_STATUS_INACTIVE {
+      vkErrorQueryNotInactive(args.QueryPool, args.Query)
+    }
+    pool.Status[args.Query] = QUERY_STATUS_COMPLETE
+
     pool.LastBoundQueue = LastBoundQueue
   }
 }
@@ -290,9 +333,33 @@ class vkCmdCopyQueryPoolResultsArgs {
 }
 
 sub void dovkCmdCopyQueryPoolResults(ref!vkCmdCopyQueryPoolResultsArgs args) {
+  if !(args.QueryPool in QueryPools) { vkErrorInvalidQueryPool(args.QueryPool) }
   pool := QueryPools[args.QueryPool]
   if pool != null {
     pool.LastBoundQueue = LastBoundQueue
+  }
+  dstIntSize := switch (as!u32(args.Flags) & as!u32(VK_QUERY_RESULT_64_BIT)) != 0 {
+    case true: as!VkDeviceSize(8)
+    case false: as!VkDeviceSize(4)
+  }
+  resultCount := getResultCount(pool)
+  dstCount := switch (as!u32(args.Flags) & as!u32(VK_QUERY_RESULT_WITH_AVAILABILITY_BIT)) != 0 {
+    case true: resultCount + 1
+    case false: resultCount
+  }
+  dstSize := dstIntSize * as!VkDeviceSize(dstCount)
+  buf := Buffers[args.DstBuffer]
+  for i in (0 .. args.QueryCount) {
+    if buf != null {
+      dstOffset := args.DstOffset + as!VkDeviceSize(i) * args.Stride
+      writeMemoryInBuffer(buf, dstOffset, dstSize)
+    }
+
+    query := i + args.FirstQuery
+    if !(query < pool.QueryCount) { vkErrorQueryOutOfRange(args.QueryPool, query) }
+    if pool.Status[query] == QUERY_STATUS_UNINITIALIZED {
+      vkErrorQueryUninitialized(args.QueryPool, query)
+    }
   }
 }
 
@@ -327,5 +394,16 @@ cmd void vkCmdCopyQueryPoolResults(
     args
 
     AddCommand(commandBuffer, cmd_vkCmdCopyQueryPoolResults, mapPos)
+  }
+}
+
+sub u32 getResultCount(ref!QueryPoolObject pool) {
+  return switch pool.QueryType {
+    case VK_QUERY_TYPE_OCCLUSION:
+      as!u32(1)
+    case VK_QUERY_TYPE_PIPELINE_STATISTICS:
+      onesCount(as!u32(pool.PipelineStatistics))
+    case VK_QUERY_TYPE_TIMESTAMP:
+      as!u32(1)
   }
 }

--- a/gapis/api/vulkan/api/util.api
+++ b/gapis/api/vulkan/api/util.api
@@ -431,3 +431,5 @@ sub T min!T(T a, T b) {
     case false: b
   }
 }
+
+extern u32 onesCount(u32 a)

--- a/gapis/api/vulkan/errors.api
+++ b/gapis/api/vulkan/errors.api
@@ -47,6 +47,10 @@ extern void vkErrInvalidDescriptorArrayElement(u64 set, u32 binding, u32 arrayIn
 extern void vkErrInvalidDescriptorBindingType(VkDescriptorSet set, u32 binding, VkDescriptorType layoutType, VkDescriptorType updateType)
 extern void vkErrCommandBufferIncomplete(VkCommandBuffer cmdbuf)
 extern void vkErrCommandBufferNotRecording(VkCommandBuffer cmdbuf)
+extern void vkErrQueryOutOfRange(VkQueryPool queryPool, u32 query)
+extern void vkErrQueryUninitialized(VkQueryPool queryPool, u32 query)
+extern void vkErrQueryNotInactive(VkQueryPool queryPool, u32 query)
+extern void vkErrQueryNotActive(VkQueryPool queryPool, u32 query)
 extern void vkErrInvalidImageLayout(VkImage img, u32 aspect, u32 layer, u32 level, VkImageLayout layout, VkImageLayout expectedLayout)
 extern void vkErrInvalidImageSubresource(VkImage img, string subresourceType, u32 value)
 
@@ -78,6 +82,19 @@ sub void vkErrorCommandBufferIncomplete(VkCommandBuffer cmdbuf) {
 
 sub void vkErrorCommandBufferNotRecording(VkCommandBuffer cmdbuf) {
   vkErrCommandBufferNotRecording(cmdbuf)
+}
+
+sub void vkErrorQueryOutOfRange(VkQueryPool queryPool, u32 query) {
+  vkErrQueryOutOfRange(queryPool, query)
+}
+sub void vkErrorQueryUninitialized(VkQueryPool queryPool, u32 query) {
+  vkErrQueryUninitialized(queryPool, query)
+}
+sub void vkErrorQueryNotInactive(VkQueryPool queryPool, u32 query) {
+  vkErrQueryNotInactive(queryPool, query)
+}
+sub void vkErrorQueryNotActive(VkQueryPool queryPool, u32 query) {
+  vkErrQueryNotActive(queryPool, query)
 }
 
 sub void vkErrorInvalidDeviceMemory(VkDeviceMemory mem) {

--- a/gapis/api/vulkan/externs.go
+++ b/gapis/api/vulkan/externs.go
@@ -17,6 +17,7 @@ package vulkan
 import (
 	"context"
 	"fmt"
+	"math/bits"
 	"reflect"
 
 	"github.com/google/gapid/core/log"
@@ -474,6 +475,38 @@ func (e externs) vkErrCommandBufferNotRecording(cmdbuf VkCommandBuffer) {
 	e.onVkError(issue)
 }
 
+func (e externs) vkErrQueryOutOfRange(queryPool VkQueryPool, query uint32) {
+	var issue replay.Issue
+	issue.Command = e.cmdID
+	issue.Severity = service.Severity_ErrorLevel
+	issue.Error = fmt.Errorf("Query %v in QueryPool %v was out of range", query, queryPool)
+	e.onVkError(issue)
+}
+
+func (e externs) vkErrQueryUninitialized(queryPool VkQueryPool, query uint32) {
+	var issue replay.Issue
+	issue.Command = e.cmdID
+	issue.Severity = service.Severity_ErrorLevel
+	issue.Error = fmt.Errorf("Query %v in QueryPool %v was uninitialized", query, queryPool)
+	e.onVkError(issue)
+}
+
+func (e externs) vkErrQueryNotInactive(queryPool VkQueryPool, query uint32) {
+	var issue replay.Issue
+	issue.Command = e.cmdID
+	issue.Severity = service.Severity_ErrorLevel
+	issue.Error = fmt.Errorf("Query %v in QueryPool %v was not in the INACTIVE state", query, queryPool)
+	e.onVkError(issue)
+}
+
+func (e externs) vkErrQueryNotActive(queryPool VkQueryPool, query uint32) {
+	var issue replay.Issue
+	issue.Command = e.cmdID
+	issue.Severity = service.Severity_ErrorLevel
+	issue.Error = fmt.Errorf("Query %v in QueryPool %v was not in the ACTIVE state", query, queryPool)
+	e.onVkError(issue)
+}
+
 func (e externs) vkErrInvalidImageLayout(img VkImage, aspect, layer, level uint32, layout VkImageLayout, expectedLayout VkImageLayout) {
 	var issue replay.Issue
 	issue.Command = e.cmdID
@@ -533,4 +566,8 @@ func (e externs) recordPresentSwapchainImage(swapchain VkSwapchainKHR, imageInde
 	if e.w != nil {
 		e.w.CloseForwardDependency(e.ctx, swapchainImage{swapchain, imageIndex})
 	}
+}
+
+func (e externs) onesCount(a uint32) uint32 {
+	return (uint32)(bits.OnesCount32(a))
 }


### PR DESCRIPTION
This fleshes out the api implementation of the following query commands, to
ensure correct dependencies.
  * `vkGetQueryPoolResults`
  * `vkCmdBeginQuery`
  * `vkCmdEndQuery`
  * `vkCmdResetQueryPool`
  * `vkCmdWriteTimestamp`
  * `vkCmdCopyQueryPoolResults`

This patch also adds additional error checking to the query commands, including
a new query status, UNINITIALIZED; each query in a query pool now starts in the
UNINITIALIZED state, and is moved to INACTIVE by vkCmdResetQueryPool; according
to the spec
([16.2. Query Operation](https://www.khronos.org/registry/vulkan/specs/1.1-extensions/html/vkspec.html#queries-operation)):
> After query pool creation, each query is in an undefined state and must be
> reset prior to use. Queries must also be reset between uses. Using a query
> that has not been reset will result in undefined behavior.

Fixes #2404