### PR TITLE
Dependency Graph: Add specialized maps to efficiently track fragment data

### DIFF
--- a/gapil/template/list.go
+++ b/gapil/template/list.go
@@ -186,3 +186,8 @@ func (f *Functions) PartitionByKey(arr interface{}, keyMacro string) (interface{
 	}
 	return slices.Interface(), nil
 }
+
+func (f *Functions) Length(arr interface{}) (int, error) {
+	v := reflect.ValueOf(arr)
+	return v.Len(), nil
+}

--- a/gapis/api/templates/api.go.tmpl
+++ b/gapis/api/templates/api.go.tmpl
@@ -291,6 +291,9 @@ import (
   }
 
   func (c {{$name}}) RefID() ϟapi.RefID { return c.refID }
+  func (c {{$name}}) NewFragmentMap() ϟapi.FragmentMap {
+    return ϟapi.NewDenseFragmentMap(1 + {{$ty.Size}})
+  }
 {{end}}
 
 
@@ -305,6 +308,7 @@ import (
   {{$name  := $.Name}}
   {{$key   := Macro "Go.Type" $.KeyType}}
   {{$value := Macro "Go.Type" $.ValueType}}
+  {{$keyFrag := Macro "MapIndexFragment" "Map" $ "Key" "key"}}
 
   type {{$name}} struct {
     Map   *map[{{$key}}]{{$value}}
@@ -339,7 +343,7 @@ import (
       v = {{Template "Go.Null" $.ValueType}}
     }
     if ϟw != nil {
-      ϟw.OnGet(ϟctx, m, ϟapi.MapIndexFragment{key}, {{Template "Reference" "Type" $.ValueType "Val" "v"}})
+      ϟw.OnGet(ϟctx, m, {{$keyFrag}}, {{Template "Reference" "Type" $.ValueType "Val" "v"}})
     }
     return v
   }
@@ -368,7 +372,7 @@ import (
       }
     {{end}}
     if ϟw != nil {
-      ϟw.OnGet(ϟctx, m, ϟapi.MapIndexFragment{key}, {{Template "Reference" "Type" $.ValueType "Val" "v"}})
+      ϟw.OnGet(ϟctx, m, {{$keyFrag}}, {{Template "Reference" "Type" $.ValueType "Val" "v"}})
     }
     return
   }
