### PR TITLE
Vulkan: Fix state rebuilder to handle status change in query pools

### DIFF
--- a/gapii/cc/vulkan_inlines.inc
+++ b/gapii/cc/vulkan_inlines.inc
@@ -20,7 +20,7 @@
 inline void VulkanSpy::notifyPendingCommandAdded(CallObserver*, VkQueue) {}
 
 inline void VulkanSpy::vkErrInvalidHandle(CallObserver*, std::string handleType, uint64_t handle){
-    GAPID_WARNING("Error: Invalid %s: %" PRIu64, handleType.c_str(), handle)
+    GAPID_DEBUG("Error: Invalid %s: %" PRIu64, handleType.c_str(), handle)
 }
 
 inline void VulkanSpy::vkErrNullPointer(CallObserver*, std::string pointerType) {
@@ -36,46 +36,46 @@ inline void VulkanSpy::vkErrUnrecognizedExtension(CallObserver*, std::string nam
 }
 
 inline void VulkanSpy::vkErrExpectNVDedicatedlyAllocatedHandle(CallObserver*, std::string handleType, uint64_t handle) {
-    GAPID_WARNING("Error: Expected handle that was allocated with a dedicated allocation: %s: %" PRIu64, handleType.c_str(), handle)
+    GAPID_DEBUG("Error: Expected handle that was allocated with a dedicated allocation: %s: %" PRIu64, handleType.c_str(), handle)
 }
 
 inline void VulkanSpy::vkErrInvalidDescriptorArrayElement(CallObserver*, uint64_t set, uint32_t binding, uint32_t array_index) {
-  GAPID_WARNING("Error: Invalid descriptor array element specified by descriptor set: %" PRIu64 ", binding: %" PRIu32 ", array index: %" PRIu32, set, binding, array_index);
+  GAPID_DEBUG("Error: Invalid descriptor array element specified by descriptor set: %" PRIu64 ", binding: %" PRIu32 ", array index: %" PRIu32, set, binding, array_index);
 }
 
 inline void VulkanSpy::vkErrCommandBufferIncomplete(CallObserver*, VkCommandBuffer cmdbuf) {
-    GAPID_WARNING("Error: Executing command buffer %zu was not in the COMPLETED state", cmdbuf)
+    GAPID_DEBUG("Error: Executing command buffer %zu was not in the COMPLETED state", cmdbuf)
 }
 
 inline void VulkanSpy::vkErrCommandBufferNotRecording(CallObserver*, VkCommandBuffer cmdbuf) {
-    GAPID_WARNING("Error: Executing command buffer %zu was not in the RECORDING state", cmdbuf)
+    GAPID_DEBUG("Error: Executing command buffer %zu was not in the RECORDING state", cmdbuf)
 }
 
 inline void VulkanSpy::vkErrQueryOutOfRange(CallObserver*, VkQueryPool queryPool, uint32_t query) {
-    GAPID_WARNING("Error: Query %" PRIu32 " in QueryPool %" PRIu64 " was out of range", query, queryPool)
+    GAPID_DEBUG("Error: Query %" PRIu32 " in QueryPool %" PRIu64 " was out of range", query, queryPool)
 }
 
 inline void VulkanSpy::vkErrQueryUninitialized(CallObserver*, VkQueryPool queryPool, uint32_t query) {
-    GAPID_WARNING("Error: Query %" PRIu32 " in QueryPool %" PRIu64 " was uninitialized", query, queryPool)
+    GAPID_DEBUG("Error: Query %" PRIu32 " in QueryPool %" PRIu64 " was uninitialized", query, queryPool)
 }
 
 inline void VulkanSpy::vkErrQueryNotInactive(CallObserver*, VkQueryPool queryPool, uint32_t query) {
-    GAPID_WARNING("Error: Query %" PRIu32 " in QueryPool %" PRIu64 " was not in the INACTIVE state", query, queryPool)
+    GAPID_DEBUG("Error: Query %" PRIu32 " in QueryPool %" PRIu64 " was not in the INACTIVE state", query, queryPool)
 }
 
 inline void VulkanSpy::vkErrQueryNotActive(CallObserver*, VkQueryPool queryPool, uint32_t query) {
-    GAPID_WARNING("Error: Query %" PRIu32 " in QueryPool %" PRIu64 " was not in the ACTIVE state", query, queryPool)
+    GAPID_DEBUG("Error: Query %" PRIu32 " in QueryPool %" PRIu64 " was not in the ACTIVE state", query, queryPool)
 }
 
 inline void VulkanSpy::vkErrInvalidImageLayout(CallObserver*, VkImage img, uint32_t aspect, uint32_t layer, uint32_t level, uint32_t layout, uint32_t expectedLayout) {
-    GAPID_WARNING("Error: Image subresource at Image: %" PRIu64 ", AspectBit: %" PRIu32 ", Layer: %" PRIu32 ", Level: %" PRIu32 " was in layout %" PRIu32 ", but was expected to be in layout %" PRIu32,
+    GAPID_DEBUG("Error: Image subresource at Image: %" PRIu64 ", AspectBit: %" PRIu32 ", Layer: %" PRIu32 ", Level: %" PRIu32 " was in layout %" PRIu32 ", but was expected to be in layout %" PRIu32,
         img, aspect, layer, level, layout, expectedLayout);
 }
 
 inline void VulkanSpy::vkErrInvalidImageSubresource(CallObserver*, VkImage img, std::string subresourceType, uint32_t value) {
-    GAPID_WARNING("Error: Accessing invalid image subresource at Image: %" PRIu64 ", %s: %" PRIu32, img, subresourceType.c_str(), value);
+    GAPID_DEBUG("Error: Accessing invalid image subresource at Image: %" PRIu64 ", %s: %" PRIu32, img, subresourceType.c_str(), value);
 }
 
 inline void VulkanSpy::vkErrInvalidDescriptorBindingType(CallObserver*, VkDescriptorSet set, uint32_t binding, uint32_t layout_type, uint32_t update_type) {
-    GAPID_WARNING("Error: Updating descriptor binding at: %" PRIu64 ": %" PRIu32 " with type: %" PRIu32 ", but the type defined in descriptor set layout is: %" PRIu32 "", set, binding, layout_type, update_type);
+    GAPID_DEBUG("Error: Updating descriptor binding at: %" PRIu64 ": %" PRIu32 " with type: %" PRIu32 ", but the type defined in descriptor set layout is: %" PRIu32 "", set, binding, layout_type, update_type);
 }


### PR DESCRIPTION
Also downgrade some errors during trace to GAPID_DEBUG level to mute
them in most use cases. Those errors will be reported during replay