### PR TITLE
Get the actually used descriptors during trace.

### DIFF
--- a/gapii/cc/BUILD.bazel
+++ b/gapii/cc/BUILD.bazel
@@ -156,6 +156,7 @@ cc_library(
         "//gapis/capture:capture_cc_proto",
         "//gapis/memory/memory_pb:memory_pb_cc_proto",
         "@com_google_protobuf//:protobuf",
+        "@spirv_reflect//:spirv-reflect",
     ],
     alwayslink = True,
 )

--- a/gapii/cc/vulkan_extras.inc
+++ b/gapii/cc/vulkan_extras.inc
@@ -98,3 +98,7 @@ void serializeGPUBuffers(StateSerializer* serializer);
 void walkImageSubRng(
     gapil::Ref<ImageObject> img, VkImageSubresourceRange rng,
     std::function<void(uint32_t aspect_bit, uint32_t layer, uint32_t level)> f);
+
+void parseShaderModule(
+    StageData* stage,
+    gapil::Ref<DescriptorInfo>& descriptors);

--- a/gapis/api/templates/mutate.go.tmpl
+++ b/gapis/api/templates/mutate.go.tmpl
@@ -106,9 +106,14 @@
       ϟw api.StateWatcher, §
       {{ForEach $.CallParameters "NameAndType" | JoinWith ", "}} §
     ) ({{if not (IsVoid $.Return.Type)}}{{Template "Go.Type" $.Return.Type}}, {{end}}error) {
-    ϟl, ϟa := ϟg.MemoryLayout, ϟg.Arena; _, _ = ϟl, ϟa
-    {{Global "CurrentFunction" $}}
-    {{Template "Block" $.Block}}
+    {{if (GetAnnotation ($) "server_disabled")}}
+      // @server_disabled
+      return nil
+    {{else}}
+      ϟl, ϟa := ϟg.MemoryLayout, ϟg.Arena; _, _ = ϟl, ϟa
+      {{Global "CurrentFunction" $}}
+      {{Template "Block" $.Block}}
+    {{end}}
   }
 {{end}}
 

--- a/gapis/api/vulkan/api/coherent_memory.api
+++ b/gapis/api/vulkan/api/coherent_memory.api
@@ -90,6 +90,21 @@ sub void writeMemoryInBuffer(ref!BufferObject buffer, VkDeviceSize offset, VkDev
 }
 
 // VkDescriptorBufferInfo binding
