### PR TITLE
Fix JDWP interception to work if debug names are missing.

### DIFF
--- a/core/java/jdbg/value.go
+++ b/core/java/jdbg/value.go
@@ -97,3 +97,9 @@ func (v Value) SetArrayValues(values interface{}) {
 		j.fail("Failed to set array (type %s) values (type %T): %v", arrayTy, values, err)
 	}
 }
+
+// Variable is a named Value.
+type Variable struct {
+	Value    Value
+	variable jdwp.VariableRequest
+}

--- a/core/java/jdwp/types.go
+++ b/core/java/jdwp/types.go
@@ -14,7 +14,10 @@
 
 package jdwp
 
-import "fmt"
+import (
+	"fmt"
+	"sort"
+)
 
 // TaggedObjectID is a type and object identifier pair.
 type TaggedObjectID struct {
@@ -146,3 +149,19 @@ func (i ArrayTypeID) String() string     { return fmt.Sprintf("ArrayTypeID<%d>",
 func (i MethodID) String() string        { return fmt.Sprintf("MethodID<%d>", uint64(i)) }
 func (i FieldID) String() string         { return fmt.Sprintf("FieldID<%d>", uint64(i)) }
 func (i FrameID) String() string         { return fmt.Sprintf("FrameID<%d>", uint64(i)) }
+
+// ArgumentSlots returns the slots that could possibly be method arguments.
+// Slots that could be method arguments are slots that are acessible at
+// location 0 and have a length > 0. Returns the result sorted by slot index.
+func (v *VariableTable) ArgumentSlots() []FrameVariable {
+	r := []FrameVariable{}
+	for _, slot := range v.Slots {
+		if slot.CodeIndex == 0 && slot.Length > 0 {
+			r = append(r, slot)
+		}
+	}
+	sort.Slice(r, func(i, j int) bool {
+		return r[i].Slot < r[j].Slot
+	})
+	return r
+}


### PR DESCRIPTION
We currently lookup an argument to one of the breakpointed methods by name. However, if the debug info is stripped, the names returned by the JVM debugger are all the empty string. This change makes it possible to look for arguments by index as well. This depends on the fact that the Android debugger always labels the "this" argument with a name[0] and that the arguments are stored in successive slots in the DEX[1].

[0] [libdexfile/dex/dex_file-inl.h:236](https://android.googlesource.com/platform/art/+/39d8c873645df7c956bf306693d95212d1d51906/libdexfile/dex/dex_file-inl.h#236)
[1]  [libdexfile/dex/dex_file-inl.h:254+](https://android.googlesource.com/platform/art/+/39d8c873645df7c956bf306693d95212d1d51906/libdexfile/dex/dex_file-inl.h#254)