### PR TITLE
Vulkan: Remove false memory accesses in non-updated coherent memory

### DIFF
--- a/gapis/api/vulkan/externs.go
+++ b/gapis/api/vulkan/externs.go
@@ -200,12 +200,6 @@ func (e externs) readMappedCoherentMemory(memoryHandle VkDeviceMemory, offsetInM
 		mem.Dataʷ(e.ctx, e.w, true).Slice(dstStart+r.Base, dstStart+r.Base+r.Size).
 			Copy(e.ctx, U8ᵖ(mem.MappedLocationʷ(e.ctx, e.w, true)).Slice(srcStart+r.Base, srcStart+r.Base+r.Size, l), e.cmd, e.s, e.b, e.w)
 	}
-	if e.w != nil {
-		dstSlice := mem.Dataʷ(e.ctx, e.w, true).Slice(dstStart, dstStart+uint64(readSize))
-		srcSlice := U8ᵖ(mem.MappedLocationʷ(e.ctx, e.w, true)).Slice(srcStart, srcStart+uint64(readSize), l)
-		e.w.OnReadSlice(e.ctx, srcSlice)
-		e.w.OnWriteSlice(e.ctx, dstSlice)
-	}
 }
 func (e externs) untrackMappedCoherentMemory(start uint64, size memory.Size) {}
 


### PR DESCRIPTION
This can occur when memory is mapped coherently, but gapii doesn't observe any
application writes to the mapped memory.

Recording a WRITE to the device memory regions that weren't not actually updated
is problematic since it can hide writes by earlier commands that actually did
write to these memory regions.