### PR TITLE
Update the version of spv-reflect that we use.

### DIFF
--- a/tools/build/workspace.bzl
+++ b/tools/build/workspace.bzl
@@ -180,7 +180,7 @@ def gapid_dependencies(android = True, mingw = True, locals = {}):
         locals = locals,
         organization = "chaoticbob",
         project = "SPIRV-Reflect",
-        commit = "5598462f987841f7c1abe9209650ea8d3e727b46",
+        commit = "8fd9b11dbd217f6b02c9d6d4e364a7f0327b219a",
         build_file = "@gapid//tools/build/third_party:spirv-reflect.BUILD",
     )
 


### PR DESCRIPTION
This merges in a fix for empty descriptor names.