### PR TITLE
Vulkan: Record touched buffers/images on recording command buffers

### DIFF
--- a/gapis/api/vulkan/api/coherent_memory.api
+++ b/gapis/api/vulkan/api/coherent_memory.api
@@ -36,6 +36,10 @@
 // TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 // MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
 
+////////////
+// Memory //
+////////////
+
 sub void readCoherentMemory(ref!DeviceMemoryObject memory, VkDeviceSize readOffset, VkDeviceSize readSize) {
   if IsMemoryCoherent(memory) && (memory.MappedLocation != null) {
     offset_in_mapped := deviceMemoryOffsetToMappedSpace(memory, readOffset)
@@ -56,6 +60,19 @@ sub void readCoherentMemory(ref!DeviceMemoryObject memory, VkDeviceSize readOffs
   }
 }
 
+
+////////////
+// Buffer //
+////////////
+
+sub void readCoherentMemoryInBuffer(ref!BufferObject buffer) {
+  memPieces := getBufferBoundMemoryPiecesInRange(buffer, as!VkDeviceSize(0), as!VkDeviceSize(0xFFFFFFFFFFFFFFFF))
+  for _, _, mp in memPieces {
+    readCoherentMemory(mp.DeviceMemory, mp.MemoryOffset, mp.Size)
+  }
+}
+
+@spy_disabled
 sub void readMemoryInBuffer(ref!BufferObject buffer, VkDeviceSize readOffset, VkDeviceSize readSize) {
   memPieces := getBufferBoundMemoryPiecesInRange(buffer, readOffset, readSize)
   for _, _, mp in memPieces {
@@ -64,7 +81,37 @@ sub void readMemoryInBuffer(ref!BufferObject buffer, VkDeviceSize readOffset, Vk
   }
 }
 
+@spy_disabled
+sub void writeMemoryInBuffer(ref!BufferObject buffer, VkDeviceSize offset, VkDeviceSize size) {
+  memPieces := getBufferBoundMemoryPiecesInRange(buffer, offset, size)
+  for _, _, mp in memPieces {
+    write(mp.DeviceMemory.Data[mp.MemoryOffset:mp.MemoryOffset+mp.Size])
+  }
+}
+
+// VkDescriptorBufferInfo binding
+
+@spy_disabled
 sub void readMemoryInBufferBindings(map!(u32, ref!VkDescriptorBufferInfo) bufferBindings, map!(u32, VkDeviceSize) bufferBindingOffsets) {
+  n := len(bufferBindings)
+  for i in (0 .. n) {
+    descBufferInfo := bufferBindings[as!u32(i)]
+    if descBufferInfo.Buffer != as!VkBuffer(0) {
+      if (descBufferInfo.Buffer in Buffers) {
+        offset := switch as!u32(i) in bufferBindingOffsets {
+          case true:
+            bufferBindingOffsets[as!u32(i)]
+          case false:
+            descBufferInfo.Offset
+        }
+        readMemoryInBuffer(Buffers[descBufferInfo.Buffer], offset, descBufferInfo.Range)
+      }
+    }
+  }
+}
+
+@spy_disabled
+sub void writeMemoryInBufferBindings(map!(u32, ref!VkDescriptorBufferInfo) bufferBindings, map!(u32, VkDeviceSize) bufferBindingOffsets) {
   n := len(bufferBindings)
   for i in (0 .. n) {
     bufferBinding := bufferBindings[as!u32(i)]
@@ -76,12 +123,15 @@ sub void readMemoryInBufferBindings(map!(u32, ref!VkDescriptorBufferInfo) buffer
           case false:
             bufferBinding.Offset
         }
-        readMemoryInBuffer(Buffers[bufferBinding.Buffer], offset, bufferBinding.Range)
+        writeMemoryInBuffer(Buffers[bufferBinding.Buffer], offset, bufferBinding.Range)
       }
     }
   }
 }
 