@@ -380,7 +384,7 @@ import (
 
   func (m {{$name}}) Addʷ(ϟctx context.Context, ϟw ϟapi.StateWatcher, key {{$key}}, val {{$value}}) {{$name}} {
     if ϟw != nil {
-      ϟw.OnSet(ϟctx, m, ϟapi.MapIndexFragment{key},
+      ϟw.OnSet(ϟctx, m, {{$keyFrag}},
         {{Template "Reference" "Type" $.ValueType "Val" "(*m.Map)[key]"}},
         {{Template "Reference" "Type" $.ValueType "Val" "val"}})
     }
@@ -390,7 +394,7 @@ import (
 
   func (m {{$name}}) CreateHandleʷ(ϟctx context.Context, ϟw ϟapi.StateWatcher, ϟg *ϟapi.GlobalState, key {{$key}}, val {{$value}}) {{$name}} {
     if ϟw != nil {
-      ϟw.OnSet(ϟctx, m, ϟapi.MapIndexFragment{key},
+      ϟw.OnSet(ϟctx, m, {{$keyFrag}},
         {{Template "Reference" "Type" $.ValueType "Val" "(*m.Map)[key]"}},
         {{Template "Reference" "Type" $.ValueType "Val" "val"}})
       if _, ok := (*m.Map)[key]; !ok {
@@ -408,7 +412,7 @@ import (
   func (m {{$name}}) DestroyHandleʷ(ϟctx context.Context, ϟw ϟapi.StateWatcher, ϟg *ϟapi.GlobalState, key {{$key}}) {
     if m.Map != nil {
       if ϟw != nil {
-        ϟw.OnSet(ϟctx, m, ϟapi.MapIndexFragment{key},
+        ϟw.OnSet(ϟctx, m, {{$keyFrag}},
           {{Template "Reference" "Type" $.ValueType "Val" "(*m.Map)[key]"}},
           ϟapi.NilReference{})
         if _, ok := (*m.Map)[key]; ok {
@@ -439,7 +443,7 @@ import (
         _, ok := (*m.Map)[key]
       {{end}}
       if ϟw != nil {
-        ϟw.OnGet(ϟctx, m, ϟapi.MapIndexFragment{key}, {{Template "Reference" "Type" $.ValueType "Val" "v"}})
+        ϟw.OnGet(ϟctx, m, {{$keyFrag}}, {{Template "Reference" "Type" $.ValueType "Val" "v"}})
       }
       return ok
     }
@@ -455,7 +459,7 @@ import (
   func (m {{$name}}) Removeʷ(ϟctx context.Context, ϟw ϟapi.StateWatcher, key {{$key}}) {
     if m.Map != nil {
       if ϟw != nil {
-        ϟw.OnSet(ϟctx, m, ϟapi.MapIndexFragment{key},
+        ϟw.OnSet(ϟctx, m, {{$keyFrag}},
           {{Template "Reference" "Type" $.ValueType "Val" "(*m.Map)[key]"}},
           ϟapi.NilReference{})
       }
@@ -589,6 +593,19 @@ import (
   }
 
   func (m {{$name}}) RefID() ϟapi.RefID { return m.refID }
+  func (m {{$name}}) NewFragmentMap() ϟapi.FragmentMap {
+    {{if $.Dense}}return ϟapi.NewDenseFragmentMap(len(*m.Map))
+    {{else}}return ϟapi.NewSparseFragmentMap()
+    {{end}}
+  }
+{{end}}
+
+
+{{define "MapIndexFragment"}}
+  {{AssertType $.Map "Map"}}
+  {{if $.Map.Dense}}ϟapi.ArrayIndexFragment{(int)({{$.Key}})}§
+  {{else}}ϟapi.MapIndexFragment{key}§
+  {{end}}
 {{end}}
 
 
@@ -749,6 +766,9 @@ import (
   }
 
   func (c {{$name}}) RefID() ϟapi.RefID { return c.refID }
+  func (c {{$name}}) NewFragmentMap() ϟapi.FragmentMap {
+    return ϟapi.NewDenseFragmentMap(1 + {{Length $.To.Fields}})
+  }
 {{end}}
 
 
@@ -1434,9 +1454,9 @@ import (
     fmt.Fprintln(f, "}")
   }
 
-  {{range $f := $.Fields}}
+  {{range $i, $f := $.Fields}}
     {{Template "DeclareGetterSetter" "Struct" $name "Prefix" "data" "Name" $f.Name "Type" $f.Type "Watch" true}}
-    {{Template "DeclareFieldID" "Class" $name "Name" $f.Name}}
+    {{Template "DeclareFieldID" "Class" $name "Name" $f.Name "Index" $i}}
   {{end}}
 
   // Arena returns the memory arena used to allocate this class.
@@ -1609,6 +1629,9 @@ import (
   }
 
   func (a {{$name}}) RefID() ϟapi.RefID { return a.refID }
+  func ({{$name}}) NewFragmentMap() ϟapi.FragmentMap {
+    return ϟapi.NewDenseFragmentMap(1 + {{Length $.Fields}})
+  }
 {{end}}
 
 
@@ -1723,12 +1746,11 @@ import (
     return ϟc
   }
 
-  {{range $p := $.FullParameters}}
+  {{range $i, $p := $.FullParameters}}
     {{$pname := Macro "Go.Parameter" $p}}
     {{Template "DeclareGetterSetter" "Struct" $name "Name" $p.Name "Type" $p.Type "PtrMethod" "true" "Watch" true}}¶
-    {{Template "DeclareFieldID" "Class" $name "Name" $p.Name}}
+    {{Template "DeclareFieldID" "Class" $name "Name" $p.Name "Index" $i}}
   {{end}}
-  {{Template "DeclareFieldID" "Class" $name "Name" "Result"}}
 
   // clone returns a shallow clone of the command. Extras are shared.
   func (ϟc *{{$name}}) clone(ϟa arena.Arena) *{{$name}} {
@@ -1753,6 +1775,9 @@ import (
   }
 
   func (ϟc *{{$name}}) RefID() ϟapi.RefID { return ϟc.refID }
+  func ({{$name}}) NewFragmentMap() ϟapi.FragmentMap {
+    return ϟapi.NewDenseFragmentMap(1 + {{Length $.FullParameters}})
+  }
 
   func (ϟc *{{$name}}) Alive() bool {
     {{if GetAnnotation $ "alive"}}
@@ -1830,9 +1855,9 @@ import (
     customState `hidden:"true" nobox:"true"`
   }
 
-  {{range $g := $.Globals}}
+  {{range $i, $g := $.Globals}}
     {{Template "DeclareGetterSetter" "Struct" "State" "Name" $g.Name "Type" $g.Type "PtrMethod" "true" "Watch" true}}¶
-    {{Template "DeclareFieldID" "Class" "State" "Name" $g.Name}}
+    {{Template "DeclareFieldID" "Class" "State" "Name" $g.Name "Index" $i}}
   {{end}}
 
   // Arena returns the memory arena used to allocate the state.
@@ -1890,6 +1915,9 @@ import (
   }
 
   func (g *State) RefID() ϟapi.RefID { return g.refID }
+  func (State) NewFragmentMap() ϟapi.FragmentMap {
+    return ϟapi.NewDenseFragmentMap(1 + {{Length $.Globals}})
+  }
 {{end}}
 
 
@@ -2239,6 +2267,7 @@ import (
   type {{$fieldID}} struct{}
   func ({{$fieldID}}) ClassName() string { return "{{$.Class}}" }
   func ({{$fieldID}}) FieldName() string { return "{{$.Name}}" }
+  func ({{$fieldID}}) FieldIndex() int { return {{$.Index}} }
 {{end}}
 
 

--- a/gapis/api/templates/api.go.tmpl
+++ b/gapis/api/templates/api.go.tmpl
@@ -2216,14 +2216,14 @@ import (
 
 {{/*
 -------------------------------------------------------------------------------
-  RefID returns a unique identifier for a reference
+  Reference returns an `api.Reference` value corresponding to the given value
 -------------------------------------------------------------------------------
 */}}
 {{define "Reference"}}
   {{AssertType $.Type "Type"}}
 
   {{if or (IsMap $.Type) (IsReference $.Type) (IsClass $.Type) (IsStaticArray $.Type)}}§
-    (ϟapi.Reference)({{$.Val}})
+    {{$.Val}}
   {{else}}ϟapi.NilReference{}
   {{end}}
 {{end}}

--- a/gapis/api/watcher.go
+++ b/gapis/api/watcher.go
@@ -17,6 +17,7 @@ package api
 import (
 	"context"
 	"fmt"
+	"math/bits"
 
 	"github.com/google/gapid/gapis/memory"
 )
@@ -82,6 +83,8 @@ type FieldFragment struct {
 
 func (f FieldFragment) Format(s fmt.State, r rune) { fmt.Fprintf(s, ".%s", f.Field.FieldName()) }
 
+func (f FieldFragment) DenseIndex() int { return 1 + f.Field.FieldIndex() }
+
 func (FieldFragment) fragment() {}
 
 // ArrayIndexFragment is a Fragment identifying an array index.
@@ -90,6 +93,7 @@ type ArrayIndexFragment struct {
 	ArrayIndex int
 }
 
+func (f ArrayIndexFragment) DenseIndex() int            { return 1 + f.ArrayIndex }
 func (f ArrayIndexFragment) Format(s fmt.State, r rune) { fmt.Fprintf(s, "[%d]", f.ArrayIndex) }
 
 func (ArrayIndexFragment) fragment() {}
@@ -108,6 +112,7 @@ func (MapIndexFragment) fragment() {}
 // map (all key/value pairs) or array (all values).
 type CompleteFragment struct{}
 
+func (CompleteFragment) DenseIndex() int            { return 0 }
 func (CompleteFragment) Format(s fmt.State, r rune) { fmt.Fprintf(s, "[*]") }
 
 func (CompleteFragment) fragment() {}
@@ -115,5 +120,154 @@ func (CompleteFragment) fragment() {}
 // Field identifies a field in an API object
 type Field interface {
 	FieldName() string
+	FieldIndex() int
 	ClassName() string
 }
+
+type FragmentMap interface {
+	Get(Fragment) (interface{}, bool)
+	Set(Fragment, interface{})
+	Delete(Fragment)
+	Clear()
+	ForeachFrag(func(Fragment, interface{}) error) error
+	EmptyClone() FragmentMap
+}
+
+type DenseFragment interface {
+	DenseIndex() int
+}
+
+type denseFragmentMapEntry struct {
+	frag  Fragment
+	value interface{}
+}
+
+type DenseFragmentMap struct {
+	Values []denseFragmentMapEntry
+}
+
+func NewDenseFragmentMap(cap int) *DenseFragmentMap {
+	return &DenseFragmentMap{
+		Values: make([]denseFragmentMapEntry, cap),
+	}
+}
+
+func (m DenseFragmentMap) Get(f Fragment) (interface{}, bool) {
+	if d, ok := f.(DenseFragment); ok {
+		i := d.DenseIndex()
+		if i < len(m.Values) {
+			a := m.Values[i]
+			if a.frag != nil {
+				if a.frag != f {
+					panic("Collision in DenseFragmentmap")
+				}
+				return a.value, true
+			}
+			return nil, false
+		}
+		return nil, false
+	} else {
+		panic("DenseFragmentMap used with non-dense fragment")
+	}
+}
+
+func (m *DenseFragmentMap) Set(f Fragment, v interface{}) {
+	if d, ok := f.(DenseFragment); ok {
+		i := d.DenseIndex()
+		n := len(m.Values)
+		if i >= n {
+			n := 1 << uint(bits.Len(uint(i)))
+			newVals := make([]denseFragmentMapEntry, n)
+			copy(newVals, m.Values)
+			m.Values = newVals
+		}
+		a := &m.Values[i]
+		if a.frag != nil && a.frag != f {
+			panic("Collision in DenseFragmentMap")
+		}
+		a.frag = f
+		a.value = v
+	} else {
+		panic("DenseFragmentMap used with non-dense fragment")
+	}
+}
+
+func (m DenseFragmentMap) Delete(f Fragment) {
+	if d, ok := f.(DenseFragment); ok {
+		i := d.DenseIndex()
+		if i < len(m.Values) {
+			m.Values[i] = denseFragmentMapEntry{}
+		}
+	} else {
+		panic("DenseFragmentMap used with non-dense fragment")
+	}
+}
+
+func (m DenseFragmentMap) ForeachFrag(f func(Fragment, interface{}) error) error {
+	for _, v := range m.Values {
+		if v.frag == nil {
+			continue
+		}
+		if err := f(v.frag, v.value); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (m DenseFragmentMap) Clear() {
+	for _, e := range m.Values {
+		e.frag = nil
+	}
+}
+
+func (m DenseFragmentMap) EmptyClone() FragmentMap {
+	return NewDenseFragmentMap(len(m.Values))
+}
+
+type SparseFragmentMap struct {
+	Map map[Fragment]interface{}
+}
+
+func NewSparseFragmentMap() *SparseFragmentMap {
+	return &SparseFragmentMap{
+		Map: make(map[Fragment]interface{}),
+	}
+}
+
+func (m SparseFragmentMap) Get(f Fragment) (interface{}, bool) {
+	v, ok := m.Map[f]
+	return v, ok
+}
+
+func (m *SparseFragmentMap) Set(f Fragment, v interface{}) {
+	m.Map[f] = v
+}
+
+func (m SparseFragmentMap) Delete(f Fragment) {
+	delete(m.Map, f)
+}
+
+func (m SparseFragmentMap) ForeachFrag(f func(Fragment, interface{}) error) error {
+	for k, v := range m.Map {
+		if err := f(k, v); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (m SparseFragmentMap) Clear() {
+	m.Map = make(map[Fragment]interface{})
+}
+
+func (m SparseFragmentMap) EmptyClone() FragmentMap {
+	return NewSparseFragmentMap()
+}
+
+type RefObject interface {
+	Reference
+	NewFragmentMap() FragmentMap
+}
+
+func (NilReference) NewFragmentMap() FragmentMap { panic("NewFragmentMap called on NilReference") }

--- a/gapis/api/watcher.go
+++ b/gapis/api/watcher.go
@@ -30,10 +30,10 @@ type StateWatcher interface {
 	OnEndCmd(ctx context.Context, cmdID CmdID, cmd Cmd)
 
 	// OnGet is called when a fragment of state (field, map key, array index) is read
-	OnGet(ctx context.Context, owner Reference, f Fragment, v Reference)
+	OnGet(ctx context.Context, owner RefObject, f Fragment, v RefObject)
 
 	// OnSet is called when a fragment of state (field, map key, array index) is written
-	OnSet(ctx context.Context, owner Reference, f Fragment, old Reference, new Reference)
+	OnSet(ctx context.Context, owner RefObject, f Fragment, old RefObject, new RefObject)
 
 	// OnWriteSlice is called when writing to a slice
 	OnWriteSlice(ctx context.Context, s memory.Slice)
@@ -87,20 +87,20 @@ func (FieldFragment) fragment() {}
 // ArrayIndexFragment is a Fragment identifying an array index.
 // This corresponds to syntax such as `myArray[3]`.
 type ArrayIndexFragment struct {
-	Index int
+	ArrayIndex int
 }
 
-func (f ArrayIndexFragment) Format(s fmt.State, r rune) { fmt.Fprintf(s, "[%d]", f.Index) }
+func (f ArrayIndexFragment) Format(s fmt.State, r rune) { fmt.Fprintf(s, "[%d]", f.ArrayIndex) }
 
 func (ArrayIndexFragment) fragment() {}
 
 // MapIndexFragment is a Fragment identifying a map index.
 // This corresponds to syntax such as `myMap["foo"]`
 type MapIndexFragment struct {
-	Index interface{}
+	MapIndex interface{}
 }
 
-func (f MapIndexFragment) Format(s fmt.State, r rune) { fmt.Fprintf(s, "[%v]", f.Index) }
+func (f MapIndexFragment) Format(s fmt.State, r rune) { fmt.Fprintf(s, "[%v]", f.MapIndex) }
 
 func (MapIndexFragment) fragment() {}
 
@@ -108,7 +108,7 @@ func (MapIndexFragment) fragment() {}
 // map (all key/value pairs) or array (all values).
 type CompleteFragment struct{}
 
-func (f CompleteFragment) Format(s fmt.State, r rune) { fmt.Fprintf(s, "[*]") }
+func (CompleteFragment) Format(s fmt.State, r rune) { fmt.Fprintf(s, "[*]") }
 
 func (CompleteFragment) fragment() {}
 

--- a/gapis/resolve/dependencygraph2/dependency_graph_builder.go
+++ b/gapis/resolve/dependencygraph2/dependency_graph_builder.go
@@ -124,7 +124,7 @@ func (b *dependencyGraphBuilder) OnEndCmd(ctx context.Context, cmdID api.CmdID, 
 	}
 }
 
-func (b *dependencyGraphBuilder) OnGet(ctx context.Context, owner api.Reference, frag api.Fragment, valueRef api.Reference) {
+func (b *dependencyGraphBuilder) OnGet(ctx context.Context, owner api.RefObject, frag api.Fragment, valueRef api.RefObject) {
 	debug(ctx, "  OnGet (%T %d)%v : %d", owner, owner.RefID(), frag, valueRef.RefID())
 	readEffect := ReadFragmentEffect{b.currentNodeID, frag}
 	writes, ok := b.fragmentWrites[owner.RefID()]
@@ -142,7 +142,7 @@ func (b *dependencyGraphBuilder) OnGet(ctx context.Context, owner api.Reference,
 	}
 }
 
-func (b *dependencyGraphBuilder) OnSet(ctx context.Context, owner api.Reference, frag api.Fragment, oldValueRef api.Reference, newValueRef api.Reference) {
+func (b *dependencyGraphBuilder) OnSet(ctx context.Context, owner api.RefObject, frag api.Fragment, oldValueRef api.RefObject, newValueRef api.RefObject) {
 	debug(ctx, "  OnSet (%T %d)%v : %d → %d", owner, owner.RefID(), frag, oldValueRef.RefID(), newValueRef.RefID())
 	if _, ok := frag.(api.CompleteFragment); ok {
 		b.fragmentWrites[owner.RefID()] = map[api.Fragment]NodeID{frag: b.currentNodeID}


### PR DESCRIPTION
The dependency graph tracker needs to track data about "fragments" (e.g. fields in a struct, keys in a map). Previously these were all stored in maps. However, in many cases the structure of the fragments allows more efficient storage. For example, the fields in a struct are known at compile time, so instead of looking up the field in a map, we can just use the field index to lookup in a slice. A similar optimization is used for maps that are marked as "dense" (meaning the keys are 0..max).