### PR TITLE
Mute the validation layer output on the gapir side by default

### DIFF
--- a/gapir/cc/context.cpp
+++ b/gapir/cc/context.cpp
@@ -157,17 +157,7 @@ void Context::onDebugMessage(uint32_t severity, uint8_t api_index,
     str_msg = std::string(msg, len);
     msg = str_msg.data();
   }
-  switch (severity) {
-    case LOG_LEVEL_ERROR:
-      GAPID_ERROR("[%d]renderer: %s", label, msg);
-      break;
-    case LOG_LEVEL_WARNING:
-      GAPID_WARNING("[%d]renderer: %s", label, msg);
-      break;
-    default:
-      GAPID_DEBUG("[%d]renderer: %s", label, msg);
-      break;
-  }
+  GAPID_DEBUG("[%d]renderer: %s", label, msg);
   mSrv->sendNotification(mNumSentDebugMessages++, severity, api_index, label,
                          str_msg, nullptr, 0);
 }


### PR DESCRIPTION
Unless the log level is higher than DEBUG, gapir stdout will not print
those messages anymore, so that the 'log' view in UI won't get polluted.

As far as I know, `Context::onDebugMessage` is only used for Vulkan's validation layer output for now.