### PR TITLE
Make AllResourceData resolvable based on resource type.

### DIFF
--- a/gapis/resolve/resolvables.proto
+++ b/gapis/resolve/resolvables.proto
@@ -99,6 +99,7 @@ message ResourceDataResolvable {
 message AllResourceDataResolvable {
   path.Command after = 1;
   path.ResolveConfig config = 2;
+  api.ResourceType type = 3;
 }
 
 message ResourceMetaResolvable {

--- a/gapis/service/service.proto
+++ b/gapis/service/service.proto
@@ -845,6 +845,7 @@ message RenderSettings {
 // Resources contains the full list of resources used by a capture.
 message Resources {
   repeated ResourcesByType types = 1;
+  map<string, api.ResourceType> resourcesToTypes = 2;
 }
 
 // ResourcesByType contains all resources of a specific type.


### PR DESCRIPTION
This means that dump_resources does not have to actually
kick off replays. It also means we don't have to store
as much data if we do not need all of it.

Fixes https://github.com/google/gapid/issues/2435