### PR TITLE
Switch to new (dependency graph) dead code elimination

### DIFF
--- a/gapis/config/config.go
+++ b/gapis/config/config.go
@@ -19,7 +19,7 @@ const (
 	DebugReplay                = false
 	DebugReplayBuilder         = false
 	DisableDeadCodeElimination = false
-	NewDeadCodeElimination     = false
+	NewDeadCodeElimination     = true
 	DeadSubCmdElimination      = false
 	DebugDeadCodeElimination   = false
 	DebugDependencyGraph       = false

--- a/gapis/resolve/dependencygraph2/dce.go
+++ b/gapis/resolve/dependencygraph2/dce.go
@@ -57,7 +57,7 @@ func DCECapture(ctx context.Context, name string, p *path.Capture, requestedCmds
 	builder := NewDCEBuilder(graph)
 	for _, cmd := range requestedCmds {
 		id := cmd.Indices[0]
-		log.I(ctx, "Requested (%d) %v\n", id, c.Commands[id])
+		log.D(ctx, "Requested (%d) %v\n", id, c.Commands[id])
 		err := builder.Request(ctx, api.SubCmdIdx(cmd.Indices))
 		if err != nil {
 			return nil, err
@@ -352,7 +352,7 @@ func (b *DCEBuilder) processLiveObs(ctx context.Context, obs ObsNode) {
 // command index, to the DCE.
 func (b *DCEBuilder) Request(ctx context.Context, fci api.SubCmdIdx) error {
 	if config.DebugDeadCodeElimination {
-		log.I(ctx, "Requesting [%v] %v", fci[0], b.graph.GetCommand(api.CmdID(fci[0])))
+		log.D(ctx, "Requesting [%v] %v", fci[0], b.graph.GetCommand(api.CmdID(fci[0])))
 	}
 	nodeID := b.graph.GetCmdNodeID((api.CmdID)(fci[0]), fci[1:])
 	if nodeID == NodeNoID {
@@ -384,7 +384,7 @@ func (b *DCEBuilder) Flush(ctx context.Context, out transform.Writer) {
 		}
 		cmdID := b.OriginalCmdID(liveCmdID)
 		if config.DebugDeadCodeElimination {
-			log.I(ctx, "Flushing [%v / %v] %v", cmdID, liveCmdID, cmd)
+			log.D(ctx, "Flushing [%v / %v] %v", cmdID, liveCmdID, cmd)
 		}
 		out.MutateAndWrite(ctx, cmdID, cmd)
 	}

--- a/gapis/resolve/dependencygraph2/forward.go
+++ b/gapis/resolve/dependencygraph2/forward.go
@@ -82,7 +82,7 @@ func (b *forwardWatcher) OpenForwardDependency(ctx context.Context, cmdCtx CmdCo
 	}
 
 	if _, ok := b.openForwardDependencies[dependencyID]; ok {
-		log.I(ctx, "OpenForwardDependency: Forward dependency opened multiple times before being closed. DependencyID: %v, close node: %v", dependencyID, cmdCtx.nodeID)
+		log.D(ctx, "OpenForwardDependency: Forward dependency opened multiple times before being closed. DependencyID: %v, close node: %v", dependencyID, cmdCtx.nodeID)
 	} else {
 		b.openForwardDependencies[dependencyID] = acc.Nodes
 	}
@@ -105,7 +105,7 @@ func (b *forwardWatcher) CloseForwardDependency(ctx context.Context, cmdCtx CmdC
 			Mode:         FORWARD_CLOSE,
 		})
 	} else {
-		log.I(ctx, "CloseForwardDependency: Forward dependency closed before being opened. DependencyID: %v, close node: %v", dependencyID, cmdCtx.nodeID)
+		log.D(ctx, "CloseForwardDependency: Forward dependency closed before being opened. DependencyID: %v, close node: %v", dependencyID, cmdCtx.nodeID)
 	}
 
 }
@@ -120,7 +120,7 @@ func (b *forwardWatcher) DropForwardDependency(ctx context.Context, cmdCtx CmdCo
 			Mode:         FORWARD_DROP,
 		})
 	} else {
-		log.I(ctx, "DropForwardDependency: Forward dependency dropped before being opened. DependencyID: %v, close node: %v", dependencyID, cmdCtx.nodeID)
+		log.D(ctx, "DropForwardDependency: Forward dependency dropped before being opened. DependencyID: %v, close node: %v", dependencyID, cmdCtx.nodeID)
 	}
 }
 


### PR DESCRIPTION
Also reduces log spam from the dependency graph builder and new DCE