### PR TITLE
Vulkan: Revert to get back the descriptor set buffer offsets reading optimization

### DIFF
--- a/gapis/api/vulkan/api/coherent_memory.api
+++ b/gapis/api/vulkan/api/coherent_memory.api
@@ -334,9 +334,50 @@ sub void readWriteMemoryInBoundDescriptorSets(
   for i in (0 .. layerCount) {
     descriptorSet := descriptorSets[as!u32(i)]
     if descriptorSet != null {
+      if !(descriptorSet.VulkanHandle in LastBoundDescriptorSetsBufferInfo) {
         offsets := bufferBindingOffsets[as!u32(i)]
         readMemoryInDescriptorSet(descriptorSet, offsets, true)
         writeMemoryInDescriptorSet(descriptorSet, offsets, true)
+
+        descriptors := new!BoundDescriptorSetBufferInfo()
+        descriptors.shouldReadBuffers = false
+        newOffsets := descriptors.bufferOffsets
+        for _, j, jj in offsets {
+          for _, k, v in jj {
+            if (!newOffsets[j][k][v]) {
+              x := newOffsets[j]
+              y := x[k]
+              y[v] = true
+              x[k] = y
+              newOffsets[j] = x
+            }
+
+          }
+        }
+        descriptors.bufferOffsets = newOffsets
+        LastBoundDescriptorSetsBufferInfo[descriptorSet.VulkanHandle] = descriptors
+      } else if LastBoundDescriptorSetsBufferInfo[descriptorSet.VulkanHandle].shouldReadBuffers {
+        offsets := bufferBindingOffsets[as!u32(i)]
+        readMemoryInDescriptorSet(descriptorSet, offsets, false)
+        writeMemoryInDescriptorSet(descriptorSet, offsets, false)
+
+        descriptors := LastBoundDescriptorSetsBufferInfo[descriptorSet.VulkanHandle]
+        descriptors.shouldReadBuffers = false
+        newOffsets := descriptors.bufferOffsets
+        for _, j, jj in offsets {
+          for _, k, v in jj {
+            if (!newOffsets[j][k][v]) {
+              x := newOffsets[j]
+              y := x[k]
+              y[v] = true
+              x[k] = y
+              newOffsets[j] = x
+            }
+          }
+        }
+        descriptors.bufferOffsets = newOffsets
+        LastBoundDescriptorSetsBufferInfo[descriptorSet.VulkanHandle] = descriptors
+      }
     }
   }
 }

--- a/gapis/api/vulkan/api/descriptor.api
+++ b/gapis/api/vulkan/api/descriptor.api
@@ -834,6 +834,19 @@ sub void updateDescriptorBufferBindingOffsets(ref!vkCmdBindDescriptorSetsArgs ar
       setObj := DescriptorSets[set]
       currentDescriptorSets[args.FirstSet + as!u32(i)] = setObj
       desc_set_buf_offsets := bufferBindingOffsets[as!u32(i)+args.FirstSet]
+      hasBeenRead := switch (set in LastBoundDescriptorSetsBufferInfo) {
+        case true:
+          MutableBool(true)
+        default:
+          MutableBool(false)
+      }
+
+      existingOffsets := switch(hasBeenRead.b) {
+        case true:
+          LastBoundDescriptorSetsBufferInfo[set].bufferOffsets
+        case false:
+          emptyBufferOffsets().BufferBindingOffsets
+      }
 
       // Since the pDynamicOffsets point into the bindings in order of
       // binding index, and then array index, we have to loop over all
@@ -858,6 +871,23 @@ sub void updateDescriptorBufferBindingOffsets(ref!vkCmdBindDescriptorSetsArgs ar
               default:
                 dynamic_offset_index.Val
             }
+            // If the offset has changed, then we may have to reprocess this
+            // descriptor set.
+            if hasBeenRead.b {
+              if !(as!u32(j) in existingOffsets) {
+                hasBeenRead.b = false
+              } else if !(as!u32(k) in existingOffsets[as!u32(j)]) {
+                hasBeenRead.b = false
+              } else if !(binding_offset in existingOffsets[as!u32(j)][as!u32(k)]) {
+                hasBeenRead.b = false
+              }
+
+              if !hasBeenRead.b {
+                LastBoundDescriptorSetsBufferInfo[set].shouldReadBuffers = true
+
+              }
+            }
+
             desc_binding_buf_offsets[as!u32(k)] = binding_offset
           }
           desc_set_buf_offsets[as!u32(j)] = desc_binding_buf_offsets

--- a/gapis/api/vulkan/api/queued_command_tracking.api
+++ b/gapis/api/vulkan/api/queued_command_tracking.api
@@ -46,6 +46,7 @@ sub void execPendingCommands(VkQueue queue, bool isRoot) {
   signaledQueues := queueMap().m
   processSubcommand := MutableBool()
   processSubcommand.b = true
+  clear(LastBoundDescriptorSetsBufferInfo)
 
   processedEntireImages := new!ImageSet()
   processedBuffers := new!BufferSet()

--- a/gapis/api/vulkan/vulkan.api
+++ b/gapis/api/vulkan/vulkan.api
@@ -345,8 +345,14 @@ enum LastSubmissionType {
 @serialize LastSubmissionType                           LastSubmission
 @untrackedMap map!(VkQueue, ref!DynamicPipelineState)   LastDynamicPipelineStates
 @untrackedMap map!(VkQueue, ref!PushConstantInfo)       LastPushConstants
+@untrackedMap map!(VkDescriptorSet, ref!BoundDescriptorSetBufferInfo) LastBoundDescriptorSetsBufferInfo
 
 @hidden bool IsRebuilding
+
+@internal class BoundDescriptorSetBufferInfo {
+  map!(u32, map!(u32, map!(VkDeviceSize, bool)))  bufferOffsets
+  bool shouldReadBuffers
+}
 
 sub ref!DrawInfo lastDrawInfo() {
   if LastBoundQueue != null {


### PR DESCRIPTION
This optimization still boosts replay code generation performance.