### PR TITLE
Lower the verbosity of the GRPC log.

### DIFF
--- a/cmd/gapis/main.go
+++ b/cmd/gapis/main.go
@@ -104,7 +104,8 @@ func run(ctx context.Context) error {
 	ctx = trace.PutManager(ctx, trace.New(ctx))
 	ctx = database.Put(ctx, database.NewInMemory(ctx))
 
-	grpclog.SetLogger(log.From(ctx))
+	// Grpc is very verbose, turn that down
+	grpclog.SetLogger(log.From(ctx).SetFilter(log.SeverityFilter(log.Error)))
 
 	var hostDevice *path.Device
 

--- a/core/log/log.go
+++ b/core/log/log.go
@@ -36,6 +36,12 @@ type Logger struct {
 	values      *values
 }
 
+// SetFilter sets the filter for the logger
+func (l *Logger) SetFilter(f Filter) *Logger {
+	l.filter = f
+	return l
+}
+
 // From returns a new Logger from the context ctx.
 func From(ctx context.Context) *Logger {
 	return &Logger{


### PR DESCRIPTION
The new version of GRPC logs more verbosely, clean that up a bit.