### PR TITLE
Vulkan: Fix many false dependencies on between vkCmdBindDescriptorSets

### DIFF
--- a/gapis/api/vulkan/api/descriptor.api
+++ b/gapis/api/vulkan/api/descriptor.api
@@ -953,9 +953,8 @@ cmd void vkCmdBindDescriptorSets(
       }
     }
 
-    bc := cmdBuf.BufferCommands.vkCmdBindDescriptorSets
-    mapPos := as!u32(len(bc))
-    bc[mapPos] = args
+    mapPos := as!u32(len(cmdBuf.BufferCommands.vkCmdBindDescriptorSets))
+    cmdBuf.BufferCommands.vkCmdBindDescriptorSets[mapPos] = args
     AddCommand(commandBuffer, cmd_vkCmdBindDescriptorSets, mapPos)
   }
 }


### PR DESCRIPTION
This local variable hid the `@untrackedMap` annotation, causing `len(bc)` to appear as a read of the entire `vkCmdBindDescriptorSets` map. This caused each `vkCmdBindDescriptorSets` to depend on every previous `vkCmdBindDescriptorSets` call.