### PR TITLE
Dependency Graph: Add option to save state/memory accesses

### DIFF
--- a/gapis/resolve/dependencygraph2/dependency_graph_builder.go
+++ b/gapis/resolve/dependencygraph2/dependency_graph_builder.go
@@ -363,6 +363,10 @@ func BuildDependencyGraph(ctx context.Context, config DependencyGraphConfig,
 
 	b.LogStats(ctx, false)
 
+	if graph.config.SaveNodeAccesses {
+		graph.setStateRefs(b.fragWatcher.GetStateRefs())
+	}
+
 	return graph, nil
 }
 

--- a/gapis/resolve/dependencygraph2/graph_builder.go
+++ b/gapis/resolve/dependencygraph2/graph_builder.go
@@ -190,6 +190,18 @@ func (b *graphBuilder) AddNodeDependencies(
 	b.depSlice = depSlice[:0]
 
 	b.graph.setDependencies(nodeID, newDepSlice)
+	if b.graph.config.SaveNodeAccesses {
+		initCmdNodeIDs := b.initCmdNodeIDs[nodeID]
+		initCmdNodeIDsCopy := make([]NodeID, len(initCmdNodeIDs))
+		copy(initCmdNodeIDsCopy, initCmdNodeIDs)
+		b.graph.setNodeAccesses(nodeID, NodeAccesses{
+			fragAccesses,
+			memAccesses,
+			forwardAccesses,
+			parent,
+			initCmdNodeIDsCopy,
+		})
+	}
 
 	stats.UniqueDeps = uint64(cap(newDepSlice))
 	b.stats.DepDist.Add(stats.UniqueDeps)

--- a/gapis/resolve/dependencygraph2/resolvables.go
+++ b/gapis/resolve/dependencygraph2/resolvables.go
@@ -31,6 +31,7 @@ func GetDependencyGraph(ctx context.Context, c *path.Capture, config DependencyG
 		IncludeInitialCommands: config.IncludeInitialCommands,
 		MergeSubCmdNodes:       config.MergeSubCmdNodes,
 		ReverseDependencies:    config.ReverseDependencies,
+		SaveNodeAccesses:       config.SaveNodeAccesses,
 	})
 	if err != nil {
 		return nil, err
@@ -55,6 +56,7 @@ func (r *DependencyGraph2Resolvable) Resolve(ctx context.Context) (interface{}, 
 		IncludeInitialCommands: r.IncludeInitialCommands,
 		MergeSubCmdNodes:       r.MergeSubCmdNodes,
 		ReverseDependencies:    r.ReverseDependencies,
+		SaveNodeAccesses:       r.SaveNodeAccesses,
 	}
 	return BuildDependencyGraph(ctx, config, c, initialCmds, initialRanges)
 }

--- a/gapis/resolve/dependencygraph2/resolvables.proto
+++ b/gapis/resolve/dependencygraph2/resolvables.proto
@@ -24,4 +24,5 @@ message DependencyGraph2Resolvable {
   bool includeInitialCommands = 2;
   bool mergeSubCmdNodes = 3;
   bool reverseDependencies = 4;
+  bool saveNodeAccesses = 5;
 }


### PR DESCRIPTION
When enabled, this will save the reads and writes of the state and memory used to find the dependencies. This is currently helpful for debugging the dependency graph and new dead code elimination, and is necessary for (though not yet fully utilized by) the current dependency graph visualizer. 

Eventually, it would be nice to be able to surface this information to users ("you have a dependency between these commands because...")

This option is disabled by default.