### PR TITLE
Dependency Graph: Subcommand parent nodes is now based on index.

### DIFF
--- a/gapis/api/subcmd_idx_trie.go
+++ b/gapis/api/subcmd_idx_trie.go
@@ -23,7 +23,7 @@ type SubCmdIdxTrie struct {
 	children map[uint64]*SubCmdIdxTrie
 }
 
-// Value returnes the value stored in the trie indexed by the given SubCmdIdx.
+// Value returns the value stored in the trie indexed by the given SubCmdIdx.
 // if no value is found by the given SubCmdIdx, returns nil.
 func (t *SubCmdIdxTrie) Value(indices SubCmdIdx) interface{} {
 	for t != nil && len(indices) > 0 && len(t.children) > 0 {
@@ -33,6 +33,30 @@ func (t *SubCmdIdxTrie) Value(indices SubCmdIdx) interface{} {
 		return nil // invalid index
 	}
 	return t.value
+}
+
+// Values returns the values stored in the trie indexed by all prefixes of the
+// SubCmdIdx, in increasing order of length; if no value is found for a prefix,
+// the result contains `nil` for that prefix.
+func (t *SubCmdIdxTrie) Values(indices SubCmdIdx) []interface{} {
+	values := make([]interface{}, len(indices)+1)
+
+	for i, ix := range indices {
+		values[i] = t.value
+		if len(t.children) == 0 {
+			t = nil
+			break
+		}
+		t = t.children[ix]
+		if t == nil {
+			break
+		}
+	}
+
+	if t != nil {
+		values[len(indices)] = t.value
+	}
+	return values
 }
 
 // SetValue sets a value to the trie with the given SubCmdIdx as index.

--- a/gapis/resolve/dependencygraph2/dependency_graph.go
+++ b/gapis/resolve/dependencygraph2/dependency_graph.go
@@ -80,6 +80,10 @@ type DependencyGraph interface {
 	// GetNodeID returns the NodeID associated with given node data
 	GetCmdNodeID(api.CmdID, api.SubCmdIdx) NodeID
 
+	// GetCmdAncestorNodeIDs returns the NodeIDs associated with the ancestors of the
+	// given subcommand.
+	GetCmdAncestorNodeIDs(api.CmdID, api.SubCmdIdx) []NodeID
+
 	// ForeachCmd iterates over all API calls in the graph.
 	// If IncludeInitialCommands is true, this includes the initial commands
 	// which reconstruct the initial state.
@@ -189,6 +193,22 @@ func (g *dependencyGraph) GetCmdNodeID(cmdID api.CmdID, idx api.SubCmdIdx) NodeI
 		return x.(NodeID)
 	}
 	return NodeNoID
+}
+
+// GetCmdAncestorNodeIDs returns the NodeIDs associated with the ancestors of the
+// given subcommand.
+func (g *dependencyGraph) GetCmdAncestorNodeIDs(cmdID api.CmdID, idx api.SubCmdIdx) []NodeID {
+	fullIdx := append(api.SubCmdIdx{(uint64)(cmdID)}, idx...)
+	values := g.cmdNodeIDs.Values(fullIdx)
+	nodeIDs := make([]NodeID, len(values))
+	for i, v := range values {
+		if v != nil {
+			nodeIDs[i] = v.(NodeID)
+		} else {
+			nodeIDs[i] = NodeNoID
+		}
+	}
+	return nodeIDs
 }
 
 // ForeachCmd iterates over all API calls in the graph.

--- a/gapis/resolve/dependencygraph2/dependency_graph_builder.go
+++ b/gapis/resolve/dependencygraph2/dependency_graph_builder.go
@@ -143,7 +143,7 @@ func (b *dependencyGraphBuilder) OnBeginSubCmd(ctx context.Context, subCmdIdx ap
 		return
 	}
 
-	subCmdCtx := b.graphBuilder.GetSubCmdContext(subCmdIdx, cmdCtx)
+	subCmdCtx := b.graphBuilder.GetSubCmdContext(cmdCtx.cmdID, subCmdIdx)
 
 	b.graphBuilder.OnBeginSubCmd(ctx, cmdCtx, subCmdCtx, recordIdx)
 	b.fragWatcher.OnBeginSubCmd(ctx, cmdCtx, subCmdCtx)


### PR DESCRIPTION
Previously, the parent node of a subcommand was determined by the nested calls to On(Begin|End)(Sub)Command. Now the parent is the (sub)command node whose SubCmdIdx is a maximum prefix of the given subcommand.

This fixes the parent of subcommand nodes within subcommand buffers from vkCmdExecuteCommands, and is generally more robust.