### PR TITLE
 Support editing shaders in GLES MEC traces.

### DIFF
--- a/gapic/src/main/com/google/gapid/models/ApiContext.java
+++ b/gapic/src/main/com/google/gapid/models/ApiContext.java
@@ -178,6 +178,11 @@ public class ApiContext
       public int hashCode() {
         return 0;
       }
+
+      @Override
+      public boolean matches(Path.Context path) {
+        return true;
+      }
     };
 
     private final Path.ID id;
@@ -272,6 +277,10 @@ public class ApiContext
     @Override
     public int hashCode() {
       return id.hashCode();
+    }
+
+    public boolean matches(Path.Context path) {
+      return Objects.equals(id, path.getID());
     }
   }
 

--- a/gapic/src/main/com/google/gapid/views/TextureView.java
+++ b/gapic/src/main/com/google/gapid/views/TextureView.java
@@ -25,6 +25,7 @@ import static com.google.gapid.widgets.Widgets.createComposite;
 import static com.google.gapid.widgets.Widgets.createMenuItem;
 import static com.google.gapid.widgets.Widgets.createTableColumn;
 import static com.google.gapid.widgets.Widgets.createTableViewer;
+import static com.google.gapid.widgets.Widgets.filling;
 import static com.google.gapid.widgets.Widgets.ifNotDisposed;
 import static com.google.gapid.widgets.Widgets.packColumns;
 import static com.google.gapid.widgets.Widgets.sorting;
@@ -76,6 +77,7 @@ import org.eclipse.swt.internal.DPIUtil;
 import org.eclipse.swt.layout.FillLayout;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
+import org.eclipse.swt.layout.RowLayout;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
@@ -121,7 +123,10 @@ public class TextureView extends Composite
     textureTable = createTableViewer(tableAndOption, SWT.BORDER | SWT.SINGLE | SWT.FULL_SELECTION);
     imageProvider = new ImageProvider(models, textureTable, widgets.loading);
     initTextureSelector(textureTable, imageProvider);
-    Button showDeleted = createCheckbox(tableAndOption, "Show deleted textures", true);
+    Composite options =
+        createComposite(tableAndOption, filling(new RowLayout(SWT.HORIZONTAL), true, false));
+    Button showDeleted = createCheckbox(options, "Show deleted textures", true);
+    Button allContexts = createCheckbox(options, "Include all contexts", true);
 
     Composite imageAndToolbar = createComposite(splitter, new GridLayout(2, false));
     ToolBar toolBar = new ToolBar(imageAndToolbar, SWT.VERTICAL | SWT.FLAT);
@@ -130,7 +135,6 @@ public class TextureView extends Composite
     splitter.setWeights(models.settings.texturesSplitterWeights);
     addListener(SWT.Dispose, e -> models.settings.texturesSplitterWeights = splitter.getWeights());
 
-    showDeleted.setLayoutData(new GridData(SWT.FILL, SWT.TOP, true, false));
     textureTable.getTable().setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
     toolBar.setLayoutData(new GridData(SWT.LEFT, SWT.FILL, false, true));
     imagePanel.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
@@ -162,6 +166,20 @@ public class TextureView extends Composite
         textureTable.removeFilter(filterDeleted);
       } else {
         textureTable.addFilter(filterDeleted);
+      }
+    });
+
+    ViewerFilter filterContexts = new ViewerFilter() {
+      @Override
+      public boolean select(Viewer viewer, Object parentElement, Object element) {
+        return models.contexts.getSelectedContext().matches(((Data)element).info.getContext());
+      }
+    };
+    allContexts.addListener(SWT.Selection, e -> {
+      if (allContexts.getSelection()) {
+        textureTable.removeFilter(filterContexts);
+      } else {
+        textureTable.addFilter(filterContexts);
       }
     });
   }

