### PR TITLE
Build with bazel 0.20.0

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -1,0 +1,2 @@
+# Symlink from the gapic/README instructions
+bazel-external

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -1,6 +1,6 @@
 # Building GAPID
 
-GAPID uses the [Bazel build system](https://bazel.build/). The current minimum required version of bazel is 0.16.1.
+GAPID uses the [Bazel build system](https://bazel.build/). The current minimum required version of bazel is 0.18.1.
 
 Bazel is able to fetch most of the dependencies required to build GAPID, but currently the Android SDK and NDK both need to be downloaded and installed by hand.
 

--- a/core/app/auth/auth.go
+++ b/core/app/auth/auth.go
@@ -96,7 +96,7 @@ func GenTokenFile() (path string, token Token) {
 func ServerInterceptor(token Token) grpc.UnaryServerInterceptor {
 	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
 		if token != NoAuth {
-			md, ok := metadata.FromContext(ctx)
+			md, ok := metadata.FromIncomingContext(ctx)
 			if !ok {
 				return nil, ErrInvalidToken
 			}
@@ -116,10 +116,10 @@ func ServerInterceptor(token Token) grpc.UnaryServerInterceptor {
 func ClientInterceptor(token Token) grpc.UnaryClientInterceptor {
 	return func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
 		if token != NoAuth {
-			if md, ok := metadata.FromContext(ctx); ok {
-				ctx = metadata.NewContext(ctx, metadata.Join(md, metadata.Pairs(rpcHeader, string(token))))
+			if md, ok := metadata.FromOutgoingContext(ctx); ok {
+				ctx = metadata.NewOutgoingContext(ctx, metadata.Join(md, metadata.Pairs(rpcHeader, string(token))))
 			} else {
-				ctx = metadata.NewContext(ctx, metadata.Pairs(rpcHeader, string(token)))
+				ctx = metadata.NewOutgoingContext(ctx, metadata.Pairs(rpcHeader, string(token)))
 			}
 		}
 		return invoker(ctx, method, req, reply, cc, opts...)

--- a/core/net/grpcutil/server.go
+++ b/core/net/grpcutil/server.go
@@ -16,6 +16,7 @@ package grpcutil
 
 import (
 	"context"
+	"math"
 	"net"
 
 	"github.com/google/gapid/core/log"
@@ -41,6 +42,7 @@ func ServeWithListener(ctx context.Context, listener net.Listener, prepare Prepa
 	options = append([]grpc.ServerOption{
 		grpc.RPCCompressor(grpc.NewGZIPCompressor()),
 		grpc.RPCDecompressor(grpc.NewGZIPDecompressor()),
+		grpc.MaxRecvMsgSize(math.MaxInt32),
 	}, options...)
 	defer listener.Close()
 	grpcServer := grpc.NewServer(options...)

--- a/kokoro/linux/build.sh
+++ b/kokoro/linux/build.sh
@@ -20,9 +20,9 @@ BUILD_ROOT=$PWD
 SRC=$PWD/github/gapid/
 
 # Get bazel.
-curl -L -k -O -s https://github.com/bazelbuild/bazel/releases/download/0.16.1/bazel-0.16.1-installer-linux-x86_64.sh
+curl -L -k -O -s https://github.com/bazelbuild/bazel/releases/download/0.20.0/bazel-0.20.0-installer-linux-x86_64.sh
 mkdir bazel
-bash bazel-0.16.1-installer-linux-x86_64.sh --prefix=$PWD/bazel
+bash bazel-0.20.0-installer-linux-x86_64.sh --prefix=$PWD/bazel
 
 # Setup environment.
 export ANDROID_NDK_HOME=/opt/android-ndk-r16b

--- a/kokoro/macos/build.sh
+++ b/kokoro/macos/build.sh
@@ -30,9 +30,9 @@ export ANDROID_HOME=$PWD/android
 export ANDROID_NDK_HOME=$PWD/android/android-ndk-r16b
 
 # Get bazel.
-curl -L -k -O -s https://github.com/bazelbuild/bazel/releases/download/0.16.1/bazel-0.16.1-installer-darwin-x86_64.sh
+curl -L -k -O -s https://github.com/bazelbuild/bazel/releases/download/0.20.0/bazel-0.20.0-installer-darwin-x86_64.sh
 mkdir bazel
-sh bazel-0.16.1-installer-darwin-x86_64.sh --prefix=$PWD/bazel
+sh bazel-0.20.0-installer-darwin-x86_64.sh --prefix=$PWD/bazel
 
 # Specify the version of XCode
 export DEVELOPER_DIR=/Applications/Xcode_8.2.app/Contents/Developer

--- a/kokoro/presubmit/build.sh
+++ b/kokoro/presubmit/build.sh
@@ -20,9 +20,9 @@ BUILD_ROOT=$PWD
 SRC=$PWD/github/gapid/
 
 # Get bazel.
-curl -L -k -O -s https://github.com/bazelbuild/bazel/releases/download/0.16.1/bazel-0.16.1-installer-linux-x86_64.sh
+curl -L -k -O -s https://github.com/bazelbuild/bazel/releases/download/0.20.0/bazel-0.20.0-installer-linux-x86_64.sh
 mkdir bazel
-bash bazel-0.16.1-installer-linux-x86_64.sh --prefix=$PWD/bazel
+bash bazel-0.20.0-installer-linux-x86_64.sh --prefix=$PWD/bazel
 
 # Get bazel build tools.
 mkdir tools

--- a/kokoro/windows/build.bat
+++ b/kokoro/windows/build.bat
@@ -41,12 +41,8 @@ c:\tools\msys64\usr\bin\bash --login -c "pacman -R --noconfirm catgets libcatget
 c:\tools\msys64\usr\bin\bash --login -c "pacman -Syu --noconfirm"
 c:\tools\msys64\usr\bin\bash --login -c "pacman -Sy --noconfirm mingw-w64-x86_64-crt-git patch"
 c:\tools\msys64\usr\bin\bash --login -c "pacman -U --noconfirm mingw-w64-x86_64-gcc*-7.3.0-2-any.pkg.tar.xz"
-set PATH=c:\tools\msys64\mingw64\bin;%PATH%
-
-REM TODO set up msvc build env
-REM set Platform="X64"
-REM set PreferredToolArchitecture="x64"
-REM call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" amd64
+set PATH=c:\tools\msys64\mingw64\bin;c:\tools\msys64\usr\bin;%PATH%
+set BAZEL_SH=C:\tools\msys64\usr\bin\bash.exe
 
 REM Install Bazel.
 wget -q https://github.com/bazelbuild/bazel/releases/download/0.20.0/bazel-0.20.0-windows-x86_64.zip

--- a/kokoro/windows/build.bat
+++ b/kokoro/windows/build.bat
@@ -49,8 +49,8 @@ REM set PreferredToolArchitecture="x64"
 REM call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" amd64
 
 REM Install Bazel.
-wget -q https://github.com/bazelbuild/bazel/releases/download/0.16.1/bazel-0.16.1-windows-x86_64.zip
-unzip -q bazel-0.16.1-windows-x86_64.zip
+wget -q https://github.com/bazelbuild/bazel/releases/download/0.20.0/bazel-0.20.0-windows-x86_64.zip
+unzip -q bazel-0.20.0-windows-x86_64.zip
 set PATH=C:\python27;%PATH%
 
 cd %SRC%

--- a/tools/build/mingw_toolchain/BUILD.bazel
+++ b/tools/build/mingw_toolchain/BUILD.bazel
@@ -19,6 +19,7 @@ cc_toolchain_suite(
     # target_cpu | compiler
     toolchains = {
         "x64_windows|mingw": "cc-compiler-mingw",
+        "x64_windows": "cc-compiler-mingw",
     },
 )
 

--- a/tools/build/rules/apic.bzl
+++ b/tools/build/rules/apic.bzl
@@ -14,6 +14,7 @@
 
 load("@io_bazel_rules_go//go:def.bzl", "go_context")
 load(":gapil.bzl", "ApicTemplate")
+load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
 
 def api_search_path(inputs):
     roots = {}
@@ -74,7 +75,6 @@ apic_binary = rule(
             default = Label("//cmd/apic:apic"),
         ),
     },
-    fragments = ["cpp"],
 )
 
 def _apic_compile_impl(ctx):
@@ -84,7 +84,8 @@ def _apic_compile_impl(ctx):
         apilist += api.includes.to_list()
     generated = depset()
 
-    target = ctx.fragments.cpp.cpu
+    cc_toolchain = find_cpp_toolchain(ctx)
+    target = cc_toolchain.cpu
     outputs = [ctx.new_file(ctx.label.name + ".o")]
     generated += outputs
 
@@ -162,8 +163,10 @@ apic_compile = rule(
             allow_files = True,
             default = Label("//cmd/apic:apic"),
         ),
+        "_cc_toolchain": attr.label(
+            default = Label("@bazel_tools//tools/cpp:current_cc_toolchain")
+        ),
     },
-    fragments = ["cpp"],
 )
 
 def _apic_template_impl(ctx):

--- a/tools/build/rules/grpc_c++.bzl
+++ b/tools/build/rules/grpc_c++.bzl
@@ -39,6 +39,7 @@
 # each change must be ported from one to the other.
 #
 load("@gapid//tools/build/rules:repository.bzl", "github_repository", "maybe_repository")
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 # The set of pollers to test against if a test exercises polling
 
@@ -324,7 +325,7 @@ def grpc_deps(locals = {}):
     )
 
     if "boringssl" not in native.existing_rules():
-        native.http_archive(
+        http_archive(
             name = "boringssl",
             # on the master-with-bazel branch
             url = "https://boringssl.googlesource.com/boringssl/+archive/6ae5a54bedae2c29e5b67382667871c527e68326.tar.gz",

--- a/tools/build/workspace.bzl
+++ b/tools/build/workspace.bzl
@@ -38,7 +38,7 @@ def gapid_dependencies(android = True, mingw = True, locals = {}):
         locals = locals,
         organization = "bazelbuild",
         project = "rules_go",
-        commit = "43f31988275463369244ce1704b2e9fb95689e44",  # 0.15.0 + patches
+        commit = "01e5a9f8483167962eddd167f7689408bdeb4e76",  # 0.16.3
     )
 
     maybe_repository(
@@ -47,7 +47,7 @@ def gapid_dependencies(android = True, mingw = True, locals = {}):
         locals = locals,
         organization = "bazelbuild",
         project = "bazel-gazelle",
-        commit = "6a1b93cc9b1c7e55e7d05a6d324bcf9d87ea3ab1",  # 0.14.0
+        commit = "c728ce9f663e2bff26361ba5978ec5c9e6816a3c",  # 0.15.0
     )
 
     maybe_repository(

--- a/tools/build/workspace.bzl
+++ b/tools/build/workspace.bzl
@@ -20,6 +20,7 @@ load("@gapid//tools/build/rules:android.bzl", "android_native_app_glue")
 load("@gapid//tools/build/rules:repository.bzl", "github_repository", "maybe_repository")
 load("@gapid//tools/build/third_party:breakpad.bzl", "breakpad")
 load("@gapid//tools/build/rules:grpc_c++.bzl", "grpc_deps")
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "new_git_repository")
 
 # Defines the repositories for GAPID's dependencies, excluding the
 # go dependencies, which require @io_bazel_rules_go to be setup.
@@ -136,7 +137,7 @@ def gapid_dependencies(android = True, mingw = True, locals = {}):
     )
 
     maybe_repository(
-        native.new_git_repository,
+        new_git_repository,
         name = "lss",
         locals = locals,
         remote = "https://chromium.googlesource.com/linux-syscall-support",

--- a/tools/build/workspace_go.bzl
+++ b/tools/build/workspace_go.bzl
@@ -19,22 +19,9 @@ load("@gapid//tools/build/rules:repository.bzl", "github_http_args")
 load("@bazel_gazelle//:deps.bzl", "go_repository")
 
 # Defines the repositories for GAPID's go dependencies.
-# After calling gapid_dependencies(), load @io_bazel_rules_go's
+# After calling gapid_dependencies(), load @bazel_gazelle's
 # go_repository and call this macro.
 def gapid_go_dependencies():
-
-    # TODO: Cannot override rules_go's golang protobuf. Would
-    # cause a cycle. This may be fixed with
-    # https://github.com/bazelbuild/rules_go/issues/1548
-    #
-    #_maybe(_github_go_repository,
-    #    name = "com_github_golang_protobuf",
-    #    organization = "golang",
-    #    project = "protobuf",
-    #    commit = "b4deda0973fb4c70b50d226b1af49f3da59f5265",
-    #    importpath = "github.com/golang/protobuf",
-    #)
-
     _maybe(_github_go_repository,
         name = "com_github_google_go_github",
         organization = "google",
@@ -60,45 +47,12 @@ def gapid_go_dependencies():
     )
 
     _maybe(_github_go_repository,
-        name = "org_golang_google_grpc",
-        organization = "grpc",
-        project = "grpc-go",
-        commit = "50955793b0183f9de69bd78e2ec251cf20aab121",
-        importpath = "google.golang.org/grpc",
-    )
-
-    _maybe(_github_go_repository,
-        name = "org_golang_x_net",
-        organization = "golang",
-        project = "net",
-        commit = "f2499483f923065a842d38eb4c7f1927e6fc6e6d",
-        importpath = "golang.org/x/net",
-    )
-
-    _maybe(_github_go_repository,
-        name = "org_golang_x_sys",
-        organization = "golang",
-        project = "sys",
-        commit = "d75a52659825e75fff6158388dddc6a5b04f9ba5",
-        importpath = "golang.org/x/sys",
-    )
-
-    _maybe(_github_go_repository,
-        name = "org_golang_x_tools",
-        organization = "golang",
-        project = "tools",
-        commit = "3da34b1b520a543128e8441cd2ffffc383111d03",
-        importpath = "golang.org/x/tools",
-    )
-
-    _maybe(_github_go_repository,
         name = "org_golang_x_crypto",
         organization = "golang",
         project = "crypto",
         commit = "1a580b3eff7814fc9b40602fd35256c63b50f491",
         importpath = "golang.org/x/crypto",
     )
-
 
 
 def _maybe(repo_rule, name, **kwargs):


### PR DESCRIPTION
Requires an updated rules_go and thus means we now build with the latest go SDK (1.11.2) as well.