### PR TITLE
DCE: Add config option to mark all initial commands alive

### DIFF
--- a/gapis/config/config.go
+++ b/gapis/config/config.go
@@ -23,6 +23,7 @@ const (
 	DeadSubCmdElimination      = false
 	DebugDeadCodeElimination   = false
 	DebugDependencyGraph       = false
+	AllInitialCommandsLive     = false
 	LogExtrasInTransforms      = false // Logs all commands' extras together with transforms
 	LogMemoryInExtras          = false // Logs all commands' read/write memory observation together with extras
 	// Logs all mappings at the end of the replay from original trace

--- a/gapis/resolve/dependencygraph2/dce.go
+++ b/gapis/resolve/dependencygraph2/dce.go
@@ -94,7 +94,7 @@ func NewDCEBuilder(graph DependencyGraph) *DCEBuilder {
 	for i := 0; i < b.graph.NumInitialCommands(); i++ {
 		cmdID := api.CmdID(i).Derived()
 		cmd := b.graph.GetCommand(cmdID)
-		if cmd.Alive() {
+		if cmd.Alive() || config.AllInitialCommandsLive {
 			nodeID := b.graph.GetCmdNodeID(cmdID, api.SubCmdIdx{})
 			if nodeID != NodeNoID && !b.isLive[nodeID] {
 				b.isLive[nodeID] = true


### PR DESCRIPTION
This option is disabled by default.