### PR TITLE
Don't crash on GLES 1.? contexts...

### DIFF
--- a/gapis/api/gles/undefined_framebuffer.go
+++ b/gapis/api/gles/undefined_framebuffer.go
@@ -31,8 +31,8 @@ func undefinedFramebuffer(ctx context.Context, device *device.Instance) transfor
 		out.MutateAndWrite(ctx, id, cmd)
 		s := out.State()
 		c := GetContext(s, cmd.Thread())
-		if c.IsNil() || !c.Other().Initialized() {
-			return // We can't do anything without a context.
+		if c.IsNil() || !c.Other().Initialized() || c.Constants().MajorVersion() < 2 {
+			return // We can't do anything without a context or GLES 1.
 		}
 		if eglMakeCurrent, ok := cmd.(*EglMakeCurrent); ok && !seenSurfaces[eglMakeCurrent.Draw()] {
 			// Render the undefined pattern for new contexts.


### PR DESCRIPTION
... at least in some places.

Skip reading constants in a 1.? context during trace time (for `eglMakeCurrent`) and don't attempt to draw the undefined FB pattern during replay.