### PR TITLE
Vulkan: Create forward dependency from vkBeginCommandBuffer to vkEndCommandBuffer

### DIFF
--- a/gapii/cc/vulkan_extras.cpp
+++ b/gapii/cc/vulkan_extras.cpp
@@ -467,6 +467,8 @@ void VulkanSpy::recordFenceReset(CallObserver*, uint64_t) {}
 void VulkanSpy::recordAcquireNextImage(CallObserver*, uint64_t, uint32_t) {}
 void VulkanSpy::recordPresentSwapchainImage(CallObserver*, uint64_t, uint32_t) {
 }
+void VulkanSpy::recordBeginCommandBuffer(CallObserver*, VkCommandBuffer) {}
+void VulkanSpy::recordEndCommandBuffer(CallObserver*, VkCommandBuffer) {}
 
 bool VulkanSpy::hasDynamicProperty(CallObserver* observer,
                                    const VkPipelineDynamicStateCreateInfo* info,

--- a/gapis/api/vulkan/api/command_buffer_control.api
+++ b/gapis/api/vulkan/api/command_buffer_control.api
@@ -360,6 +360,9 @@ cmd void vkFreeCommandBuffers(
   }
 }
 
+extern void recordBeginCommandBuffer(VkCommandBuffer commandBuffer)
+extern void recordEndCommandBuffer(VkCommandBuffer commandBuffer)
+
 @threadSafety("app")
 @indirect("VkCommandBuffer", "VkDevice")
 cmd VkResult vkBeginCommandBuffer(
@@ -410,6 +413,7 @@ cmd VkResult vkBeginCommandBuffer(
     buff.Recording = RECORDING
     resetCommandBuffer(buff)
   }
+  recordBeginCommandBuffer(commandBuffer)
   return ?
 }
 
@@ -426,6 +430,7 @@ cmd VkResult vkEndCommandBuffer(
     }
     buff.Recording = COMPLETED
   }
+  recordEndCommandBuffer(commandBuffer)
   return ?
 }
 

--- a/gapis/api/vulkan/externs.go
+++ b/gapis/api/vulkan/externs.go
@@ -568,6 +568,18 @@ func (e externs) recordPresentSwapchainImage(swapchain VkSwapchainKHR, imageInde
 	}
 }
 
+func (e externs) recordBeginCommandBuffer(commandBuffer VkCommandBuffer) {
+	if e.w != nil {
+		e.w.OpenForwardDependency(e.ctx, commandBuffer)
+	}
+}
+
+func (e externs) recordEndCommandBuffer(commandBuffer VkCommandBuffer) {
+	if e.w != nil {
+		e.w.CloseForwardDependency(e.ctx, commandBuffer)
+	}
+}
+
 func (e externs) onesCount(a uint32) uint32 {
 	return (uint32)(bits.OnesCount32(a))
 }


### PR DESCRIPTION
This dependency is not usually needed for DCE, but is necessary when explicitly requesting the vkBeginCommandBuffer or individual vkCmd* calls, in which case the vkEndCommandBuffer call might be dropped by the DCE. The forward dependency from vkBeginCommandBuffer to vkEndCommandBuffer added by this patch ensures that, if any vkCmd* call is included by the DCE, then the corresponding vkBeginCommandBuffer and vkEndCommandBuffer calls are both also included by the DCE.