### PR TITLE
Vulkan: Show first layer in case of layered rendering

### DIFF
--- a/gapis/api/vulkan/api/image.api
+++ b/gapis/api/vulkan/api/image.api
@@ -745,6 +745,25 @@ sub void transitionImageLayout(ref!ImageObject img, VkImageSubresourceRange rng,
   }
 }
 
+sub void transitionImageViewLayout(
+    ref!ImageViewObject view,
+    VkImageLayout oldLayout,
+    VkImageLayout newLayout) {
+  if is2DView3DImage(view) {
+    rng := VkImageSubresourceRange(
+      aspectMask: view.SubresourceRange.aspectMask,
+      baseMipLevel: view.SubresourceRange.baseMipLevel,
+      levelCount: view.SubresourceRange.levelCount,
+      baseArrayLayer: 0,
+      layerCount: 1)
+    transitionImageLayout(
+      view.Image, rng, oldLayout, newLayout)
+  } else {
+    transitionImageLayout(
+      view.Image, view.SubresourceRange, oldLayout, newLayout)
+  }
+}
+
 // ----------------------------------------------------------------------------
 // Vulkan 1.1 Commands
 // ----------------------------------------------------------------------------

--- a/gapis/api/vulkan/api/renderpass_framebuffer.api
+++ b/gapis/api/vulkan/api/renderpass_framebuffer.api
@@ -331,20 +331,20 @@ sub void dovkCmdNextSubpass(ref!vkCmdNextSubpassArgs Unused) {
     subpass := ldi.RenderPass.SubpassDescriptions[ldi.LastSubpass]
     for _ , _ , a in subpass.InputAttachments {
       attachment := ldi.Framebuffer.ImageAttachments[a.Attachment]
-      transitionImageLayout(attachment.Image, attachment.SubresourceRange, VK_IMAGE_LAYOUT_UNDEFINED, a.Layout)
+      transitionImageViewLayout(attachment, VK_IMAGE_LAYOUT_UNDEFINED, a.Layout)
     }
     for _ , _ , a in subpass.ColorAttachments {
       attachment := ldi.Framebuffer.ImageAttachments[a.Attachment]
-      transitionImageLayout(attachment.Image, attachment.SubresourceRange, VK_IMAGE_LAYOUT_UNDEFINED, a.Layout)
+      transitionImageViewLayout(attachment, VK_IMAGE_LAYOUT_UNDEFINED, a.Layout)
     }
     for _ , _ , a in subpass.ResolveAttachments {
       attachment := ldi.Framebuffer.ImageAttachments[a.Attachment]
-      transitionImageLayout(attachment.Image, attachment.SubresourceRange, VK_IMAGE_LAYOUT_UNDEFINED, a.Layout)
+      transitionImageViewLayout(attachment, VK_IMAGE_LAYOUT_UNDEFINED, a.Layout)
     }
     if subpass.DepthStencilAttachment != null {
       dsRef := subpass.DepthStencilAttachment
       attachment := ldi.Framebuffer.ImageAttachments[dsRef.Attachment]
-      transitionImageLayout(attachment.Image, attachment.SubresourceRange, VK_IMAGE_LAYOUT_UNDEFINED, dsRef.Layout)
+      transitionImageViewLayout(attachment, VK_IMAGE_LAYOUT_UNDEFINED, dsRef.Layout)
     }
   }
   popAndPushMarkerForNextSubpass(ldi.LastSubpass)
@@ -433,7 +433,7 @@ sub void storeImageAttachment(u32 attachmentID) {
     desc := ldi.RenderPass.AttachmentDescriptions[attachmentID]
     if attachment.Image != null {
       if desc.initialLayout != desc.finalLayout {
-        transitionImageLayout(attachment.Image, attachment.SubresourceRange, VK_IMAGE_LAYOUT_UNDEFINED, desc.finalLayout)
+        transitionImageViewLayout(attachment, VK_IMAGE_LAYOUT_UNDEFINED, desc.finalLayout)
       }
       switch desc.storeOp {
         case VK_ATTACHMENT_STORE_OP_STORE: {

--- a/gapis/api/vulkan/vulkan.api
+++ b/gapis/api/vulkan/vulkan.api
@@ -211,6 +211,7 @@ sub ref!ExtensionSet supportedDeviceExtensions() {
   supported.ExtensionNames["VK_KHR_shader_draw_parameters"] = true
   supported.ExtensionNames["VK_KHR_relaxed_block_layout"] = true
   supported.ExtensionNames["VK_KHR_16bit_storage"] = true
+  supported.ExtensionNames["VK_KHR_maintenance1"] = true
   return supported
 }
 


### PR DESCRIPTION
In cases of layered rendering at vkQueueSubmit, show the first layer in
the framebuffer view.

This is the last bit to support VK_KHR_maintenance1 extension