+sub void readCoherentMemoryInBufferBindings(map!(u32, ref!VkDescriptorBufferInfo) bufferBindings) {
+  n := len(bufferBindings)
+  rcb := LastBoundQueue.ReadCoherentBuffers
+  for i in (0 .. n) {
+    descBufferInfo := bufferBindings[as!u32(i)]
+    if descBufferInfo.Buffer != as!VkBuffer(0) {
+      if !(descBufferInfo.Buffer in rcb) {
+        if (descBufferInfo.Buffer in Buffers) {
+          rcb[descBufferInfo.Buffer] = true
+          readCoherentMemoryInBuffer(Buffers[descBufferInfo.Buffer])
+        }
+      }
+    }
+  }
+}
 
 @spy_disabled
 sub void readMemoryInBufferBindings(map!(u32, ref!VkDescriptorBufferInfo) bufferBindings, map!(u32, VkDeviceSize) bufferBindingOffsets) {
@@ -130,6 +145,20 @@ sub void writeMemoryInBufferBindings(map!(u32, ref!VkDescriptorBufferInfo) buffe
 }
 
 // VkBufferView binding
+sub void readCoherentMemoryInBufferViewBindings(map!(u32, VkBufferView) bufferViews) {
+  rcb := LastBoundQueue.ReadCoherentBuffers
+  for _, _, v in bufferViews {
+    if v in BufferViews {
+      view := BufferViews[v]
+      if !(view.Buffer.VulkanHandle in rcb) {
+        if (view.Buffer.VulkanHandle in Buffers) {
+          LastBoundQueue.ReadCoherentBuffers[view.Buffer.VulkanHandle] = true
+          readCoherentMemoryInBuffer(view.Buffer)
+        }
+      }
+    }
+  }
+}
 
 @spy_disabled
 sub void readMemoryInBufferViewBindings(map!(u32, VkBufferView) bufferViews) {
@@ -299,8 +328,20 @@ sub void updateImageViewQueue(ref!ImageViewObject view) {
 
 // VkImageViews used as Framebuffer attachments are handled in
 // renderpass_framebuffer.api
-
-// VkDescriptorImageInfo bindings, should only be called in subcommands
+@server_disabled
+sub void readCoherentMemoryInImageBindings(map!(u32, ref!VkDescriptorImageInfo) imageBindings) {
+  for _, _, v in imageBindings {
+    _ = Samplers[v.Sampler]
+    if v.ImageView != as!VkImageView(0) {
+      if (v.ImageView in ImageViews) {
+        view := ImageViews[v.ImageView]
+        updateImageViewQueue(view)
+        imageObj := view.Image
+        readCoherentMemoryInImage(imageObj)
+      }
+    }
+  }
+}
 
 @spy_disabled
 sub void readMemoryInImageBindings(map!(u32, ref!VkDescriptorImageInfo) imageBindings) {
@@ -330,69 +371,80 @@ sub void writeMemoryInImageBindings(map!(u32, ref!VkDescriptorImageInfo) imageBi
   }
 }
 
-
-///////////////////
-// DescriptorSet //
-///////////////////
-
-@spy_disabled
-sub void readMemoryInDescriptorSet(ref!DescriptorSetObject descriptor_set, map!(u32, map!(u32, VkDeviceSize)) bufferBindingOffsets, bool processImages) {
+@server_disabled
+sub void readCoherentMemoryInDescriptor(ref!DescriptorSetObject descriptor_set, u32 b, u32 arrayCount) {
   if descriptor_set != null {
-    for _, i, binding in descriptor_set.Bindings {
-      if binding != null {
-        switch binding.BindingType {
-          case
-            VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
-            VK_DESCRIPTOR_TYPE_STORAGE_BUFFER,
-            VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC,
-            VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC:
-              if as!u32(i) in bufferBindingOffsets {
-                readMemoryInBufferBindings(binding.BufferBinding, bufferBindingOffsets[as!u32(i)])
-              } else {
-                readMemoryInBufferBindings(binding.BufferBinding, null)
-              }
-          case VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER,
-            VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER:
-              readMemoryInBufferViewBindings(binding.BufferViewBindings)
-          case
-            VK_DESCRIPTOR_TYPE_SAMPLER,
-            VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
-            VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE,
-            VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
-            VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT:
-            if (processImages) {
-              readMemoryInImageBindings(binding.ImageBinding)
-            }
-          default: {}
-        }
+    binding := descriptor_set.Bindings[b]
+    if binding != null {
+      switch binding.BindingType {
+        case
+          VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
+          VK_DESCRIPTOR_TYPE_STORAGE_BUFFER,
+          VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC,
+          VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC:
+            readCoherentMemoryInBufferBindings(binding.BufferBinding)
+        case VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER,
+          VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER:
+            readCoherentMemoryInBufferViewBindings(binding.BufferViewBindings)
+        case
+          VK_DESCRIPTOR_TYPE_SAMPLER,
+          VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
+          VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE,
+          VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
+          VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT:
+          readCoherentMemoryInImageBindings(binding.ImageBinding)
+        default: {}
       }
     }
   }
 }
 
+///////////////////
+// DescriptorSet //
+///////////////////
+@psy_disabled
+sub void readMemoryInDescriptor(ref!DescriptorSetObject descriptor_set, u32 b, u32 arrayCount, map!(u32, VkDeviceSize) bufferBindingOffsets) {
+  if descriptor_set != null {
+    binding := descriptor_set.Bindings[b]
+    if binding != null {
+      switch binding.BindingType {
+        case
+          VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
+          VK_DESCRIPTOR_TYPE_STORAGE_BUFFER,
+          VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC,
+          VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC:
+            readMemoryInBufferBindings(binding.BufferBinding, bufferBindingOffsets)
+        case VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER,
+          VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER:
+            readMemoryInBufferViewBindings(binding.BufferViewBindings)
+        case
+          VK_DESCRIPTOR_TYPE_SAMPLER,
+          VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
+          VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE,
+          VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
+          VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT:
+          readMemoryInImageBindings(binding.ImageBinding)
+        default: {}
+      }
+    }
+  }
+}
 
 @spy_disabled
-sub void writeMemoryInDescriptorSet(ref!DescriptorSetObject descriptor_set, map!(u32, map!(u32, VkDeviceSize)) bufferBindingOffsets, bool processImages) {
+sub void writeMemoryInDescriptor(ref!DescriptorSetObject descriptor_set, u32 b, u32 arrayCount, map!(u32, VkDeviceSize) bufferBindingOffsets) {
   if descriptor_set != null {
-    for _, i, binding in descriptor_set.Bindings {
-      if binding != null {
-        switch binding.BindingType {
-          case
-            VK_DESCRIPTOR_TYPE_STORAGE_BUFFER,
-            VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC:
-              if as!u32(i) in bufferBindingOffsets {
-                writeMemoryInBufferBindings(binding.BufferBinding, bufferBindingOffsets[as!u32(i)])
-              } else {
-                writeMemoryInBufferBindings(binding.BufferBinding, null)
-              }
-          case VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER:
-              writeMemoryInBufferViewBindings(binding.BufferViewBindings)
-          case VK_DESCRIPTOR_TYPE_STORAGE_IMAGE:
-            if (processImages) {
-              writeMemoryInImageBindings(binding.ImageBinding)
-            }
-          default: {}
-        }
+    binding := descriptor_set.Bindings[b]
+    if binding != null {
+      switch binding.BindingType {
+        case
+          VK_DESCRIPTOR_TYPE_STORAGE_BUFFER,
+          VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC:
+            writeMemoryInBufferBindings(binding.BufferBinding, bufferBindingOffsets)
+        case VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER:
+            writeMemoryInBufferViewBindings(binding.BufferViewBindings)
+        case VK_DESCRIPTOR_TYPE_STORAGE_IMAGE:
+            writeMemoryInImageBindings(binding.ImageBinding)
+        default: {}
       }
     }
   }
@@ -405,67 +457,42 @@ sub void writeMemoryInDescriptorSet(ref!DescriptorSetObject descriptor_set, map!
 
 // Bound descriptor sets
 
-@spy_disabled
 sub void readWriteMemoryInBoundDescriptorSets(
-    ref!PipelineLayoutObject pipelineLayout,
+    map!(u32, DescriptorUsage) usedDescriptors,
     map!(u32, ref!DescriptorSetObject) descriptorSets,
     map!(u32, map!(u32, map!(u32, VkDeviceSize))) bufferBindingOffsets) {
-  layerCount := len(pipelineLayout.SetLayouts)
-  for i in (0 .. layerCount) {
-    descriptorSet := descriptorSets[as!u32(i)]
-    if descriptorSet != null {
-      if !(descriptorSet.VulkanHandle in LastBoundDescriptorSetsBufferInfo) {
-        offsets := bufferBindingOffsets[as!u32(i)]
-        readMemoryInDescriptorSet(descriptorSet, offsets, true)
-        writeMemoryInDescriptorSet(descriptorSet, offsets, true)
 
-        descriptors := new!BoundDescriptorSetBufferInfo()
-        descriptors.shouldReadBuffers = false
-        newOffsets := descriptors.bufferOffsets
-        for _, j, jj in offsets {
-          for _, k, v in jj {
-            if (!newOffsets[j][k][v]) {
-              x := newOffsets[j]
-              y := x[k]
-              y[v] = true
-              x[k] = y
-              newOffsets[j] = x
-            }
-
-          }
-        }
-        descriptors.bufferOffsets = newOffsets
-        LastBoundDescriptorSetsBufferInfo[descriptorSet.VulkanHandle] = descriptors
-      } else if LastBoundDescriptorSetsBufferInfo[descriptorSet.VulkanHandle].shouldReadBuffers {
-        offsets := bufferBindingOffsets[as!u32(i)]
-        readMemoryInDescriptorSet(descriptorSet, offsets, false)
-        writeMemoryInDescriptorSet(descriptorSet, offsets, false)
-
-        descriptors := LastBoundDescriptorSetsBufferInfo[descriptorSet.VulkanHandle]
-        descriptors.shouldReadBuffers = false
-        newOffsets := descriptors.bufferOffsets
-        for _, j, jj in offsets {
-          for _, k, v in jj {
-            if (!newOffsets[j][k][v]) {
-              x := newOffsets[j]
-              y := x[k]
-              y[v] = true
-              x[k] = y
-              newOffsets[j] = x
-            }
-          }
-        }
-        descriptors.bufferOffsets = newOffsets
-        LastBoundDescriptorSetsBufferInfo[descriptorSet.VulkanHandle] = descriptors
+  for _, _, desc in usedDescriptors {
+    if !(desc.Set in descriptorSets) { vkErrInvalidDescriptorArrayElement(as!u64(desc.Set), desc.Binding, desc.DescriptorCount) } else {
+      descriptorSet := descriptorSets[desc.Set]
+      if descriptorSet != null {
+        offsets := bufferBindingOffsets[desc.Set]
+        readCoherentMemoryInDescriptor(descriptorSet, desc.Binding, desc.DescriptorCount)
+        readMemoryInDescriptor(descriptorSet, desc.Binding, desc.DescriptorCount, offsets[desc.Binding])
+        writeMemoryInDescriptor(descriptorSet, desc.Binding, desc.DescriptorCount, offsets[desc.Binding])
       }
     }
   }
 }
 
+@server_disabled
+sub void readCoherentMemoryInCurrentPipelineBoundVertexBuffers(u32 vertexCount, u32 instanceCount, u32 firstVertex, u32 firstInstance) {
+  ldi := lastDrawInfo()
+  for _ , _ , vertex_binding in ldi.GraphicsPipeline.VertexInputState.BindingDescriptions {
+    bound_vertex_buffer := ldi.BoundVertexBuffers[vertex_binding.binding]
+    backing_buf := bound_vertex_buffer.Buffer
+    readCoherentMemoryInBuffer(backing_buf)
+  }
+}
+
 // Bound vertex/index buffers
+sub void readMemoryInCurrentPipelineBoundVertexBuffers(u32 vertexCount, u32 instanceCount, u32 firstVertex, u32 firstInstance) {
+    readCoherentMemoryInCurrentPipelineBoundVertexBuffers(vertexCount, instanceCount, firstVertex, firstInstance)
+    trackMemoryInCurrentPipelineBoundVertexBuffers(vertexCount, instanceCount, firstVertex, firstInstance)
+}
 
 @spy_disabled
-sub void readMemoryInCurrentPipelineBoundVertexBuffers(u32 vertexCount, u32 instanceCount, u32 firstVertex, u32 firstInstance) {
+sub void trackMemoryInCurrentPipelineBoundVertexBuffers(u32 vertexCount, u32 instanceCount, u32 firstVertex, u32 firstInstance) {
   ldi := lastDrawInfo()
   for _ , _ , vertex_binding in ldi.GraphicsPipeline.VertexInputState.BindingDescriptions {
     if vertex_binding.binding in ldi.BoundVertexBuffers {

--- a/gapis/api/vulkan/api/command_buffer_control.api
+++ b/gapis/api/vulkan/api/command_buffer_control.api
@@ -270,14 +270,6 @@ enum SemaphoreUpdate {
   @untracked @unused BufferCommands       BufferCommands
   @unused ref!CommandBufferBegin          BeginInfo
   @unused ref!VulkanDebugMarkerInfo       DebugInfo
-
-  // Caching touched resources to help the state tracking performance
-  @hidden @unused @untracked @untrackedMap @nobox
-  map!(VkImage, ref!ImageCoverage)        TouchedImages
-  @hidden @unused @untracked @untrackedMap @nobox
-  map!(VkBuffer, bool)                    TouchedBuffers
-  @hidden @unused @untracked @untrackedMap @nobox
-  map!(VkDescriptorSet, bool)             ProcessedDescriptorSets
 }
 
 sub void AddCommand(
@@ -522,9 +514,6 @@ sub void resetCommandBuffer(ref!CommandBufferObject obj) {
   resetBufferCommands(obj)
   clear(obj.CommandReferences)
   resetCmd(obj.VulkanHandle)
-  clear(obj.TouchedImages)
-  clear(obj.TouchedBuffers)
-  clear(obj.ProcessedDescriptorSets)
 }
 
 //////////////////////////////

--- a/gapis/api/vulkan/api/copy_clear_commands.api
+++ b/gapis/api/vulkan/api/copy_clear_commands.api
@@ -42,14 +42,13 @@
   map!(u32, VkBufferCopy) CopyRegions
 }
 
-@spy_disabled
 sub void dovkCmdCopyBuffer(ref!vkCmdCopyBufferArgs buffer) {
   if !(buffer.SrcBuffer in Buffers) { vkErrorInvalidBuffer(buffer.SrcBuffer) }
   if !(buffer.DstBuffer in Buffers) { vkErrorInvalidBuffer(buffer.DstBuffer) }
   sourceBuffer := Buffers[buffer.SrcBuffer]
   destBuffer := Buffers[buffer.DstBuffer]
   for _ , _ , region in buffer.CopyRegions {
-    readMemoryInBuffer(sourceBuffer, region.srcOffset, region.size)
+    readCoherentMemoryInBuffer(sourceBuffer)
     copyBufferToBuffer(destBuffer, region.dstOffset, sourceBuffer, region.srcOffset, region.size)
   }
 }
@@ -197,8 +196,6 @@ cmd void vkCmdCopyBuffer(
         vkErrorInvalidBuffer(dstBuffer)
       } else {
         cmdBuf := CommandBuffers[commandBuffer]
-        cmdBuf.TouchedBuffers[srcBuffer] = true
-        cmdBuf.TouchedBuffers[dstBuffer] = true
 
         args := new!vkCmdCopyBufferArgs(
           SrcBuffer:  srcBuffer,
@@ -228,17 +225,9 @@ class vkCmdCopyImageArgs {
 }
 
 @spy_disabled
-sub void dovkCmdCopyImage(ref!vkCmdCopyImageArgs args) {
-  if !(args.SrcImage in Images) { vkErrorInvalidImage(args.SrcImage) }
-  if !(args.DstImage in Images) { vkErrorInvalidImage(args.DstImage) }
+sub void trackVkCmdCopyImage(ref!vkCmdCopyImageArgs args) {
   srcImageObject := Images[args.SrcImage]
   dstImageObject := Images[args.DstImage]
-
-  // The following read on coherent memory of the source image does not affect the data in imageLevel.Data, as they are different memory spaces.
-  // But such a read is necessary if the backing memory of the source image is coherent, as we need the read observations on all memory changes
-  // in order to replay correctly. However, as the UI's texture data comes from imageLevel.Data, just using the following call will not bring
-  // the changes in coherent memory to the UI's texture view.
-  readCoherentMemoryInImage(srcImageObject)
 
   srcFormat := srcImageObject.Info.Format
   srcElementAndTexelBlockSize := getElementAndTexelBlockSize(srcFormat)
@@ -349,6 +338,19 @@ sub void dovkCmdCopyImage(ref!vkCmdCopyImageArgs args) {
   }
 }
 
+sub void dovkCmdCopyImage(ref!vkCmdCopyImageArgs args) {
+  if !(args.SrcImage in Images) { vkErrorInvalidImage(args.SrcImage) }
+  if !(args.DstImage in Images) { vkErrorInvalidImage(args.DstImage) }
+  srcImageObject := Images[args.SrcImage]
+
+  // The following read on coherent memory of the source image does not affect the data in imageLevel.Data, as they are different memory spaces.
+  // But such a read is necessary if the backing memory of the source image is coherent, as we need the read observations on all memory changes
+  // in order to replay correctly. However, as the UI's texture data comes from imageLevel.Data, just using the following call will not bring
+  // the changes in coherent memory to the UI's texture view.
+  readCoherentMemoryInImage(srcImageObject)
+  trackVkCmdCopyImage(args)
+}
+
 @threadSafety("app")
 @indirect("VkCommandBuffer", "VkDevice")
 @threadsafe
@@ -366,11 +368,9 @@ cmd void vkCmdCopyImage(
     if !(srcImage in Images) {
       vkErrorInvalidImage(srcImage)
     } else {
-      srcImgObj := Images[srcImage]
       if !(dstImage in Images) {
         vkErrorInvalidImage(dstImage)
       } else {
-        dstImgObj := Images[dstImage]
         cmdBuf := CommandBuffers[commandBuffer]
         args := new!vkCmdCopyImageArgs(
           SrcImage:        srcImage,
@@ -380,24 +380,8 @@ cmd void vkCmdCopyImage(
         )
         regions := pRegions[0:regionCount]
         for i in (0 .. regionCount) {
-          r := regions[i]
-          args.Regions[as!u32(i)] = r
-          commandBufferTouchImage(cmdBuf, srcImgObj,
-            VkImageSubresourceRange(
-              r.srcSubresource.aspectMask,
-              r.srcSubresource.mipLevel,
-              as!u32(1),
-              r.srcSubresource.baseArrayLayer,
-              r.srcSubresource.layerCount))
-          commandBufferTouchImage(cmdBuf, dstImgObj,
-            VkImageSubresourceRange(
-              r.dstSubresource.aspectMask,
-              r.dstSubresource.mipLevel,
-              as!u32(1),
-              r.dstSubresource.baseArrayLayer,
-              r.dstSubresource.layerCount))
+          args.Regions[i] = regions[i]
         }
-
         mapPos := as!u32(len(cmdBuf.BufferCommands.vkCmdCopyImage))
         cmdBuf.BufferCommands.vkCmdCopyImage[mapPos] = args
 
@@ -418,17 +402,9 @@ class vkCmdBlitImageArgs {
 }
 
 @spy_disabled
-sub void dovkCmdBlitImage(ref!vkCmdBlitImageArgs args) {
-  if !(args.SrcImage in Images) { vkErrorInvalidImage(args.SrcImage) }
-  if !(args.DstImage in Images) { vkErrorInvalidImage(args.DstImage) }
+sub void trackVkCmdBlitImage(ref!vkCmdBlitImageArgs args) {
   srcImageObject := Images[args.SrcImage]
   dstImageObject := Images[args.DstImage]
-
-  // The following read on coherent memory of the source image does not affect the data in imageLevel.Data, as they are different memory spaces.
-  // But such a read is necessary if the backing memory of the source image is coherent, as we need the read observations on all memory changes
-  // in order to replay correctly. However, as the UI's texture data comes from imageLevel.Data, just using the following call will not bring
-  // the changes in coherent memory to the UI's texture view.
-  readCoherentMemoryInImage(srcImageObject)
 
   srcFormat := srcImageObject.Info.Format
   srcElementAndTexelBlockSize := getElementAndTexelBlockSize(srcFormat)
@@ -530,6 +506,19 @@ sub void dovkCmdBlitImage(ref!vkCmdBlitImageArgs args) {
   }
 }
 
+sub void dovkCmdBlitImage(ref!vkCmdBlitImageArgs args) {
+  if !(args.SrcImage in Images) { vkErrorInvalidImage(args.SrcImage) }
+  if !(args.DstImage in Images) { vkErrorInvalidImage(args.DstImage) }
+  srcImageObject := Images[args.SrcImage]
+
+  // The following read on coherent memory of the source image does not affect the data in imageLevel.Data, as they are different memory spaces.
+  // But such a read is necessary if the backing memory of the source image is coherent, as we need the read observations on all memory changes
+  // in order to replay correctly. However, as the UI's texture data comes from imageLevel.Data, just using the following call will not bring
+  // the changes in coherent memory to the UI's texture view.
+  readCoherentMemoryInImage(srcImageObject)
+  trackVkCmdBlitImage(args)
+}
+
 @threadSafety("app")
 @indirect("VkCommandBuffer", "VkDevice")
 @threadsafe
@@ -548,11 +537,9 @@ cmd void vkCmdBlitImage(
     if !(srcImage in Images) {
       vkErrorInvalidImage(srcImage)
     } else {
-      srcImgObj := Images[srcImage]
       if !(dstImage in Images) {
         vkErrorInvalidImage(dstImage)
       } else {
-        dstImgObj := Images[dstImage]
         cmdBuf := CommandBuffers[commandBuffer]
         args := new!vkCmdBlitImageArgs(
           SrcImage:        srcImage,
@@ -561,26 +548,12 @@ cmd void vkCmdBlitImage(
           DstImageLayout:  dstImageLayout,
           Filter:          filter
         )
+
         regions := pRegions[0:regionCount]
         for i in (0 .. regionCount) {
           r := regions[i]
           args.Regions[as!u32(i)] = r
-          commandBufferTouchImage(cmdBuf, srcImgObj,
-            VkImageSubresourceRange(
-              r.srcSubresource.aspectMask,
-              r.srcSubresource.mipLevel,
-              as!u32(1),
-              r.srcSubresource.baseArrayLayer,
-              r.srcSubresource.layerCount))
-          commandBufferTouchImage(cmdBuf, dstImgObj,
-            VkImageSubresourceRange(
-              r.dstSubresource.aspectMask,
-              r.dstSubresource.mipLevel,
-              as!u32(1),
-              r.dstSubresource.baseArrayLayer,
-              r.dstSubresource.layerCount))
         }
-
         mapPos := as!u32(len(cmdBuf.BufferCommands.vkCmdBlitImage))
         cmdBuf.BufferCommands.vkCmdBlitImage[mapPos] = args
 
@@ -712,9 +685,12 @@ class vkCmdCopyBufferToImageArgs {
   map!(u32, VkBufferImageCopy) Regions
 }
 
-@spy_disabled
+
 sub void dovkCmdCopyBufferToImage(ref!vkCmdCopyBufferToImageArgs args) {
-  copyImageBuffer(args.SrcBuffer, args.DstImage, args.Layout, args.Regions, true)
+  if (!args.SrcBuffer in Buffers) { vkErrorInvalidBuffer(args.SrcBuffer) } else {
+    readCoherentMemoryInBuffer(Buffers[args.SrcBuffer])
+    copyImageBuffer(args.SrcBuffer, args.DstImage, args.Layout, args.Regions, true)
+  }
 }
 
 @threadSafety("app")
@@ -736,9 +712,7 @@ cmd void vkCmdCopyBufferToImage(
       if !(dstImage in Images) {
         vkErrorInvalidImage(dstImage)
       } else {
-        dstImgObj := Images[dstImage]
         cmdBuf := CommandBuffers[commandBuffer]
-        cmdBuf.TouchedBuffers[srcBuffer] = true
 
         regions := pRegions[0:regionCount]
         read(regions)
@@ -746,12 +720,6 @@ cmd void vkCmdCopyBufferToImage(
         for i in (0 .. regionCount) {
           r := regions[i]
           args.Regions[as!u32(i)] = r
-          commandBufferTouchImage(cmdBuf, dstImgObj, VkImageSubresourceRange(
-              r.imageSubresource.aspectMask,
-              r.imageSubresource.mipLevel,
-              as!u32(1),
-              r.imageSubresource.baseArrayLayer,
-              r.imageSubresource.layerCount))
         }
 
         mapPos := as!u32(len(cmdBuf.BufferCommands.vkCmdCopyBufferToImage))
@@ -771,9 +739,11 @@ class vkCmdCopyImageToBufferArgs {
   map!(u32, VkBufferImageCopy) Regions
 }
 
-@spy_disabled
 sub void dovkCmdCopyImageToBuffer(ref!vkCmdCopyImageToBufferArgs args) {
-  copyImageBuffer(args.DstBuffer, args.SrcImage, args.SrcImageLayout, args.Regions, false)
+  if (!args.SrcImage in Images) { vkErrorInvalidImage(args.SrcImage) } else {
+    readCoherentMemoryInImage(Images[args.SrcImage])
+    copyImageBuffer(args.DstBuffer, args.SrcImage, args.SrcImageLayout, args.Regions, false)
+  }
 }
 
 @threadSafety("app")
@@ -795,9 +765,7 @@ cmd void vkCmdCopyImageToBuffer(
       if !(srcImage in Images) {
         vkErrorInvalidImage(srcImage)
       } else {
-        srcImgObj := Images[srcImage]
         cmdBuf := CommandBuffers[commandBuffer]
-        cmdBuf.TouchedBuffers[dstBuffer] = true
 
         regions := pRegions[0:regionCount]
         args := new!vkCmdCopyImageToBufferArgs(
@@ -808,13 +776,6 @@ cmd void vkCmdCopyImageToBuffer(
         for i in (0 .. regionCount) {
           r := regions[i]
           args.Regions[as!u32(i)] = r
-          commandBufferTouchImage(cmdBuf, srcImgObj,
-            VkImageSubresourceRange(
-              r.imageSubresource.aspectMask,
-              r.imageSubresource.mipLevel,
-              as!u32(1),
-              r.imageSubresource.baseArrayLayer,
-              r.imageSubresource.layerCount))
         }
 
         mapPos := as!u32(len(cmdBuf.BufferCommands.vkCmdCopyImageToBuffer))
@@ -862,7 +823,6 @@ cmd void vkCmdUpdateBuffer(
       vkErrorInvalidBuffer(dstBuffer)
     } else {
       cmdBuf := CommandBuffers[commandBuffer]
-      cmdBuf.TouchedBuffers[dstBuffer] = true
 
       args := new!vkCmdUpdateBufferArgs(
         dstBuffer,
@@ -915,7 +875,6 @@ cmd void vkCmdFillBuffer(
       vkErrorInvalidBuffer(dstBuffer)
     } else {
       cmdBuf := CommandBuffers[commandBuffer]
-      cmdBuf.TouchedBuffers[dstBuffer] = true
 
       args := new!vkCmdFillBufferArgs(
         dstBuffer,
@@ -965,12 +924,10 @@ cmd void vkCmdClearColorImage(
     if !(image in Images) {
       vkErrorInvalidImage(image)
     } else {
-      imgObj := Images[image]
       if pColor == null {
         vkErrorNullPointer("VkClearColorValue")
       } else {
         cmdBuf := CommandBuffers[commandBuffer]
-
         color := pColor[0]
         ranges := pRanges[0:rangeCount]
         args := new!vkCmdClearColorImageArgs(
@@ -980,7 +937,6 @@ cmd void vkCmdClearColorImage(
         )
         for i in (0 .. rangeCount) {
           args.Ranges[as!u32(i)] = ranges[i]
-          commandBufferTouchImage(cmdBuf, imgObj, ranges[i])
         }
 
         mapPos := as!u32(len(cmdBuf.BufferCommands.vkCmdClearColorImage))
@@ -1025,12 +981,10 @@ cmd void vkCmdClearDepthStencilImage(
     if !(image in Images) {
       vkErrorInvalidImage(image)
     } else {
-      imgObj := Images[image]
       if pDepthStencil == null {
         vkErrorNullPointer("VkClearDepthStencilValue")
       } else {
         cmdBuf := CommandBuffers[commandBuffer]
-
         depthStencil := pDepthStencil[0]
         ranges := pRanges[0:rangeCount]
         args := new!vkCmdClearDepthStencilImageArgs(
@@ -1040,7 +994,6 @@ cmd void vkCmdClearDepthStencilImage(
         )
         for i in (0 .. rangeCount) {
           args.Ranges[as!u32(i)] = ranges[i]
-          commandBufferTouchImage(cmdBuf, imgObj, ranges[i])
         }
 
         mapPos := as!u32(len(cmdBuf.BufferCommands.vkCmdClearDepthStencilImage))
@@ -1102,7 +1055,6 @@ cmd void vkCmdClearAttachments(
   map!(u32, VkImageResolve) ResolveRegions
 }
 
-@spy_disabled
 sub void dovkCmdResolveImage(ref!vkCmdResolveImageArgs args) {
   if !(args.SrcImage in Images) { vkErrorInvalidImage(args.SrcImage) }
   if !(args.DstImage in Images) { vkErrorInvalidImage(args.DstImage) }
@@ -1124,6 +1076,7 @@ sub void dovkCmdResolveImage(ref!vkCmdResolveImageArgs args) {
     dst := Images[args.DstImage]
 
     updateImageQueue(src, srcRange)
+    readCoherentMemoryInImage(src)
     readImageSubresource(src, srcRange)
     updateImageQueue(dst, dstRange)
     writeImageSubresource(dst, dstRange)
@@ -1147,12 +1100,9 @@ cmd void vkCmdResolveImage(
     if !(srcImage in Images) {
       vkErrorInvalidImage(srcImage)
     } else {
-      srcImg := Images[srcImage]
       if !(dstImage in Images) {
         vkErrorInvalidImage(dstImage)
       } else {
-        dstImg := Images[dstImage]
-
         cmdBuf := CommandBuffers[commandBuffer]
         args := new!vkCmdResolveImageArgs(
           SrcImage:        srcImage,
@@ -1163,21 +1113,6 @@ cmd void vkCmdResolveImage(
         regions := pRegions[0:regionCount]
         for i in (0 .. regionCount) {
           args.ResolveRegions[as!u32(i)] = regions[i]
-
-          srcRng := VkImageSubresourceRange(
-            regions[i].srcSubresource.aspectMask,
-            regions[i].srcSubresource.mipLevel,
-            1,
-            regions[i].srcSubresource.baseArrayLayer,
-            regions[i].srcSubresource.layerCount)
-          commandBufferTouchImage(cmdBuf, srcImg, srcRng)
-          dstRng := VkImageSubresourceRange(
-            regions[i].dstSubresource.aspectMask,
-            regions[i].dstSubresource.mipLevel,
-            1,
-            regions[i].dstSubresource.baseArrayLayer,
-            regions[i].dstSubresource.layerCount)
-          commandBufferTouchImage(cmdBuf, dstImg, dstRng)
         }
 
         mapPos := as!u32(len(cmdBuf.BufferCommands.vkCmdResolveImage))

--- a/gapis/api/vulkan/api/descriptor.api
+++ b/gapis/api/vulkan/api/descriptor.api
@@ -249,10 +249,6 @@ cmd VkResult vkResetDescriptorPool(
   @unused ref!VulkanDebugMarkerInfo     DebugInfo
 
   @untracked @untrackedMap @unused @hidden @nobox
-  map!(VkImage, ref!ImageCoverage)      LinkedImages
-  @untracked @untrackedMap @unused @hidden @nobox
-  map!(VkBuffer, bool)                  LinkedBuffers
-  @untracked @untrackedMap @unused @hidden @nobox
   map!(VkCommandBuffer, bool)           CommandBufferUsers
 }
 
@@ -712,79 +708,6 @@ cmd void vkUpdateDescriptorSets(
     }
     dstSet.Bindings[c.DstBinding] = dstBinding
   }
-
-  // Then update the list of linked images and buffers for each modified
-  // descriptor sets. This is to avoid traveling all the bindings and array
-  // elements again when a command buffer binds these descriptor sets.
-  for _, set, _ in modifiedDescriptorSets.val {
-    setObj := DescriptorSets[set]
-
-    // TODO: Notify the command buffers that contain vkCmdBindDescriptorSets
-    // with the updated descriptor sets, if the descriptor sets' pools are
-    // created with VK_DESCRIPTOR_POOL_CREATE_UPDATE_AFTER_BIND_BIT_EXT and
-    // their layouts created with
-    // VK_DESCRIPTOR_SET_LAYOUT_CREATE_UPDATE_AFTER_BIND_POOL_BIT_EXT.
-    //for _, cb, _ in setObj.CommandBufferUsers {
-    //  if cb in CommandBuffers {
-    //    cbObj := CommandBuffers[cb]
-    //    delete(cbObj.ProcessedDescriptorSets, set)
-    //  }
-    //}
-    //clear(setObj.CommandBufferUsers)
-
-    clear(setObj.LinkedBuffers)
-    clear(setObj.LinkedImages)
-
-    for _, _, binding in setObj.Bindings {
-      switch binding.BindingType {
-        case VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
-          VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE,
-          VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
-          VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT: {
-          for _, _, ib in binding.ImageBinding {
-            if ib.ImageView in ImageViews {
-              viewObj := ImageViews[ib.ImageView]
-              if viewObj.Image.VulkanHandle in Images {
-                imgObj := viewObj.Image
-                descriptorSetLinkImage(setObj, imgObj, viewObj.SubresourceRange)
-              }
-            }
-          }
-        }
-
-        case VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER,
-          VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER: {
-          for _, _, bv in binding.BufferViewBindings {
-            if bv in BufferViews {
-              viewObj := BufferViews[bv]
-              if viewObj.Buffer.VulkanHandle in Buffers {
-                setObj.LinkedBuffers[viewObj.Buffer.VulkanHandle] = true
-              }
-            }
-          }
-        }
-
-        case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
-          VK_DESCRIPTOR_TYPE_STORAGE_BUFFER,
-          VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC,
-          VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC: {
-          for _, _, bb in binding.BufferBinding {
-            if bb.Buffer in Buffers {
-              setObj.LinkedBuffers[bb.Buffer] = true
-            }
-          }
-        }
-
-        case VK_DESCRIPTOR_TYPE_SAMPLER: {
-          // do nothing
-        }
-
-        default: {
-          // do nothing, we should never reach here.
-        }
-      }
-    }
-  }
 }
 
 /////////////////////////////
@@ -805,10 +728,8 @@ emptyBufferOffsets {
   map!(u32, map!(u32, map!(VkDeviceSize, bool))) BufferBindingOffsets
 }
 
-@spy_disabled
 sub void updateDescriptorBufferBindingOffsets(ref!vkCmdBindDescriptorSetsArgs args) {
   _ = PipelineLayouts[args.Layout]
-  dynamic_offset_index := MutableU32(0)
 
   computeInfo := lastComputeInfo()
   drawInfo := lastDrawInfo()
@@ -819,6 +740,28 @@ sub void updateDescriptorBufferBindingOffsets(ref!vkCmdBindDescriptorSetsArgs ar
     case VK_PIPELINE_BIND_POINT_GRAPHICS:
       drawInfo.DescriptorSets
   }
+
+  numDescSets := len(args.DescriptorSets)
+  for i in (0 .. numDescSets) {
+    if args.DescriptorSets[as!u32(i)] in DescriptorSets {
+      set := args.DescriptorSets[as!u32(i)]
+      setObj := DescriptorSets[set]
+      if currentDescriptorSets[args.FirstSet + as!u32(i)] != setObj {
+        currentDescriptorSets[args.FirstSet + as!u32(i)] = setObj
+      }
+    }
+  }
+
+  trackDescriptorBufferBindingOffsets(args)
+}
+
+@spy_disabled
+sub void trackDescriptorBufferBindingOffsets(ref!vkCmdBindDescriptorSetsArgs args) {
+  _ = PipelineLayouts[args.Layout]
+  dynamic_offset_index := MutableU32(0)
+
+  computeInfo := lastComputeInfo()
+  drawInfo := lastDrawInfo()
 
   bufferBindingOffsets := switch args.PipelineBindPoint {
     case VK_PIPELINE_BIND_POINT_COMPUTE:
@@ -832,22 +775,8 @@ sub void updateDescriptorBufferBindingOffsets(ref!vkCmdBindDescriptorSetsArgs ar
     if args.DescriptorSets[as!u32(i)] in DescriptorSets {
       set := args.DescriptorSets[as!u32(i)]
       setObj := DescriptorSets[set]
-      currentDescriptorSets[args.FirstSet + as!u32(i)] = setObj
       desc_set_buf_offsets := bufferBindingOffsets[as!u32(i)+args.FirstSet]
-      hasBeenRead := switch (set in LastBoundDescriptorSetsBufferInfo) {
-        case true:
-          MutableBool(true)
-        default:
-          MutableBool(false)
-      }
-
-      existingOffsets := switch(hasBeenRead.b) {
-        case true:
-          LastBoundDescriptorSetsBufferInfo[set].bufferOffsets
-        case false:
-          emptyBufferOffsets().BufferBindingOffsets
-      }
-
+      
       // Since the pDynamicOffsets point into the bindings in order of
       // binding index, and then array index, we have to loop over all
       // of the Bindings in order of the binding number.
@@ -871,23 +800,7 @@ sub void updateDescriptorBufferBindingOffsets(ref!vkCmdBindDescriptorSetsArgs ar
               default:
                 dynamic_offset_index.Val
             }
-            // If the offset has changed, then we may have to reprocess this
-            // descriptor set.
-            if hasBeenRead.b {
-              if !(as!u32(j) in existingOffsets) {
-                hasBeenRead.b = false
-              } else if !(as!u32(k) in existingOffsets[as!u32(j)]) {
-                hasBeenRead.b = false
-              } else if !(binding_offset in existingOffsets[as!u32(j)][as!u32(k)]) {
-                hasBeenRead.b = false
-              }
-
-              if !hasBeenRead.b {
-                LastBoundDescriptorSetsBufferInfo[set].shouldReadBuffers = true
-
-              }
-            }
-
+            
             desc_binding_buf_offsets[as!u32(k)] = binding_offset
           }
           desc_set_buf_offsets[as!u32(j)] = desc_binding_buf_offsets
@@ -934,25 +847,6 @@ cmd void vkCmdBindDescriptorSets(
     for i in (0 .. descriptorSetCount) {
       args.DescriptorSets[i] = sets[i]
     }
-    for i in (0 .. descriptorSetCount) {
-      set := sets[i]
-      if !(set in cmdBuf.ProcessedDescriptorSets) {
-        if !(set in DescriptorSets) {
-          vkErrorInvalidDescriptorSet(set)
-        } else {
-          setObj := DescriptorSets[set]
-          for _, buf, _ in setObj.LinkedBuffers {
-            cmdBuf.TouchedBuffers[buf] = true
-          }
-          for _, img, cov in setObj.LinkedImages {
-            cmdBuf.TouchedImages[img] = cov
-          }
-          cmdBuf.ProcessedDescriptorSets[set] = true
-          DescriptorSets[set].CommandBufferUsers[commandBuffer] = true
-        }
-      }
-    }
-
     mapPos := as!u32(len(cmdBuf.BufferCommands.vkCmdBindDescriptorSets))
     cmdBuf.BufferCommands.vkCmdBindDescriptorSets[mapPos] = args
     AddCommand(commandBuffer, cmd_vkCmdBindDescriptorSets, mapPos)

--- a/gapis/api/vulkan/api/draw_commands.api
+++ b/gapis/api/vulkan/api/draw_commands.api
@@ -80,7 +80,6 @@ cmd void vkCmdBindIndexBuffer(
       IndexType:  indexType
     )
     cmdBuf := CommandBuffers[commandBuffer]
-    cmdBuf.TouchedBuffers[buffer] = true
 
     mapPos := as!u32(len(cmdBuf.BufferCommands.vkCmdBindIndexBuffer))
     cmdBuf.BufferCommands.vkCmdBindIndexBuffer[mapPos] = args
@@ -141,9 +140,6 @@ cmd void vkCmdBindVertexBuffers(
       args.Offsets[i] = offsets[i]
     }
     cmdBuf := CommandBuffers[commandBuffer]
-    for i in (0 .. bindingCount) {
-      cmdBuf.TouchedBuffers[buffers[i]] = true
-    }
     mapPos := as!u32(len(cmdBuf.BufferCommands.vkCmdBindVertexBuffers))
     cmdBuf.BufferCommands.vkCmdBindVertexBuffers[mapPos] = args
 
@@ -157,7 +153,6 @@ cmd void vkCmdBindVertexBuffers(
   u32 FirstVertex
   u32 FirstInstance
 }
-
 
 sub void dovkCmdDraw(ref!vkCmdDrawArgs draw) {
   readDrawState()
@@ -201,6 +196,13 @@ vkCmdDrawIndexedArgs {
   u32 FirstInstance
 }
 
+@server_disabled
+sub void readCoherentMemoryInBoundIndexBuffer() {
+  lastDraw := lastDrawInfo()
+  indexBuffer := lastDraw.BoundIndexBuffer.BoundBuffer.Buffer
+  readCoherentMemoryInBuffer(indexBuffer)
+}
+
 @spy_disabled
 sub void readBoundIndexBuffer(u32 indexCount, u32 firstIndex) {
   // Loop through the index buffer, and find the low and high
@@ -223,6 +225,7 @@ sub void readBoundIndexBuffer(u32 indexCount, u32 firstIndex) {
 sub void dovkCmdDrawIndexed(ref!vkCmdDrawIndexedArgs draw) {
   readDrawState()
   useRenderPass()
+  readCoherentMemoryInBoundIndexBuffer()
   readBoundIndexBuffer(draw.IndexCount, draw.FirstIndex)
   // Read the whole vertex buffer.
   readMemoryInCurrentPipelineBoundVertexBuffers(0xFFFFFFFF, draw.InstanceCount, 0, draw.FirstInstance)
@@ -308,7 +311,7 @@ cmd void vkCmdDrawIndirect(
     args := new!vkCmdDrawIndirectArgs(buffer, offset, drawCount, stride)
 
     cmdBuf := CommandBuffers[commandBuffer]
-    cmdBuf.TouchedBuffers[buffer] = true
+
     mapPos := as!u32(len(cmdBuf.BufferCommands.vkCmdDrawIndirect))
     cmdBuf.BufferCommands.vkCmdDrawIndirect[mapPos] = args
 
@@ -323,16 +326,17 @@ cmd void vkCmdDrawIndirect(
   u32          Stride
 }
 
-@spy_disabled
 sub void readIndexedIndirectDrawBuffer(VkBuffer buf, VkDeviceSize offset, u32 drawCount, u32 stride ) {
     if !(buf in Buffers) {
       vkErrorInvalidBuffer(buf)
     } else {
       command_size := as!VkDeviceSize(16)
       indirect_buffer_read_size := as!VkDeviceSize((drawCount - 1) * stride) + command_size
+      readCoherentMemoryInBuffer(Buffers[buf])
       readMemoryInBuffer(Buffers[buf], offset, indirect_buffer_read_size)
       // Read through the whole index buffer.
       indexBuffer := lastDrawInfo().BoundIndexBuffer.BoundBuffer.Buffer
+      readCoherentMemoryInBuffer(indexBuffer)
       readMemoryInBuffer(indexBuffer, 0, indexBuffer.Info.Size)
     }
 }
@@ -342,6 +346,7 @@ sub void dovkCmdDrawIndexedIndirect(ref!vkCmdDrawIndexedIndirectArgs draw) {
   if draw.DrawCount > 0 {
     ldi := lastDrawInfo()
     readWriteMemoryInBoundGraphicsDescriptorSets()
+    readCoherentMemoryInBuffer(Buffers[draw.Buffer])
     readIndexedIndirectDrawBuffer(draw.Buffer, draw.Offset, draw.DrawCount, draw.Stride)
     // Read through all the vertex buffers.
     readMemoryInCurrentPipelineBoundVertexBuffers(0xFFFFFFFF, 0xFFFFFFFF, 0, 0)
@@ -367,7 +372,6 @@ cmd void vkCmdDrawIndexedIndirect(
     args := new!vkCmdDrawIndexedIndirectArgs(buffer, offset, drawCount, stride)
 
     cmdBuf := CommandBuffers[commandBuffer]
-    cmdBuf.TouchedBuffers[buffer] = true
     mapPos := as!u32(len(cmdBuf.BufferCommands.vkCmdDrawIndexedIndirect))
     cmdBuf.BufferCommands.vkCmdDrawIndexedIndirect[mapPos] = args
 
@@ -414,9 +418,9 @@ class vkCmdDispatchIndirectArgs {
   VkDeviceSize Offset
 }
 
-@spy_disabled
 sub void readIndirectDispatchBuffer(VkBuffer buf, VkDeviceSize offset) {
   command_size := as!VkDeviceSize(12)
+  readCoherentMemoryInBuffer(Buffers[buf])
   readMemoryInBuffer(Buffers[buf], offset, command_size)
 }
 
@@ -441,7 +445,6 @@ cmd void vkCmdDispatchIndirect(
     args := new!vkCmdDispatchIndirectArgs(buffer, offset)
 
     cmdBuf := CommandBuffers[commandBuffer]
-    cmdBuf.TouchedBuffers[buffer] = true
     mapPos := as!u32(len(cmdBuf.BufferCommands.vkCmdDispatchIndirect))
     cmdBuf.BufferCommands.vkCmdDispatchIndirect[mapPos] = args
 
@@ -449,20 +452,18 @@ cmd void vkCmdDispatchIndirect(
   }
 }
 
-@spy_disabled
 sub void readWriteMemoryInBoundGraphicsDescriptorSets() {
   ldi := lastDrawInfo()
   readWriteMemoryInBoundDescriptorSets(
-    ldi.GraphicsPipeline.Layout,
+    ldi.GraphicsPipeline.UsedDescriptors,
     ldi.DescriptorSets,
     ldi.BufferBindingOffsets)
 }
 
-@spy_disabled
 sub void readWriteMemoryInBoundComputeDescriptorSets() {
   lci := lastComputeInfo()
   readWriteMemoryInBoundDescriptorSets(
-    lci.ComputePipeline.PipelineLayout,
+    lci.ComputePipeline.UsedDescriptors,
     lci.DescriptorSets,
     lci.BufferBindingOffsets)
 }

--- a/gapis/api/vulkan/api/pipeline.api
+++ b/gapis/api/vulkan/api/pipeline.api
@@ -203,6 +203,7 @@ cmd void vkDestroyPipelineLayout(
   //       It will have been set for you correctly
   @unused s32                       BasePipelineIndex
   @unused ref!VulkanDebugMarkerInfo DebugInfo
+  @unused map!(u32, DescriptorUsage) UsedDescriptors
 }
 
 @resource
@@ -218,6 +219,7 @@ cmd void vkDestroyPipelineLayout(
   //       It will have been set for you correctly
   @unused s32                       BasePipelineIndex
   @unused ref!VulkanDebugMarkerInfo DebugInfo
+  @unused map!(u32, DescriptorUsage) UsedDescriptors
 }
 
 @internal
@@ -295,6 +297,10 @@ cmd VkResult vkCreateGraphicsPipelines(
         }
         spec_data.Data = clone(as!u8*(spec_info.pData)[0:spec_info.dataSize])
         stage_data.Specialization = spec_data
+      }
+      moduleDescriptors := stage_data.Module.Descriptors.Descriptors[as!string(stage_create_info.pName)]
+      for _, _, d in moduleDescriptors {
+        obj.UsedDescriptors[len(obj.UsedDescriptors)] = d
       }
       obj.Stages[j] = stage_data
     }
@@ -543,6 +549,7 @@ cmd VkResult vkCreateGraphicsPipelines(
       obj.BasePipelineIndex = 0
       obj.BasePipeline = as!VkPipeline(0)
     }
+
     createdPipelines.Objects[i] = obj
   }
 
@@ -637,6 +644,10 @@ cmd VkResult vkCreateComputePipelines(
       obj.BasePipelineIndex = 0
       obj.BasePipeline = as!VkPipeline(0)
     }
+    moduleDescriptors := stage_data.Module.Descriptors.Descriptors[as!string(stage_create_info.pName)]
+    for _, _, d in moduleDescriptors {
+      obj.UsedDescriptors[len(obj.UsedDescriptors)] = d
+    }
     created_pipelines.Objects[i] = obj
   }
 
@@ -673,12 +684,23 @@ cmd void vkDestroyPipeline(
 // Shader modules //
 ////////////////////
 
+@internal class DescriptorUsage {
+  u32 Set
+  u32 Binding
+  u32 DescriptorCount
+}
+
+@internal class DescriptorInfo {
+  map!(string, map!(u32, DescriptorUsage)) Descriptors
+}
+
 @resource
 @internal class ShaderModuleObject {
   @unused VkDevice                  Device
   @unused u32[]                     Words
   @unused VkShaderModule            VulkanHandle
   @unused ref!VulkanDebugMarkerInfo DebugInfo
+  @unused ref!DescriptorInfo        Descriptors
 }
 
 @indirect("VkDevice")
@@ -705,6 +727,7 @@ cmd VkResult vkCreateShaderModule(
 
   num_words := as!u64(create_info.codeSize) / 4
   object := new!ShaderModuleObject(device, clone(create_info.pCode[0:num_words]))
+  object.Descriptors = fetchUsedDescriptors(object)
 
   handle := ?
   if pShaderModule == null { vkErrorNullPointer("VkShaderModule") }

--- a/gapis/api/vulkan/api/query_pool.api
+++ b/gapis/api/vulkan/api/query_pool.api
@@ -384,7 +384,6 @@ cmd void vkCmdCopyQueryPoolResults(
         vkErrorInvalidBuffer(dstBuffer)
       } else {
         cmdBuf := CommandBuffers[commandBuffer]
-        cmdBuf.TouchedBuffers[dstBuffer] = true
 
         args := new!vkCmdCopyQueryPoolResultsArgs(
           QueryPool:   queryPool,

--- a/gapis/api/vulkan/api/queue.api
+++ b/gapis/api/vulkan/api/queue.api
@@ -49,6 +49,7 @@
   map!(VkSemaphore, ref!SemaphoreObject)                         PendingSemaphores
   @unused ref!VulkanDebugMarkerInfo                              DebugInfo
   @untracked @untrackedMap dense_map!(u32, ref!CommandReference) PendingCommands
+  @untracked @untrackedMap map!(VkBuffer, bool) ReadCoherentBuffers
 }
 
 @threadSafety("system")

--- a/gapis/api/vulkan/api/queued_command_tracking.api
+++ b/gapis/api/vulkan/api/queued_command_tracking.api
@@ -46,11 +46,7 @@ sub void execPendingCommands(VkQueue queue, bool isRoot) {
   signaledQueues := queueMap().m
   processSubcommand := MutableBool()
   processSubcommand.b = true
-  clear(LastBoundDescriptorSetsBufferInfo)
-
-  processedEntireImages := new!ImageSet()
-  processedBuffers := new!BufferSet()
-  processedCommandBuffers := new!CommandBufferSet()
+  clear(LastBoundQueue.ReadCoherentBuffers)
 
   numPendingCmds := len(q.PendingCommands)
   for i in (0 .. numPendingCmds) {
@@ -193,52 +189,10 @@ sub void execPendingCommands(VkQueue queue, bool isRoot) {
               }
             }
           }
-
           postBindSparse(cmd.SparseBinds)
         } // Done sparse images
 
         if ((cmd.Buffer != as!VkCommandBuffer(0))) {
-          // Process all the touched buffers and images here, ahead of the
-          // subcommands to improve state tracking performance. This should be
-          // ignored during the GAPIS state mutation.
-          if !(cmd.Buffer in processedCommandBuffers.val) {
-            cb := CommandBuffers[cmd.Buffer]
-            for _, img, cov in cb.TouchedImages {
-              if !(img in processedEntireImages.val) {
-                if img in Images {
-                  imgObj := Images[img]
-                  readCoherentMemoryInImage(imgObj)
-                  if cov.Entire {
-                    rng := VkImageSubresourceRange(
-                      aspectMask: imgObj.ImageAspect,
-                      baseMipLevel: as!u32(0),
-                      levelCount: imgObj.Info.MipLevels,
-                      baseArrayLayer: 0,
-                      layerCount: imgObj.Info.ArrayLayers,
-                    )
-                    updateImageQueue(imgObj, rng)
-                    processedEntireImages.val[img] = true
-                  } else {
-                    for _, _, rng in cov.Ranges {
-                      updateImageQueue(imgObj, rng)
-                    }
-                  }
-                }
-              }
-            }
-            for _, buf, _ in cb.TouchedBuffers {
-              if !(buf in processedBuffers.val) {
-                if buf in Buffers {
-                  bufObj := Buffers[buf]
-                  bufObj.LastBoundQueue = LastBoundQueue
-                  readCoherentMemoryInBuffer(bufObj)
-                  processedBuffers.val[buf] = true
-                }
-              }
-            }
-            processedCommandBuffers.val[cmd.Buffer] = true
-          }
-
           onPreSubcommand(cmd)
           callCommand(cmd)
 

--- a/gapis/api/vulkan/api/renderpass_framebuffer.api
+++ b/gapis/api/vulkan/api/renderpass_framebuffer.api
@@ -310,18 +310,6 @@ cmd void vkCmdBeginRenderPass(
     vkErrorInvalidCommandBuffer(commandBuffer)
   } else {
     cmdBuf := CommandBuffers[commandBuffer]
-    if (begin_info.framebuffer in Framebuffers) {
-      if (begin_info.renderPass in RenderPasses) {
-        fb := Framebuffers[begin_info.framebuffer]
-        for i in (0 .. len(fb.ImageAttachments)) {
-          att := fb.ImageAttachments[as!u32(i)]
-          if att.Image != null {
-            commandBufferTouchImage(cmdBuf, att.Image, att.SubresourceRange)
-          }
-        }
-      }
-    }
-
     args := new!vkCmdBeginRenderPassArgs(
       Contents:     contents,
       RenderPass:   begin_info.renderPass,
@@ -434,6 +422,7 @@ sub void loadImageAttachment(u32 attachmentID) {
     if attachment.Image != null {
       switch desc.loadOp {
         case VK_ATTACHMENT_LOAD_OP_LOAD: {
+          readCoherentMemoryInImage(attachment.Image)
           readImageView(attachment)
           updateImageViewQueue(attachment)
         }

--- a/gapis/api/vulkan/api/util.api
+++ b/gapis/api/vulkan/api/util.api
@@ -379,38 +379,6 @@ sub void touchImageCoverage(ref!ImageObject image, ref!ImageCoverage coverage, V
   }
 }
 
-sub void commandBufferTouchEntireImage(ref!CommandBufferObject cmdbuf, ref!ImageObject image) {
-  if !(image.VulkanHandle in cmdbuf.TouchedImages) {
-    cmdbuf.TouchedImages[image.VulkanHandle] = new!ImageCoverage()
-  }
-  coverage := cmdbuf.TouchedImages[image.VulkanHandle]
-  touchEntireImageCoverage(coverage)
-}
-
-sub void commandBufferTouchImage(ref!CommandBufferObject cmdbuf, ref!ImageObject image, VkImageSubresourceRange rng) {
-  if !(image.VulkanHandle in cmdbuf.TouchedImages) {
-    cmdbuf.TouchedImages[image.VulkanHandle] = new!ImageCoverage()
-  }
-  coverage := cmdbuf.TouchedImages[image.VulkanHandle]
-  touchImageCoverage(image, coverage, rng)
-}
-
-sub void descriptorSetLinkEntireImage(ref!DescriptorSetObject descSet, ref!ImageObject image) {
-  if !(image.VulkanHandle in descSet.LinkedImages) {
-    descSet.LinkedImages[image.VulkanHandle] = new!ImageCoverage()
-  }
-  coverage := descSet.LinkedImages[image.VulkanHandle]
-  touchEntireImageCoverage(coverage)
-}
-
-sub void descriptorSetLinkImage(ref!DescriptorSetObject descSet, ref!ImageObject image, VkImageSubresourceRange rng) {
-  if !(image.VulkanHandle in descSet.LinkedImages) {
-    descSet.LinkedImages[image.VulkanHandle] = new!ImageCoverage()
-  }
-  coverage := descSet.LinkedImages[image.VulkanHandle]
-  touchImageCoverage(image, coverage, rng)
-}
-
 @untracked @internal
 class DescriptorSetSet {
   @untrackedMap @untracked

--- a/gapis/api/vulkan/externs.go
+++ b/gapis/api/vulkan/externs.go
@@ -391,6 +391,15 @@ func (e externs) fetchImageMemoryRequirements(dev VkDevice, img VkImage, hasSpar
 	return NilImageMemoryRequirementsʳ
 }
 
+func (e externs) fetchUsedDescriptors(ShaderModuleObjectʳ) DescriptorInfoʳ {
+	for _, ee := range e.cmd.Extras().All() {
+		if p, ok := ee.(DescriptorInfo); ok {
+			return MakeDescriptorInfoʳ(e.s.Arena).Set(p).Clone(e.s.Arena, api.CloneContext{})
+		}
+	}
+	return MakeDescriptorInfoʳ(e.s.Arena)
+}
+
 func (e externs) fetchBufferMemoryRequirements(dev VkDevice, buf VkBuffer) VkMemoryRequirements {
 	// Only fetch memory requirements for application commands, skip any commands
 	// inserted by GAPID

--- a/gapis/api/vulkan/state_rebuilder.go
+++ b/gapis/api/vulkan/state_rebuilder.go
@@ -2127,7 +2127,8 @@ func (sb *stateBuilder) createRenderPass(rp RenderPassObjectʳ) {
 }
 
 func (sb *stateBuilder) createShaderModule(sm ShaderModuleObjectʳ) {
-	sb.write(sb.cb.VkCreateShaderModule(
+	sbExtra := sm.Descriptors().Get().Clone(sb.newState.Arena, api.CloneContext{})
+	csm := sb.cb.VkCreateShaderModule(
 		sm.Device(),
 		sb.MustAllocReadData(NewVkShaderModuleCreateInfo(sb.ta,
 			VkStructureType_VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO, // sType
@@ -2139,7 +2140,9 @@ func (sb *stateBuilder) createShaderModule(sm ShaderModuleObjectʳ) {
 		memory.Nullptr,
 		sb.MustAllocWriteData(sm.VulkanHandle()).Ptr(),
 		VkResult_VK_SUCCESS,
-	))
+	)
+	csm.Extras().Add(sbExtra)
+	sb.write(csm)
 }
 
 func isShaderModuleInState(sm ShaderModuleObjectʳ, st *api.GlobalState) bool {

--- a/gapis/api/vulkan/vulkan.api
+++ b/gapis/api/vulkan/vulkan.api
@@ -119,6 +119,7 @@ extern ref!PhysicalDevicesFormatProperties fetchPhysicalDeviceFormatProperties(V
 extern ref!ImageMemoryRequirements fetchImageMemoryRequirements(VkDevice device, VkImage image, bool hasSparseBit)
 extern VkMemoryRequirements fetchBufferMemoryRequirements(VkDevice device, VkBuffer buffer)
 extern ref!LinearImageLayouts fetchLinearImageSubresourceLayouts(VkDevice device, ref!ImageObject image, VkImageSubresourceRange rng)
+extern ref!DescriptorInfo fetchUsedDescriptors(ref!ShaderModuleObject pipeline)
 
 ///////////////////////
 // Function pointers //
@@ -354,7 +355,6 @@ enum LastSubmissionType {
 @serialize LastSubmissionType                           LastSubmission
 @untrackedMap map!(VkQueue, ref!DynamicPipelineState)   LastDynamicPipelineStates
 @untrackedMap map!(VkQueue, ref!PushConstantInfo)       LastPushConstants
-@untrackedMap map!(VkDescriptorSet, ref!BoundDescriptorSetBufferInfo) LastBoundDescriptorSetsBufferInfo
 
 @hidden bool IsRebuilding
 

--- a/gapis/shadertools/shadertools.go
+++ b/gapis/shadertools/shadertools.go
@@ -422,3 +422,85 @@ func ParseDescriptorSets(shader []uint32, entryPoint string) (DescriptorSets, er
 
 	return res, nil
 }
+
+// ParseDescriptorSets determines what descriptor sets are implied by the shader
+func ParseAllDescriptorSets(shader []uint32) (map[string]DescriptorSets, error) {
+	out := make(map[string]DescriptorSets)
+	spvReflectErr := func(res C.SpvReflectResult) error {
+		if res == C.SPV_REFLECT_RESULT_SUCCESS {
+			return nil
+		}
+		return fmt.Errorf("SPIRV-Reflect failed with error code %v\n", res)
+	}
+	module := C.SpvReflectShaderModule{}
+
+	shaderPtr := unsafe.Pointer(nil)
+	if len(shader) > 0 {
+		shaderPtr = unsafe.Pointer(&shader[0])
+	}
+	if err := spvReflectErr(C.spvReflectCreateShaderModule(
+		C.size_t(len(shader)*4),
+		shaderPtr,
+		&module)); err != nil {
+		return nil, err
+	}
+	defer C.spvReflectDestroyShaderModule(&module)
+
+	nEntryPoints := module.entry_point_count
+
+	for i := uint32(0); i < uint32(nEntryPoints); i++ {
+		entryPointStruct := module.entry_points
+
+		setCount := C.uint32_t(0)
+		if err := spvReflectErr(C.spvReflectEnumerateEntryPointDescriptorSets(
+			&module,
+			entryPointStruct.name,
+			&setCount,
+			nil)); err != nil {
+			return nil, err
+		}
+		sets := make([]*C.SpvReflectDescriptorSet, setCount)
+		setsPtr := unsafe.Pointer(nil)
+		if setCount > 0 {
+			setsPtr = unsafe.Pointer(&sets[0])
+		}
+		if err := spvReflectErr(C.spvReflectEnumerateEntryPointDescriptorSets(
+			&module,
+			entryPointStruct.name,
+			&setCount,
+			(**C.SpvReflectDescriptorSet)(setsPtr),
+		)); err != nil {
+			return nil, err
+		}
+
+		res := DescriptorSets{}
+		for _, set := range sets {
+			bindings := make(DescriptorSet, set.binding_count)
+			for i := C.uint32_t(0); i < set.binding_count; i++ {
+				bindingPtr := uintptr(unsafe.Pointer(set.bindings)) +
+					uintptr(i)*unsafe.Sizeof(*set.bindings)
+				binding := *(**C.SpvReflectDescriptorBinding)(unsafe.Pointer(bindingPtr))
+				// If it's an array, need to get total descriptor count
+				descriptorCount := C.uint32_t(1)
+				for j := C.uint32_t(0); j < binding.array.dims_count; j++ {
+					descriptorCount *= binding.array.dims[j]
+				}
+				bindings[i] = DescriptorBinding{
+					Set:             uint32(binding.set),
+					Binding:         uint32(binding.binding),
+					SpirvId:         uint32(binding.spirv_id),
+					DescriptorType:  uint32(binding.descriptor_type),
+					DescriptorCount: uint32(descriptorCount),
+					ShaderStage:     uint32(entryPointStruct.shader_stage),
+				}
+			}
+			sort.Slice(bindings, func(i, j int) bool {
+				return descriptorBindingLess(bindings[i], bindings[j])
+			})
+			res[uint32(set.set)] = bindings
+		}
+		out[C.GoString(entryPointStruct.name)] = res
+	}
+
+	return out, nil
+}


### PR DESCRIPTION
This means we no longer have to track unused descriptors.
This undoes some of our previous optimizations in this area,
because they are significantly more complicated, and this
supercedes them.