+// VkBufferView binding
+
+@spy_disabled
 sub void readMemoryInBufferViewBindings(map!(u32, VkBufferView) bufferViews) {
   for _, _, v in bufferViews {
     if v in BufferViews {
@@ -93,6 +143,84 @@ sub void readMemoryInBufferViewBindings(map!(u32, VkBufferView) bufferViews) {
   }
 }
 
+
+@spy_disabled
+sub void writeMemoryInBufferViewBindings(map!(u32, VkBufferView) bufferViews) {
+  for _, _, v in bufferViews {
+    if v in BufferViews {
+      view := BufferViews[v]
+      if (view.Buffer.VulkanHandle in Buffers) {
+        writeMemoryInBuffer(view.Buffer, view.Offset, view.Range)
+      }
+    }
+  }
+}
+
+///////////
+// Image //
+///////////
+
+sub void readCoherentMemoryInImage(ref!ImageObject image) {
+  if image != null {
+    mem := image.BoundMemory
+    if mem != null {
+      // Host access to image memory is only well-defined for images created with
+      // VK_IMAGE_TILING_LINEAR tiling and for image subresources of those images
+      // which are currently in either VK_IMAGE_LAYOUT_PREINITIALIZED or
+      // VK_IMAGE_LAYOUT_GENERAL layout.
+      // TODO: Complete the layout tracking logic then update this if statement
+      // to check the layout of the underlying image.
+      if image.Info.Tiling == VK_IMAGE_TILING_LINEAR {
+        readCoherentMemory(mem, image.BoundMemoryOffset, inferImageSize(image))
+      }
+    }
+  }
+}
+
+// VkImageSubresourceRange data
+
+@spy_disabled
+sub void readImageSubresource(ref!ImageObject image, VkImageSubresourceRange rng) {
+  readCoherentMemoryInImage(image)
+  layerCount := imageSubresourceLayerCount(image, rng)
+  levelCount := imageSubresourceLevelCount(image, rng)
+  for _ , _ , aspectBit in unpackImageAspectFlags(rng.aspectMask) {
+    for _, i, layer in image.Aspects[aspectBit].Layers {
+      if (i >= rng.baseArrayLayer) && (i < rng.baseArrayLayer + layerCount) {
+        for _, k, level in layer.Levels {
+          if (k >= rng.baseMipLevel) && (k < rng.baseMipLevel + levelCount) {
+            read(level.Data)
+          }
+        }
+      }
+    }
+  }
+}
+
+@spy_disabled
+sub void writeImageSubresource(ref!ImageObject image, VkImageSubresourceRange rng) {
+  layerCount := imageSubresourceLayerCount(image, rng)
+  levelCount := imageSubresourceLevelCount(image, rng)
+  for _ , _ , aspectBit in unpackImageAspectFlags(rng.aspectMask) {
+    if aspectBit in image.Aspects {
+      aspect := image.Aspects[aspectBit]
+      for layerIndex in (rng.baseArrayLayer .. rng.baseArrayLayer + layerCount) {
+        layer := aspect.Layers[layerIndex]
+        for mipLevel in (rng.baseMipLevel .. rng.baseMipLevel + levelCount) {
+          level := layer.Levels[mipLevel]
+          write(level.Data)
+        }
+      }
+    }
+  }
+}
+
+// VkImageViews used as Framebuffer attachments are handled in
+// renderpass_framebuffer.api
+
+// VkDescriptorImageInfo bindings, should only be called in subcommands
+
+@spy_disabled
 sub void readMemoryInImageBindings(map!(u32, ref!VkDescriptorImageInfo) imageBindings) {
   for _, _, v in imageBindings {
     _ = Samplers[v.Sampler]
@@ -108,6 +236,26 @@ sub void readMemoryInImageBindings(map!(u32, ref!VkDescriptorImageInfo) imageBin
   }
 }
 
+@spy_disabled
+sub void writeMemoryInImageBindings(map!(u32, ref!VkDescriptorImageInfo) imageBindings) {
+  for _, _, v in imageBindings {
+    _ = Samplers[v.Sampler]
+    if v.ImageView != as!VkImageView(0) {
+      imageViewObj := ImageViews[v.ImageView]
+      imageObj := imageViewObj.Image
+      rng := imageViewObj.SubresourceRange
+      writeImageSubresource(imageObj, rng)
+      updateImageQueue(imageObj, rng)
+    }
+  }
+}
+
+
+///////////////////
+// DescriptorSet //
+///////////////////
+
+@spy_disabled
 sub void readMemoryInDescriptorSet(ref!DescriptorSetObject descriptor_set, map!(u32, map!(u32, VkDeviceSize)) bufferBindingOffsets, bool processImages) {
   if descriptor_set != null {
     for _, i, binding in descriptor_set.Bindings {
@@ -142,67 +290,8 @@ sub void readMemoryInDescriptorSet(ref!DescriptorSetObject descriptor_set, map!(
   }
 }
 
-sub void writeMemoryInBuffer(ref!BufferObject buffer, VkDeviceSize offset, VkDeviceSize size) {
-  mem := buffer.Memory
-  if mem != null {
-    begin := buffer.MemoryOffset + offset
-    actualSize := switch as!u64(size) {
-      case 0xFFFFFFFFFFFFFFFF:
-        buffer.Info.Size - offset
-      default:
-        size
-    }
-    end := begin + actualSize
-    if len(mem.Data) != 0 {
-      write(mem.Data[begin : end])
-    }
-  }
-}
 
-sub void writeMemoryInBufferBindings(map!(u32, ref!VkDescriptorBufferInfo) bufferBindings, map!(u32, VkDeviceSize) bufferBindingOffsets) {
-  n := len(bufferBindings)
-  for i in (0 .. n) {
-    bufferBinding := bufferBindings[as!u32(i)]
-    if bufferBinding.Buffer != as!VkBuffer(0) {
-      if (bufferBinding.Buffer in Buffers) {
-        offset := switch as!u32(i) in bufferBindingOffsets {
-          case true:
-            bufferBindingOffsets[as!u32(i)]
-          case false:
-            bufferBinding.Offset
-        }
-        writeMemoryInBuffer(Buffers[bufferBinding.Buffer], offset, bufferBinding.Range)
-      }
-    }
-  }
-}
-
-sub void writeMemoryInBufferViewBindings(map!(u32, VkBufferView) bufferViews) {
-  for _, _, v in bufferViews {
-    if v in BufferViews {
-      view := BufferViews[v]
-      if (view.Buffer.VulkanHandle in Buffers) {
-        writeMemoryInBuffer(view.Buffer, view.Offset, view.Range)
-      }
-    }
-  }
-}
-
-sub void writeMemoryInImageBindings(map!(u32, ref!VkDescriptorImageInfo) imageBindings) {
-  for _, _, v in imageBindings {
-    _ = Samplers[v.Sampler]
-    if v.ImageView != as!VkImageView(0) {
-      if (v.ImageView in ImageViews) {
-        imageViewObj := ImageViews[v.ImageView]
-        imageObj := imageViewObj.Image
-        rng := imageViewObj.SubresourceRange
-        writeImageSubresource(imageObj, rng)
-        updateImageQueue(imageObj, rng)
-      }
-    }
-  }
-}
-
+@spy_disabled
 sub void writeMemoryInDescriptorSet(ref!DescriptorSetObject descriptor_set, map!(u32, map!(u32, VkDeviceSize)) bufferBindingOffsets, bool processImages) {
   if descriptor_set != null {
     for _, i, binding in descriptor_set.Bindings {
@@ -229,6 +318,14 @@ sub void writeMemoryInDescriptorSet(ref!DescriptorSetObject descriptor_set, map!
   }
 }
 
+
+/////////////////////
+// Bound resources //
+/////////////////////
+
+// Bound descriptor sets
+
+@spy_disabled
 sub void readWriteMemoryInBoundDescriptorSets(
     ref!PipelineLayoutObject pipelineLayout,
     map!(u32, ref!DescriptorSetObject) descriptorSets,
@@ -237,69 +334,16 @@ sub void readWriteMemoryInBoundDescriptorSets(
   for i in (0 .. layerCount) {
     descriptorSet := descriptorSets[as!u32(i)]
     if descriptorSet != null {
-      if !(descriptorSet.VulkanHandle in ProcessedDescriptorSets.val) {
         offsets := bufferBindingOffsets[as!u32(i)]
         readMemoryInDescriptorSet(descriptorSet, offsets, true)
         writeMemoryInDescriptorSet(descriptorSet, offsets, true)
-        
-        descriptors := ProcessedDescriptorSet()
-        descriptors.shouldReadBuffers = false
-        newOffsets := descriptors.bufferOffsets
-        for _, j, jj in offsets {
-          for _, k, v in jj {
-            if (!newOffsets[j][k][v]) {
-              x := newOffsets[j]
-              y := x[k]
-              y[v] = true
-              x[k] = y
-              newOffsets[j] = x
-            }
-            
-          }
-        }
-        descriptors.bufferOffsets = newOffsets
-        ProcessedDescriptorSets.val[descriptorSet.VulkanHandle] = descriptors
-      } else if ProcessedDescriptorSets.val[descriptorSet.VulkanHandle].shouldReadBuffers {
-        offsets := bufferBindingOffsets[as!u32(i)]
-        readMemoryInDescriptorSet(descriptorSet, offsets, false)
-        writeMemoryInDescriptorSet(descriptorSet, offsets, false)
-        
-        descriptors := ProcessedDescriptorSets.val[descriptorSet.VulkanHandle]
-        descriptors.shouldReadBuffers = false
-        newOffsets := descriptors.bufferOffsets
-        for _, j, jj in offsets {
-          for _, k, v in jj {
-            if (!newOffsets[j][k][v]) {
-              x := newOffsets[j]
-              y := x[k]
-              y[v] = true
-              x[k] = y
-              newOffsets[j] = x
-            }
-          }
-        }
-        descriptors.bufferOffsets = newOffsets
-        ProcessedDescriptorSets.val[descriptorSet.VulkanHandle] = descriptors
-      }
     }
   }
 }
 
-sub void readCoherentMemoryInImage(ref!ImageObject image) {
-  mem := image.BoundMemory
-  if mem != null {
-    // Host access to image memory is only well-defined for images created with
-    // VK_IMAGE_TILING_LINEAR tiling and for image subresources of those images
-    // which are currently in either VK_IMAGE_LAYOUT_PREINITIALIZED or
-    // VK_IMAGE_LAYOUT_GENERAL layout.
-    // TODO: Complete the layout tracking logic then update this if statement
-    // to check the layout of the underlying image.
-    if image.Info.Tiling == VK_IMAGE_TILING_LINEAR {
-      readCoherentMemory(mem, image.BoundMemoryOffset, inferImageSize(image))
-    }
-  }
-}
+// Bound vertex/index buffers
 
+@spy_disabled
 sub void readMemoryInCurrentPipelineBoundVertexBuffers(u32 vertexCount, u32 instanceCount, u32 firstVertex, u32 firstInstance) {
   ldi := lastDrawInfo()
   for _ , _ , vertex_binding in ldi.GraphicsPipeline.VertexInputState.BindingDescriptions {
@@ -331,6 +375,11 @@ sub void readMemoryInCurrentPipelineBoundVertexBuffers(u32 vertexCount, u32 inst
     }
   }
 }
+
+
+//////////
+// Util //
+//////////
 
 sub bool IsMemoryCoherent(ref!DeviceMemoryObject memory) {
   physical_device := PhysicalDevices[Devices[memory.Device].PhysicalDevice]

--- a/gapis/api/vulkan/api/command_buffer_control.api
+++ b/gapis/api/vulkan/api/command_buffer_control.api
@@ -269,6 +269,14 @@ enum SemaphoreUpdate {
   @unused BufferCommands                  BufferCommands
   @unused ref!CommandBufferBegin          BeginInfo
   @unused ref!VulkanDebugMarkerInfo       DebugInfo
+
+  // Caching touched resources to help the state tracking performance
+  @hidden @unused @untracked @untrackedMap @nobox
+  map!(VkImage, ref!ImageCoverage)        TouchedImages
+  @hidden @unused @untracked @untrackedMap @nobox
+  map!(VkBuffer, bool)                    TouchedBuffers
+  @hidden @unused @untracked @untrackedMap @nobox
+  map!(VkDescriptorSet, bool)             ProcessedDescriptorSets
 }
 
 sub void AddCommand(
@@ -455,53 +463,53 @@ cmd VkResult vkResetCommandBuffer(
 }
 
 sub void resetBufferCommands(ref!CommandBufferObject obj) {
-  clear(obj.BufferCommands.vkCmdBindPipeline)  
-  clear(obj.BufferCommands.vkCmdSetViewport)  
-  clear(obj.BufferCommands.vkCmdSetScissor)  
-  clear(obj.BufferCommands.vkCmdSetLineWidth)  
-  clear(obj.BufferCommands.vkCmdSetDepthBias)  
-  clear(obj.BufferCommands.vkCmdSetBlendConstants)  
-  clear(obj.BufferCommands.vkCmdSetDepthBounds)  
-  clear(obj.BufferCommands.vkCmdSetStencilCompareMask)  
-  clear(obj.BufferCommands.vkCmdSetStencilWriteMask)  
-  clear(obj.BufferCommands.vkCmdSetStencilReference)  
-  clear(obj.BufferCommands.vkCmdBindDescriptorSets)  
-  clear(obj.BufferCommands.vkCmdBindIndexBuffer)  
-  clear(obj.BufferCommands.vkCmdBindVertexBuffers)  
-  clear(obj.BufferCommands.vkCmdDraw)  
-  clear(obj.BufferCommands.vkCmdDrawIndexed)  
-  clear(obj.BufferCommands.vkCmdDrawIndirect)  
-  clear(obj.BufferCommands.vkCmdDrawIndexedIndirect)  
-  clear(obj.BufferCommands.vkCmdDispatch)  
-  clear(obj.BufferCommands.vkCmdDispatchIndirect)  
-  clear(obj.BufferCommands.vkCmdCopyBuffer)  
-  clear(obj.BufferCommands.vkCmdCopyImage)  
-  clear(obj.BufferCommands.vkCmdBlitImage)  
-  clear(obj.BufferCommands.vkCmdCopyBufferToImage)  
-  clear(obj.BufferCommands.vkCmdCopyImageToBuffer)  
-  clear(obj.BufferCommands.vkCmdUpdateBuffer)  
-  clear(obj.BufferCommands.vkCmdFillBuffer)  
-  clear(obj.BufferCommands.vkCmdClearColorImage)  
-  clear(obj.BufferCommands.vkCmdClearDepthStencilImage)  
-  clear(obj.BufferCommands.vkCmdClearAttachments)  
-  clear(obj.BufferCommands.vkCmdResolveImage)  
-  clear(obj.BufferCommands.vkCmdSetEvent)  
-  clear(obj.BufferCommands.vkCmdResetEvent)  
-  clear(obj.BufferCommands.vkCmdWaitEvents)  
-  clear(obj.BufferCommands.vkCmdPipelineBarrier)  
-  clear(obj.BufferCommands.vkCmdBeginQuery)  
-  clear(obj.BufferCommands.vkCmdEndQuery)  
-  clear(obj.BufferCommands.vkCmdResetQueryPool)  
-  clear(obj.BufferCommands.vkCmdWriteTimestamp)  
-  clear(obj.BufferCommands.vkCmdCopyQueryPoolResults)  
-  clear(obj.BufferCommands.vkCmdPushConstants)  
-  clear(obj.BufferCommands.vkCmdBeginRenderPass)  
-  clear(obj.BufferCommands.vkCmdNextSubpass)  
-  clear(obj.BufferCommands.vkCmdEndRenderPass)  
-  clear(obj.BufferCommands.vkCmdExecuteCommands)  
-  clear(obj.BufferCommands.vkCmdDebugMarkerBeginEXT)  
-  clear(obj.BufferCommands.vkCmdDebugMarkerEndEXT)  
-  clear(obj.BufferCommands.vkCmdDebugMarkerInsertEXT)  
+  clear(obj.BufferCommands.vkCmdBindPipeline)
+  clear(obj.BufferCommands.vkCmdSetViewport)
+  clear(obj.BufferCommands.vkCmdSetScissor)
+  clear(obj.BufferCommands.vkCmdSetLineWidth)
+  clear(obj.BufferCommands.vkCmdSetDepthBias)
+  clear(obj.BufferCommands.vkCmdSetBlendConstants)
+  clear(obj.BufferCommands.vkCmdSetDepthBounds)
+  clear(obj.BufferCommands.vkCmdSetStencilCompareMask)
+  clear(obj.BufferCommands.vkCmdSetStencilWriteMask)
+  clear(obj.BufferCommands.vkCmdSetStencilReference)
+  clear(obj.BufferCommands.vkCmdBindDescriptorSets)
+  clear(obj.BufferCommands.vkCmdBindIndexBuffer)
+  clear(obj.BufferCommands.vkCmdBindVertexBuffers)
+  clear(obj.BufferCommands.vkCmdDraw)
+  clear(obj.BufferCommands.vkCmdDrawIndexed)
+  clear(obj.BufferCommands.vkCmdDrawIndirect)
+  clear(obj.BufferCommands.vkCmdDrawIndexedIndirect)
+  clear(obj.BufferCommands.vkCmdDispatch)
+  clear(obj.BufferCommands.vkCmdDispatchIndirect)
+  clear(obj.BufferCommands.vkCmdCopyBuffer)
+  clear(obj.BufferCommands.vkCmdCopyImage)
+  clear(obj.BufferCommands.vkCmdBlitImage)
+  clear(obj.BufferCommands.vkCmdCopyBufferToImage)
+  clear(obj.BufferCommands.vkCmdCopyImageToBuffer)
+  clear(obj.BufferCommands.vkCmdUpdateBuffer)
+  clear(obj.BufferCommands.vkCmdFillBuffer)
+  clear(obj.BufferCommands.vkCmdClearColorImage)
+  clear(obj.BufferCommands.vkCmdClearDepthStencilImage)
+  clear(obj.BufferCommands.vkCmdClearAttachments)
+  clear(obj.BufferCommands.vkCmdResolveImage)
+  clear(obj.BufferCommands.vkCmdSetEvent)
+  clear(obj.BufferCommands.vkCmdResetEvent)
+  clear(obj.BufferCommands.vkCmdWaitEvents)
+  clear(obj.BufferCommands.vkCmdPipelineBarrier)
+  clear(obj.BufferCommands.vkCmdBeginQuery)
+  clear(obj.BufferCommands.vkCmdEndQuery)
+  clear(obj.BufferCommands.vkCmdResetQueryPool)
+  clear(obj.BufferCommands.vkCmdWriteTimestamp)
+  clear(obj.BufferCommands.vkCmdCopyQueryPoolResults)
+  clear(obj.BufferCommands.vkCmdPushConstants)
+  clear(obj.BufferCommands.vkCmdBeginRenderPass)
+  clear(obj.BufferCommands.vkCmdNextSubpass)
+  clear(obj.BufferCommands.vkCmdEndRenderPass)
+  clear(obj.BufferCommands.vkCmdExecuteCommands)
+  clear(obj.BufferCommands.vkCmdDebugMarkerBeginEXT)
+  clear(obj.BufferCommands.vkCmdDebugMarkerEndEXT)
+  clear(obj.BufferCommands.vkCmdDebugMarkerInsertEXT)
 }
 
 sub void resetCommandBuffer(ref!CommandBufferObject obj) {
@@ -511,6 +519,9 @@ sub void resetCommandBuffer(ref!CommandBufferObject obj) {
   resetBufferCommands(obj)
   clear(obj.CommandReferences)
   resetCmd(obj.VulkanHandle)
+  clear(obj.TouchedImages)
+  clear(obj.TouchedBuffers)
+  clear(obj.ProcessedDescriptorSets)
 }
 
 //////////////////////////////
@@ -533,6 +544,7 @@ cmd void vkCmdExecuteCommands(
   if !(commandBuffer in CommandBuffers) {
     vkErrorInvalidCommandBuffer(commandBuffer)
   } else {
+    primaryCmdBuf := CommandBuffers[commandBuffer]
     cmd_buffers := pCommandBuffers[0:commandBufferCount]
     args := new!vkCmdExecuteCommandsArgs()
     for i in (0 .. commandBufferCount) {
@@ -543,9 +555,8 @@ cmd void vkCmdExecuteCommands(
       }
     }
 
-    mapPos := as!u32(len(CommandBuffers[commandBuffer].BufferCommands.vkCmdExecuteCommands))
-    CommandBuffers[commandBuffer].BufferCommands.vkCmdExecuteCommands[mapPos] =
-    args
+    mapPos := as!u32(len(primaryCmdBuf.BufferCommands.vkCmdExecuteCommands))
+    primaryCmdBuf.BufferCommands.vkCmdExecuteCommands[mapPos] = args
 
     AddCommand(commandBuffer, cmd_vkCmdExecuteCommands, mapPos)
   }

--- a/gapis/api/vulkan/api/copy_clear_commands.api
+++ b/gapis/api/vulkan/api/copy_clear_commands.api
@@ -42,6 +42,7 @@
   map!(u32, VkBufferCopy) CopyRegions
 }
 
+@spy_disabled
 sub void dovkCmdCopyBuffer(ref!vkCmdCopyBufferArgs buffer) {
   if !(buffer.SrcBuffer in Buffers) { vkErrorInvalidBuffer(buffer.SrcBuffer) }
   if !(buffer.DstBuffer in Buffers) { vkErrorInvalidBuffer(buffer.DstBuffer) }
@@ -121,6 +122,7 @@ sub map!(VkDeviceSize, OpaqueResourceMemoryBoundPiece) getBufferBoundMemoryPiece
   return ret_val.Map
 }
 
+@spy_disabled
 sub void copyBufferToBuffer(ref!BufferObject dstBuf, VkDeviceSize dstOffset, ref!BufferObject srcBuf, VkDeviceSize srcOffset, VkDeviceSize size) {
   if (dstBuf.Memory != null) && (srcBuf.Memory != null) {
     // No sparse binding in either dst and src
@@ -185,23 +187,35 @@ cmd void vkCmdCopyBuffer(
     VkBuffer            dstBuffer,
     u32                 regionCount,
     const VkBufferCopy* pRegions) {
-  if !(commandBuffer in CommandBuffers) { vkErrorInvalidCommandBuffer(commandBuffer) }
-  if !(srcBuffer in Buffers) { vkErrorInvalidBuffer(srcBuffer) }
-  if !(srcBuffer in Buffers) { vkErrorInvalidBuffer(dstBuffer) }
-  args := new!vkCmdCopyBufferArgs(
-    SrcBuffer:  srcBuffer,
-    DstBuffer:  dstBuffer
-  )
-  regions := pRegions[0:regionCount]
-  for i in (0 .. regionCount) {
-    args.CopyRegions[i] = regions[i]
+  if !(commandBuffer in CommandBuffers) {
+    vkErrorInvalidCommandBuffer(commandBuffer)
+  } else {
+    if !(srcBuffer in Buffers) {
+      vkErrorInvalidBuffer(srcBuffer)
+    } else {
+      if !(dstBuffer in Buffers) {
+        vkErrorInvalidBuffer(dstBuffer)
+      } else {
+        cmdBuf := CommandBuffers[commandBuffer]
+        cmdBuf.TouchedBuffers[srcBuffer] = true
+        cmdBuf.TouchedBuffers[dstBuffer] = true
+
+        args := new!vkCmdCopyBufferArgs(
+          SrcBuffer:  srcBuffer,
+          DstBuffer:  dstBuffer
+        )
+        regions := pRegions[0:regionCount]
+        for i in (0 .. regionCount) {
+          args.CopyRegions[i] = regions[i]
+        }
+
+        mapPos := as!u32(len(cmdBuf.BufferCommands.vkCmdCopyBuffer))
+        cmdBuf.BufferCommands.vkCmdCopyBuffer[mapPos] = args
+
+        AddCommand(commandBuffer, cmd_vkCmdCopyBuffer, mapPos)
+      }
+    }
   }
-
-  mapPos := as!u32(len(CommandBuffers[commandBuffer].BufferCommands.vkCmdCopyBuffer))
-  CommandBuffers[commandBuffer].BufferCommands.vkCmdCopyBuffer[mapPos] =
-  args
-
-  AddCommand(commandBuffer, cmd_vkCmdCopyBuffer, mapPos)
 }
 
 @internal
@@ -213,6 +227,7 @@ class vkCmdCopyImageArgs {
   map!(u32, VkImageCopy) Regions
 }
 
+@spy_disabled
 sub void dovkCmdCopyImage(ref!vkCmdCopyImageArgs args) {
   if !(args.SrcImage in Images) { vkErrorInvalidImage(args.SrcImage) }
   if !(args.DstImage in Images) { vkErrorInvalidImage(args.DstImage) }
@@ -312,25 +327,51 @@ cmd void vkCmdCopyImage(
     VkImageLayout      dstImageLayout,
     u32                regionCount,
     const VkImageCopy* pRegions) {
-  if !(commandBuffer in CommandBuffers) { vkErrorInvalidCommandBuffer(commandBuffer) }
-  if !(srcImage in Images) { vkErrorInvalidImage(srcImage) }
-  if !(dstImage in Images) { vkErrorInvalidImage(dstImage) }
-  args := new!vkCmdCopyImageArgs(
-    SrcImage:        srcImage,
-    SrcImageLayout:  srcImageLayout,
-    DstImage:        dstImage,
-    DstImageLayout:  dstImageLayout
-  )
-  regions := pRegions[0:regionCount]
-  for i in (0 .. regionCount) {
-    args.Regions[as!u32(i)] = regions[i]
+  if !(commandBuffer in CommandBuffers) {
+    vkErrorInvalidCommandBuffer(commandBuffer)
+  } else {
+    if !(srcImage in Images) {
+      vkErrorInvalidImage(srcImage)
+    } else {
+      srcImgObj := Images[srcImage]
+      if !(dstImage in Images) {
+        vkErrorInvalidImage(dstImage)
+      } else {
+        dstImgObj := Images[dstImage]
+        cmdBuf := CommandBuffers[commandBuffer]
+        args := new!vkCmdCopyImageArgs(
+          SrcImage:        srcImage,
+          SrcImageLayout:  srcImageLayout,
+          DstImage:        dstImage,
+          DstImageLayout:  dstImageLayout
+        )
+        regions := pRegions[0:regionCount]
+        for i in (0 .. regionCount) {
+          r := regions[i]
+          args.Regions[as!u32(i)] = r
+          commandBufferTouchImage(cmdBuf, srcImgObj,
+            VkImageSubresourceRange(
+              r.srcSubresource.aspectMask,
+              r.srcSubresource.mipLevel,
+              as!u32(1),
+              r.srcSubresource.baseArrayLayer,
+              r.srcSubresource.layerCount))
+          commandBufferTouchImage(cmdBuf, dstImgObj,
+            VkImageSubresourceRange(
+              r.dstSubresource.aspectMask,
+              r.dstSubresource.mipLevel,
+              as!u32(1),
+              r.dstSubresource.baseArrayLayer,
+              r.dstSubresource.layerCount))
+        }
+
+        mapPos := as!u32(len(cmdBuf.BufferCommands.vkCmdCopyImage))
+        cmdBuf.BufferCommands.vkCmdCopyImage[mapPos] = args
+
+        AddCommand(commandBuffer, cmd_vkCmdCopyImage, mapPos)
+      }
+    }
   }
-
-  mapPos := as!u32(len(CommandBuffers[commandBuffer].BufferCommands.vkCmdCopyImage))
-  CommandBuffers[commandBuffer].BufferCommands.vkCmdCopyImage[mapPos] =
-  args
-
-  AddCommand(commandBuffer, cmd_vkCmdCopyImage, mapPos)
 }
 
 @internal
@@ -343,6 +384,7 @@ class vkCmdBlitImageArgs {
   VkFilter               Filter
 }
 
+@spy_disabled
 sub void dovkCmdBlitImage(ref!vkCmdBlitImageArgs args) {
   if !(args.SrcImage in Images) { vkErrorInvalidImage(args.SrcImage) }
   if !(args.DstImage in Images) { vkErrorInvalidImage(args.DstImage) }
@@ -467,26 +509,52 @@ cmd void vkCmdBlitImage(
     u32                regionCount,
     const VkImageBlit* pRegions,
     VkFilter           filter) {
-  if !(commandBuffer in CommandBuffers) { vkErrorInvalidCommandBuffer(commandBuffer) }
-  if !(srcImage in Images) { vkErrorInvalidImage(srcImage) }
-  if !(dstImage in Images) { vkErrorInvalidImage(dstImage) }
-  args := new!vkCmdBlitImageArgs(
-    SrcImage:        srcImage,
-    SrcImageLayout:  srcImageLayout,
-    DstImage:        dstImage,
-    DstImageLayout:  dstImageLayout,
-    Filter:          filter
-  )
-  regions := pRegions[0:regionCount]
-  for i in (0 .. regionCount) {
-    args.Regions[as!u32(i)] = regions[i]
+  if !(commandBuffer in CommandBuffers) {
+    vkErrorInvalidCommandBuffer(commandBuffer)
+  } else {
+    if !(srcImage in Images) {
+      vkErrorInvalidImage(srcImage)
+    } else {
+      srcImgObj := Images[srcImage]
+      if !(dstImage in Images) {
+        vkErrorInvalidImage(dstImage)
+      } else {
+        dstImgObj := Images[dstImage]
+        cmdBuf := CommandBuffers[commandBuffer]
+        args := new!vkCmdBlitImageArgs(
+          SrcImage:        srcImage,
+          SrcImageLayout:  srcImageLayout,
+          DstImage:        dstImage,
+          DstImageLayout:  dstImageLayout,
+          Filter:          filter
+        )
+        regions := pRegions[0:regionCount]
+        for i in (0 .. regionCount) {
+          r := regions[i]
+          args.Regions[as!u32(i)] = r
+          commandBufferTouchImage(cmdBuf, srcImgObj,
+            VkImageSubresourceRange(
+              r.srcSubresource.aspectMask,
+              r.srcSubresource.mipLevel,
+              as!u32(1),
+              r.srcSubresource.baseArrayLayer,
+              r.srcSubresource.layerCount))
+          commandBufferTouchImage(cmdBuf, dstImgObj,
+            VkImageSubresourceRange(
+              r.dstSubresource.aspectMask,
+              r.dstSubresource.mipLevel,
+              as!u32(1),
+              r.dstSubresource.baseArrayLayer,
+              r.dstSubresource.layerCount))
+        }
+
+        mapPos := as!u32(len(cmdBuf.BufferCommands.vkCmdBlitImage))
+        cmdBuf.BufferCommands.vkCmdBlitImage[mapPos] = args
+
+        AddCommand(commandBuffer, cmd_vkCmdBlitImage, mapPos)
+      }
+    }
   }
-
-  mapPos := as!u32(len(CommandBuffers[commandBuffer].BufferCommands.vkCmdBlitImage))
-  CommandBuffers[commandBuffer].BufferCommands.vkCmdBlitImage[mapPos] =
-  args
-
-  AddCommand(commandBuffer, cmd_vkCmdBlitImage, mapPos)
 }
 
 @internal
@@ -507,7 +575,7 @@ sub RowLengthAndImageHeight getRowLengthAndImageHeight(VkBufferImageCopy region)
   return RowLengthAndImageHeight(rowLength, imageHeight)
 }
 
-
+@spy_disabled
 sub void copyImageBuffer(VkBuffer buffer, VkImage image, VkImageLayout layout, map!(u32, VkBufferImageCopy) regions, bool isSrcBuffer) {
   if !(image in Images) { vkErrorInvalidImage(image) }
   if !(buffer in Buffers) { vkErrorInvalidBuffer(buffer) }
@@ -611,6 +679,7 @@ class vkCmdCopyBufferToImageArgs {
   map!(u32, VkBufferImageCopy) Regions
 }
 
+@spy_disabled
 sub void dovkCmdCopyBufferToImage(ref!vkCmdCopyBufferToImageArgs args) {
   copyImageBuffer(args.SrcBuffer, args.DstImage, args.Layout, args.Regions, true)
 }
@@ -625,21 +694,40 @@ cmd void vkCmdCopyBufferToImage(
     VkImageLayout            dstImageLayout,
     u32                      regionCount,
     const VkBufferImageCopy* pRegions) {
-  if !(commandBuffer in CommandBuffers) { vkErrorInvalidCommandBuffer(commandBuffer) }
-  if !(srcBuffer in Buffers) { vkErrorInvalidBuffer(srcBuffer) }
-  if !(dstImage in Images) { vkErrorInvalidImage(dstImage) }
-  regions := pRegions[0:regionCount]
-  read(regions)
-  args := new!vkCmdCopyBufferToImageArgs(srcBuffer, dstImage, dstImageLayout)
-  for i in (0 .. regionCount) {
-    args.Regions[as!u32(i)] = regions[i]
+  if !(commandBuffer in CommandBuffers) {
+    vkErrorInvalidCommandBuffer(commandBuffer)
+  } else {
+    if !(srcBuffer in Buffers) {
+      vkErrorInvalidBuffer(srcBuffer)
+    } else {
+      if !(dstImage in Images) {
+        vkErrorInvalidImage(dstImage)
+      } else {
+        dstImgObj := Images[dstImage]
+        cmdBuf := CommandBuffers[commandBuffer]
+        cmdBuf.TouchedBuffers[srcBuffer] = true
+
+        regions := pRegions[0:regionCount]
+        read(regions)
+        args := new!vkCmdCopyBufferToImageArgs(srcBuffer, dstImage, dstImageLayout)
+        for i in (0 .. regionCount) {
+          r := regions[i]
+          args.Regions[as!u32(i)] = r
+          commandBufferTouchImage(cmdBuf, dstImgObj, VkImageSubresourceRange(
+              r.imageSubresource.aspectMask,
+              r.imageSubresource.mipLevel,
+              as!u32(1),
+              r.imageSubresource.baseArrayLayer,
+              r.imageSubresource.layerCount))
+        }
+
+        mapPos := as!u32(len(cmdBuf.BufferCommands.vkCmdCopyBufferToImage))
+        cmdBuf.BufferCommands.vkCmdCopyBufferToImage[mapPos] = args
+
+        AddCommand(commandBuffer, cmd_vkCmdCopyBufferToImage, mapPos)
+      }
+    }
   }
-
-  mapPos := as!u32(len(CommandBuffers[commandBuffer].BufferCommands.vkCmdCopyBufferToImage))
-  CommandBuffers[commandBuffer].BufferCommands.vkCmdCopyBufferToImage[mapPos] =
-  args
-
-  AddCommand(commandBuffer, cmd_vkCmdCopyBufferToImage, mapPos)
 }
 
 @internal
@@ -650,6 +738,7 @@ class vkCmdCopyImageToBufferArgs {
   map!(u32, VkBufferImageCopy) Regions
 }
 
+@spy_disabled
 sub void dovkCmdCopyImageToBuffer(ref!vkCmdCopyImageToBufferArgs args) {
   copyImageBuffer(args.DstBuffer, args.SrcImage, args.SrcImageLayout, args.Regions, false)
 }
@@ -664,24 +753,44 @@ cmd void vkCmdCopyImageToBuffer(
     VkBuffer                 dstBuffer,
     u32                      regionCount,
     const VkBufferImageCopy* pRegions) {
-  if !(commandBuffer in CommandBuffers) { vkErrorInvalidCommandBuffer(commandBuffer) }
-  if !(dstBuffer in Buffers) { vkErrorInvalidBuffer(dstBuffer) }
-  if !(srcImage in Images) { vkErrorInvalidImage(srcImage) }
-  regions := pRegions[0:regionCount]
-  args := new!vkCmdCopyImageToBufferArgs(
-    SrcImage:        srcImage,
-    SrcImageLayout:  srcImageLayout,
-    DstBuffer:       dstBuffer,
-  )
-  for i in (0 .. regionCount) {
-    args.Regions[as!u32(i)] = regions[i]
+  if !(commandBuffer in CommandBuffers) {
+    vkErrorInvalidCommandBuffer(commandBuffer)
+  } else {
+    if !(dstBuffer in Buffers) {
+      vkErrorInvalidBuffer(dstBuffer)
+    } else {
+      if !(srcImage in Images) {
+        vkErrorInvalidImage(srcImage)
+      } else {
+        srcImgObj := Images[srcImage]
+        cmdBuf := CommandBuffers[commandBuffer]
+        cmdBuf.TouchedBuffers[dstBuffer] = true
+
+        regions := pRegions[0:regionCount]
+        args := new!vkCmdCopyImageToBufferArgs(
+          SrcImage:        srcImage,
+          SrcImageLayout:  srcImageLayout,
+          DstBuffer:       dstBuffer,
+        )
+        for i in (0 .. regionCount) {
+          r := regions[i]
+          args.Regions[as!u32(i)] = r
+          commandBufferTouchImage(cmdBuf, srcImgObj,
+            VkImageSubresourceRange(
+              r.imageSubresource.aspectMask,
+              r.imageSubresource.mipLevel,
+              as!u32(1),
+              r.imageSubresource.baseArrayLayer,
+              r.imageSubresource.layerCount))
+        }
+
+        mapPos := as!u32(len(cmdBuf.BufferCommands.vkCmdCopyImageToBuffer))
+        cmdBuf.BufferCommands.vkCmdCopyImageToBuffer[mapPos] = args
+
+        AddCommand(commandBuffer, cmd_vkCmdCopyImageToBuffer, mapPos)
+      }
+    }
   }
-
-  mapPos := as!u32(len(CommandBuffers[commandBuffer].BufferCommands.vkCmdCopyImageToBuffer))
-  CommandBuffers[commandBuffer].BufferCommands.vkCmdCopyImageToBuffer[mapPos] =
-  args
-
-  AddCommand(commandBuffer, cmd_vkCmdCopyImageToBuffer, mapPos)
 }
 
 @internal class vkCmdUpdateBufferArgs {
@@ -691,6 +800,7 @@ cmd void vkCmdCopyImageToBuffer(
   u8[]         Data
 }
 
+@spy_disabled
 sub void dovkCmdUpdateBuffer(ref!vkCmdUpdateBufferArgs args) {
   if !(args.DstBuffer in Buffers) { vkErrorInvalidBuffer(args.DstBuffer) }
   Buffers[args.DstBuffer].LastBoundQueue = LastBoundQueue
@@ -712,20 +822,28 @@ cmd void vkCmdUpdateBuffer(
     VkDeviceSize    dstOffset,
     VkDeviceSize    dataSize,
     const void*     pData) {
-  if !(commandBuffer in CommandBuffers) { vkErrorInvalidCommandBuffer(commandBuffer) }
-  if !(dstBuffer in Buffers) { vkErrorInvalidBuffer(dstBuffer) }
-  args := new!vkCmdUpdateBufferArgs(
-    dstBuffer,
-    dstOffset,
-    dataSize,
-  )
-  args.Data = clone(as!u8*(pData)[0:dataSize])
+  if !(commandBuffer in CommandBuffers) {
+    vkErrorInvalidCommandBuffer(commandBuffer)
+  } else {
+    if !(dstBuffer in Buffers) {
+      vkErrorInvalidBuffer(dstBuffer)
+    } else {
+      cmdBuf := CommandBuffers[commandBuffer]
+      cmdBuf.TouchedBuffers[dstBuffer] = true
 
-  mapPos := as!u32(len(CommandBuffers[commandBuffer].BufferCommands.vkCmdUpdateBuffer))
-  CommandBuffers[commandBuffer].BufferCommands.vkCmdUpdateBuffer[mapPos] =
-  args
+      args := new!vkCmdUpdateBufferArgs(
+        dstBuffer,
+        dstOffset,
+        dataSize,
+      )
+      args.Data = clone(as!u8*(pData)[0:dataSize])
 
-  AddCommand(commandBuffer, cmd_vkCmdUpdateBuffer, mapPos)
+      mapPos := as!u32(len(cmdBuf.BufferCommands.vkCmdUpdateBuffer))
+      cmdBuf.BufferCommands.vkCmdUpdateBuffer[mapPos] = args
+
+      AddCommand(commandBuffer, cmd_vkCmdUpdateBuffer, mapPos)
+    }
+  }
 }
 
 @internal
@@ -736,6 +854,7 @@ class vkCmdFillBufferArgs {
   u32          Data
 }
 
+@spy_disabled
 sub void dovkCmdFillBuffer(ref!vkCmdFillBufferArgs args) {
   if !(args.Buffer in Buffers) { vkErrorInvalidBuffer(args.Buffer) }
   buf := Buffers[args.Buffer]
@@ -756,20 +875,28 @@ cmd void vkCmdFillBuffer(
     VkDeviceSize    dstOffset,
     VkDeviceSize    size,
     u32             data) {
-  if !(commandBuffer in CommandBuffers) { vkErrorInvalidCommandBuffer(commandBuffer) }
-  if !(dstBuffer in Buffers) { vkErrorInvalidBuffer(dstBuffer) }
-  args := new!vkCmdFillBufferArgs(
-    dstBuffer,
-    dstOffset,
-    size,
-    data
-  )
+  if !(commandBuffer in CommandBuffers) {
+    vkErrorInvalidCommandBuffer(commandBuffer)
+  } else {
+    if !(dstBuffer in Buffers) {
+      vkErrorInvalidBuffer(dstBuffer)
+    } else {
+      cmdBuf := CommandBuffers[commandBuffer]
+      cmdBuf.TouchedBuffers[dstBuffer] = true
 
-  mapPos := as!u32(len(CommandBuffers[commandBuffer].BufferCommands.vkCmdFillBuffer))
-  CommandBuffers[commandBuffer].BufferCommands.vkCmdFillBuffer[mapPos] =
-  args
+      args := new!vkCmdFillBufferArgs(
+        dstBuffer,
+        dstOffset,
+        size,
+        data
+      )
 
-  AddCommand(commandBuffer, cmd_vkCmdFillBuffer, mapPos)
+      mapPos := as!u32(len(cmdBuf.BufferCommands.vkCmdFillBuffer))
+      cmdBuf.BufferCommands.vkCmdFillBuffer[mapPos] = args
+
+      AddCommand(commandBuffer, cmd_vkCmdFillBuffer, mapPos)
+    }
+  }
 }
 
 @internal
@@ -780,6 +907,7 @@ class vkCmdClearColorImageArgs {
   map!(u32, VkImageSubresourceRange) Ranges
 }
 
+@spy_disabled
 sub void dovkCmdClearColorImage(ref!vkCmdClearColorImageArgs args) {
   if !(args.Image in Images) { vkErrorInvalidImage(args.Image) }
   image := Images[args.Image]
@@ -798,25 +926,37 @@ cmd void vkCmdClearColorImage(
     const VkClearColorValue*       pColor,
     u32                            rangeCount,
     const VkImageSubresourceRange* pRanges) {
-  if !(commandBuffer in CommandBuffers) { vkErrorInvalidCommandBuffer(commandBuffer) }
-  if !(image in Images) { vkErrorInvalidImage(image) }
-  if pColor == null { vkErrorNullPointer("VkClearColorValue") }
-  color := pColor[0]
-  ranges := pRanges[0:rangeCount]
-  args := new!vkCmdClearColorImageArgs(
-    Image:        image,
-    ImageLayout:  imageLayout,
-    Color:        color,
-  )
-  for i in (0 .. rangeCount) {
-    args.Ranges[as!u32(i)] = ranges[i]
+  if !(commandBuffer in CommandBuffers) {
+    vkErrorInvalidCommandBuffer(commandBuffer)
+  } else {
+    if !(image in Images) {
+      vkErrorInvalidImage(image)
+    } else {
+      imgObj := Images[image]
+      if pColor == null {
+        vkErrorNullPointer("VkClearColorValue")
+      } else {
+        cmdBuf := CommandBuffers[commandBuffer]
+
+        color := pColor[0]
+        ranges := pRanges[0:rangeCount]
+        args := new!vkCmdClearColorImageArgs(
+          Image:        image,
+          ImageLayout:  imageLayout,
+          Color:        color,
+        )
+        for i in (0 .. rangeCount) {
+          args.Ranges[as!u32(i)] = ranges[i]
+          commandBufferTouchImage(cmdBuf, imgObj, ranges[i])
+        }
+
+        mapPos := as!u32(len(cmdBuf.BufferCommands.vkCmdClearColorImage))
+        cmdBuf.BufferCommands.vkCmdClearColorImage[mapPos] = args
+
+        AddCommand(commandBuffer, cmd_vkCmdClearColorImage, mapPos)
+      }
+    }
   }
-
-  mapPos := as!u32(len(CommandBuffers[commandBuffer].BufferCommands.vkCmdClearColorImage))
-  CommandBuffers[commandBuffer].BufferCommands.vkCmdClearColorImage[mapPos] =
-  args
-
-  AddCommand(commandBuffer, cmd_vkCmdClearColorImage, mapPos)
 }
 
 @internal
@@ -827,6 +967,7 @@ class vkCmdClearDepthStencilImageArgs {
   map!(u32, VkImageSubresourceRange) Ranges
 }
 
+@spy_disabled
 sub void dovkCmdClearDepthStencilImage(ref!vkCmdClearDepthStencilImageArgs args) {
   if !(args.Image in Images) { vkErrorInvalidImage(args.Image) }
   image := Images[args.Image]
@@ -845,25 +986,37 @@ cmd void vkCmdClearDepthStencilImage(
     const VkClearDepthStencilValue* pDepthStencil,
     u32                             rangeCount,
     const VkImageSubresourceRange*  pRanges) {
-  if !(commandBuffer in CommandBuffers) { vkErrorInvalidCommandBuffer(commandBuffer) }
-  if !(image in Images) { vkErrorInvalidImage(image) }
-  if pDepthStencil == null { vkErrorNullPointer("VkClearDepthStencilValue") }
-  depthStencil := pDepthStencil[0]
-  ranges := pRanges[0:rangeCount]
-  args := new!vkCmdClearDepthStencilImageArgs(
-    Image:         image,
-    ImageLayout:   imageLayout,
-    DepthStencil:  depthStencil,
-  )
-  for i in (0 .. rangeCount) {
-    args.Ranges[as!u32(i)] = ranges[i]
+  if !(commandBuffer in CommandBuffers) {
+    vkErrorInvalidCommandBuffer(commandBuffer)
+  } else {
+    if !(image in Images) {
+      vkErrorInvalidImage(image)
+    } else {
+      imgObj := Images[image]
+      if pDepthStencil == null {
+        vkErrorNullPointer("VkClearDepthStencilValue")
+      } else {
+        cmdBuf := CommandBuffers[commandBuffer]
+
+        depthStencil := pDepthStencil[0]
+        ranges := pRanges[0:rangeCount]
+        args := new!vkCmdClearDepthStencilImageArgs(
+          Image:         image,
+          ImageLayout:   imageLayout,
+          DepthStencil:  depthStencil,
+        )
+        for i in (0 .. rangeCount) {
+          args.Ranges[as!u32(i)] = ranges[i]
+          commandBufferTouchImage(cmdBuf, imgObj, ranges[i])
+        }
+
+        mapPos := as!u32(len(cmdBuf.BufferCommands.vkCmdClearDepthStencilImage))
+        cmdBuf.BufferCommands.vkCmdClearDepthStencilImage[mapPos] = args
+
+        AddCommand(commandBuffer, cmd_vkCmdClearDepthStencilImage, mapPos)
+      }
+    }
   }
-
-  mapPos := as!u32(len(CommandBuffers[commandBuffer].BufferCommands.vkCmdClearDepthStencilImage))
-  CommandBuffers[commandBuffer].BufferCommands.vkCmdClearDepthStencilImage[mapPos] =
-  args
-
-  AddCommand(commandBuffer, cmd_vkCmdClearDepthStencilImage, mapPos)
 }
 
 @internal
@@ -872,6 +1025,7 @@ class vkCmdClearAttachmentsArgs {
   map!(u32, VkClearRect)       Rects
 }
 
+@spy_disabled
 sub void dovkCmdClearAttachments(ref!vkCmdClearAttachmentsArgs args) {
   useRenderPass()
 }
@@ -885,22 +1039,26 @@ cmd void vkCmdClearAttachments(
     const VkClearAttachment* pAttachments,
     u32                      rectCount,
     const VkClearRect*       pRects) {
-  if !(commandBuffer in CommandBuffers) { vkErrorInvalidCommandBuffer(commandBuffer) }
-  args := new!vkCmdClearAttachmentsArgs()
-  attachments := pAttachments[0:attachmentCount]
-  rects := pRects[0:rectCount]
-  for i in (0 .. attachmentCount) {
-    args.Attachments[as!u32(i)] = attachments[i]
-  }
-  for i in (0 .. rectCount) {
-    args.Rects[as!u32(i)] = rects[i]
-  }
+  if !(commandBuffer in CommandBuffers) {
+    vkErrorInvalidCommandBuffer(commandBuffer)
+  } else {
+    cmdBuf := CommandBuffers[commandBuffer]
 
-  mapPos := as!u32(len(CommandBuffers[commandBuffer].BufferCommands.vkCmdClearAttachments))
-  CommandBuffers[commandBuffer].BufferCommands.vkCmdClearAttachments[mapPos] =
-  args
+    args := new!vkCmdClearAttachmentsArgs()
+    attachments := pAttachments[0:attachmentCount]
+    rects := pRects[0:rectCount]
+    for i in (0 .. attachmentCount) {
+      args.Attachments[as!u32(i)] = attachments[i]
+    }
+    for i in (0 .. rectCount) {
+      args.Rects[as!u32(i)] = rects[i]
+    }
 
-  AddCommand(commandBuffer, cmd_vkCmdClearAttachments, mapPos)
+    mapPos := as!u32(len(cmdBuf.BufferCommands.vkCmdClearAttachments))
+    cmdBuf.BufferCommands.vkCmdClearAttachments[mapPos] = args
+
+    AddCommand(commandBuffer, cmd_vkCmdClearAttachments, mapPos)
+  }
 }
 
 @internal class vkCmdResolveImageArgs {
@@ -911,6 +1069,7 @@ cmd void vkCmdClearAttachments(
   map!(u32, VkImageResolve) ResolveRegions
 }
 
+@spy_disabled
 sub void dovkCmdResolveImage(ref!vkCmdResolveImageArgs args) {
   if !(args.SrcImage in Images) { vkErrorInvalidImage(args.SrcImage) }
   if !(args.DstImage in Images) { vkErrorInvalidImage(args.DstImage) }
@@ -949,23 +1108,50 @@ cmd void vkCmdResolveImage(
     VkImageLayout         dstImageLayout,
     u32                   regionCount,
     const VkImageResolve* pRegions) {
-  if !(commandBuffer in CommandBuffers) { vkErrorInvalidCommandBuffer(commandBuffer) }
-  if !(srcImage in Images) { vkErrorInvalidImage(srcImage) }
-  if !(dstImage in Images) { vkErrorInvalidImage(dstImage) }
-  args := new!vkCmdResolveImageArgs(
-    SrcImage:        srcImage,
-    SrcImageLayout:  srcImageLayout,
-    DstImage:        dstImage,
-    DstImageLayout:  dstImageLayout
-  )
-  regions := pRegions[0:regionCount]
-  for i in (0 .. regionCount) {
-    args.ResolveRegions[as!u32(i)] = regions[i]
+  if !(commandBuffer in CommandBuffers) {
+    vkErrorInvalidCommandBuffer(commandBuffer)
+  } else {
+    if !(srcImage in Images) {
+      vkErrorInvalidImage(srcImage)
+    } else {
+      srcImg := Images[srcImage]
+      if !(dstImage in Images) {
+        vkErrorInvalidImage(dstImage)
+      } else {
+        dstImg := Images[dstImage]
+
+        cmdBuf := CommandBuffers[commandBuffer]
+        args := new!vkCmdResolveImageArgs(
+          SrcImage:        srcImage,
+          SrcImageLayout:  srcImageLayout,
+          DstImage:        dstImage,
+          DstImageLayout:  dstImageLayout
+        )
+        regions := pRegions[0:regionCount]
+        for i in (0 .. regionCount) {
+          args.ResolveRegions[as!u32(i)] = regions[i]
+
+          srcRng := VkImageSubresourceRange(
+            regions[i].srcSubresource.aspectMask,
+            regions[i].srcSubresource.mipLevel,
+            1,
+            regions[i].srcSubresource.baseArrayLayer,
+            regions[i].srcSubresource.layerCount)
+          commandBufferTouchImage(cmdBuf, srcImg, srcRng)
+          dstRng := VkImageSubresourceRange(
+            regions[i].dstSubresource.aspectMask,
+            regions[i].dstSubresource.mipLevel,
+            1,
+            regions[i].dstSubresource.baseArrayLayer,
+            regions[i].dstSubresource.layerCount)
+          commandBufferTouchImage(cmdBuf, dstImg, dstRng)
+        }
+
+        mapPos := as!u32(len(cmdBuf.BufferCommands.vkCmdResolveImage))
+        cmdBuf.BufferCommands.vkCmdResolveImage[mapPos] = args
+
+        AddCommand(commandBuffer, cmd_vkCmdResolveImage, mapPos)
+      }
+    }
   }
-
-  mapPos := as!u32(len(CommandBuffers[commandBuffer].BufferCommands.vkCmdResolveImage))
-  CommandBuffers[commandBuffer].BufferCommands.vkCmdResolveImage[mapPos] =
-  args
-
-  AddCommand(commandBuffer, cmd_vkCmdResolveImage, mapPos)
 }

--- a/gapis/api/vulkan/api/descriptor.api
+++ b/gapis/api/vulkan/api/descriptor.api
@@ -239,13 +239,21 @@ cmd VkResult vkResetDescriptorPool(
 }
 
 @internal class DescriptorSetObject {
-  @unused VkDevice         Device
-  @unused VkDescriptorSet  VulkanHandle
-  @unused VkDescriptorPool DescriptorPool
+  @unused VkDevice                      Device
+  @unused VkDescriptorSet               VulkanHandle
+  @unused VkDescriptorPool              DescriptorPool
+
   // Map from a binding number to its bound array of buffers.
   map!(u32, ref!DescriptorBinding)      Bindings
-  ref!DescriptorSetLayoutObject     Layout
-  @unused ref!VulkanDebugMarkerInfo DebugInfo
+  ref!DescriptorSetLayoutObject         Layout
+  @unused ref!VulkanDebugMarkerInfo     DebugInfo
+
+  @untracked @untrackedMap @unused @hidden @nobox
+  map!(VkImage, ref!ImageCoverage)      LinkedImages
+  @untracked @untrackedMap @unused @hidden @nobox
+  map!(VkBuffer, bool)                  LinkedBuffers
+  @untracked @untrackedMap @unused @hidden @nobox
+  map!(VkCommandBuffer, bool)           CommandBufferUsers
 }
 
 @threadSafety("app")
@@ -561,10 +569,13 @@ cmd void vkUpdateDescriptorSets(
 
   }
 
+  modifiedDescriptorSets := new!DescriptorSetSet()
+
   writes := RewriteWriteDescriptorSets(
     descriptorWriteCount,
     pDescriptorWrites)
   for _ , _ , w in writes {
+    modifiedDescriptorSets.val[w.DstSet] = true
     set := DescriptorSets[w.DstSet]
     binding := w.Binding
     arrayIndex := w.BindingArrayIndex
@@ -633,6 +644,7 @@ cmd void vkUpdateDescriptorSets(
     descriptorCopyCount,
     pDescriptorCopies)
   for _ , _ , c in copies {
+    modifiedDescriptorSets.val[c.DstSet] = true
     srcSet := DescriptorSets[c.SrcSet]
     dstSet := DescriptorSets[c.DstSet]
     srcBinding := switch (c.SrcBinding in srcSet.Bindings) {
@@ -705,6 +717,79 @@ cmd void vkUpdateDescriptorSets(
     }
     dstSet.Bindings[c.DstBinding] = dstBinding
   }
+
+  // Then update the list of linked images and buffers for each modified
+  // descriptor sets. This is to avoid traveling all the bindings and array
+  // elements again when a command buffer binds these descriptor sets.
+  for _, set, _ in modifiedDescriptorSets.val {
+    setObj := DescriptorSets[set]
+
+    // TODO: Notify the command buffers that contain vkCmdBindDescriptorSets
+    // with the updated descriptor sets, if the descriptor sets' pools are
+    // created with VK_DESCRIPTOR_POOL_CREATE_UPDATE_AFTER_BIND_BIT_EXT and
+    // their layouts created with
+    // VK_DESCRIPTOR_SET_LAYOUT_CREATE_UPDATE_AFTER_BIND_POOL_BIT_EXT.
+    //for _, cb, _ in setObj.CommandBufferUsers {
+    //  if cb in CommandBuffers {
+    //    cbObj := CommandBuffers[cb]
+    //    delete(cbObj.ProcessedDescriptorSets, set)
+    //  }
+    //}
+    //clear(setObj.CommandBufferUsers)
+
+    clear(setObj.LinkedBuffers)
+    clear(setObj.LinkedImages)
+
+    for _, _, binding in setObj.Bindings {
+      switch binding.BindingType {
+        case VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
+          VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE,
+          VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
+          VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT: {
+          for _, _, ib in binding.ImageBinding {
+            if ib.ImageView in ImageViews {
+              viewObj := ImageViews[ib.ImageView]
+              if viewObj.Image.VulkanHandle in Images {
+                imgObj := viewObj.Image
+                descriptorSetLinkImage(setObj, imgObj, viewObj.SubresourceRange)
+              }
+            }
+          }
+        }
+
+        case VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER,
+          VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER: {
+          for _, _, bv in binding.BufferViewBindings {
+            if bv in BufferViews {
+              viewObj := BufferViews[bv]
+              if viewObj.Buffer.VulkanHandle in Buffers {
+                setObj.LinkedBuffers[viewObj.Buffer.VulkanHandle] = true
+              }
+            }
+          }
+        }
+
+        case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
+          VK_DESCRIPTOR_TYPE_STORAGE_BUFFER,
+          VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC,
+          VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC: {
+          for _, _, bb in binding.BufferBinding {
+            if bb.Buffer in Buffers {
+              setObj.LinkedBuffers[bb.Buffer] = true
+            }
+          }
+        }
+
+        case VK_DESCRIPTOR_TYPE_SAMPLER: {
+          // do nothing
+        }
+
+        default: {
+          // do nothing, we should never reach here.
+        }
+      }
+    }
+  }
 }
 
 /////////////////////////////
@@ -716,16 +801,17 @@ vkCmdBindDescriptorSetsArgs {
   VkPipelineBindPoint        PipelineBindPoint
   VkPipelineLayout           Layout
   u32                        FirstSet
-  map!(u32, VkDescriptorSet) DescriptorSets
-  map!(u32, u32)             DynamicOffsets
+  dense_map!(u32, VkDescriptorSet) DescriptorSets
+  dense_map!(u32, u32)             DynamicOffsets
 }
 
-@internal class 
+@internal class
 emptyBufferOffsets {
   map!(u32, map!(u32, map!(VkDeviceSize, bool))) BufferBindingOffsets
 }
 
-sub void dovkCmdBindDescriptorSets(ref!vkCmdBindDescriptorSetsArgs args) {
+@spy_disabled
+sub void updateDescriptorBufferBindingOffsets(ref!vkCmdBindDescriptorSetsArgs args) {
   _ = PipelineLayouts[args.Layout]
   dynamic_offset_index := MutableU32(0)
 
@@ -753,19 +839,6 @@ sub void dovkCmdBindDescriptorSets(ref!vkCmdBindDescriptorSetsArgs args) {
       setObj := DescriptorSets[set]
       currentDescriptorSets[args.FirstSet + as!u32(i)] = setObj
       desc_set_buf_offsets := bufferBindingOffsets[as!u32(i)+args.FirstSet]
-      hasBeenRead := switch (set in ProcessedDescriptorSets.val) {
-        case true:
-          MutableBool(true)
-        default:
-          MutableBool(false)
-      }
-
-      existingOffsets := switch(hasBeenRead.b) {
-        case true:
-          ProcessedDescriptorSets.val[set].bufferOffsets
-        case false:
-          emptyBufferOffsets().BufferBindingOffsets
-      }
 
       // Since the pDynamicOffsets point into the bindings in order of
       // binding index, and then array index, we have to loop over all
@@ -776,38 +849,19 @@ sub void dovkCmdBindDescriptorSets(ref!vkCmdBindDescriptorSetsArgs args) {
           binding := setObj.Bindings[j]
           numBufferBindings := len(binding.BufferBinding)
           for k in (0 .. numBufferBindings) {
-            bufferBinding := binding.BufferBinding[as!u32(k)]
+            bufferInfo := binding.BufferBinding[as!u32(k)]
 
             binding_offset := switch binding.BindingType {
               case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC:
-                as!VkDeviceSize(args.DynamicOffsets[dynamic_offset_index.Val]) + bufferBinding.Offset
+                as!VkDeviceSize(args.DynamicOffsets[dynamic_offset_index.Val]) + bufferInfo.Offset
               default:
-                bufferBinding.Offset
+                bufferInfo.Offset
             }
             dynamic_offset_index.Val = switch binding.BindingType {
               case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC:
                 dynamic_offset_index.Val + 1
               default:
                 dynamic_offset_index.Val
-            }
-            
-            // If the offset has changed, then we may have to reprocess this
-            // descriptor set.
-            if hasBeenRead.b {
-              if !(as!u32(j) in existingOffsets) {
-                hasBeenRead.b = false
-              } else if !(as!u32(k) in existingOffsets[as!u32(j)]) {
-                hasBeenRead.b = false
-              } else if !(binding_offset in existingOffsets[as!u32(j)][as!u32(k)]) {
-                hasBeenRead.b = false
-              }
-
-              if !hasBeenRead.b {
-                oldSets := ProcessedDescriptorSets.val[set].bufferOffsets
-                ProcessedDescriptorSets.val[set] = 
-                  ProcessedDescriptorSet(oldSets, true)
-
-              }
             }
             desc_binding_buf_offsets[as!u32(k)] = binding_offset
           }
@@ -817,6 +871,10 @@ sub void dovkCmdBindDescriptorSets(ref!vkCmdBindDescriptorSetsArgs args) {
       bufferBindingOffsets[as!u32(i)+args.FirstSet] = desc_set_buf_offsets
     }
   }
+}
+
+sub void dovkCmdBindDescriptorSets(ref!vkCmdBindDescriptorSetsArgs args) {
+  updateDescriptorBufferBindingOffsets(args)
 }
 
 @threadSafety("app")
@@ -831,29 +889,46 @@ cmd void vkCmdBindDescriptorSets(
     const VkDescriptorSet* pDescriptorSets,
     u32                    dynamicOffsetCount,
     const u32*             pDynamicOffsets) {
-  if pDescriptorSets == null { vkErrorNullPointer("VkDescriptorSet") }
-  sets := pDescriptorSets[0:descriptorSetCount]
-  if !(layout in PipelineLayouts) { vkErrorInvalidPipelineLayout(layout) }
-  args := new!vkCmdBindDescriptorSetsArgs(
-    PipelineBindPoint: pipelineBindPoint,
-    Layout:            layout,
-    FirstSet:          firstSet
-  )
-
-  dynamic_offsets := pDynamicOffsets[0:dynamicOffsetCount]
-  for i in (0 .. dynamicOffsetCount) {
-    args.DynamicOffsets[i] = dynamic_offsets[i]
-  }
-  for i in (0 .. descriptorSetCount) {
-    set := sets[i]
-    if !(set in DescriptorSets) { vkErrorInvalidDescriptorSet(set) }
-    args.DescriptorSets[i] = set
-  }
-
   if !(commandBuffer in CommandBuffers) {
     vkErrorInvalidCommandBuffer(commandBuffer)
   } else {
-    bc := CommandBuffers[commandBuffer].BufferCommands.vkCmdBindDescriptorSets
+    cmdBuf := CommandBuffers[commandBuffer]
+
+    if pDescriptorSets == null { vkErrorNullPointer("VkDescriptorSet") }
+    sets := pDescriptorSets[0:descriptorSetCount]
+    args := new!vkCmdBindDescriptorSetsArgs(
+      PipelineBindPoint: pipelineBindPoint,
+      Layout:            layout,
+      FirstSet:          firstSet
+    )
+
+    dynamic_offsets := pDynamicOffsets[0:dynamicOffsetCount]
+    for i in (0 .. dynamicOffsetCount) {
+      args.DynamicOffsets[i] = dynamic_offsets[i]
+    }
+    for i in (0 .. descriptorSetCount) {
+      args.DescriptorSets[i] = sets[i]
+    }
+    for i in (0 .. descriptorSetCount) {
+      set := sets[i]
+      if !(set in cmdBuf.ProcessedDescriptorSets) {
+        if !(set in DescriptorSets) {
+          vkErrorInvalidDescriptorSet(set)
+        } else {
+          setObj := DescriptorSets[set]
+          for _, buf, _ in setObj.LinkedBuffers {
+            cmdBuf.TouchedBuffers[buf] = true
+          }
+          for _, img, cov in setObj.LinkedImages {
+            cmdBuf.TouchedImages[img] = cov
+          }
+          cmdBuf.ProcessedDescriptorSets[set] = true
+          DescriptorSets[set].CommandBufferUsers[commandBuffer] = true
+        }
+      }
+    }
+
+    bc := cmdBuf.BufferCommands.vkCmdBindDescriptorSets
     mapPos := as!u32(len(bc))
     bc[mapPos] = args
     AddCommand(commandBuffer, cmd_vkCmdBindDescriptorSets, mapPos)
@@ -893,9 +968,10 @@ cmd void vkCmdPushConstants(
       layout,                stageFlags, offset, size, clone(as!u8*(pValues)[0:size])
     )
 
-    mapPos := as!u32(len(CommandBuffers[commandBuffer].BufferCommands.vkCmdPushConstants))
-    CommandBuffers[commandBuffer].BufferCommands.vkCmdPushConstants[mapPos] =
-    args
+    cmdBuf := CommandBuffers[commandBuffer]
+
+    mapPos := as!u32(len(cmdBuf.BufferCommands.vkCmdPushConstants))
+    cmdBuf.BufferCommands.vkCmdPushConstants[mapPos] = args
 
     AddCommand(commandBuffer, cmd_vkCmdPushConstants, mapPos)
   }

--- a/gapis/api/vulkan/api/draw_commands.api
+++ b/gapis/api/vulkan/api/draw_commands.api
@@ -51,11 +51,14 @@ vkCmdBindIndexBufferArgs {
 
 
 sub void dovkCmdBindIndexBuffer(ref!vkCmdBindIndexBufferArgs buffer) {
-  if !(buffer.Buffer in Buffers) { vkErrorInvalidBuffer(buffer.Buffer) }
-  buff := Buffers[buffer.Buffer]
-  lastDrawInfo().BoundIndexBuffer = new!BoundIndexBuffer(buffer.IndexType,
-    BoundBuffer(buff, buffer.Offset, 0))
-  buff.LastBoundQueue = LastBoundQueue
+  if !(buffer.Buffer in Buffers) {
+    vkErrorInvalidBuffer(buffer.Buffer)
+  } else {
+    buff := Buffers[buffer.Buffer]
+    lastDrawInfo().BoundIndexBuffer = new!BoundIndexBuffer(buffer.IndexType,
+      BoundBuffer(buff, buffer.Offset, 0))
+    buff.LastBoundQueue = LastBoundQueue
+  }
 }
 
 
@@ -76,10 +79,11 @@ cmd void vkCmdBindIndexBuffer(
       Offset:     offset,
       IndexType:  indexType
     )
+    cmdBuf := CommandBuffers[commandBuffer]
+    cmdBuf.TouchedBuffers[buffer] = true
 
-    mapPos := as!u32(len(CommandBuffers[commandBuffer].BufferCommands.vkCmdBindIndexBuffer))
-    CommandBuffers[commandBuffer].BufferCommands.vkCmdBindIndexBuffer[mapPos] =
-    args
+    mapPos := as!u32(len(cmdBuf.BufferCommands.vkCmdBindIndexBuffer))
+    cmdBuf.BufferCommands.vkCmdBindIndexBuffer[mapPos] = args
 
     AddCommand(commandBuffer, cmd_vkCmdBindIndexBuffer, mapPos)
   }
@@ -102,11 +106,14 @@ sub void dovkCmdBindVertexBuffers(ref!vkCmdBindVertexBuffersArgs bind) {
   n := len(bind.Buffers)
   for i in (0 .. n) {
     v := bind.Buffers[as!u32(i)]
-    if !(v in Buffers) { vkErrorInvalidBuffer(v) }
-    lastDrawInfo().BoundVertexBuffers[as!u32(i) + bind.FirstBinding] = BoundBuffer(
-      Buffers[v], bind.Offsets[as!u32(i)],
-      Buffers[v].Info.Size - bind.Offsets[as!u32(i)])
-    Buffers[v].LastBoundQueue = LastBoundQueue
+    if !(v in Buffers) {
+      vkErrorInvalidBuffer(v)
+    } else {
+      lastDrawInfo().BoundVertexBuffers[as!u32(i) + bind.FirstBinding] = BoundBuffer(
+        Buffers[v], bind.Offsets[as!u32(i)],
+        Buffers[v].Info.Size - bind.Offsets[as!u32(i)])
+      Buffers[v].LastBoundQueue = LastBoundQueue
+    }
   }
 }
 
@@ -119,24 +126,26 @@ cmd void vkCmdBindVertexBuffers(
     u32                 bindingCount,
     const VkBuffer*     pBuffers,
     const VkDeviceSize* pOffsets) {
-  args := new!vkCmdBindVertexBuffersArgs(
-    FirstBinding:  firstBinding,
-    BindingCount:  bindingCount
-  )
-  buffers := pBuffers[0:bindingCount]
-  offsets := pOffsets[0:bindingCount]
-  for i in (0 .. bindingCount) {
-    if !(buffers[i] in Buffers) { vkErrorInvalidBuffer(buffers[i]) }
-    args.Buffers[i] = buffers[i]
-    args.Offsets[i] = offsets[i]
-  }
-
   if !(commandBuffer in CommandBuffers) {
     vkErrorInvalidCommandBuffer(commandBuffer)
   } else {
-    mapPos := as!u32(len(CommandBuffers[commandBuffer].BufferCommands.vkCmdBindVertexBuffers))
-    CommandBuffers[commandBuffer].BufferCommands.vkCmdBindVertexBuffers[mapPos] =
-    args
+    args := new!vkCmdBindVertexBuffersArgs(
+      FirstBinding:  firstBinding,
+      BindingCount:  bindingCount
+    )
+    buffers := pBuffers[0:bindingCount]
+    offsets := pOffsets[0:bindingCount]
+    for i in (0 .. bindingCount) {
+      if !(buffers[i] in Buffers) { vkErrorInvalidBuffer(buffers[i]) }
+      args.Buffers[i] = buffers[i]
+      args.Offsets[i] = offsets[i]
+    }
+    cmdBuf := CommandBuffers[commandBuffer]
+    for i in (0 .. bindingCount) {
+      cmdBuf.TouchedBuffers[buffers[i]] = true
+    }
+    mapPos := as!u32(len(cmdBuf.BufferCommands.vkCmdBindVertexBuffers))
+    cmdBuf.BufferCommands.vkCmdBindVertexBuffers[mapPos] = args
 
     AddCommand(commandBuffer, cmd_vkCmdBindVertexBuffers, mapPos)
   }
@@ -175,9 +184,9 @@ cmd void vkCmdDraw(
   } else {
     args := new!vkCmdDrawArgs(vertexCount, instanceCount, firstVertex, firstInstance)
 
-    mapPos := as!u32(len(CommandBuffers[commandBuffer].BufferCommands.vkCmdDraw))
-    CommandBuffers[commandBuffer].BufferCommands.vkCmdDraw[mapPos] =
-    args
+    cmdBuf := CommandBuffers[commandBuffer]
+    mapPos := as!u32(len(cmdBuf.BufferCommands.vkCmdDraw))
+    cmdBuf.BufferCommands.vkCmdDraw[mapPos] = args
 
     AddCommand(commandBuffer, cmd_vkCmdDraw, mapPos)
   }
@@ -192,10 +201,8 @@ vkCmdDrawIndexedArgs {
   u32 FirstInstance
 }
 
-sub void dovkCmdDrawIndexed(ref!vkCmdDrawIndexedArgs draw) {
-  readDrawState()
-  useRenderPass()
-
+@spy_disabled
+sub void readBoundIndexBuffer(u32 indexCount, u32 firstIndex) {
   // Loop through the index buffer, and find the low and high
   // vertices. Then read all of the applicable vertex buffers.
   lastDraw := lastDrawInfo()
@@ -206,17 +213,22 @@ sub void dovkCmdDrawIndexed(ref!vkCmdDrawIndexedArgs draw) {
     case VK_INDEX_TYPE_UINT32:
       as!VkDeviceSize(4)
   }
-
-  numBytes := as!VkDeviceSize(draw.IndexCount) * indexSize
-  startOffset := lastDraw.BoundIndexBuffer.BoundBuffer.Offset + (indexSize * as!VkDeviceSize(draw.FirstIndex))
+  numBytes := as!VkDeviceSize(indexCount) * indexSize
+  startOffset := lastDraw.BoundIndexBuffer.BoundBuffer.Offset + (indexSize * as!VkDeviceSize(firstIndex))
 
   // Read the data of the index buffer.
   readMemoryInBuffer(indexBuffer, startOffset, numBytes)
+}
+
+sub void dovkCmdDrawIndexed(ref!vkCmdDrawIndexedArgs draw) {
+  readDrawState()
+  useRenderPass()
+  readBoundIndexBuffer(draw.IndexCount, draw.FirstIndex)
   // Read the whole vertex buffer.
   readMemoryInCurrentPipelineBoundVertexBuffers(0xFFFFFFFF, draw.InstanceCount, 0, draw.FirstInstance)
   readWriteMemoryInBoundGraphicsDescriptorSets()
   clearLastDrawInfoDrawCommandParameters()
-  lastDraw.CommandParameters.DrawIndexed = draw
+  lastDrawInfo().CommandParameters.DrawIndexed = draw
 }
 
 @threadSafety("app")
@@ -241,9 +253,9 @@ cmd void vkCmdDrawIndexed(
       FirstInstance:  firstInstance
     )
 
-    mapPos := as!u32(len(CommandBuffers[commandBuffer].BufferCommands.vkCmdDrawIndexed))
-    CommandBuffers[commandBuffer].BufferCommands.vkCmdDrawIndexed[mapPos] =
-    args
+    cmdBuf := CommandBuffers[commandBuffer]
+    mapPos := as!u32(len(cmdBuf.BufferCommands.vkCmdDrawIndexed))
+    cmdBuf.BufferCommands.vkCmdDrawIndexed[mapPos] = args
 
     AddCommand(commandBuffer, cmd_vkCmdDrawIndexed, mapPos)
   }
@@ -256,16 +268,22 @@ cmd void vkCmdDrawIndexed(
   u32          Stride
 }
 
+@spy_disabled
+sub void readIndirectDrawBuffer(VkBuffer buf, VkDeviceSize offset, u32 drawCount, u32 stride) {
+  if !(buf in Buffers) {
+    vkErrorInvalidBuffer(buf)
+  } else {
+    command_size := as!VkDeviceSize(16)
+    indirect_buffer_read_size := as!VkDeviceSize((drawCount - 1) * stride) + command_size
+    readMemoryInBuffer(Buffers[buf], offset, indirect_buffer_read_size)
+  }
+}
+
 sub void dovkCmdDrawIndirect(ref!vkCmdDrawIndirectArgs draw) {
   useRenderPass()
-
   if draw.DrawCount > 0 {
-    readDrawState()
     readWriteMemoryInBoundGraphicsDescriptorSets()
-    command_size := as!VkDeviceSize(16)
-    indirect_buffer_read_size := as!VkDeviceSize((draw.DrawCount - 1) * draw.Stride) + command_size
-    if !(draw.Buffer in Buffers) { vkErrorInvalidBuffer(draw.Buffer) }
-    readMemoryInBuffer(Buffers[draw.Buffer], draw.Offset, indirect_buffer_read_size)
+    readIndirectDrawBuffer(draw.Buffer, draw.Offset, draw.DrawCount, draw.Stride)
     // Read through all the vertex buffers, as we cannot assume the buffer given to indirect draw is host
     readMemoryInCurrentPipelineBoundVertexBuffers(0xFFFFFFFF, 0xFFFFFFFF, 0, 0)
     clearLastDrawInfoDrawCommandParameters()
@@ -289,9 +307,10 @@ cmd void vkCmdDrawIndirect(
     if !(buffer in Buffers) { vkErrorInvalidBuffer(buffer) }
     args := new!vkCmdDrawIndirectArgs(buffer, offset, drawCount, stride)
 
-    mapPos := as!u32(len(CommandBuffers[commandBuffer].BufferCommands.vkCmdDrawIndirect))
-    CommandBuffers[commandBuffer].BufferCommands.vkCmdDrawIndirect[mapPos] =
-    args
+    cmdBuf := CommandBuffers[commandBuffer]
+    cmdBuf.TouchedBuffers[buffer] = true
+    mapPos := as!u32(len(cmdBuf.BufferCommands.vkCmdDrawIndirect))
+    cmdBuf.BufferCommands.vkCmdDrawIndirect[mapPos] = args
 
     AddCommand(commandBuffer, cmd_vkCmdDrawIndirect, mapPos)
   }
@@ -304,20 +323,26 @@ cmd void vkCmdDrawIndirect(
   u32          Stride
 }
 
+@spy_disabled
+sub void readIndexedIndirectDrawBuffer(VkBuffer buf, VkDeviceSize offset, u32 drawCount, u32 stride ) {
+    if !(buf in Buffers) {
+      vkErrorInvalidBuffer(buf)
+    } else {
+      command_size := as!VkDeviceSize(16)
+      indirect_buffer_read_size := as!VkDeviceSize((drawCount - 1) * stride) + command_size
+      readMemoryInBuffer(Buffers[buf], offset, indirect_buffer_read_size)
+      // Read through the whole index buffer.
+      indexBuffer := lastDrawInfo().BoundIndexBuffer.BoundBuffer.Buffer
+      readMemoryInBuffer(indexBuffer, 0, indexBuffer.Info.Size)
+    }
+}
+
 sub void dovkCmdDrawIndexedIndirect(ref!vkCmdDrawIndexedIndirectArgs draw) {
   useRenderPass()
-
   if draw.DrawCount > 0 {
-    readDrawState()
     ldi := lastDrawInfo()
     readWriteMemoryInBoundGraphicsDescriptorSets()
-    command_size := as!VkDeviceSize(16)
-    indirect_buffer_read_size := as!VkDeviceSize((draw.DrawCount - 1) * draw.Stride) + command_size
-    if !(draw.Buffer in Buffers) { vkErrorInvalidBuffer(draw.Buffer) }
-    readMemoryInBuffer(Buffers[draw.Buffer], draw.Offset, indirect_buffer_read_size)
-    // Read through the whole index buffer.
-    indexBuffer := ldi.BoundIndexBuffer.BoundBuffer.Buffer
-    readMemoryInBuffer(indexBuffer, 0, indexBuffer.Info.Size)
+    readIndexedIndirectDrawBuffer(draw.Buffer, draw.Offset, draw.DrawCount, draw.Stride)
     // Read through all the vertex buffers.
     readMemoryInCurrentPipelineBoundVertexBuffers(0xFFFFFFFF, 0xFFFFFFFF, 0, 0)
     clearLastDrawInfoDrawCommandParameters()
@@ -341,9 +366,10 @@ cmd void vkCmdDrawIndexedIndirect(
     if !(buffer in Buffers) { vkErrorInvalidBuffer(buffer) }
     args := new!vkCmdDrawIndexedIndirectArgs(buffer, offset, drawCount, stride)
 
-    mapPos := as!u32(len(CommandBuffers[commandBuffer].BufferCommands.vkCmdDrawIndexedIndirect))
-    CommandBuffers[commandBuffer].BufferCommands.vkCmdDrawIndexedIndirect[mapPos] =
-    args
+    cmdBuf := CommandBuffers[commandBuffer]
+    cmdBuf.TouchedBuffers[buffer] = true
+    mapPos := as!u32(len(cmdBuf.BufferCommands.vkCmdDrawIndexedIndirect))
+    cmdBuf.BufferCommands.vkCmdDrawIndexedIndirect[mapPos] = args
 
     AddCommand(commandBuffer, cmd_vkCmdDrawIndexedIndirect, mapPos)
   }
@@ -374,9 +400,9 @@ cmd void vkCmdDispatch(
   } else {
     args := new!vkCmdDispatchArgs(groupCountX, groupCountY, groupCountZ)
 
-    mapPos := as!u32(len(CommandBuffers[commandBuffer].BufferCommands.vkCmdDispatch))
-    CommandBuffers[commandBuffer].BufferCommands.vkCmdDispatch[mapPos] =
-    args
+    cmdBuf := CommandBuffers[commandBuffer]
+    mapPos := as!u32(len(cmdBuf.BufferCommands.vkCmdDispatch))
+    cmdBuf.BufferCommands.vkCmdDispatch[mapPos] = args
 
     AddCommand(commandBuffer, cmd_vkCmdDispatch, mapPos)
   }
@@ -388,11 +414,15 @@ class vkCmdDispatchIndirectArgs {
   VkDeviceSize Offset
 }
 
-sub void dovkCmdDispatchIndirect(ref!vkCmdDispatchIndirectArgs dispatch) {
+@spy_disabled
+sub void readIndirectDispatchBuffer(VkBuffer buf, VkDeviceSize offset) {
   command_size := as!VkDeviceSize(12)
-  if !(dispatch.Buffer in Buffers) { vkErrorInvalidBuffer(dispatch.Buffer) }
-  readMemoryInBuffer(Buffers[dispatch.Buffer], dispatch.Offset, command_size)
+  readMemoryInBuffer(Buffers[buf], offset, command_size)
+}
+
+sub void dovkCmdDispatchIndirect(ref!vkCmdDispatchIndirectArgs dispatch) {
   readComputeState()
+  readIndirectDispatchBuffer(dispatch.Buffer, dispatch.Offset)
   readWriteMemoryInBoundComputeDescriptorSets()
 }
 
@@ -410,14 +440,16 @@ cmd void vkCmdDispatchIndirect(
     if !(buffer in Buffers) { vkErrorInvalidBuffer(buffer) }
     args := new!vkCmdDispatchIndirectArgs(buffer, offset)
 
-    mapPos := as!u32(len(CommandBuffers[commandBuffer].BufferCommands.vkCmdDispatchIndirect))
-    CommandBuffers[commandBuffer].BufferCommands.vkCmdDispatchIndirect[mapPos] =
-    args
+    cmdBuf := CommandBuffers[commandBuffer]
+    cmdBuf.TouchedBuffers[buffer] = true
+    mapPos := as!u32(len(cmdBuf.BufferCommands.vkCmdDispatchIndirect))
+    cmdBuf.BufferCommands.vkCmdDispatchIndirect[mapPos] = args
 
     AddCommand(commandBuffer, cmd_vkCmdDispatchIndirect, mapPos)
   }
 }
 
+@spy_disabled
 sub void readWriteMemoryInBoundGraphicsDescriptorSets() {
   ldi := lastDrawInfo()
   readWriteMemoryInBoundDescriptorSets(
@@ -426,6 +458,7 @@ sub void readWriteMemoryInBoundGraphicsDescriptorSets() {
     ldi.BufferBindingOffsets)
 }
 
+@spy_disabled
 sub void readWriteMemoryInBoundComputeDescriptorSets() {
   lci := lastComputeInfo()
   readWriteMemoryInBoundDescriptorSets(

--- a/gapis/api/vulkan/api/image.api
+++ b/gapis/api/vulkan/api/image.api
@@ -584,7 +584,7 @@ cmd void vkDestroySampler(
     AllocationCallbacks pAllocator) {
   if !(device in Devices) { vkErrorInvalidDevice(device) }
   if sampler in Samplers {
-    obj := Samplers[sampler] 
+    obj := Samplers[sampler]
     if obj != null {
       for _, vkDesSet, bindingAndIndices in obj.DescriptorUsers {
         if vkDesSet in DescriptorSets {
@@ -625,7 +625,7 @@ sub void updateImageQueue(ref!ImageObject image, VkImageSubresourceRange rng) {
   }
 }
 
-sub void setQueueInRange(ref!ImageObject image, VkImageSubresourceRange rng, 
+sub void setQueueInRange(ref!ImageObject image, VkImageSubresourceRange rng,
     ref!QueueObject queue) {
   layerCount := imageSubresourceLayerCount(image, rng)
   levelCount := imageSubresourceLevelCount(image, rng)
@@ -639,41 +639,6 @@ sub void setQueueInRange(ref!ImageObject image, VkImageSubresourceRange rng,
               level.LastBoundQueue = queue
             }
           }
-        }
-      }
-    }
-  }
-}
-
-@spy_disabled
-sub void readImageSubresource(ref!ImageObject image, VkImageSubresourceRange rng) {
-  layerCount := imageSubresourceLayerCount(image, rng)
-  levelCount := imageSubresourceLevelCount(image, rng)
-  for _ , _ , aspectBit in unpackImageAspectFlags(rng.aspectMask) {
-    for _, i, layer in image.Aspects[aspectBit].Layers {
-      if (i >= rng.baseArrayLayer) && (i < rng.baseArrayLayer + layerCount) {
-        for _, k, level in layer.Levels {
-          if (k >= rng.baseMipLevel) && (k < rng.baseMipLevel + levelCount) {
-            read(level.Data)
-          }
-        }
-      }
-    }
-  }
-}
-
-@spy_disabled
-sub void writeImageSubresource(ref!ImageObject image, VkImageSubresourceRange rng) {
-  layerCount := imageSubresourceLayerCount(image, rng)
-  levelCount := imageSubresourceLevelCount(image, rng)
-  for _ , _ , aspectBit in unpackImageAspectFlags(rng.aspectMask) {
-    if aspectBit in image.Aspects {
-      aspect := image.Aspects[aspectBit]
-      for layerIndex in (rng.baseArrayLayer .. rng.baseArrayLayer + layerCount) {
-        layer := aspect.Layers[layerIndex]
-        for mipLevel in (rng.baseMipLevel .. rng.baseMipLevel + levelCount) {
-          level := layer.Levels[mipLevel]
-          write(level.Data)
         }
       }
     }

--- a/gapis/api/vulkan/api/pipeline.api
+++ b/gapis/api/vulkan/api/pipeline.api
@@ -349,7 +349,7 @@ cmd VkResult vkCreateGraphicsPipelines(
           next.Ptr = as!VulkanStructHeader*(next.Ptr)[0:1][0].PNext
         }
       }
-      
+
       obj.TessellationState = new!TessellationStateData(
         PatchControlPoints: tessellation_state.patchControlPoints
       )
@@ -368,7 +368,7 @@ cmd VkResult vkCreateGraphicsPipelines(
           next.Ptr = as!VulkanStructHeader*(next.Ptr)[0:1][0].PNext
         }
       }
-      
+
 
       viewport_data := new!ViewportData()
 
@@ -746,7 +746,7 @@ cmd VkResult vkCreatePipelineCache(
       next.Ptr = as!VulkanStructHeader*(next.Ptr)[0:1][0].PNext
     }
   }
-  
+
   read(as!u8*(create_info.pInitialData)[0:create_info.initialDataSize])
   handle := ?
   if pPipelineCache == null { vkErrorNullPointer("VkPipelineCache") }

--- a/gapis/api/vulkan/api/query_pool.api
+++ b/gapis/api/vulkan/api/query_pool.api
@@ -186,9 +186,9 @@ cmd void vkCmdBeginQuery(
       queryPool,          query, flags
     )
 
-    mapPos := as!u32(len(CommandBuffers[commandBuffer].BufferCommands.vkCmdBeginQuery))
-    CommandBuffers[commandBuffer].BufferCommands.vkCmdBeginQuery[mapPos] =
-    args
+    cmdBuf := CommandBuffers[commandBuffer]
+    mapPos := as!u32(len(cmdBuf.BufferCommands.vkCmdBeginQuery))
+    cmdBuf.BufferCommands.vkCmdBeginQuery[mapPos] = args
 
     AddCommand(commandBuffer, cmd_vkCmdBeginQuery, mapPos)
   }
@@ -227,9 +227,9 @@ cmd void vkCmdEndQuery(
       queryPool,        query
     )
 
-    mapPos := as!u32(len(CommandBuffers[commandBuffer].BufferCommands.vkCmdEndQuery))
-    CommandBuffers[commandBuffer].BufferCommands.vkCmdEndQuery[mapPos] =
-    args
+    cmdBuf := CommandBuffers[commandBuffer]
+    mapPos := as!u32(len(cmdBuf.BufferCommands.vkCmdEndQuery))
+    cmdBuf.BufferCommands.vkCmdEndQuery[mapPos] = args
 
     AddCommand(commandBuffer, cmd_vkCmdEndQuery, mapPos)
   }
@@ -270,9 +270,9 @@ cmd void vkCmdResetQueryPool(
       queryPool,              firstQuery, queryCount
     )
 
-    mapPos := as!u32(len(CommandBuffers[commandBuffer].BufferCommands.vkCmdResetQueryPool))
-    CommandBuffers[commandBuffer].BufferCommands.vkCmdResetQueryPool[mapPos] =
-    args
+    cmdBuf := CommandBuffers[commandBuffer]
+    mapPos := as!u32(len(cmdBuf.BufferCommands.vkCmdResetQueryPool))
+    cmdBuf.BufferCommands.vkCmdResetQueryPool[mapPos] = args
 
     AddCommand(commandBuffer, cmd_vkCmdResetQueryPool, mapPos)
   }
@@ -313,9 +313,9 @@ cmd void vkCmdWriteTimestamp(
       pipelineStage,          queryPool, query
     )
 
-    mapPos := as!u32(len(CommandBuffers[commandBuffer].BufferCommands.vkCmdWriteTimestamp))
-    CommandBuffers[commandBuffer].BufferCommands.vkCmdWriteTimestamp[mapPos] =
-    args
+    cmdBuf := CommandBuffers[commandBuffer]
+    mapPos := as!u32(len(cmdBuf.BufferCommands.vkCmdWriteTimestamp))
+    cmdBuf.BufferCommands.vkCmdWriteTimestamp[mapPos] = args
 
     AddCommand(commandBuffer, cmd_vkCmdWriteTimestamp, mapPos)
   }
@@ -377,23 +377,31 @@ cmd void vkCmdCopyQueryPoolResults(
   if !(commandBuffer in CommandBuffers) {
     vkErrorInvalidCommandBuffer(commandBuffer)
   } else {
-    if !(queryPool in QueryPools) { vkErrorInvalidQueryPool(queryPool) }
-    if !(dstBuffer in Buffers) { vkErrorInvalidBuffer(dstBuffer) }
-    args := new!vkCmdCopyQueryPoolResultsArgs(
-      QueryPool:   queryPool,
-      FirstQuery:  firstQuery,
-      QueryCount:  queryCount,
-      DstBuffer:   dstBuffer,
-      DstOffset:   dstOffset,
-      Stride:      stride,
-      Flags:       flags
-    )
+    if !(queryPool in QueryPools) {
+      vkErrorInvalidQueryPool(queryPool)
+    } else {
+      if !(dstBuffer in Buffers) {
+        vkErrorInvalidBuffer(dstBuffer)
+      } else {
+        cmdBuf := CommandBuffers[commandBuffer]
+        cmdBuf.TouchedBuffers[dstBuffer] = true
 
-    mapPos := as!u32(len(CommandBuffers[commandBuffer].BufferCommands.vkCmdCopyQueryPoolResults))
-    CommandBuffers[commandBuffer].BufferCommands.vkCmdCopyQueryPoolResults[mapPos] =
-    args
+        args := new!vkCmdCopyQueryPoolResultsArgs(
+          QueryPool:   queryPool,
+          FirstQuery:  firstQuery,
+          QueryCount:  queryCount,
+          DstBuffer:   dstBuffer,
+          DstOffset:   dstOffset,
+          Stride:      stride,
+          Flags:       flags
+        )
 
-    AddCommand(commandBuffer, cmd_vkCmdCopyQueryPoolResults, mapPos)
+        mapPos := as!u32(len(cmdBuf.BufferCommands.vkCmdCopyQueryPoolResults))
+        cmdBuf.BufferCommands.vkCmdCopyQueryPoolResults[mapPos] = args
+
+        AddCommand(commandBuffer, cmd_vkCmdCopyQueryPoolResults, mapPos)
+      }
+    }
   }
 }
 

--- a/gapis/api/vulkan/api/queue.api
+++ b/gapis/api/vulkan/api/queue.api
@@ -333,7 +333,7 @@ cmd VkResult vkQueueBindSparse(
       bindsToQueue := new!SparseMemoryBinds()
       memoryBinds := bufferBindInfo.pBinds[0:bufferBindInfo.bindCount]
       for k in (0 .. bufferBindInfo.bindCount) {
-        if (memoryBinds[k].memory != as!VkDeviceMemory(0)) && 
+        if (memoryBinds[k].memory != as!VkDeviceMemory(0)) &&
             !(memoryBinds[k].memory in DeviceMemories) {
           vkErrorInvalidDeviceMemory(memoryBinds[k].memory)
         }
@@ -351,7 +351,7 @@ cmd VkResult vkQueueBindSparse(
       for k in (0 .. opaqueBindInfo.bindCount) {
         if (memoryBinds[k].memory != as!VkDeviceMemory(0)) &&
             !(memoryBinds[k].memory in DeviceMemories) {
-          vkErrorInvalidDeviceMemory(memoryBinds[k].memory) 
+          vkErrorInvalidDeviceMemory(memoryBinds[k].memory)
         }
         bindsToQueue.SparseMemoryBinds[k] = memoryBinds[k]
       }
@@ -366,8 +366,8 @@ cmd VkResult vkQueueBindSparse(
       imageMemoryBinds := imageBindInfo.pBinds[0:imageBindInfo.bindCount]
       for k in (0 .. imageBindInfo.bindCount) {
         if (imageMemoryBinds[k].memory != as!VkDeviceMemory(0)) &&
-              !(imageMemoryBinds[k].memory in DeviceMemories) { 
-            vkErrorInvalidDeviceMemory(imageMemoryBinds[k].memory) 
+              !(imageMemoryBinds[k].memory in DeviceMemories) {
+            vkErrorInvalidDeviceMemory(imageMemoryBinds[k].memory)
         }
         bindsToQueue.SparseImageMemoryBinds[k] = imageMemoryBinds[k]
       }

--- a/gapis/api/vulkan/api/queued_command_tracking.api
+++ b/gapis/api/vulkan/api/queued_command_tracking.api
@@ -46,7 +46,10 @@ sub void execPendingCommands(VkQueue queue, bool isRoot) {
   signaledQueues := queueMap().m
   processSubcommand := MutableBool()
   processSubcommand.b = true
-  ProcessedDescriptorSets = UsedDescriptorSets()
+
+  processedEntireImages := new!ImageSet()
+  processedBuffers := new!BufferSet()
+  processedCommandBuffers := new!CommandBufferSet()
 
   numPendingCmds := len(q.PendingCommands)
   for i in (0 .. numPendingCmds) {
@@ -194,6 +197,47 @@ sub void execPendingCommands(VkQueue queue, bool isRoot) {
         } // Done sparse images
 
         if ((cmd.Buffer != as!VkCommandBuffer(0))) {
+          // Process all the touched buffers and images here, ahead of the
+          // subcommands to improve state tracking performance. This should be
+          // ignored during the GAPIS state mutation.
+          if !(cmd.Buffer in processedCommandBuffers.val) {
+            cb := CommandBuffers[cmd.Buffer]
+            for _, img, cov in cb.TouchedImages {
+              if !(img in processedEntireImages.val) {
+                if img in Images {
+                  imgObj := Images[img]
+                  readCoherentMemoryInImage(imgObj)
+                  if cov.Entire {
+                    rng := VkImageSubresourceRange(
+                      aspectMask: imgObj.ImageAspect,
+                      baseMipLevel: as!u32(0),
+                      levelCount: imgObj.Info.MipLevels,
+                      baseArrayLayer: 0,
+                      layerCount: imgObj.Info.ArrayLayers,
+                    )
+                    updateImageQueue(imgObj, rng)
+                    processedEntireImages.val[img] = true
+                  } else {
+                    for _, _, rng in cov.Ranges {
+                      updateImageQueue(imgObj, rng)
+                    }
+                  }
+                }
+              }
+            }
+            for _, buf, _ in cb.TouchedBuffers {
+              if !(buf in processedBuffers.val) {
+                if buf in Buffers {
+                  bufObj := Buffers[buf]
+                  bufObj.LastBoundQueue = LastBoundQueue
+                  readCoherentMemoryInBuffer(bufObj)
+                  processedBuffers.val[buf] = true
+                }
+              }
+            }
+            processedCommandBuffers.val[cmd.Buffer] = true
+          }
+
           onPreSubcommand(cmd)
           callCommand(cmd)
 

--- a/gapis/api/vulkan/api/renderpass_framebuffer.api
+++ b/gapis/api/vulkan/api/renderpass_framebuffer.api
@@ -275,23 +275,36 @@ cmd void vkCmdBeginRenderPass(
       next.Ptr = as!VulkanStructHeader*(next.Ptr)[0:1][0].PNext
     }
   }
-  args := new!vkCmdBeginRenderPassArgs(
-    Contents:     contents,
-    RenderPass:   begin_info.renderPass,
-    Framebuffer:  begin_info.framebuffer,
-    RenderArea:   begin_info.renderArea
-  )
-  clear_values := begin_info.pClearValues[0:begin_info.clearValueCount]
-  for i in (0 .. begin_info.clearValueCount) {
-    args.ClearValues[i] = clear_values[i]
-  }
 
   if !(commandBuffer in CommandBuffers) {
     vkErrorInvalidCommandBuffer(commandBuffer)
   } else {
-    mapPos := as!u32(len(CommandBuffers[commandBuffer].BufferCommands.vkCmdBeginRenderPass))
-    CommandBuffers[commandBuffer].BufferCommands.vkCmdBeginRenderPass[mapPos] =
-    args
+    cmdBuf := CommandBuffers[commandBuffer]
+    if (begin_info.framebuffer in Framebuffers) {
+      if (begin_info.renderPass in RenderPasses) {
+        fb := Framebuffers[begin_info.framebuffer]
+        for i in (0 .. len(fb.ImageAttachments)) {
+          att := fb.ImageAttachments[as!u32(i)]
+          if att.Image != null {
+            commandBufferTouchImage(cmdBuf, att.Image, att.SubresourceRange)
+          }
+        }
+      }
+    }
+
+    args := new!vkCmdBeginRenderPassArgs(
+      Contents:     contents,
+      RenderPass:   begin_info.renderPass,
+      Framebuffer:  begin_info.framebuffer,
+      RenderArea:   begin_info.renderArea
+    )
+    clear_values := begin_info.pClearValues[0:begin_info.clearValueCount]
+    for i in (0 .. begin_info.clearValueCount) {
+      args.ClearValues[i] = clear_values[i]
+    }
+
+    mapPos := as!u32(len(cmdBuf.BufferCommands.vkCmdBeginRenderPass))
+    cmdBuf.BufferCommands.vkCmdBeginRenderPass[mapPos] = args
 
     AddCommand(commandBuffer, cmd_vkCmdBeginRenderPass, mapPos)
   }
@@ -336,11 +349,11 @@ cmd void vkCmdNextSubpass(
   if !(commandBuffer in CommandBuffers) {
     vkErrorInvalidCommandBuffer(commandBuffer)
   } else {
+    cmdBuf := CommandBuffers[commandBuffer]
     args := new!vkCmdNextSubpassArgs(contents)
 
-    mapPos := as!u32(len(CommandBuffers[commandBuffer].BufferCommands.vkCmdNextSubpass))
-    CommandBuffers[commandBuffer].BufferCommands.vkCmdNextSubpass[mapPos] =
-    args
+    mapPos := as!u32(len(cmdBuf.BufferCommands.vkCmdNextSubpass))
+    cmdBuf.BufferCommands.vkCmdNextSubpass[mapPos] = args
 
     AddCommand(commandBuffer, cmd_vkCmdNextSubpass, mapPos)
   }
@@ -372,16 +385,17 @@ cmd void vkCmdEndRenderPass(
   if !(commandBuffer in CommandBuffers) {
     vkErrorInvalidCommandBuffer(commandBuffer)
   } else {
+    cmdBuf := CommandBuffers[commandBuffer]
     args := new!vkCmdEndRenderPassArgs()
 
-    mapPos := as!u32(len(CommandBuffers[commandBuffer].BufferCommands.vkCmdEndRenderPass))
-    CommandBuffers[commandBuffer].BufferCommands.vkCmdEndRenderPass[mapPos] =
-    args
+    mapPos := as!u32(len(cmdBuf.BufferCommands.vkCmdEndRenderPass))
+    cmdBuf.BufferCommands.vkCmdEndRenderPass[mapPos] = args
 
     AddCommand(commandBuffer, cmd_vkCmdEndRenderPass, mapPos)
   }
 }
 
+@spy_disabled
 sub void loadImageAttachment(u32 attachmentID) {
   VK_ATTACHMENT_UNUSED := as!u32(0xFFFFFFFF)
   if attachmentID != VK_ATTACHMENT_UNUSED {
@@ -404,6 +418,7 @@ sub void loadImageAttachment(u32 attachmentID) {
   }
 }
 
+@spy_disabled
 sub void storeImageAttachment(u32 attachmentID) {
   VK_ATTACHMENT_UNUSED := as!u32(0xFFFFFFFF)
   if attachmentID != VK_ATTACHMENT_UNUSED {

--- a/gapis/api/vulkan/api/util.api
+++ b/gapis/api/vulkan/api/util.api
@@ -347,6 +347,94 @@ sub u32 getDepthElementSize(VkFormat format, bool inBuffer) {
   }
 }
 
+@internal class ImageCoverage {
+  bool Entire
+  dense_map!(u32, VkImageSubresourceRange) Ranges
+}
+
+sub void touchEntireImageCoverage(ref!ImageCoverage coverage) {
+  coverage.Entire = true
+}
+
+sub void touchImageCoverage(ref!ImageObject image, ref!ImageCoverage coverage, VkImageSubresourceRange rng) {
+  if !coverage.Entire {
+    if isEntireSubresource(image, rng) {
+      touchEntireImageCoverage(coverage)
+    } else {
+      b := MutableBool(false)
+      for _, _, r in coverage.Ranges {
+        if (r.aspectMask == rng.aspectMask) &&
+        (r.baseMipLevel == rng.baseMipLevel) &&
+        (r.levelCount == rng.levelCount) &&
+        (r.baseArrayLayer == rng.baseArrayLayer) &&
+        (r.layerCount == rng.layerCount) {
+          b.b = true
+        }
+      }
+      if !b.b {
+        pos := as!u32(len(coverage.Ranges))
+        coverage.Ranges[pos] = rng
+      }
+    }
+  }
+}
+
+sub void commandBufferTouchEntireImage(ref!CommandBufferObject cmdbuf, ref!ImageObject image) {
+  if !(image.VulkanHandle in cmdbuf.TouchedImages) {
+    cmdbuf.TouchedImages[image.VulkanHandle] = new!ImageCoverage()
+  }
+  coverage := cmdbuf.TouchedImages[image.VulkanHandle]
+  touchEntireImageCoverage(coverage)
+}
+
+sub void commandBufferTouchImage(ref!CommandBufferObject cmdbuf, ref!ImageObject image, VkImageSubresourceRange rng) {
+  if !(image.VulkanHandle in cmdbuf.TouchedImages) {
+    cmdbuf.TouchedImages[image.VulkanHandle] = new!ImageCoverage()
+  }
+  coverage := cmdbuf.TouchedImages[image.VulkanHandle]
+  touchImageCoverage(image, coverage, rng)
+}
+
+sub void descriptorSetLinkEntireImage(ref!DescriptorSetObject descSet, ref!ImageObject image) {
+  if !(image.VulkanHandle in descSet.LinkedImages) {
+    descSet.LinkedImages[image.VulkanHandle] = new!ImageCoverage()
+  }
+  coverage := descSet.LinkedImages[image.VulkanHandle]
+  touchEntireImageCoverage(coverage)
+}
+
+sub void descriptorSetLinkImage(ref!DescriptorSetObject descSet, ref!ImageObject image, VkImageSubresourceRange rng) {
+  if !(image.VulkanHandle in descSet.LinkedImages) {
+    descSet.LinkedImages[image.VulkanHandle] = new!ImageCoverage()
+  }
+  coverage := descSet.LinkedImages[image.VulkanHandle]
+  touchImageCoverage(image, coverage, rng)
+}
+
+@untracked @internal
+class DescriptorSetSet {
+  @untrackedMap @untracked
+  map!(VkDescriptorSet, bool) val
+}
+
+@untracked @internal
+class ImageSet {
+  @untrackedMap @untracked
+  map!(VkImage, bool) val
+}
+
+@untracked @internal
+class BufferSet {
+  @untrackedMap @untracked
+  map!(VkBuffer, bool) val
+}
+
+@untracked @internal
+class CommandBufferSet {
+  @untrackedMap @untracked
+  map!(VkCommandBuffer, bool) val
+}
+
 @internal class AllBits {
   @untrackedMap @untracked
   map!(VkImageAspectFlags, ref!unpackedImageAspectFlagBits) allBits
@@ -372,7 +460,7 @@ sub dense_map!(u32, VkImageAspectFlagBits) unpackImageAspectFlags(VkImageAspectF
     }
     allBits.allBits[flag] = m
   }
-  
+ 
   return allBits.allBits[flag].Bits
 }
 

--- a/gapis/api/vulkan/vulkan.api
+++ b/gapis/api/vulkan/vulkan.api
@@ -248,9 +248,9 @@ sub ref!ExtensionSet supportedDeviceExtensions() {
 
 @internal class DynamicPipelineState {
   // The viewports set by vkCmdSetViewport
-  map!(u32, VkViewport) Viewports
+  dense_map!(u32, VkViewport) Viewports
   // The Scissors set by vkCmdSetScissor
-  map!(u32, VkRect2D) Scissors
+  dense_map!(u32, VkRect2D) Scissors
   // The value set by vkCmdSetLineWidth
   f32 LineWidth
   // The constant factor set by vkCmdSetDepthBias
@@ -343,18 +343,8 @@ enum LastSubmissionType {
 @serialize @untrackedMap map!(VkQueue, ref!ComputeInfo) LastComputeInfos
 @serialize @untracked PresentInfo                       LastPresentInfo
 @serialize LastSubmissionType                           LastSubmission
-@hidden @serialize UsedDescriptorSets                   ProcessedDescriptorSets
 @untrackedMap map!(VkQueue, ref!DynamicPipelineState)   LastDynamicPipelineStates
 @untrackedMap map!(VkQueue, ref!PushConstantInfo)       LastPushConstants
-
-@internal class ProcessedDescriptorSet {
-  map!(u32, map!(u32, map!(VkDeviceSize, bool))) bufferOffsets
-  bool shouldReadBuffers
-}
-
-@internal class UsedDescriptorSets {
-  map!(VkDescriptorSet, ProcessedDescriptorSet) val
-}
 
 @hidden bool IsRebuilding
 


### PR DESCRIPTION
This is to avoid traversing through bound index, vertex, descriptor
buffers and images at VkQueueSubmit during trace. The goal is to avoid
the deep loop iterations to improve the state tracking performance during
tracing.

Also moved a bit the unlock/lock position, to allow more overlapping for 
multi-thread apps.

Also annotate as many spy_disabled as possible for memory related subroutines.