### PR TITLE
Vulkan: vkCmdClear(Depth|Color)Image now writes image memory

### DIFF
--- a/gapis/api/vulkan/api/copy_clear_commands.api
+++ b/gapis/api/vulkan/api/copy_clear_commands.api
@@ -769,6 +769,11 @@ class vkCmdClearColorImageArgs {
 }
 
 sub void dovkCmdClearColorImage(ref!vkCmdClearColorImageArgs args) {
+  if !(args.Image in Images) { vkErrorInvalidImage(args.Image) }
+  image := Images[args.Image]
+  for _, _, r in args.Ranges {
+    writeImageSubresource(image, r)
+  }
 }
 
 @threadSafety("app")
@@ -811,6 +816,11 @@ class vkCmdClearDepthStencilImageArgs {
 }
 
 sub void dovkCmdClearDepthStencilImage(ref!vkCmdClearDepthStencilImageArgs args) {
+  if !(args.Image in Images) { vkErrorInvalidImage(args.Image) }
+  image := Images[args.Image]
+  for _, _, r in args.Ranges {
+    writeImageSubresource(image, r)
+  }
 }
 
 @threadSafety("app")


### PR DESCRIPTION
This is necessary for correct dependencies on these commands.