### PR TITLE
Vulkan: Fix the attachment image layout tracking

### DIFF
--- a/gapis/api/vulkan/api/renderpass_framebuffer.api
+++ b/gapis/api/vulkan/api/renderpass_framebuffer.api
@@ -403,7 +403,6 @@ cmd void vkCmdEndRenderPass(
   }
 }
 
-@spy_disabled
 sub void loadImageAttachment(u32 attachmentID) {
   VK_ATTACHMENT_UNUSED := as!u32(0xFFFFFFFF)
   if attachmentID != VK_ATTACHMENT_UNUSED {
@@ -426,7 +425,6 @@ sub void loadImageAttachment(u32 attachmentID) {
   }
 }
 
-@spy_disabled
 sub void storeImageAttachment(u32 attachmentID) {
   VK_ATTACHMENT_UNUSED := as!u32(0xFFFFFFFF)
   if attachmentID != VK_ATTACHMENT_UNUSED {

--- a/gapis/api/vulkan/state_rebuilder.go
+++ b/gapis/api/vulkan/state_rebuilder.go
@@ -1482,8 +1482,7 @@ func (sb *stateBuilder) createImage(img ImageObjectʳ, imgPrimer *imagePrimer) {
 	attBits := VkImageUsageFlags(VkImageUsageFlagBits_VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VkImageUsageFlagBits_VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT)
 	storageBit := VkImageUsageFlags(VkImageUsageFlagBits_VK_IMAGE_USAGE_STORAGE_BIT)
 
-	isDepth := (img.Info().Usage() & VkImageUsageFlags(VkImageUsageFlagBits_VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT)) != 0
-	primeByBufCopy := (img.Info().Usage()&transDstBit) != 0 && (!isDepth)
+	primeByBufCopy := (img.Info().Usage() & transDstBit) != 0
 	primeByRendering := (!primeByBufCopy) && ((img.Info().Usage() & attBits) != 0)
 	primeByImageStore := (!primeByBufCopy) && (!primeByRendering) && ((img.Info().Usage() & storageBit) != 0)
 	primeByPreinitialization := (!primeByBufCopy) && (!primeByRendering) && (!primeByImageStore) && (img.Info().Tiling() == VkImageTiling_VK_IMAGE_TILING_LINEAR) && (img.Info().InitialLayout() == VkImageLayout_VK_IMAGE_LAYOUT_PREINITIALIZED)


### PR DESCRIPTION
The loadAttachment and storeAttachment subroutine should not be labelled
with @spy_disabled, as we need to track the attachments' layout