--- a/gapis/api/gles/resources.go
+++ b/gapis/api/gles/resources.go
@@ -222,6 +222,7 @@ func (t Textureʳ) SetResourceData(
 	data *api.ResourceData,
 	resources api.ResourceMap,
 	edits api.ReplaceCallback,
+	mutate api.MutateInitialState,
 	r *path.ResolveConfig) error {
 
 	return fmt.Errorf("SetResourceData is not supported for Texture")
@@ -313,6 +314,7 @@ func (s Shaderʳ) SetResourceData(
 	data *api.ResourceData,
 	resourceIDs api.ResourceMap,
 	edits api.ReplaceCallback,
+	mutate api.MutateInitialState,
 	r *path.ResolveConfig) error {
 
 	cmdIdx := at.Indices[0]
@@ -612,6 +614,7 @@ func (p Programʳ) SetResourceData(
 	data *api.ResourceData,
 	resources api.ResourceMap,
 	edits api.ReplaceCallback,
+	mutate api.MutateInitialState,
 	r *path.ResolveConfig) error {
 
 	return fmt.Errorf("SetResourceData is not supported for Program")

--- a/gapis/api/resource.go
+++ b/gapis/api/resource.go
@@ -52,6 +52,7 @@ type Resource interface {
 		data *ResourceData,
 		resources ResourceMap,
 		edits ReplaceCallback,
+		mutate MutateInitialState,
 		r *path.ResolveConfig) error
 }
 
@@ -63,6 +64,9 @@ type ResourceMeta struct {
 
 // ReplaceCallback is called from SetResourceData to propagate changes to current command stream.
 type ReplaceCallback func(where uint64, with interface{})
+
+// MutateInitialState is called from SetResourceData to get a mutable instance of the initial state.
+type MutateInitialState func(API API) State
 
 // Interface compliance check
 var _ = image.Convertable((*ResourceData)(nil))

--- a/gapis/api/vulkan/resources.go
+++ b/gapis/api/vulkan/resources.go
@@ -747,6 +747,7 @@ func (t ImageObjectʳ) SetResourceData(
 	data *api.ResourceData,
 	resources api.ResourceMap,
 	edits api.ReplaceCallback,
+	mutate api.MutateInitialState,
 	r *path.ResolveConfig) error {
 
 	return fmt.Errorf("SetResourceData is not supported for ImageObject")
@@ -797,6 +798,7 @@ func (shader ShaderModuleObjectʳ) SetResourceData(
 	data *api.ResourceData,
 	resourceIDs api.ResourceMap,
 	edits api.ReplaceCallback,
+	mutate api.MutateInitialState,
 	r *path.ResolveConfig) error {
 
 	ctx = log.Enter(ctx, "ShaderModuleObject.SetResourceData()")
@@ -952,6 +954,7 @@ func (p GraphicsPipelineObjectʳ) SetResourceData(
 	*api.ResourceData,
 	api.ResourceMap,
 	api.ReplaceCallback,
+	api.MutateInitialState,
 	*path.ResolveConfig) error {
 	return fmt.Errorf("SetResourceData is not supported on GraphicsPipeline")
 }
@@ -1021,6 +1024,7 @@ func (p ComputePipelineObjectʳ) SetResourceData(
 	*api.ResourceData,
 	api.ResourceMap,
 	api.ReplaceCallback,
+	api.MutateInitialState,
 	*path.ResolveConfig) error {
 	return fmt.Errorf("SetResourceData is not supported on ComputePipeline")
 }

--- a/gapis/capture/capture.go
+++ b/gapis/capture/capture.go
@@ -169,6 +169,23 @@ func (c *Capture) NewState(ctx context.Context) *api.GlobalState {
 	return out
 }
 
+// CloneInitialState clones this capture's initial state and returns it.
+func (c *Capture) CloneInitialState(a arena.Arena) *InitialState {
+	if c.InitialState == nil {
+		return nil
+	}
+
+	is := &InitialState{
+		Memory: c.InitialState.Memory,
+		APIs:   make(map[api.API]api.State, len(c.InitialState.APIs)),
+	}
+	for api, s := range c.InitialState.APIs {
+		is.APIs[api] = s.Clone(a)
+	}
+
+	return is
+}
+
 // Service returns the service.Capture description for this capture.
 func (c *Capture) Service(ctx context.Context, p *path.Capture) *service.Capture {
 	apis := make([]*path.API, len(c.APIs))

--- a/gapis/resolve/set.go
+++ b/gapis/resolve/set.go
@@ -65,46 +65,12 @@ func change(ctx context.Context, a arena.Arena, p path.Node, val interface{}, r 
 		return nil, fmt.Errorf("Reports are immutable")
 
 	case *path.MultiResourceData:
-		meta, err := ResourceMeta(ctx, p.IDs, p.After, r)
-		if err != nil {
-			return nil, err
-		}
-
-		cmdIdx := p.After.Indices[0]
-		// If we change resource data, subcommands do not affect this, so change
-		// the main comand.
-
-		oldCmds, err := NCmds(ctx, p.After.Capture, cmdIdx+1)
-		if err != nil {
-			return nil, err
-		}
-
-		cmds := make([]api.Cmd, len(oldCmds))
-		copy(cmds, oldCmds)
-
-		replaceCommands := func(where uint64, with interface{}) {
-			cmds[where] = with.(api.Cmd)
-		}
-
 		data, ok := val.(*api.MultiResourceData)
 		if !ok {
 			return nil, fmt.Errorf("Expected ResourceData, got %T", val)
 		}
 
-		for i, resource := range meta.Resources {
-			if err := resource.SetResourceData(
-				ctx,
-				p.After,
-				data.Resources[i],
-				meta.IDMap,
-				replaceCommands,
-				r); err != nil {
-				return nil, err
-			}
-		}
-
-		// Store the new command list
-		c, err := changeCommands(ctx, a, p.After.Capture, cmds)
+		c, err := changeResources(ctx, a, p.After, p.IDs, data.Resources, r)
 		if err != nil {
 			return nil, err
 		}
@@ -118,48 +84,12 @@ func change(ctx context.Context, a arena.Arena, p path.Node, val interface{}, r 
 		}, nil
 
 	case *path.ResourceData:
-		meta, err := ResourceMeta(ctx, []*path.ID{p.ID}, p.After, r)
-		if err != nil {
-			return nil, err
-		}
-
-		cmdIdx := p.After.Indices[0]
-		// If we change resource data, subcommands do not affect this, so change
-		// the main command.
-
-		oldCmds, err := NCmds(ctx, p.After.Capture, cmdIdx+1)
-		if err != nil {
-			return nil, err
-		}
-
-		cmds := make([]api.Cmd, len(oldCmds))
-		copy(cmds, oldCmds)
-
-		replaceCommands := func(where uint64, with interface{}) {
-			cmds[where] = with.(api.Cmd)
-		}
-
 		data, ok := val.(*api.ResourceData)
 		if !ok {
 			return nil, fmt.Errorf("Expected ResourceData, got %T", val)
 		}
 
-		if len(meta.Resources) != 1 {
-			return nil, fmt.Errorf("Expected a single resource, got %d", len(meta.Resources))
-		}
-
-		if err := meta.Resources[0].SetResourceData(
-			ctx,
-			p.After,
-			data,
-			meta.IDMap,
-			replaceCommands,
-			r); err != nil {
-			return nil, err
-		}
-
-		// Store the new command list
-		c, err := changeCommands(ctx, a, p.After.Capture, cmds)
+		c, err := changeResources(ctx, a, p.After, []*path.ID{p.ID}, []*api.ResourceData{data}, r)
 		if err != nil {
 			return nil, err
 		}
@@ -359,6 +289,47 @@ func change(ctx context.Context, a arena.Arena, p path.Node, val interface{}, r 
 		}
 	}
 	return nil, fmt.Errorf("Unknown path type %T", p)
+}
+
+func changeResources(ctx context.Context, a arena.Arena, after *path.Command, ids []*path.ID, data []*api.ResourceData, r *path.ResolveConfig) (*path.Capture, error) {
+	meta, err := ResourceMeta(ctx, ids, after, r)
+	if err != nil {
+		return nil, err
+	}
+	if len(meta.Resources) != len(ids) {
+		return nil, fmt.Errorf("Expected %d resource(s), got %d", len(ids), len(meta.Resources))
+	}
+
+	cmdIdx := after.Indices[0]
+	// If we change resource data, subcommands do not affect this, so change
+	// the main command.
+
+	oldCmds, err := NCmds(ctx, after.Capture, cmdIdx+1)
+	if err != nil {
+		return nil, err
+	}
+
+	cmds := make([]api.Cmd, len(oldCmds))
+	copy(cmds, oldCmds)
+
+	replaceCommands := func(where uint64, with interface{}) {
+		cmds[where] = with.(api.Cmd)
+	}
+
+	for i, resource := range meta.Resources {
+		if err := resource.SetResourceData(
+			ctx,
+			after,
+			data[i],
+			meta.IDMap,
+			replaceCommands,
+			r); err != nil {
+			return nil, err
+		}
+	}
+
+	// Store the new command list
+	return changeCommands(ctx, a, after.Capture, cmds)
 }
 
 func changeCommands(ctx context.Context, a arena.Arena, p *path.Capture, newCmds []api.Cmd) (*path.Capture, error) {

--- a/gapis/service/service.proto
+++ b/gapis/service/service.proto
@@ -844,6 +844,8 @@ message ResourcesByType {
 message Resource {
   // The resource's unique identifier.
   path.ID ID = 1;
+  // The context that created this resource.
+  path.Context context = 8;
   // The resource identifier used for display.
   string handle = 2;
   // The resource label.


### PR DESCRIPTION
Adds support for editing shaders that were created before the MEC capture started and thus have no `glShaderSource` call in the trace.

As a dependency, this also adds support for tracking the context that created a resource and allows the texture view to filter by context (see #1025).

Fixes #2066 