### PR TITLE
Improve gofuse.

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -1,2 +1,3 @@
 # Symlink from the gapic/README instructions
 bazel-external
+fused


### PR DESCRIPTION
Add more external dependency name mappings.
Symlink all files, not just go files, so that you can work from the fused directory and still view .api files etc.
Ignore certain files.
Add fused directory to .bazelignore, as it will now contain .bazel files.
Limit generated files in bin/ to just gapid files, otherwise the better externals collection includes them too.
Better externals collection by resolving the external directory inside the user's Bazel cache.