### PR TITLE
Step (1/Many) MultiGPU Support for Vulkan 1.1

### DIFF
--- a/gapis/api/vulkan/api/coherent_memory.api
+++ b/gapis/api/vulkan/api/coherent_memory.api
@@ -40,8 +40,9 @@
 // Memory //
 ////////////
 
-sub void readCoherentMemory(ref!DeviceMemoryObject memory, VkDeviceSize readOffset, VkDeviceSize readSize) {
-  if IsMemoryCoherent(memory) && (memory.MappedLocation != null) {
+sub void readCoherentMemory(ref!DeviceMemoryObject memory, VkDeviceSize readOffset, VkDeviceSize readSize,
+      u32 deviceIndex) {
+  if IsMemoryCoherent(memory, deviceIndex) && (memory.MappedLocation != null) {
     offset_in_mapped := deviceMemoryOffsetToMappedSpace(memory, readOffset)
     if offset_in_mapped != as!VkDeviceSize(0xFFFFFFFFFFFFFFFF) {
       read_size_in_mapped := switch (
@@ -54,7 +55,7 @@ sub void readCoherentMemory(ref!DeviceMemoryObject memory, VkDeviceSize readOffs
       }
       if (offset_in_mapped + read_size_in_mapped) > offset_in_mapped {
         readMappedCoherentMemory(memory.VulkanHandle, as!u64(offset_in_mapped),
-          as!size(read_size_in_mapped))
+          as!size(read_size_in_mapped), deviceIndex)
       }
     }
   }
@@ -65,32 +66,32 @@ sub void readCoherentMemory(ref!DeviceMemoryObject memory, VkDeviceSize readOffs
 // Buffer //
 ////////////
 
-sub void readCoherentMemoryInBuffer(ref!BufferObject buffer) {
+sub void readCoherentMemoryInBuffer(ref!BufferObject buffer, u32 deviceIndex) {
   memPieces := getBufferBoundMemoryPiecesInRange(buffer, as!VkDeviceSize(0), as!VkDeviceSize(0xFFFFFFFFFFFFFFFF))
   for _, _, mp in memPieces {
-    readCoherentMemory(mp.DeviceMemory, mp.MemoryOffset, mp.Size)
+    readCoherentMemory(mp.DeviceMemory, mp.MemoryOffset, mp.Size, deviceIndex)
   }
 }
 
 @spy_disabled
-sub void readMemoryInBuffer(ref!BufferObject buffer, VkDeviceSize readOffset, VkDeviceSize readSize) {
+sub void readMemoryInBuffer(ref!BufferObject buffer, VkDeviceSize readOffset, VkDeviceSize readSize, u32 deviceIndex) {
   memPieces := getBufferBoundMemoryPiecesInRange(buffer, readOffset, readSize)
   for _, _, mp in memPieces {
-    readCoherentMemory(mp.DeviceMemory, mp.MemoryOffset, mp.Size)
-    read(mp.DeviceMemory.Data[mp.MemoryOffset:mp.MemoryOffset+mp.Size])
+    readCoherentMemory(mp.DeviceMemory, mp.MemoryOffset, mp.Size, deviceIndex)
+    read(mp.DeviceMemory.DeviceGroupMemories[deviceIndex].Data[mp.MemoryOffset:mp.MemoryOffset+mp.Size])
   }
 }
 
 @spy_disabled
-sub void writeMemoryInBuffer(ref!BufferObject buffer, VkDeviceSize offset, VkDeviceSize size) {
+sub void writeMemoryInBuffer(ref!BufferObject buffer, VkDeviceSize offset, VkDeviceSize size, u32 deviceIndex) {
   memPieces := getBufferBoundMemoryPiecesInRange(buffer, offset, size)
   for _, _, mp in memPieces {
-    write(mp.DeviceMemory.Data[mp.MemoryOffset:mp.MemoryOffset+mp.Size])
+    write(mp.DeviceMemory.DeviceGroupMemories[deviceIndex].Data[mp.MemoryOffset:mp.MemoryOffset+mp.Size])
   }
 }
 
 // VkDescriptorBufferInfo binding
-sub void readCoherentMemoryInBufferBindings(map!(u32, ref!VkDescriptorBufferInfo) bufferBindings) {
+sub void readCoherentMemoryInBufferBindings(map!(u32, ref!VkDescriptorBufferInfo) bufferBindings, u32 deviceIndex) {
   n := len(bufferBindings)
   rcb := LastBoundQueue.ReadCoherentBuffers
   for i in (0 .. n) {
@@ -99,7 +100,7 @@ sub void readCoherentMemoryInBufferBindings(map!(u32, ref!VkDescriptorBufferInfo
       if !(descBufferInfo.Buffer in rcb) {
         if (descBufferInfo.Buffer in Buffers) {
           rcb[descBufferInfo.Buffer] = true
-          readCoherentMemoryInBuffer(Buffers[descBufferInfo.Buffer])
+          readCoherentMemoryInBuffer(Buffers[descBufferInfo.Buffer], deviceIndex)
         }
       }
     }
@@ -107,7 +108,7 @@ sub void readCoherentMemoryInBufferBindings(map!(u32, ref!VkDescriptorBufferInfo
 }
 
 @spy_disabled
-sub void readMemoryInBufferBindings(map!(u32, ref!VkDescriptorBufferInfo) bufferBindings, map!(u32, VkDeviceSize) bufferBindingOffsets) {
+sub void readMemoryInBufferBindings(map!(u32, ref!VkDescriptorBufferInfo) bufferBindings, map!(u32, VkDeviceSize) bufferBindingOffsets, u32 deviceIndex) {
   n := len(bufferBindings)
   for i in (0 .. n) {
     descBufferInfo := bufferBindings[as!u32(i)]
@@ -119,14 +120,14 @@ sub void readMemoryInBufferBindings(map!(u32, ref!VkDescriptorBufferInfo) buffer
           case false:
             descBufferInfo.Offset
         }
-        readMemoryInBuffer(Buffers[descBufferInfo.Buffer], offset, descBufferInfo.Range)
+        readMemoryInBuffer(Buffers[descBufferInfo.Buffer], offset, descBufferInfo.Range, deviceIndex)
       }
     }
   }
 }
 
 @spy_disabled
-sub void writeMemoryInBufferBindings(map!(u32, ref!VkDescriptorBufferInfo) bufferBindings, map!(u32, VkDeviceSize) bufferBindingOffsets) {
+sub void writeMemoryInBufferBindings(map!(u32, ref!VkDescriptorBufferInfo) bufferBindings, map!(u32, VkDeviceSize) bufferBindingOffsets, u32 deviceIndex) {
   n := len(bufferBindings)
   for i in (0 .. n) {
     bufferBinding := bufferBindings[as!u32(i)]
@@ -138,14 +139,14 @@ sub void writeMemoryInBufferBindings(map!(u32, ref!VkDescriptorBufferInfo) buffe
           case false:
             bufferBinding.Offset
         }
-        writeMemoryInBuffer(Buffers[bufferBinding.Buffer], offset, bufferBinding.Range)
+        writeMemoryInBuffer(Buffers[bufferBinding.Buffer], offset, bufferBinding.Range, deviceIndex)
       }
     }
   }
 }
 
 // VkBufferView binding
-sub void readCoherentMemoryInBufferViewBindings(map!(u32, VkBufferView) bufferViews) {
+sub void readCoherentMemoryInBufferViewBindings(map!(u32, VkBufferView) bufferViews, u32 deviceIndex) {
   rcb := LastBoundQueue.ReadCoherentBuffers
   for _, _, v in bufferViews {
     if v in BufferViews {
@@ -153,7 +154,7 @@ sub void readCoherentMemoryInBufferViewBindings(map!(u32, VkBufferView) bufferVi
       if !(view.Buffer.VulkanHandle in rcb) {
         if (view.Buffer.VulkanHandle in Buffers) {
           LastBoundQueue.ReadCoherentBuffers[view.Buffer.VulkanHandle] = true
-          readCoherentMemoryInBuffer(view.Buffer)
+          readCoherentMemoryInBuffer(view.Buffer, deviceIndex)
         }
       }
     }
@@ -161,24 +162,24 @@ sub void readCoherentMemoryInBufferViewBindings(map!(u32, VkBufferView) bufferVi
 }
 
 @spy_disabled
-sub void readMemoryInBufferViewBindings(map!(u32, VkBufferView) bufferViews) {
+sub void readMemoryInBufferViewBindings(map!(u32, VkBufferView) bufferViews, u32 deviceIndex) {
   for _, _, v in bufferViews {
     if v in BufferViews {
       view := BufferViews[v]
       if (view.Buffer.VulkanHandle in Buffers) {
-        readMemoryInBuffer(view.Buffer, view.Offset, view.Range)
+        readMemoryInBuffer(view.Buffer, view.Offset, view.Range, deviceIndex)
       }
     }
   }
 }
 
 @spy_disabled
-sub void writeMemoryInBufferViewBindings(map!(u32, VkBufferView) bufferViews) {
+sub void writeMemoryInBufferViewBindings(map!(u32, VkBufferView) bufferViews, u32 deviceIndex) {
   for _, _, v in bufferViews {
     if v in BufferViews {
       view := BufferViews[v]
       if (view.Buffer.VulkanHandle in Buffers) {
-        writeMemoryInBuffer(view.Buffer, view.Offset, view.Range)
+        writeMemoryInBuffer(view.Buffer, view.Offset, view.Range, deviceIndex)
       }
     }
   }
@@ -188,7 +189,7 @@ sub void writeMemoryInBufferViewBindings(map!(u32, VkBufferView) bufferViews) {
 // Image //
 ///////////
 
-sub void readCoherentMemoryInImage(ref!ImageObject image) {
+sub void readCoherentMemoryInImage(ref!ImageObject image, u32 deviceIndex) {
   if image != null {
     for _, _, m in image.PlaneMemoryInfo {
       mem := m.BoundMemory
@@ -200,7 +201,7 @@ sub void readCoherentMemoryInImage(ref!ImageObject image) {
         // TODO: Complete the layout tracking logic then update this if statement
         // to check the layout of the underlying image.
         if image.Info.Tiling == VK_IMAGE_TILING_LINEAR {
-          readCoherentMemory(mem, m.BoundMemoryOffset, inferImageSize(image))
+          readCoherentMemory(mem, m.BoundMemoryOffset, inferImageSize(image), deviceIndex)
         }
       }
     }
@@ -210,8 +211,9 @@ sub void readCoherentMemoryInImage(ref!ImageObject image) {
 // VkImageSubresourceRange data
 
 @spy_disabled
-sub void accessImageSubresourceSlice(ref!ImageObject image, VkImageSubresourceRange rng, u32 baseDepth, u32 depthCount, bool isWrite) {
+sub void accessImageSubresourceSlice(ref!ImageObject image, VkImageSubresourceRange rng, u32 baseDepth, u32 depthCount, u32 deviceIndex, bool isWrite) {
   VK_REMAINING_ARRAY_LAYERS := as!u32(0xFFFFFFFF)
+  readCoherentMemoryInImage(image, deviceIndex)
   layerCount := imageSubresourceLayerCount(image, rng)
   levelCount := imageSubresourceLevelCount(image, rng)
 
@@ -265,19 +267,19 @@ sub void accessImageSubresourceSlice(ref!ImageObject image, VkImageSubresourceRa
 }
 
 @spy_disabled
-sub void accessImageSubresource(ref!ImageObject image, VkImageSubresourceRange rng, bool isWrite) {
+sub void accessImageSubresource(ref!ImageObject image, VkImageSubresourceRange rng, u32 deviceIndex, bool isWrite) {
   VK_REMAINING_ARRAY_LAYERS := as!u32(0xFFFFFFFF)
-  accessImageSubresourceSlice(image, rng, 0, VK_REMAINING_ARRAY_LAYERS, isWrite)
+  accessImageSubresourceSlice(image, rng, 0, VK_REMAINING_ARRAY_LAYERS, deviceIndex, isWrite)
 }
 
 @spy_disabled
-sub void readImageSubresource(ref!ImageObject image, VkImageSubresourceRange rng) {
-  accessImageSubresource(image, rng, false)
+sub void readImageSubresource(ref!ImageObject image, VkImageSubresourceRange rng, u32 deviceIndex) {
+  accessImageSubresource(image, rng, deviceIndex, false)
 }
 
 @spy_disabled
-sub void writeImageSubresource(ref!ImageObject image, VkImageSubresourceRange rng) {
-  accessImageSubresource(image, rng, true)
+sub void writeImageSubresource(ref!ImageObject image, VkImageSubresourceRange rng, u32 deviceIndex) {
+  accessImageSubresource(image, rng, deviceIndex, true)
 }
 
 sub bool is2DView3DImage(ref!ImageViewObject view) {
@@ -286,7 +288,7 @@ sub bool is2DView3DImage(ref!ImageViewObject view) {
 }
 
 @spy_disabled
-sub void accessImageView(ref!ImageViewObject view, bool isWrite) {
+sub void accessImageView(ref!ImageViewObject view, u32 deviceIndex, bool isWrite) {
   if is2DView3DImage(view) {
     rng := VkImageSubresourceRange(
           aspectMask: view.SubresourceRange.aspectMask,
@@ -296,20 +298,20 @@ sub void accessImageView(ref!ImageViewObject view, bool isWrite) {
           layerCount: 1)
     baseDepth := view.SubresourceRange.baseArrayLayer
     depthCount := view.SubresourceRange.layerCount
-    accessImageSubresourceSlice(view.Image, rng, baseDepth, depthCount, isWrite)
+    accessImageSubresourceSlice(view.Image, rng, baseDepth, depthCount, deviceIndex, isWrite)
   } else {
-    accessImageSubresource(view.Image, view.SubresourceRange, isWrite)
+    accessImageSubresource(view.Image, view.SubresourceRange, deviceIndex, isWrite)
   }
 }
 
 @spy_disabled
-sub void readImageView(ref!ImageViewObject view) {
-  accessImageView(view, false)
+sub void readImageView(ref!ImageViewObject view, u32 deviceIndex) {
+  accessImageView(view, deviceIndex, false)
 }
 
 @spy_disabled
-sub void writeImageView(ref!ImageViewObject view) {
-  accessImageView(view, true)
+sub void writeImageView(ref!ImageViewObject view, u32 deviceIndex) {
+  accessImageView(view, deviceIndex, true)
 }
 
 @spy_disabled
@@ -330,7 +332,7 @@ sub void updateImageViewQueue(ref!ImageViewObject view) {
 // VkImageViews used as Framebuffer attachments are handled in
 // renderpass_framebuffer.api
 @server_disabled
-sub void readCoherentMemoryInImageBindings(map!(u32, ref!VkDescriptorImageInfo) imageBindings) {
+sub void readCoherentMemoryInImageBindings(map!(u32, ref!VkDescriptorImageInfo) imageBindings, u32 deviceIndex) {
   for _, _, v in imageBindings {
     _ = Samplers[v.Sampler]
     if v.ImageView != as!VkImageView(0) {
@@ -338,42 +340,42 @@ sub void readCoherentMemoryInImageBindings(map!(u32, ref!VkDescriptorImageInfo) 
         view := ImageViews[v.ImageView]
         updateImageViewQueue(view)
         imageObj := view.Image
-        readCoherentMemoryInImage(imageObj)
+        readCoherentMemoryInImage(imageObj, deviceIndex)
       }
     }
   }
 }
 
 @spy_disabled
-sub void readMemoryInImageBindings(map!(u32, ref!VkDescriptorImageInfo) imageBindings) {
+sub void readMemoryInImageBindings(map!(u32, ref!VkDescriptorImageInfo) imageBindings, u32 deviceIndex) {
   for _, _, v in imageBindings {
     _ = Samplers[v.Sampler]
     if v.ImageView != as!VkImageView(0) {
       if (v.ImageView in ImageViews) {
         view := ImageViews[v.ImageView]
         updateImageViewQueue(view)
-        readImageView(view)
+        readImageView(view, deviceIndex)
       }
     }
   }
 }
 
 @spy_disabled
-sub void writeMemoryInImageBindings(map!(u32, ref!VkDescriptorImageInfo) imageBindings) {
+sub void writeMemoryInImageBindings(map!(u32, ref!VkDescriptorImageInfo) imageBindings, u32 deviceIndex) {
   for _, _, v in imageBindings {
     _ = Samplers[v.Sampler]
     if v.ImageView != as!VkImageView(0) {
       if (v.ImageView in ImageViews) {
         view := ImageViews[v.ImageView]
         updateImageViewQueue(view)
-        writeImageView(view)
+        writeImageView(view, deviceIndex)
       }
     }
   }
 }
 
 @server_disabled
-sub void readCoherentMemoryInDescriptor(ref!DescriptorSetObject descriptor_set, u32 b, u32 arrayCount) {
+sub void readCoherentMemoryInDescriptor(ref!DescriptorSetObject descriptor_set, u32 b, u32 arrayCount, u32 deviceIndex) {
   if descriptor_set != null {
     binding := descriptor_set.Bindings[b]
     if binding != null {
@@ -383,17 +385,17 @@ sub void readCoherentMemoryInDescriptor(ref!DescriptorSetObject descriptor_set, 
           VK_DESCRIPTOR_TYPE_STORAGE_BUFFER,
           VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC,
           VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC:
-            readCoherentMemoryInBufferBindings(binding.BufferBinding)
+            readCoherentMemoryInBufferBindings(binding.BufferBinding, deviceIndex)
         case VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER,
           VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER:
-            readCoherentMemoryInBufferViewBindings(binding.BufferViewBindings)
+            readCoherentMemoryInBufferViewBindings(binding.BufferViewBindings, deviceIndex)
         case
           VK_DESCRIPTOR_TYPE_SAMPLER,
           VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
           VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE,
           VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
           VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT:
-          readCoherentMemoryInImageBindings(binding.ImageBinding)
+          readCoherentMemoryInImageBindings(binding.ImageBinding, deviceIndex)
         default: {}
       }
     }
@@ -404,7 +406,7 @@ sub void readCoherentMemoryInDescriptor(ref!DescriptorSetObject descriptor_set, 
 // DescriptorSet //
 ///////////////////
 @spy_disabled
-sub void readMemoryInDescriptor(ref!DescriptorSetObject descriptor_set, u32 b, u32 arrayCount, map!(u32, VkDeviceSize) bufferBindingOffsets) {
+sub void readMemoryInDescriptor(ref!DescriptorSetObject descriptor_set, u32 b, u32 arrayCount, map!(u32, VkDeviceSize) bufferBindingOffsets, u32 deviceIndex) {
   if descriptor_set != null {
     binding := descriptor_set.Bindings[b]
     if binding != null {
@@ -414,17 +416,17 @@ sub void readMemoryInDescriptor(ref!DescriptorSetObject descriptor_set, u32 b, u
           VK_DESCRIPTOR_TYPE_STORAGE_BUFFER,
           VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC,
           VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC:
-            readMemoryInBufferBindings(binding.BufferBinding, bufferBindingOffsets)
+            readMemoryInBufferBindings(binding.BufferBinding, bufferBindingOffsets, deviceIndex)
         case VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER,
           VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER:
-            readMemoryInBufferViewBindings(binding.BufferViewBindings)
+            readMemoryInBufferViewBindings(binding.BufferViewBindings, deviceIndex)
         case
           VK_DESCRIPTOR_TYPE_SAMPLER,
           VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
           VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE,
           VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
           VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT:
-          readMemoryInImageBindings(binding.ImageBinding)
+          readMemoryInImageBindings(binding.ImageBinding, deviceIndex)
         default: {}
       }
     }
@@ -432,7 +434,7 @@ sub void readMemoryInDescriptor(ref!DescriptorSetObject descriptor_set, u32 b, u
 }
 
 @spy_disabled
-sub void writeMemoryInDescriptor(ref!DescriptorSetObject descriptor_set, u32 b, u32 arrayCount, map!(u32, VkDeviceSize) bufferBindingOffsets) {
+sub void writeMemoryInDescriptor(ref!DescriptorSetObject descriptor_set, u32 b, u32 arrayCount, map!(u32, VkDeviceSize) bufferBindingOffsets, u32 deviceIndex) {
   if descriptor_set != null {
     binding := descriptor_set.Bindings[b]
     if binding != null {
@@ -440,11 +442,11 @@ sub void writeMemoryInDescriptor(ref!DescriptorSetObject descriptor_set, u32 b, 
         case
           VK_DESCRIPTOR_TYPE_STORAGE_BUFFER,
           VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC:
-            writeMemoryInBufferBindings(binding.BufferBinding, bufferBindingOffsets)
+            writeMemoryInBufferBindings(binding.BufferBinding, bufferBindingOffsets, deviceIndex)
         case VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER:
-            writeMemoryInBufferViewBindings(binding.BufferViewBindings)
+            writeMemoryInBufferViewBindings(binding.BufferViewBindings, deviceIndex)
         case VK_DESCRIPTOR_TYPE_STORAGE_IMAGE:
-            writeMemoryInImageBindings(binding.ImageBinding)
+            writeMemoryInImageBindings(binding.ImageBinding, deviceIndex)
         default: {}
       }
     }
@@ -460,40 +462,41 @@ sub void writeMemoryInDescriptor(ref!DescriptorSetObject descriptor_set, u32 b, 
 sub void readWriteMemoryInBoundDescriptorSets(
     map!(u32, DescriptorUsage) usedDescriptors,
     map!(u32, ref!DescriptorSetObject) descriptorSets,
-    map!(u32, map!(u32, map!(u32, VkDeviceSize))) bufferBindingOffsets) {
+    map!(u32, map!(u32, map!(u32, VkDeviceSize))) bufferBindingOffsets,
+    u32 deviceIndex) {
 
   for _, _, desc in usedDescriptors {
     if !(desc.Set in descriptorSets) { vkErrInvalidDescriptorArrayElement(as!u64(desc.Set), desc.Binding, desc.DescriptorCount) } else {
       descriptorSet := descriptorSets[desc.Set]
       if descriptorSet != null {
-        readCoherentMemoryInDescriptor(descriptorSet, desc.Binding, desc.DescriptorCount)
+        readCoherentMemoryInDescriptor(descriptorSet, desc.Binding, desc.DescriptorCount, deviceIndex)
         // Do not create a temporary for these bufferBindingOffsets, since the temporary
         // will be created (an unused) on trace side as well.
-        readMemoryInDescriptor(descriptorSet, desc.Binding, desc.DescriptorCount, bufferBindingOffsets[desc.Set][desc.Binding])
-        writeMemoryInDescriptor(descriptorSet, desc.Binding, desc.DescriptorCount, bufferBindingOffsets[desc.Set][desc.Binding])
+        readMemoryInDescriptor(descriptorSet, desc.Binding, desc.DescriptorCount, bufferBindingOffsets[desc.Set][desc.Binding], deviceIndex)
+        writeMemoryInDescriptor(descriptorSet, desc.Binding, desc.DescriptorCount, bufferBindingOffsets[desc.Set][desc.Binding], deviceIndex)
       }
     }
   }
 }
 
 @server_disabled
-sub void readCoherentMemoryInCurrentPipelineBoundVertexBuffers(u32 vertexCount, u32 instanceCount, u32 firstVertex, u32 firstInstance) {
+sub void readCoherentMemoryInCurrentPipelineBoundVertexBuffers(u32 vertexCount, u32 instanceCount, u32 firstVertex, u32 firstInstance, u32 deviceIndex) {
   ldi := lastDrawInfo()
   for _ , _ , vertex_binding in ldi.GraphicsPipeline.VertexInputState.BindingDescriptions {
     bound_vertex_buffer := ldi.BoundVertexBuffers[vertex_binding.binding]
     backing_buf := bound_vertex_buffer.Buffer
-    readCoherentMemoryInBuffer(backing_buf)
+    readCoherentMemoryInBuffer(backing_buf, deviceIndex)
   }
 }
 
 // Bound vertex/index buffers
-sub void readMemoryInCurrentPipelineBoundVertexBuffers(u32 vertexCount, u32 instanceCount, u32 firstVertex, u32 firstInstance) {
-    readCoherentMemoryInCurrentPipelineBoundVertexBuffers(vertexCount, instanceCount, firstVertex, firstInstance)
-    trackMemoryInCurrentPipelineBoundVertexBuffers(vertexCount, instanceCount, firstVertex, firstInstance)
+sub void readMemoryInCurrentPipelineBoundVertexBuffers(u32 vertexCount, u32 instanceCount, u32 firstVertex, u32 firstInstance, u32 deviceIndex) {
+    readCoherentMemoryInCurrentPipelineBoundVertexBuffers(vertexCount, instanceCount, firstVertex, firstInstance, deviceIndex)
+    trackMemoryInCurrentPipelineBoundVertexBuffers(vertexCount, instanceCount, firstVertex, firstInstance, deviceIndex)
 }
 
 @spy_disabled
-sub void trackMemoryInCurrentPipelineBoundVertexBuffers(u32 vertexCount, u32 instanceCount, u32 firstVertex, u32 firstInstance) {
+sub void trackMemoryInCurrentPipelineBoundVertexBuffers(u32 vertexCount, u32 instanceCount, u32 firstVertex, u32 firstInstance, u32 deviceIndex) {
   ldi := lastDrawInfo()
   for _ , _ , vertex_binding in ldi.GraphicsPipeline.VertexInputState.BindingDescriptions {
     if vertex_binding.binding in ldi.BoundVertexBuffers {
@@ -519,7 +522,7 @@ sub void trackMemoryInCurrentPipelineBoundVertexBuffers(u32 vertexCount, u32 ins
           case false:
             as!VkDeviceSize(num_vertices * vertex_binding.stride)
         }
-        readMemoryInBuffer(backing_buf, start_offset, num)
+        readMemoryInBuffer(backing_buf, start_offset, num, deviceIndex)
       }
     }
   }
@@ -530,8 +533,8 @@ sub void trackMemoryInCurrentPipelineBoundVertexBuffers(u32 vertexCount, u32 ins
 // Util //
 //////////
 
-sub bool IsMemoryCoherent(ref!DeviceMemoryObject memory) {
-  physical_device := PhysicalDevices[Devices[memory.Device].PhysicalDevice]
+sub bool IsMemoryCoherent(ref!DeviceMemoryObject memory, u32 deviceIndex) {
+  physical_device := PhysicalDevices[Devices[memory.Device].PhysicalDevices[deviceIndex]]
   return 0 != (as!u32(physical_device.MemoryProperties.memoryTypes[memory.MemoryTypeIndex].propertyFlags) &
   as!u32(VK_MEMORY_PROPERTY_HOST_COHERENT_BIT))
 }

--- a/gapis/api/vulkan/api/copy_clear_commands.api
+++ b/gapis/api/vulkan/api/copy_clear_commands.api
@@ -48,7 +48,7 @@ sub void dovkCmdCopyBuffer(ref!vkCmdCopyBufferArgs buffer) {
   sourceBuffer := Buffers[buffer.SrcBuffer]
   destBuffer := Buffers[buffer.DstBuffer]
   for _ , _ , region in buffer.CopyRegions {
-    readCoherentMemoryInBuffer(sourceBuffer)
+    readCoherentMemoryInBuffer(sourceBuffer, LastBoundQueue.CurrentDeviceIndex)
     copyBufferToBuffer(destBuffer, region.dstOffset, sourceBuffer, region.srcOffset, region.size)
   }
 }
@@ -130,7 +130,7 @@ sub void copyBufferToBuffer(ref!BufferObject dstBuf, VkDeviceSize dstOffset, ref
     srcMemEnd := min!VkDeviceSize(srcMemOffset + size, srcBuf.Memory.AllocationSize)
     dstMemEnd := min!VkDeviceSize(dstMemOffset + size, dstBuf.Memory.AllocationSize)
     if (srcMemOffset < srcMemEnd) && (dstMemOffset < dstMemEnd) {
-      copy(dstBuf.Memory.Data[dstMemOffset:dstMemEnd], srcBuf.Memory.Data[srcMemOffset:srcMemEnd])
+      copy(dstBuf.Memory.DeviceGroupMemories[LastBoundQueue.CurrentDeviceIndex].Data[dstMemOffset:dstMemEnd], srcBuf.Memory.DeviceGroupMemories[LastBoundQueue.CurrentDeviceIndex].Data[srcMemOffset:srcMemEnd])
     }
 
   } else if (dstBuf.Memory != null) && (len(srcBuf.SparseMemoryBindings) != 0) {
@@ -141,8 +141,8 @@ sub void copyBufferToBuffer(ref!BufferObject dstBuf, VkDeviceSize dstOffset, ref
         dstMemOffset := as!u64((smp.ResourceOffset - srcOffset) + dstOffset)
         if dstMemOffset < as!u64(dstBuf.Memory.AllocationSize) {
           memSize := min!u64(as!u64(smp.Size), as!u64(dstBuf.Memory.AllocationSize) - dstMemOffset)
-          copy(dstBuf.Memory.Data[dstMemOffset:dstMemOffset + memSize],
-            srcBuf.Memory.Data[srcMemOffset:srcMemOffset + memSize])
+          copy(dstBuf.Memory.DeviceGroupMemories[LastBoundQueue.CurrentDeviceIndex].Data[dstMemOffset:dstMemOffset + memSize],
+            srcBuf.Memory.DeviceGroupMemories[LastBoundQueue.CurrentDeviceIndex].Data[srcMemOffset:srcMemOffset + memSize])
         }
       }
 
@@ -154,8 +154,8 @@ sub void copyBufferToBuffer(ref!BufferObject dstBuf, VkDeviceSize dstOffset, ref
           srcMemOffset := (dmp.ResourceOffset - dstOffset) + srcOffset
           if srcMemOffset < as!VkDeviceSize(srcBuf.Memory.AllocationSize) {
             memSize := min!VkDeviceSize(dmp.Size, as!VkDeviceSize(srcBuf.Memory.AllocationSize) - srcMemOffset)
-            copy(dstBuf.Memory.Data[dstMemOffset:dstMemOffset + memSize],
-              srcBuf.Memory.Data[srcMemOffset:srcMemOffset + memSize])
+            copy(dstBuf.Memory.DeviceGroupMemories[LastBoundQueue.CurrentDeviceIndex].Data[dstMemOffset:dstMemOffset + memSize],
+              srcBuf.Memory.DeviceGroupMemories[LastBoundQueue.CurrentDeviceIndex].Data[srcMemOffset:srcMemOffset + memSize])
           }
         }
 
@@ -170,8 +170,8 @@ sub void copyBufferToBuffer(ref!BufferObject dstBuf, VkDeviceSize dstOffset, ref
               srcMemOffset := as!u64(smp.MemoryOffset)
               dstMemOffset := as!u64((smp.ResourceOffset - tmpSrcOffset) + dmp.ResourceOffset)
               memSize := as!u64(smp.Size)
-              copy(dstBuf.Memory.Data[dstMemOffset:dstMemOffset + memSize],
-                srcBuf.Memory.Data[srcMemOffset:srcMemOffset + memSize])
+              copy(dstBuf.Memory.DeviceGroupMemories[LastBoundQueue.CurrentDeviceIndex].Data[dstMemOffset:dstMemOffset + memSize],
+                srcBuf.Memory.DeviceGroupMemories[LastBoundQueue.CurrentDeviceIndex].Data[srcMemOffset:srcMemOffset + memSize])
             }
           }
         }
@@ -349,7 +349,7 @@ sub void dovkCmdCopyImage(ref!vkCmdCopyImageArgs args) {
   // But such a read is necessary if the backing memory of the source image is coherent, as we need the read observations on all memory changes
   // in order to replay correctly. However, as the UI's texture data comes from imageLevel.Data, just using the following call will not bring
   // the changes in coherent memory to the UI's texture view.
-  readCoherentMemoryInImage(srcImageObject)
+  readCoherentMemoryInImage(srcImageObject, LastBoundQueue.CurrentDeviceIndex)
   trackVkCmdCopyImage(args)
 }
 
@@ -519,7 +519,7 @@ sub void dovkCmdBlitImage(ref!vkCmdBlitImageArgs args) {
   // But such a read is necessary if the backing memory of the source image is coherent, as we need the read observations on all memory changes
   // in order to replay correctly. However, as the UI's texture data comes from imageLevel.Data, just using the following call will not bring
   // the changes in coherent memory to the UI's texture view.
-  readCoherentMemoryInImage(srcImageObject)
+  readCoherentMemoryInImage(srcImageObject, LastBoundQueue.CurrentDeviceIndex)
   trackVkCmdBlitImage(args)
 }
 
@@ -641,7 +641,7 @@ sub void copyImageBuffer(VkBuffer buffer, VkImage image, VkImageLayout layout, m
                 imgStart := as!VkDeviceSize((rowStartBlock + x) * elementSizeInImage)
                 rowStartInExtent := (rowStartBlockInExtent + x) * elementSize
                 bufStart := as!VkDeviceSize(bufferLayerOffset + rowStartInExtent)
-                readMemoryInBuffer(bufferObject, bufStart, as!VkDeviceSize(elementSize))
+                readMemoryInBuffer(bufferObject, bufStart, as!VkDeviceSize(elementSize), LastBoundQueue.CurrentDeviceIndex)
                 // Discard the 4th byte in the buffer for current pixel.
                 bufMemPieces := getBufferBoundMemoryPiecesInRange(bufferObject, bufStart, as!VkDeviceSize(elementSizeInImage))
                 for _ , _ , piece in bufMemPieces {
@@ -650,9 +650,9 @@ sub void copyImageBuffer(VkBuffer buffer, VkImage image, VkImageLayout layout, m
                   imgPieceStart := (piece.ResourceOffset - bufStart) + imgStart
                   imgPieceEnd := imgPieceStart + piece.Size
                   if isSrcBuffer {
-                    copy(imageLevel.Data[imgPieceStart:imgPieceEnd], piece.DeviceMemory.Data[bufMemStart:bufMemEnd])
+                    copy(imageLevel.Data[imgPieceStart:imgPieceEnd], piece.DeviceMemory.DeviceGroupMemories[LastBoundQueue.CurrentDeviceIndex].Data[bufMemStart:bufMemEnd])
                   } else {
-                    copy(piece.DeviceMemory.Data[bufMemStart:bufMemEnd], imageLevel.Data[imgPieceStart:imgPieceEnd])
+                    copy(piece.DeviceMemory.DeviceGroupMemories[LastBoundQueue.CurrentDeviceIndex].Data[bufMemStart:bufMemEnd], imageLevel.Data[imgPieceStart:imgPieceEnd])
                   }
                 }
               }
@@ -661,7 +661,7 @@ sub void copyImageBuffer(VkBuffer buffer, VkImage image, VkImageLayout layout, m
               imgStart := (rowStartBlock + xStart) * elementSize
               rowStartInExtent := rowStartBlockInExtent * elementSize
               bufStart := as!VkDeviceSize(bufferLayerOffset + rowStartInExtent)
-              readMemoryInBuffer(bufferObject, bufStart, copySize)
+              readMemoryInBuffer(bufferObject, bufStart, copySize, LastBoundQueue.CurrentDeviceIndex)
               bufMemPieces := getBufferBoundMemoryPiecesInRange(bufferObject, bufStart, copySize)
               for _ , _ , piece in bufMemPieces {
                 bufMemStart := piece.MemoryOffset
@@ -669,9 +669,9 @@ sub void copyImageBuffer(VkBuffer buffer, VkImage image, VkImageLayout layout, m
                 imgPieceStart := as!u64(piece.ResourceOffset - bufStart) + imgStart
                 imgPieceEnd := imgPieceStart + as!u64(piece.Size)
                 if isSrcBuffer {
-                  copy(imageLevel.Data[imgPieceStart:imgPieceEnd], piece.DeviceMemory.Data[bufMemStart:bufMemEnd])
+                  copy(imageLevel.Data[imgPieceStart:imgPieceEnd], piece.DeviceMemory.DeviceGroupMemories[LastBoundQueue.CurrentDeviceIndex].Data[bufMemStart:bufMemEnd])
                 } else {
-                  copy(piece.DeviceMemory.Data[bufMemStart:bufMemEnd], imageLevel.Data[imgPieceStart:imgPieceEnd])
+                  copy(piece.DeviceMemory.DeviceGroupMemories[LastBoundQueue.CurrentDeviceIndex].Data[bufMemStart:bufMemEnd], imageLevel.Data[imgPieceStart:imgPieceEnd])
                 }
               }
             }
@@ -693,7 +693,7 @@ class vkCmdCopyBufferToImageArgs {
 
 sub void dovkCmdCopyBufferToImage(ref!vkCmdCopyBufferToImageArgs args) {
   if (!args.SrcBuffer in Buffers) { vkErrorInvalidBuffer(args.SrcBuffer) } else {
-    readCoherentMemoryInBuffer(Buffers[args.SrcBuffer])
+    readCoherentMemoryInBuffer(Buffers[args.SrcBuffer], LastBoundQueue.CurrentDeviceIndex)
     copyImageBuffer(args.SrcBuffer, args.DstImage, args.Layout, args.Regions, true)
   }
 }
@@ -746,7 +746,7 @@ class vkCmdCopyImageToBufferArgs {
 
 sub void dovkCmdCopyImageToBuffer(ref!vkCmdCopyImageToBufferArgs args) {
   if (!args.SrcImage in Images) { vkErrorInvalidImage(args.SrcImage) } else {
-    readCoherentMemoryInImage(Images[args.SrcImage])
+    readCoherentMemoryInImage(Images[args.SrcImage], LastBoundQueue.CurrentDeviceIndex)
     copyImageBuffer(args.DstBuffer, args.SrcImage, args.SrcImageLayout, args.Regions, false)
   }
 }
@@ -808,7 +808,7 @@ sub void dovkCmdUpdateBuffer(ref!vkCmdUpdateBufferArgs args) {
   for _ , _ , p in bufPieces {
     srcOffset := p.ResourceOffset - args.DstOffset
     size := min!VkDeviceSize(p.Size, as!VkDeviceSize(len(args.Data)) - srcOffset)
-    copy(buff.Memory.Data[p.MemoryOffset:p.MemoryOffset + size], args.Data[srcOffset:srcOffset + size])
+    copy(buff.Memory.DeviceGroupMemories[LastBoundQueue.CurrentDeviceIndex].Data[p.MemoryOffset:p.MemoryOffset + size], args.Data[srcOffset:srcOffset + size])
   }
 }
 
@@ -858,8 +858,8 @@ sub void dovkCmdFillBuffer(ref!vkCmdFillBufferArgs args) {
   buf := Buffers[args.Buffer]
   bufPieces := getBufferBoundMemoryPiecesInRange(buf, args.DstOffset, args.Size)
   for _ , _ , p in bufPieces {
-    if as!VkDeviceSize(len(p.DeviceMemory.Data)) >= (p.MemoryOffset + p.Size) {
-      write(p.DeviceMemory.Data[p.MemoryOffset: p.MemoryOffset + p.Size])
+    if as!VkDeviceSize(len(p.DeviceMemory.DeviceGroupMemories[LastBoundQueue.CurrentDeviceIndex].Data)) >= (p.MemoryOffset + p.Size) {
+      write(p.DeviceMemory.DeviceGroupMemories[LastBoundQueue.CurrentDeviceIndex].Data[p.MemoryOffset: p.MemoryOffset + p.Size])
     }
   }
 }
@@ -909,7 +909,7 @@ sub void dovkCmdClearColorImage(ref!vkCmdClearColorImageArgs args) {
   if !(args.Image in Images) { vkErrorInvalidImage(args.Image) }
   image := Images[args.Image]
   for _, _, r in args.Ranges {
-    writeImageSubresource(image, r)
+    writeImageSubresource(image, r, LastBoundQueue.CurrentDeviceIndex)
   }
 }
 
@@ -966,7 +966,7 @@ sub void dovkCmdClearDepthStencilImage(ref!vkCmdClearDepthStencilImageArgs args)
   if !(args.Image in Images) { vkErrorInvalidImage(args.Image) }
   image := Images[args.Image]
   for _, _, r in args.Ranges {
-    writeImageSubresource(image, r)
+    writeImageSubresource(image, r, LastBoundQueue.CurrentDeviceIndex)
   }
 }
 
@@ -1081,10 +1081,10 @@ sub void dovkCmdResolveImage(ref!vkCmdResolveImageArgs args) {
     dst := Images[args.DstImage]
 
     updateImageQueue(src, srcRange)
-    readCoherentMemoryInImage(src)
-    readImageSubresource(src, srcRange)
+    readCoherentMemoryInImage(src, LastBoundQueue.CurrentDeviceIndex)
+    readImageSubresource(src, srcRange, LastBoundQueue.CurrentDeviceIndex)
     updateImageQueue(dst, dstRange)
-    writeImageSubresource(dst, dstRange)
+    writeImageSubresource(dst, dstRange, LastBoundQueue.CurrentDeviceIndex)
   }
 }
 

--- a/gapis/api/vulkan/api/device.api
+++ b/gapis/api/vulkan/api/device.api
@@ -43,14 +43,14 @@
 }
 
 @internal class DeviceObject {
-  VkPhysicalDevice                   PhysicalDevice
-  @unused map!(u32, string)          EnabledExtensions
-  @unused map!(u32, string)          EnabledLayers
-  @unused map!(u32, QueueInfo)       Queues
-  @unused map!(u32, ref!QueueObject) QueueObjects
-  @unused VkPhysicalDeviceFeatures   EnabledFeatures
-  @unused VkDevice                   VulkanHandle
-  @unused ref!VulkanDebugMarkerInfo  DebugInfo
+  @unused map!(u32, VkPhysicalDevice) PhysicalDevices
+  @unused map!(u32, string)           EnabledExtensions
+  @unused map!(u32, string)           EnabledLayers
+  @unused map!(u32, QueueInfo)        Queues
+  @unused map!(u32, ref!QueueObject)  QueueObjects
+  @unused VkPhysicalDeviceFeatures    EnabledFeatures
+  @unused VkDevice                    VulkanHandle
+  @unused ref!VulkanDebugMarkerInfo   DebugInfo
 
   // Vulkan 1.1
   @unused ref!VariablePointerFeatures VariablePointerFeatures
@@ -81,7 +81,7 @@ cmd VkResult vkCreateDevice(
   // replayCreateVkDevice() in synthetic.api. Change both together.
   device := createDeviceObject(pCreateInfo)
   if !(physicalDevice in PhysicalDevices) { vkErrorInvalidPhysicalDevice(physicalDevice) }
-  device.PhysicalDevice = physicalDevice
+  device.PhysicalDevices[0] = physicalDevice
 
   handle := ?
   if pDevice == null { vkErrorNullPointer("VkDevice*") }

--- a/gapis/api/vulkan/api/draw_commands.api
+++ b/gapis/api/vulkan/api/draw_commands.api
@@ -159,7 +159,7 @@ sub void dovkCmdDraw(ref!vkCmdDrawArgs draw) {
   useRenderPass()
 
   readWriteMemoryInBoundGraphicsDescriptorSets()
-  readMemoryInCurrentPipelineBoundVertexBuffers(draw.VertexCount, draw.InstanceCount, draw.FirstVertex, draw.FirstInstance)
+  readMemoryInCurrentPipelineBoundVertexBuffers(draw.VertexCount, draw.InstanceCount, draw.FirstVertex, draw.FirstInstance, LastBoundQueue.CurrentDeviceIndex)
   clearLastDrawInfoDrawCommandParameters()
   lastDrawInfo().CommandParameters.Draw = draw
 }
@@ -200,7 +200,7 @@ vkCmdDrawIndexedArgs {
 sub void readCoherentMemoryInBoundIndexBuffer() {
   lastDraw := lastDrawInfo()
   indexBuffer := lastDraw.BoundIndexBuffer.BoundBuffer.Buffer
-  readCoherentMemoryInBuffer(indexBuffer)
+  readCoherentMemoryInBuffer(indexBuffer, LastBoundQueue.CurrentDeviceIndex)
 }
 
 @spy_disabled
@@ -219,7 +219,7 @@ sub void readBoundIndexBuffer(u32 indexCount, u32 firstIndex) {
   startOffset := lastDraw.BoundIndexBuffer.BoundBuffer.Offset + (indexSize * as!VkDeviceSize(firstIndex))
 
   // Read the data of the index buffer.
-  readMemoryInBuffer(indexBuffer, startOffset, numBytes)
+  readMemoryInBuffer(indexBuffer, startOffset, numBytes, LastBoundQueue.CurrentDeviceIndex)
 }
 
 sub void dovkCmdDrawIndexed(ref!vkCmdDrawIndexedArgs draw) {
@@ -228,7 +228,7 @@ sub void dovkCmdDrawIndexed(ref!vkCmdDrawIndexedArgs draw) {
   readCoherentMemoryInBoundIndexBuffer()
   readBoundIndexBuffer(draw.IndexCount, draw.FirstIndex)
   // Read the whole vertex buffer.
-  readMemoryInCurrentPipelineBoundVertexBuffers(0xFFFFFFFF, draw.InstanceCount, 0, draw.FirstInstance)
+  readMemoryInCurrentPipelineBoundVertexBuffers(0xFFFFFFFF, draw.InstanceCount, 0, draw.FirstInstance, LastBoundQueue.CurrentDeviceIndex)
   readWriteMemoryInBoundGraphicsDescriptorSets()
   clearLastDrawInfoDrawCommandParameters()
   lastDrawInfo().CommandParameters.DrawIndexed = draw
@@ -278,7 +278,7 @@ sub void readIndirectDrawBuffer(VkBuffer buf, VkDeviceSize offset, u32 drawCount
   } else {
     command_size := as!VkDeviceSize(16)
     indirect_buffer_read_size := as!VkDeviceSize((drawCount - 1) * stride) + command_size
-    readMemoryInBuffer(Buffers[buf], offset, indirect_buffer_read_size)
+    readMemoryInBuffer(Buffers[buf], offset, indirect_buffer_read_size, LastBoundQueue.CurrentDeviceIndex)
   }
 }
 
@@ -288,7 +288,7 @@ sub void dovkCmdDrawIndirect(ref!vkCmdDrawIndirectArgs draw) {
     readWriteMemoryInBoundGraphicsDescriptorSets()
     readIndirectDrawBuffer(draw.Buffer, draw.Offset, draw.DrawCount, draw.Stride)
     // Read through all the vertex buffers, as we cannot assume the buffer given to indirect draw is host
-    readMemoryInCurrentPipelineBoundVertexBuffers(0xFFFFFFFF, 0xFFFFFFFF, 0, 0)
+    readMemoryInCurrentPipelineBoundVertexBuffers(0xFFFFFFFF, 0xFFFFFFFF, 0, 0, LastBoundQueue.CurrentDeviceIndex)
     clearLastDrawInfoDrawCommandParameters()
     lastDrawInfo().CommandParameters.DrawIndirect = draw
   }
@@ -332,12 +332,12 @@ sub void readIndexedIndirectDrawBuffer(VkBuffer buf, VkDeviceSize offset, u32 dr
     } else {
       command_size := as!VkDeviceSize(16)
       indirect_buffer_read_size := as!VkDeviceSize((drawCount - 1) * stride) + command_size
-      readCoherentMemoryInBuffer(Buffers[buf])
-      readMemoryInBuffer(Buffers[buf], offset, indirect_buffer_read_size)
+      readCoherentMemoryInBuffer(Buffers[buf], LastBoundQueue.CurrentDeviceIndex)
+      readMemoryInBuffer(Buffers[buf], offset, indirect_buffer_read_size, LastBoundQueue.CurrentDeviceIndex)
       // Read through the whole index buffer.
       indexBuffer := lastDrawInfo().BoundIndexBuffer.BoundBuffer.Buffer
-      readCoherentMemoryInBuffer(indexBuffer)
-      readMemoryInBuffer(indexBuffer, 0, indexBuffer.Info.Size)
+      readCoherentMemoryInBuffer(indexBuffer, LastBoundQueue.CurrentDeviceIndex)
+      readMemoryInBuffer(indexBuffer, 0, indexBuffer.Info.Size, LastBoundQueue.CurrentDeviceIndex)
     }
 }
 
@@ -346,11 +346,11 @@ sub void dovkCmdDrawIndexedIndirect(ref!vkCmdDrawIndexedIndirectArgs draw) {
   if draw.DrawCount > 0 {
     ldi := lastDrawInfo()
     readWriteMemoryInBoundGraphicsDescriptorSets()
-    readCoherentMemoryInBuffer(Buffers[draw.Buffer])
+    readCoherentMemoryInBuffer(Buffers[draw.Buffer], LastBoundQueue.CurrentDeviceIndex)
     readIndexedIndirectDrawBuffer(draw.Buffer, draw.Offset, draw.DrawCount, draw.Stride)
 
     // Read through all the vertex buffers.
-    readMemoryInCurrentPipelineBoundVertexBuffers(0xFFFFFFFF, 0xFFFFFFFF, 0, 0)
+    readMemoryInCurrentPipelineBoundVertexBuffers(0xFFFFFFFF, 0xFFFFFFFF, 0, 0, LastBoundQueue.CurrentDeviceIndex)
     clearLastDrawInfoDrawCommandParameters()
     ldi.CommandParameters.DrawIndexedIndirect = draw
   }
@@ -421,8 +421,8 @@ class vkCmdDispatchIndirectArgs {
 
 sub void readIndirectDispatchBuffer(VkBuffer buf, VkDeviceSize offset) {
   command_size := as!VkDeviceSize(12)
-  readCoherentMemoryInBuffer(Buffers[buf])
-  readMemoryInBuffer(Buffers[buf], offset, command_size)
+  readCoherentMemoryInBuffer(Buffers[buf], LastBoundQueue.CurrentDeviceIndex)
+  readMemoryInBuffer(Buffers[buf], offset, command_size, LastBoundQueue.CurrentDeviceIndex)
 }
 
 sub void dovkCmdDispatchIndirect(ref!vkCmdDispatchIndirectArgs dispatch) {
@@ -458,7 +458,8 @@ sub void readWriteMemoryInBoundGraphicsDescriptorSets() {
   readWriteMemoryInBoundDescriptorSets(
     ldi.GraphicsPipeline.UsedDescriptors,
     ldi.DescriptorSets,
-    ldi.BufferBindingOffsets)
+    ldi.BufferBindingOffsets,
+    LastBoundQueue.CurrentDeviceIndex)
 }
 
 sub void readWriteMemoryInBoundComputeDescriptorSets() {
@@ -466,7 +467,8 @@ sub void readWriteMemoryInBoundComputeDescriptorSets() {
   readWriteMemoryInBoundDescriptorSets(
     lci.ComputePipeline.UsedDescriptors,
     lci.DescriptorSets,
-    lci.BufferBindingOffsets)
+    lci.BufferBindingOffsets,
+    LastBoundQueue.CurrentDeviceIndex)
 }
 
 @internal class DynamicStateSet {

--- a/gapis/api/vulkan/api/image.api
+++ b/gapis/api/vulkan/api/image.api
@@ -374,7 +374,7 @@ sub void BindImageMemory(
                 (as!u64(level.LinearLayout.size) > as!u64(tightlyPackedSize)) {
               loffset := as!u64(memoryOffset + level.LinearLayout.offset)
               lsize := as!u64(level.LinearLayout.size)
-              level.Data = getImagePlaneMemoryInfo(imageObject, plane).BoundMemory.Data[loffset:loffset + lsize]
+              level.Data = getImagePlaneMemoryInfo(imageObject, plane).BoundMemory.DeviceGroupMemories[0].Data[loffset:loffset + lsize]
             } else {
               level.Data = make!u8(tightlyPackedSize)
             }

--- a/gapis/api/vulkan/api/memory.api
+++ b/gapis/api/vulkan/api/memory.api
@@ -40,6 +40,10 @@
 // Device memory //
 ///////////////////
 
+@internal class DeviceMemoryData {
+  @hidden @nobox @internal u8[] Data
+}
+
 @internal class DeviceMemoryObject {
   VkDevice                Device
   @unused VkDeviceMemory  VulkanHandle
@@ -50,7 +54,7 @@
   void*                   MappedLocation
   u32                     MemoryTypeIndex
   @spy_disabled
-  @hidden @nobox @internal u8[]     Data
+  dense_map!(u32, ref!DeviceMemoryData) DeviceGroupMemories
   @unused ref!VulkanDebugMarkerInfo DebugInfo
   ref!MemoryDedicatedAllocationInfo DedicatedAllocationNV
   // Vulkan 1.1 promoted from extension: VK_KHR_dedicated_allocation
@@ -83,7 +87,9 @@ cmd VkResult vkAllocateMemory(
     MappedLocation:   null,
     MemoryTypeIndex:  allocateInfo.memoryTypeIndex
   )
-  memoryObject.Data = make!u8(allocateInfo.allocationSize)
+  memoryObject.DeviceGroupMemories[0] = new!DeviceMemoryData(
+        Data: make!u8(allocateInfo.allocationSize)
+  )
 
   // Handle pNext
   if allocateInfo.pNext != null {
@@ -166,8 +172,10 @@ cmd VkResult vkMapMemory(
 
   mapMemory(memory, ppData, as!u8*(memoryLocation)[0:memoryObject.MappedSize])
   memoryObject.MappedLocation = memoryLocation
-  if (IsMemoryCoherent(memoryObject)) {
-    trackMappedCoherentMemory(as!u64(memoryObject.MappedLocation), as!size(memoryObject.MappedSize))
+  for _, j, _ in memoryObject.DeviceGroupMemories {
+    if (IsMemoryCoherent(memoryObject, j)) {
+      trackMappedCoherentMemory(as!u64(memoryObject.MappedLocation), as!size(memoryObject.MappedSize))
+    }
   }
   return ?
 }
@@ -181,9 +189,10 @@ cmd void vkUnmapMemory(
   if !(memory in DeviceMemories) { vkErrorInvalidDeviceMemory(memory) }
   memoryObject := DeviceMemories[memory]
   mappedLocation := as!u8*(memoryObject.MappedLocation)
-  if (IsMemoryCoherent(memoryObject)) {
-    readCoherentMemory(memoryObject, memoryObject.MappedOffset, memoryObject.MappedSize)
-    untrackMappedCoherentMemory(as!u64(memoryObject.MappedLocation), as!size(memoryObject.MappedSize))
+  for _, j, _ in memoryObject.DeviceGroupMemories {
+    if (IsMemoryCoherent(memoryObject, j)) {
+      trackMappedCoherentMemory(as!u64(memoryObject.MappedLocation), as!size(memoryObject.MappedSize))
+    }
   }
   unmapMemory(memory, mappedLocation[0:memoryObject.MappedSize])
   memoryObject.MappedSize = 0
@@ -218,15 +227,17 @@ cmd VkResult vkFlushMappedMemoryRanges(
     // TODO: Log errors if flush offset - mapped offset is negative or
     // flushRange.size is out of bounds.
 
-    if (IsMemoryCoherent(memoryObject)) {
-      readCoherentMemory(memoryObject, flushRange.offset, flushRange.size)
-    } else {
-      if (flushRange.size == 0xFFFFFFFFFFFFFFFF) {
-        // copy() contains an implicit read observation
-        copy(memoryObject.Data[flushRange.offset:memoryObject.MappedOffset + memoryObject.MappedSize], (mappedLocation)[flushStart:memoryObject.MappedSize])
+    for _, j, _ in memoryObject.DeviceGroupMemories {
+      if (IsMemoryCoherent(memoryObject, j)) {
+        readCoherentMemory(memoryObject, flushRange.offset, flushRange.size, j)
       } else {
-        // copy() contains an implicit read observation
-        copy(memoryObject.Data[flushRange.offset:flushRange.offset + flushRange.size], (mappedLocation)[flushStart:flushStart + flushRange.size])
+        if (flushRange.size == 0xFFFFFFFFFFFFFFFF) {
+          // copy() contains an implicit read observation
+          copy(memoryObject.DeviceGroupMemories[j].Data[flushRange.offset:memoryObject.MappedOffset + memoryObject.MappedSize], (mappedLocation)[flushStart:memoryObject.MappedSize])
+        } else {
+          // copy() contains an implicit read observation
+          copy(memoryObject.DeviceGroupMemories[j].Data[flushRange.offset:flushRange.offset + flushRange.size], (mappedLocation)[flushStart:flushStart + flushRange.size])
+        }
       }
     }
   }

--- a/gapis/api/vulkan/api/query_pool.api
+++ b/gapis/api/vulkan/api/query_pool.api
@@ -352,7 +352,7 @@ sub void dovkCmdCopyQueryPoolResults(ref!vkCmdCopyQueryPoolResultsArgs args) {
   for i in (0 .. args.QueryCount) {
     if buf != null {
       dstOffset := args.DstOffset + as!VkDeviceSize(i) * args.Stride
-      writeMemoryInBuffer(buf, dstOffset, dstSize)
+      writeMemoryInBuffer(buf, dstOffset, dstSize, LastBoundQueue.CurrentDeviceIndex)
     }
 
     query := i + args.FirstQuery

--- a/gapis/api/vulkan/api/queue.api
+++ b/gapis/api/vulkan/api/queue.api
@@ -47,6 +47,7 @@
   @unused VkQueue                                                VulkanHandle
   map!(VkEvent, ref!EventObject)                                 PendingEvents
   map!(VkSemaphore, ref!SemaphoreObject)                         PendingSemaphores
+  @unused u32                                                    CurrentDeviceIndex
   @unused ref!VulkanDebugMarkerInfo                              DebugInfo
   @untracked @untrackedMap dense_map!(u32, ref!CommandReference) PendingCommands
   @untracked @untrackedMap map!(VkBuffer, bool) ReadCoherentBuffers
@@ -69,7 +70,9 @@ cmd void vkGetDeviceQueue(
       VulkanHandle:  id)
     dev := Devices[device]
     dev.QueueObjects[len(dev.QueueObjects)] = Queues[id]
-    _ = PhysicalDevices[dev.PhysicalDevice].QueueFamilyProperties[queueFamilyIndex]
+    for _, _, d in dev.PhysicalDevices {
+      _ = PhysicalDevices[d].QueueFamilyProperties[queueFamilyIndex]
+    }
   }
   if pQueue == null { vkErrorNullPointer("VkQueue") }
   pQueue[0] = id

--- a/gapis/api/vulkan/api/queued_command_tracking.api
+++ b/gapis/api/vulkan/api/queued_command_tracking.api
@@ -42,6 +42,7 @@
 
 sub void execPendingCommands(VkQueue queue, bool isRoot) {
   q := Queues[queue]
+  q.CurrentDeviceIndex = 0
   newCmds := emptyDenseMap().m
   signaledQueues := queueMap().m
   processSubcommand := MutableBool()

--- a/gapis/api/vulkan/api/renderpass_framebuffer.api
+++ b/gapis/api/vulkan/api/renderpass_framebuffer.api
@@ -422,14 +422,14 @@ sub void loadImageAttachment(u32 attachmentID) {
     if attachment.Image != null {
       switch desc.loadOp {
         case VK_ATTACHMENT_LOAD_OP_LOAD: {
-          readCoherentMemoryInImage(attachment.Image)
-          readImageView(attachment)
+          readCoherentMemoryInImage(attachment.Image, LastBoundQueue.CurrentDeviceIndex)
+          readImageView(attachment, LastBoundQueue.CurrentDeviceIndex)
           updateImageViewQueue(attachment)
         }
         default: {
           // write to the attachment image, to prevent any dependencies on previous writes
           updateImageViewQueue(attachment)
-          writeImageView(attachment)
+          writeImageView(attachment, LastBoundQueue.CurrentDeviceIndex)
         }
       }
     }
@@ -448,7 +448,7 @@ sub void storeImageAttachment(u32 attachmentID) {
       }
       switch desc.storeOp {
         case VK_ATTACHMENT_STORE_OP_STORE: {
-          writeImageView(attachment)
+          writeImageView(attachment, LastBoundQueue.CurrentDeviceIndex)
           updateImageViewQueue(attachment)
         }
         default: {

--- a/gapis/api/vulkan/api/synchronization.api
+++ b/gapis/api/vulkan/api/synchronization.api
@@ -635,8 +635,8 @@ sub void processMemoryBarriers(VkPipelineStageFlags       srcStageMask,
       }
     }
     for _ , _ , mem in DeviceMemories {
-      read(mem.Data)
-      write(mem.Data)
+      read(mem.DeviceGroupMemories[LastBoundQueue.CurrentDeviceIndex].Data)
+      write(mem.DeviceGroupMemories[LastBoundQueue.CurrentDeviceIndex].Data)
     }
   }
 }
@@ -648,8 +648,8 @@ sub void processBufferBarriers(VkPipelineStageFlags             srcStageMask,
   for _ , _ , v in bufferBarriers {
     if !(v.buffer in Buffers) { vkErrorInvalidBuffer(v.buffer) } else {
       buf := Buffers[v.buffer]
-      readMemoryInBuffer(buf, v.offset, v.size)
-      writeMemoryInBuffer(buf, v.offset, v.size)
+      readMemoryInBuffer(buf, v.offset, v.size, LastBoundQueue.CurrentDeviceIndex)
+      writeMemoryInBuffer(buf, v.offset, v.size, LastBoundQueue.CurrentDeviceIndex)
       // TODO (#2395): transition queue family ownership
     }
   }
@@ -658,8 +658,8 @@ sub void processBufferBarriers(VkPipelineStageFlags             srcStageMask,
 @spy_disabled
 sub void processImageBarrier(VkImageMemoryBarrier v, ref!ImageObject image) {
   if v.oldLayout != VK_IMAGE_LAYOUT_UNDEFINED {
-    readImageSubresource(image, v.subresourceRange)
+    readImageSubresource(image, v.subresourceRange, LastBoundQueue.CurrentDeviceIndex)
   }
-  writeImageSubresource(image, v.subresourceRange)
+  writeImageSubresource(image, v.subresourceRange, LastBoundQueue.CurrentDeviceIndex)
   // TODO (#2395): transition queue family ownership
 }

--- a/gapis/api/vulkan/custom_replay.go
+++ b/gapis/api/vulkan/custom_replay.go
@@ -840,6 +840,10 @@ func (a *ReplayAllocateImageMemory) Mutate(ctx context.Context, id api.CmdID, s 
 	imageHeight := imageObject.Info().Extent().Height()
 	imageFormat, err := getImageFormatFromVulkanFormat(imageObject.Info().Fmt())
 	imageSize := VkDeviceSize(imageFormat.Size(int(imageWidth), int(imageHeight), 1))
+	// TODO(awoloszyn): mGPU
+	memoryData := NewU32ːDeviceMemoryDataʳDense_ᵐ(arena)
+	memoryData.Add(0, NewDeviceMemoryDataʳ(arena,
+		MakeU8ˢ(uint64(imageSize), s)))
 	memoryObject := NewDeviceMemoryObjectʳ(arena,
 		a.Device(),                        // Device
 		memory,                            // VulkanHandle
@@ -849,7 +853,7 @@ func (a *ReplayAllocateImageMemory) Mutate(ctx context.Context, id api.CmdID, s 
 		0,                                 // MappedSize
 		0,                                 // MappedLocation
 		0,                                 // MemoryTypeIndex
-		MakeU8ˢ(uint64(imageSize), s),     // Data
+		memoryData,                        // Data
 		NilVulkanDebugMarkerInfoʳ,         // DebugInfo
 		NilMemoryDedicatedAllocationInfoʳ, // DedicatedAllocationNV
 		NilMemoryDedicatedAllocationInfoʳ, // DedicatedAllocationKHR

--- a/gapis/api/vulkan/draw_call_mesh.go
+++ b/gapis/api/vulkan/draw_call_mesh.go
@@ -195,7 +195,8 @@ func getIndicesData(ctx context.Context, s *api.GlobalState, thread uint64, boun
 		// In the order of the offsets in the buffer
 		for _, bufOffset := range backingMemoryPieces.Keys() {
 			piece := backingMemoryPieces.Get(bufOffset)
-			data, err := piece.DeviceMemory().Data().Slice(
+			// TODO(awoloszyn): mGPU
+			data, err := piece.DeviceMemory().DeviceGroupMemories().Get(0).Data().Slice(
 				uint64(piece.MemoryOffset()),
 				uint64(piece.MemoryOffset()+piece.Size())).Read(ctx, nil, s, nil)
 			if err != nil {
@@ -351,7 +352,8 @@ func getVerticesData(ctx context.Context, s *api.GlobalState, thread uint64,
 	for _, bo := range backingMemoryPieces.Keys() {
 		ds := uint64(backingMemoryPieces.Get(bo).MemoryOffset())
 		de := uint64(backingMemoryPieces.Get(bo).Size()) + ds
-		data, err := backingMemoryPieces.Get(bo).DeviceMemory().Data().Slice(ds, de).Read(ctx, nil, s, nil)
+		// TODO(awoloszyn): mGPU
+		data, err := backingMemoryPieces.Get(bo).DeviceMemory().DeviceGroupMemories().Get(0).Data().Slice(ds, de).Read(ctx, nil, s, nil)
 		if err != nil {
 			return nil, err
 		}

--- a/gapis/api/vulkan/extensions/khr_swapchain.api
+++ b/gapis/api/vulkan/extensions/khr_swapchain.api
@@ -311,7 +311,8 @@ cmd VkResult vkQueuePresentKHR(
         levelCount:      image.Info.MipLevels,
         baseArrayLayer:  0,
         layerCount:      image.Info.ArrayLayers)
-    readImageSubresource(image, rng)
+    //TODO(awoloszyn): MultiGPU: Fix this
+    readImageSubresource(image, rng, 0)
     updateImageQueue(image, rng)
     LastPresentInfo.PresentImages[LastPresentInfo.PresentImageCount] =
     image

--- a/gapis/api/vulkan/externs.go
+++ b/gapis/api/vulkan/externs.go
@@ -193,7 +193,9 @@ func (e externs) unmapMemory(handle VkDeviceMemory, slice memory.Slice) {
 }
 
 func (e externs) trackMappedCoherentMemory(start uint64, size memory.Size) {}
-func (e externs) readMappedCoherentMemory(memoryHandle VkDeviceMemory, offsetInMapped uint64, readSize memory.Size) {
+
+// TODO(awoloszyn): mGPU
+func (e externs) readMappedCoherentMemory(memoryHandle VkDeviceMemory, offsetInMapped uint64, readSize memory.Size, deviceIndex uint32) {
 	l := e.s.MemoryLayout
 	mem := GetState(e.s).DeviceMemoriesʷ(e.ctx, e.w, true).Getʷ(e.ctx, e.w, true, memoryHandle)
 	mappedOffset := uint64(mem.MappedOffsetʷ(e.ctx, e.w, true))
@@ -204,8 +206,9 @@ func (e externs) readMappedCoherentMemory(memoryHandle VkDeviceMemory, offsetInM
 	absSrcMemRng := memory.Range{Base: absSrcStart, Size: uint64(readSize)}
 
 	writeRngList := e.s.Memory.ApplicationPool().Slice(absSrcMemRng).ValidRanges()
+	// TODO(awoloszyn): mGPU
 	for _, r := range writeRngList {
-		mem.Dataʷ(e.ctx, e.w, true).Slice(dstStart+r.Base, dstStart+r.Base+r.Size).
+		mem.DeviceGroupMemoriesʷ(e.ctx, e.w, true).Getʷ(e.ctx, e.w, true, 0).Dataʷ(e.ctx, e.w, true).Slice(dstStart+r.Base, dstStart+r.Base+r.Size).
 			Copy(e.ctx, U8ᵖ(mem.MappedLocationʷ(e.ctx, e.w, true)).Slice(srcStart+r.Base, srcStart+r.Base+r.Size, l), e.cmd, e.s, e.b, e.w)
 	}
 }

--- a/gapis/api/vulkan/image_primer.go
+++ b/gapis/api/vulkan/image_primer.go
@@ -97,7 +97,8 @@ func (p *imagePrimer) allocStagingImages(img ImageObjectʳ, aspect VkImageAspect
 	stagingInfo.SetUsage(VkImageUsageFlags(VkImageUsageFlagBits_VK_IMAGE_USAGE_TRANSFER_DST_BIT | VkImageUsageFlagBits_VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT | VkImageUsageFlagBits_VK_IMAGE_USAGE_SAMPLED_BIT))
 
 	dev := p.sb.s.Devices().Get(img.Device())
-	phyDevMemProps := p.sb.s.PhysicalDevices().Get(dev.PhysicalDevice()).MemoryProperties()
+	//TODO(awoloszyn): mGpu
+	phyDevMemProps := p.sb.s.PhysicalDevices().Get(dev.PhysicalDevices().Get(0)).MemoryProperties()
 	// TODO: Handle multi-planar images
 	memInfo, _ := subGetImagePlaneMemoryInfo(p.sb.ctx, nil, api.CmdNoID, nil, p.sb.oldState, GetState(p.sb.oldState), 0, nil, nil, img, VkImageAspectFlagBits(0))
 	memRequirement := memInfo.MemoryRequirements()
@@ -284,7 +285,8 @@ func (h *ipStoreHandler) store(job *ipStoreJob, queue VkQueue) error {
 
 	dev := job.storeTarget.Device()
 
-	phyDev := h.sb.s.Devices().Get(dev).PhysicalDevice()
+	// TODO(awoloszyn): mGPU
+	phyDev := h.sb.s.Devices().Get(dev).PhysicalDevices().Get(0)
 	maxTexelBufferElements := uint32(specMaxTexelBufferElements)
 	if h.sb.s.PhysicalDevices().Get(phyDev).PhysicalDeviceProperties().Limits().MaxTexelBufferElements() > specMaxTexelBufferElements {
 		maxTexelBufferElements = h.sb.s.PhysicalDevices().Get(phyDev).PhysicalDeviceProperties().Limits().MaxTexelBufferElements()

--- a/gapis/api/vulkan/memory_breakdown.go
+++ b/gapis/api/vulkan/memory_breakdown.go
@@ -289,7 +289,8 @@ func (s *State) getMemoryTypeFlags(device VkDevice, typeIndex uint32) (VkMemoryP
 	if deviceObject.IsNil() {
 		return VkMemoryPropertyFlags(0), fmt.Errorf("Failed to find device %v", device)
 	}
-	physicalDevice := deviceObject.PhysicalDevice()
+	// TODO(awoloszyn): mGPU
+	physicalDevice := deviceObject.PhysicalDevices().Get(0)
 	physicalDeviceObject := s.PhysicalDevices().Get(physicalDevice)
 	if physicalDeviceObject.IsNil() {
 		return VkMemoryPropertyFlags(0), fmt.Errorf("Failed to find physical device %v", physicalDevice)

--- a/gapis/api/vulkan/overdraw.go
+++ b/gapis/api/vulkan/overdraw.go
@@ -444,7 +444,8 @@ func (s *stencilOverdraw) getBestStencilFormat(ctx context.Context,
 	preferred VkFormat,
 ) (VkFormat, error) {
 	deviceInfo := st.Devices().Get(device)
-	physicalDeviceInfo := st.PhysicalDevices().Get(deviceInfo.PhysicalDevice())
+	//TODO(awoloszyn): mGpu
+	physicalDeviceInfo := st.PhysicalDevices().Get(deviceInfo.PhysicalDevices().Get(0))
 	formatProps := physicalDeviceInfo.FormatProperties()
 	// It should have an entry for every format
 	if !formatProps.Contains(VkFormat_VK_FORMAT_UNDEFINED) {
@@ -617,11 +618,12 @@ func (*stencilOverdraw) createImage(ctx context.Context,
 		return stencilImage{}, fmt.Errorf("Invalid device %v",
 			device)
 	}
+	// TODO(awoloszyn): mGPU
 	physicalDeviceInfo, ok := st.PhysicalDevices().Lookup(
-		deviceInfo.PhysicalDevice())
+		deviceInfo.PhysicalDevices().Get(0))
 	if !ok {
 		return stencilImage{}, fmt.Errorf("Invalid physical device %v",
-			deviceInfo.PhysicalDevice())
+			deviceInfo.PhysicalDevices().Get(0))
 	}
 	physicalDeviceMemoryPropertiesData := alloc(physicalDeviceInfo.MemoryProperties())
 
@@ -1352,9 +1354,11 @@ func (*stencilOverdraw) createDepthCopyBuffer(ctx context.Context,
 	bufferInfoData := alloc(bufferInfo)
 
 	bufferMemoryTypeIndex := uint32(0)
+	// TODO(awoloszyn): mGPU
 	physicalDevice := st.PhysicalDevices().Get(
-		st.Devices().Get(device).PhysicalDevice(),
+		st.Devices().Get(device).PhysicalDevices().Get(0),
 	)
+
 	for i := uint32(0); i < physicalDevice.MemoryProperties().MemoryTypeCount(); i++ {
 		t := physicalDevice.MemoryProperties().MemoryTypes().Get(int(i))
 		if 0 != (t.PropertyFlags() & VkMemoryPropertyFlags(

--- a/gapis/api/vulkan/query_timestamps.go
+++ b/gapis/api/vulkan/query_timestamps.go
@@ -458,7 +458,8 @@ func (t *queryTimestamps) Transform(ctx context.Context, id api.CmdID, cmd api.C
 		queueFamilyIndex := queue.Family()
 		vkDevice := queue.Device()
 		device := GetState(s).Devices().Get(vkDevice)
-		vkPhysicalDevice := device.PhysicalDevice()
+		// TODO(awoloszyn): mGPU
+		vkPhysicalDevice := device.PhysicalDevices().Get(0)
 		physicalDevice := GetState(s).PhysicalDevices().Get(vkPhysicalDevice)
 		timestampPeriod := physicalDevice.PhysicalDeviceProperties().Limits().TimestampPeriod()
 

--- a/gapis/api/vulkan/read_framebuffer.go
+++ b/gapis/api/vulkan/read_framebuffer.go
@@ -279,7 +279,8 @@ func postImageData(ctx context.Context,
 	vkQueue := queue.VulkanHandle()
 	vkDevice := queue.Device()
 	device := GetState(s).Devices().Get(vkDevice)
-	vkPhysicalDevice := device.PhysicalDevice()
+	// TODO(awoloszyn): mGPU
+	vkPhysicalDevice := device.PhysicalDevices().Get(0)
 	physicalDevice := GetState(s).PhysicalDevices().Get(vkPhysicalDevice)
 
 	if properties, ok := physicalDevice.QueueFamilyProperties().Lookup(queue.Family()); ok {

--- a/gapis/api/vulkan/state.go
+++ b/gapis/api/vulkan/state.go
@@ -104,7 +104,8 @@ func (st *State) getPresentAttachmentInfo(attachment api.FramebufferAttachment) 
 			queue := st.Queues().Get(st.LastPresentInfo().Queue())
 			vkDevice := queue.Device()
 			device := st.Devices().Get(vkDevice)
-			vkPhysicalDevice := device.PhysicalDevice()
+			// TODO(awoloszyn): mGPU
+			vkPhysicalDevice := device.PhysicalDevices().Get(0)
 			physicalDevice := st.PhysicalDevices().Get(vkPhysicalDevice)
 			if properties, ok := physicalDevice.QueueFamilyProperties().Lookup(queue.Family()); ok {
 				if properties.QueueFlags()&VkQueueFlags(VkQueueFlagBits_VK_QUEUE_GRAPHICS_BIT) != 0 {

--- a/gapis/api/vulkan/state_rebuilder.go
+++ b/gapis/api/vulkan/state_rebuilder.go
@@ -698,7 +698,7 @@ func (sb *stateBuilder) createDevice(d DeviceObjectʳ) {
 	}
 
 	sb.write(sb.cb.VkCreateDevice(
-		d.PhysicalDevice(),
+		d.PhysicalDevices().Get(0),
 		sb.MustAllocReadData(NewVkDeviceCreateInfo(sb.ta,
 			VkStructureType_VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO, // sType
 			NewVoidᶜᵖ(pNext),                   // pNext
@@ -969,7 +969,8 @@ func (sb *stateBuilder) createDeviceMemory(mem DeviceMemoryObjectʳ, allowDedica
 }
 
 func (sb *stateBuilder) GetScratchBufferMemoryIndex(device DeviceObjectʳ) uint32 {
-	physicalDeviceObject := sb.s.PhysicalDevices().Get(device.PhysicalDevice())
+	//TODO(awoloszyn):mGPU
+	physicalDeviceObject := sb.s.PhysicalDevices().Get(device.PhysicalDevices().Get(0))
 
 	typeBits := uint32((uint64(1) << uint64(physicalDeviceObject.MemoryProperties().MemoryTypeCount())) - 1)
 	if sb.s.TransferBufferMemoryRequirements().Contains(device.VulkanHandle()) {
@@ -1064,7 +1065,8 @@ func (sb *stateBuilder) getQueueFor(queueFlagBits VkQueueFlagBits, queueFamilyIn
 	}
 	flagPass := func(q QueueObjectʳ) bool {
 		dev := sb.s.Devices().Get(q.Device())
-		phyDev := sb.s.PhysicalDevices().Get(dev.PhysicalDevice())
+		// TODO(awoloszyn): mGPU
+		phyDev := sb.s.PhysicalDevices().Get(dev.PhysicalDevices().Get(0))
 		familyProp := phyDev.QueueFamilyProperties().Get(q.Family())
 		if uint32(familyProp.QueueFlags())&uint32(queueFlagBits) != 0 {
 			return true
@@ -1232,7 +1234,8 @@ func (sb *stateBuilder) createBuffer(buffer BufferObjectʳ) {
 		if sparseResidency || IsFullyBound(0, buffer.Info().Size(), buffer.SparseMemoryBindings()) {
 			for _, bind := range buffer.SparseMemoryBindings().All() {
 				size := bind.Size()
-				dataSlice := sb.s.DeviceMemories().Get(bind.Memory()).Data().Slice(
+				// TODO(awoloszyn): mGPU
+				dataSlice := sb.s.DeviceMemories().Get(bind.Memory()).DeviceGroupMemories().Get(0).Data().Slice(
 					uint64(bind.MemoryOffset()),
 					uint64(bind.MemoryOffset()+size))
 				contents = append(contents, newBufferSubRangeFillInfoFromSlice(sb, dataSlice, uint64(offset)))
@@ -1260,7 +1263,8 @@ func (sb *stateBuilder) createBuffer(buffer BufferObjectʳ) {
 		))
 
 		size := buffer.Info().Size()
-		dataSlice := buffer.Memory().Data().Slice(
+		// TODO(awoloszyn): mGPU
+		dataSlice := buffer.Memory().DeviceGroupMemories().Get(0).Data().Slice(
 			uint64(buffer.MemoryOffset()),
 			uint64(buffer.MemoryOffset()+size))
 		contents = append(contents, newBufferSubRangeFillInfoFromSlice(sb, dataSlice, uint64(offset)))

--- a/gapis/api/vulkan/synthetic.api
+++ b/gapis/api/vulkan/synthetic.api
@@ -40,7 +40,8 @@ cmd VkResult ReplayCreateVkDevice(
   // vkCreateDevice() in vulkan.api. Change both together.
 
   device := createDeviceObject(pCreateInfo)
-  device.PhysicalDevice = physicalDevice
+  // TODO(awoloszyn): mGPU
+  device.PhysicalDevices[0] = physicalDevice
 
   handle := ?
   if pDevice == null {vkErrorNullPointer("VkDevice")}

--- a/gapis/api/vulkan/templates/vk_spy_helpers.cpp.tmpl
+++ b/gapis/api/vulkan/templates/vk_spy_helpers.cpp.tmpl
@@ -110,7 +110,7 @@ PFN_vkVoidFunction VulkanSpy::SpyOverride_vkGetDeviceProcAddr(VkDevice device, c
     {{end}}
     // This is not strictly correct, but some applications incorrectly
     // call vkGetDeviceProcAddr, when they actually mean vkGetInstanceProcAddr.
-    PFN_vkVoidFunction f = SpyOverride_vkGetInstanceProcAddr(mState.PhysicalDevices[mState.Devices[device]->mPhysicalDevice]->mInstance, pName);
+    PFN_vkVoidFunction f = SpyOverride_vkGetInstanceProcAddr(mState.PhysicalDevices[mState.Devices[device]->mPhysicalDevices[0]]->mInstance, pName);
 
     // If we do not support the function as an instance function OR a device function, then defer to the actual device.
     // It is likely that this will cause a failure in the future, as we will miss any state

--- a/gapis/api/vulkan/vulkan.api
+++ b/gapis/api/vulkan/vulkan.api
@@ -101,7 +101,7 @@ import "errors.api"
 extern void mapMemory(VkDeviceMemory handle, void** mem, u8[] slice)
 extern void unmapMemory(VkDeviceMemory handle, u8[] slice)
 extern void trackMappedCoherentMemory(u64 start, size size)
-extern void readMappedCoherentMemory(VkDeviceMemory memory, u64 offset_in_mapped, size readSize)
+extern void readMappedCoherentMemory(VkDeviceMemory memory, u64 offset_in_mapped, size readSize, u32 deviceIndex)
 extern void untrackMappedCoherentMemory(u64 start, size size)
 extern bool hasDynamicProperty(const VkPipelineDynamicStateCreateInfo* info, VkDynamicState state)
 extern void notifyPendingCommandAdded(VkQueue queue)
@@ -429,7 +429,7 @@ sub ref!PushConstantInfo lastPushConstants() {
   if LastBoundQueue != null {
     if !(LastBoundQueue.VulkanHandle in LastPushConstants) {
       dev := Devices[LastBoundQueue.Device]
-      physDev := PhysicalDevices[dev.PhysicalDevice]
+      physDev := PhysicalDevices[dev.PhysicalDevices[LastBoundQueue.CurrentDeviceIndex]]
       LastPushConstants[LastBoundQueue.VulkanHandle] = new!PushConstantInfo(make!u8(physDev.PhysicalDeviceProperties.limits.maxPushConstantsSize))
     }
   }


### PR DESCRIPTION
This is the first set of refactorings necessary to handle mGPU support
in Vulkan 1.1. This abstracts out VkDeviceMemory and VkPhysicalDevices
into multiple copies.

We still have to handle multiple Queue context / descriptors / etc.
We also have to still handle memory for images.