### PR TITLE
Rename server_disabled/spy_disabled for subroutines.

### DIFF
--- a/gapis/api/templates/api_spy.cpp.tmpl
+++ b/gapis/api/templates/api_spy.cpp.tmpl
@@ -316,8 +316,8 @@
   {{$args      := Strings "CallObserver* observer" "const std::function<void()>& call" (Macro "C++.CallParameters" $) | JoinWith ", "}}
 
   {{Template "C++.SubReturnType" $}} {{$spyname}}::{{$name}}({{$args}}) {
-    {{if (GetAnnotation ($) "spy_disabled")}}
-      // @spy_disabled
+    {{if (GetAnnotation ($) "strict_dependency")}}
+      // @strict_dependency
     {{else}}
       {{Global "CurrentCommand" $}}
       {{Template "C++.Block" $.Block}}
@@ -351,8 +351,8 @@
 */}}
 {{define "CallSub"}}
   {{AssertType $ "Call"}}
-  {{if (and ($.Target.Function.Subroutine) (GetAnnotation $.Target.Function "spy_disabled")) }}
-   // spy_disabled
+  {{if (and ($.Target.Function.Subroutine) (GetAnnotation $.Target.Function "strict_dependency")) }}
+   // strict_dependency
   {{else                   }}{{Template "C++.Statement.Default" $}}
   {{end}}
 {{end}}

--- a/gapis/api/templates/mutate.go.tmpl
+++ b/gapis/api/templates/mutate.go.tmpl
@@ -106,14 +106,9 @@
       ϟw api.StateWatcher, §
       {{ForEach $.CallParameters "NameAndType" | JoinWith ", "}} §
     ) ({{if not (IsVoid $.Return.Type)}}{{Template "Go.Type" $.Return.Type}}, {{end}}error) {
-    {{if (GetAnnotation ($) "server_disabled")}}
-      // @server_disabled
-      return nil
-    {{else}}
-      ϟl, ϟa := ϟg.MemoryLayout, ϟg.Arena; _, _ = ϟl, ϟa
-      {{Global "CurrentFunction" $}}
-      {{Template "Block" $.Block}}
-    {{end}}
+    ϟl, ϟa := ϟg.MemoryLayout, ϟg.Arena; _, _ = ϟl, ϟa
+    {{Global "CurrentFunction" $}}
+    {{Template "Block" $.Block}}
   }
 {{end}}
 
@@ -353,7 +348,7 @@
   {{else if IsReturn       $}}{{Template "Return" $}}
   {{else if IsIteration    $}}{{Template "Iteration" $}}
   {{else if IsMapIteration $}}{{Template "MapIteration" $}}
-  {{else if IsCall         $}}{{Template "Go.Call" $}}
+  {{else if IsCall         $}}{{Template "Call" $}}
   {{else if IsRead         $}}{{Template "Go.Read" $.Slice}}.OnReadʷ(ϟctx, ϟc, ϟg, ϟb, ϟw)
   {{else if IsWrite        $}}{{Template "Go.Read" $.Slice}}.OnWriteʷ(ϟctx, ϟc, ϟg, ϟb, ϟw)
   {{else if IsFence        $}}{{Template "Fence" $}}
@@ -363,6 +358,25 @@
   {{end}}
 {{end}}
 
+
+{{/*
+-------------------------------------------------------------------------------
+  Emits the logic to potentially short-circuit a Go call.
+-------------------------------------------------------------------------------
+*/}}
+{{define "Call"}}
+ {{if (and ($.Target.Function.Subroutine) (GetAnnotation $.Target.Function "strict_dependency"))}}
+  if ϟw != nil {
+    {{Template "Go.Call" $}}
+  }
+  {{else if (and ($.Target.Function.Subroutine) (GetAnnotation $.Target.Function "relaxed_dependency"))}}
+  if ϟw == nil {
+    {{Template "Go.Call" $}}
+  }
+  {{else}}
+    {{Template "Go.Call" $}}
+  {{end}}
+{{end}}
 
 {{/*
 -------------------------------------------------------------------------------

--- a/gapis/api/vulkan/api/coherent_memory.api
+++ b/gapis/api/vulkan/api/coherent_memory.api
@@ -72,7 +72,7 @@ sub void readCoherentMemoryInBuffer(ref!BufferObject buffer) {
   }
 }
 
-@spy_disabled
+@strict_dependency
 sub void readMemoryInBuffer(ref!BufferObject buffer, VkDeviceSize readOffset, VkDeviceSize readSize) {
   memPieces := getBufferBoundMemoryPiecesInRange(buffer, readOffset, readSize)
   for _, _, mp in memPieces {
@@ -81,7 +81,7 @@ sub void readMemoryInBuffer(ref!BufferObject buffer, VkDeviceSize readOffset, Vk
   }
 }
 
-@spy_disabled
+@strict_dependency
 sub void writeMemoryInBuffer(ref!BufferObject buffer, VkDeviceSize offset, VkDeviceSize size) {
   memPieces := getBufferBoundMemoryPiecesInRange(buffer, offset, size)
   for _, _, mp in memPieces {
@@ -106,7 +106,7 @@ sub void readCoherentMemoryInBufferBindings(map!(u32, ref!VkDescriptorBufferInfo
   }
 }
 
-@spy_disabled
+@strict_dependency
 sub void readMemoryInBufferBindings(map!(u32, ref!VkDescriptorBufferInfo) bufferBindings, map!(u32, VkDeviceSize) bufferBindingOffsets) {
   n := len(bufferBindings)
   for i in (0 .. n) {
@@ -125,7 +125,7 @@ sub void readMemoryInBufferBindings(map!(u32, ref!VkDescriptorBufferInfo) buffer
   }
 }
 
-@spy_disabled
+@strict_dependency
 sub void writeMemoryInBufferBindings(map!(u32, ref!VkDescriptorBufferInfo) bufferBindings, map!(u32, VkDeviceSize) bufferBindingOffsets) {
   n := len(bufferBindings)
   for i in (0 .. n) {
@@ -160,7 +160,7 @@ sub void readCoherentMemoryInBufferViewBindings(map!(u32, VkBufferView) bufferVi
   }
 }
 
-@spy_disabled
+@strict_dependency
 sub void readMemoryInBufferViewBindings(map!(u32, VkBufferView) bufferViews) {
   for _, _, v in bufferViews {
     if v in BufferViews {
@@ -173,7 +173,7 @@ sub void readMemoryInBufferViewBindings(map!(u32, VkBufferView) bufferViews) {
 }
 
 
-@spy_disabled
+@strict_dependency
 sub void writeMemoryInBufferViewBindings(map!(u32, VkBufferView) bufferViews) {
   for _, _, v in bufferViews {
     if v in BufferViews {
@@ -208,7 +208,7 @@ sub void readCoherentMemoryInImage(ref!ImageObject image) {
 
 // VkImageSubresourceRange data
 
-@spy_disabled
+@strict_dependency
 sub void accessImageSubresourceSlice(ref!ImageObject image, VkImageSubresourceRange rng, u32 baseDepth, u32 depthCount, bool isWrite) {
   VK_REMAINING_ARRAY_LAYERS := as!u32(0xFFFFFFFF)
   layerCount := imageSubresourceLayerCount(image, rng)
@@ -263,18 +263,18 @@ sub void accessImageSubresourceSlice(ref!ImageObject image, VkImageSubresourceRa
   }
 }
 
-@spy_disabled
+@strict_dependency
 sub void accessImageSubresource(ref!ImageObject image, VkImageSubresourceRange rng, bool isWrite) {
   VK_REMAINING_ARRAY_LAYERS := as!u32(0xFFFFFFFF)
   accessImageSubresourceSlice(image, rng, 0, VK_REMAINING_ARRAY_LAYERS, isWrite)
 }
 
-@spy_disabled
+@strict_dependency
 sub void readImageSubresource(ref!ImageObject image, VkImageSubresourceRange rng) {
   accessImageSubresource(image, rng, false)
 }
 
-@spy_disabled
+@strict_dependency
 sub void writeImageSubresource(ref!ImageObject image, VkImageSubresourceRange rng) {
   accessImageSubresource(image, rng, true)
 }
@@ -284,7 +284,7 @@ sub bool is2DView3DImage(ref!ImageViewObject view) {
       ((view.Type == VK_IMAGE_VIEW_TYPE_2D) || (view.Type == VK_IMAGE_VIEW_TYPE_2D_ARRAY)))
 }
 
-@spy_disabled
+@strict_dependency
 sub void accessImageView(ref!ImageViewObject view, bool isWrite) {
   if is2DView3DImage(view) {
     rng := VkImageSubresourceRange(
@@ -301,17 +301,16 @@ sub void accessImageView(ref!ImageViewObject view, bool isWrite) {
   }
 }
 
-@spy_disabled
+@strict_dependency
 sub void readImageView(ref!ImageViewObject view) {
   accessImageView(view, false)
 }
 
-@spy_disabled
+@strict_dependency
 sub void writeImageView(ref!ImageViewObject view) {
   accessImageView(view, true)
 }
 
-@spy_disabled
 sub void updateImageViewQueue(ref!ImageViewObject view) {
   if is2DView3DImage(view) {
     rng := VkImageSubresourceRange(
@@ -328,7 +327,7 @@ sub void updateImageViewQueue(ref!ImageViewObject view) {
 
 // VkImageViews used as Framebuffer attachments are handled in
 // renderpass_framebuffer.api
-@server_disabled
+@relaxed_dependency
 sub void readCoherentMemoryInImageBindings(map!(u32, ref!VkDescriptorImageInfo) imageBindings) {
   for _, _, v in imageBindings {
     _ = Samplers[v.Sampler]
@@ -343,7 +342,7 @@ sub void readCoherentMemoryInImageBindings(map!(u32, ref!VkDescriptorImageInfo) 
   }
 }
 
-@spy_disabled
+@strict_dependency
 sub void readMemoryInImageBindings(map!(u32, ref!VkDescriptorImageInfo) imageBindings) {
   for _, _, v in imageBindings {
     _ = Samplers[v.Sampler]
@@ -357,7 +356,7 @@ sub void readMemoryInImageBindings(map!(u32, ref!VkDescriptorImageInfo) imageBin
   }
 }
 
-@spy_disabled
+@strict_dependency
 sub void writeMemoryInImageBindings(map!(u32, ref!VkDescriptorImageInfo) imageBindings) {
   for _, _, v in imageBindings {
     _ = Samplers[v.Sampler]
@@ -371,7 +370,7 @@ sub void writeMemoryInImageBindings(map!(u32, ref!VkDescriptorImageInfo) imageBi
   }
 }
 
-@server_disabled
+@relaxed_dependency
 sub void readCoherentMemoryInDescriptor(ref!DescriptorSetObject descriptor_set, u32 b, u32 arrayCount) {
   if descriptor_set != null {
     binding := descriptor_set.Bindings[b]
@@ -402,7 +401,7 @@ sub void readCoherentMemoryInDescriptor(ref!DescriptorSetObject descriptor_set, 
 ///////////////////
 // DescriptorSet //
 ///////////////////
-@spy_disabled
+@strict_dependency
 sub void readMemoryInDescriptor(ref!DescriptorSetObject descriptor_set, u32 b, u32 arrayCount, map!(u32, VkDeviceSize) bufferBindingOffsets) {
   if descriptor_set != null {
     binding := descriptor_set.Bindings[b]
@@ -430,7 +429,7 @@ sub void readMemoryInDescriptor(ref!DescriptorSetObject descriptor_set, u32 b, u
   }
 }
 
-@spy_disabled
+@strict_dependency
 sub void writeMemoryInDescriptor(ref!DescriptorSetObject descriptor_set, u32 b, u32 arrayCount, map!(u32, VkDeviceSize) bufferBindingOffsets) {
   if descriptor_set != null {
     binding := descriptor_set.Bindings[b]
@@ -475,7 +474,7 @@ sub void readWriteMemoryInBoundDescriptorSets(
   }
 }
 
-@server_disabled
+@relaxed_dependency
 sub void readCoherentMemoryInCurrentPipelineBoundVertexBuffers(u32 vertexCount, u32 instanceCount, u32 firstVertex, u32 firstInstance) {
   ldi := lastDrawInfo()
   for _ , _ , vertex_binding in ldi.GraphicsPipeline.VertexInputState.BindingDescriptions {
@@ -491,7 +490,7 @@ sub void readMemoryInCurrentPipelineBoundVertexBuffers(u32 vertexCount, u32 inst
     trackMemoryInCurrentPipelineBoundVertexBuffers(vertexCount, instanceCount, firstVertex, firstInstance)
 }
 
-@spy_disabled
+@strict_dependency
 sub void trackMemoryInCurrentPipelineBoundVertexBuffers(u32 vertexCount, u32 instanceCount, u32 firstVertex, u32 firstInstance) {
   ldi := lastDrawInfo()
   for _ , _ , vertex_binding in ldi.GraphicsPipeline.VertexInputState.BindingDescriptions {

--- a/gapis/api/vulkan/api/copy_clear_commands.api
+++ b/gapis/api/vulkan/api/copy_clear_commands.api
@@ -121,7 +121,7 @@ sub map!(VkDeviceSize, OpaqueResourceMemoryBoundPiece) getBufferBoundMemoryPiece
   return ret_val.Map
 }
 
-@spy_disabled
+@strict_dependency
 sub void copyBufferToBuffer(ref!BufferObject dstBuf, VkDeviceSize dstOffset, ref!BufferObject srcBuf, VkDeviceSize srcOffset, VkDeviceSize size) {
   if (dstBuf.Memory != null) && (srcBuf.Memory != null) {
     // No sparse binding in either dst and src
@@ -224,7 +224,7 @@ class vkCmdCopyImageArgs {
   map!(u32, VkImageCopy) Regions
 }
 
-@spy_disabled
+@strict_dependency
 sub void trackVkCmdCopyImage(ref!vkCmdCopyImageArgs args) {
   srcImageObject := Images[args.SrcImage]
   dstImageObject := Images[args.DstImage]
@@ -401,7 +401,7 @@ class vkCmdBlitImageArgs {
   VkFilter               Filter
 }
 
-@spy_disabled
+@strict_dependency
 sub void trackVkCmdBlitImage(ref!vkCmdBlitImageArgs args) {
   srcImageObject := Images[args.SrcImage]
   dstImageObject := Images[args.DstImage]
@@ -581,7 +581,7 @@ sub RowLengthAndImageHeight getRowLengthAndImageHeight(VkBufferImageCopy region)
   return RowLengthAndImageHeight(rowLength, imageHeight)
 }
 
-@spy_disabled
+@strict_dependency
 sub void copyImageBuffer(VkBuffer buffer, VkImage image, VkImageLayout layout, map!(u32, VkBufferImageCopy) regions, bool isSrcBuffer) {
   if !(image in Images) { vkErrorInvalidImage(image) }
   if !(buffer in Buffers) { vkErrorInvalidBuffer(buffer) }
@@ -794,7 +794,7 @@ cmd void vkCmdCopyImageToBuffer(
   u8[]         Data
 }
 
-@spy_disabled
+@strict_dependency
 sub void dovkCmdUpdateBuffer(ref!vkCmdUpdateBufferArgs args) {
   if !(args.DstBuffer in Buffers) { vkErrorInvalidBuffer(args.DstBuffer) }
   Buffers[args.DstBuffer].LastBoundQueue = LastBoundQueue
@@ -847,7 +847,7 @@ class vkCmdFillBufferArgs {
   u32          Data
 }
 
-@spy_disabled
+@strict_dependency
 sub void dovkCmdFillBuffer(ref!vkCmdFillBufferArgs args) {
   if !(args.Buffer in Buffers) { vkErrorInvalidBuffer(args.Buffer) }
   buf := Buffers[args.Buffer]
@@ -896,10 +896,10 @@ class vkCmdClearColorImageArgs {
   VkImage                            Image
   VkImageLayout                      ImageLayout
   VkClearColorValue                  Color
-  map!(u32, VkImageSubresourceRange) Ranges
+  dense_map!(u32, VkImageSubresourceRange) Ranges
 }
 
-@spy_disabled
+@strict_dependency
 sub void dovkCmdClearColorImage(ref!vkCmdClearColorImageArgs args) {
   if !(args.Image in Images) { vkErrorInvalidImage(args.Image) }
   image := Images[args.Image]
@@ -953,10 +953,10 @@ class vkCmdClearDepthStencilImageArgs {
   VkImage                            Image
   VkImageLayout                      ImageLayout
   VkClearDepthStencilValue           DepthStencil
-  map!(u32, VkImageSubresourceRange) Ranges
+  dense_map!(u32, VkImageSubresourceRange) Ranges
 }
 
-@spy_disabled
+@strict_dependency
 sub void dovkCmdClearDepthStencilImage(ref!vkCmdClearDepthStencilImageArgs args) {
   if !(args.Image in Images) { vkErrorInvalidImage(args.Image) }
   image := Images[args.Image]
@@ -1007,11 +1007,11 @@ cmd void vkCmdClearDepthStencilImage(
 
 @internal
 class vkCmdClearAttachmentsArgs {
-  map!(u32, VkClearAttachment) Attachments
-  map!(u32, VkClearRect)       Rects
+  dense_map!(u32, VkClearAttachment) Attachments
+  dense_map!(u32, VkClearRect)       Rects
 }
 
-@spy_disabled
+@strict_dependency
 sub void dovkCmdClearAttachments(ref!vkCmdClearAttachmentsArgs args) {
   useRenderPass()
 }

--- a/gapis/api/vulkan/api/descriptor.api
+++ b/gapis/api/vulkan/api/descriptor.api
@@ -755,7 +755,7 @@ sub void updateDescriptorBufferBindingOffsets(ref!vkCmdBindDescriptorSetsArgs ar
   trackDescriptorBufferBindingOffsets(args)
 }
 
-@spy_disabled
+@strict_dependency
 sub void trackDescriptorBufferBindingOffsets(ref!vkCmdBindDescriptorSetsArgs args) {
   _ = PipelineLayouts[args.Layout]
   dynamic_offset_index := MutableU32(0)
@@ -895,7 +895,7 @@ cmd void vkCmdPushConstants(
   }
 }
 
-@spy_disabled
+@strict_dependency
 sub void readPushConstants(VkPipelineBindPoint bindPoint) {
   layout := boundPipelineLayout(bindPoint)
   pushConstants := lastPushConstants()
@@ -909,7 +909,7 @@ sub void readPushConstants(VkPipelineBindPoint bindPoint) {
 
 // Util
 
-@spy_disabled
+@strict_dependency
 sub void registerDescriptorUser!T(ref!T user, VkDescriptorSet descSet, u32 binding, u32 arrayIndex) {
   if !(descSet in user.DescriptorUsers) {
     bindings := user.DescriptorUsers[descSet]

--- a/gapis/api/vulkan/api/draw_commands.api
+++ b/gapis/api/vulkan/api/draw_commands.api
@@ -88,30 +88,30 @@ cmd void vkCmdBindIndexBuffer(
   }
 }
 
+@internal
+class BufferOffset {
+  VkBuffer buffer
+  VkDeviceSize offset
+}
+
 @internal class
 vkCmdBindVertexBuffersArgs {
   u32                     FirstBinding
   u32                     BindingCount
-  map!(u32, VkBuffer)     Buffers
-  map!(u32, VkDeviceSize) Offsets
-}
-
-@internal
-class CmdBindBuffer {
-  map!(u32, BoundBuffer) BoundBuffers
+  dense_map!(u32, BufferOffset) BuffersOffsets
 }
 
 sub void dovkCmdBindVertexBuffers(ref!vkCmdBindVertexBuffersArgs bind) {
-  n := len(bind.Buffers)
+  n := len(bind.BuffersOffsets)
   for i in (0 .. n) {
-    v := bind.Buffers[as!u32(i)]
-    if !(v in Buffers) {
-      vkErrorInvalidBuffer(v)
+    v := bind.BuffersOffsets[as!u32(i)]
+    if !(v.buffer in Buffers) {
+      vkErrorInvalidBuffer(v.buffer)
     } else {
       lastDrawInfo().BoundVertexBuffers[as!u32(i) + bind.FirstBinding] = BoundBuffer(
-        Buffers[v], bind.Offsets[as!u32(i)],
-        Buffers[v].Info.Size - bind.Offsets[as!u32(i)])
-      Buffers[v].LastBoundQueue = LastBoundQueue
+        Buffers[v.buffer], v.offset,
+        Buffers[v.buffer].Info.Size - v.offset)
+      Buffers[v.buffer].LastBoundQueue = LastBoundQueue
     }
   }
 }
@@ -136,8 +136,7 @@ cmd void vkCmdBindVertexBuffers(
     offsets := pOffsets[0:bindingCount]
     for i in (0 .. bindingCount) {
       if !(buffers[i] in Buffers) { vkErrorInvalidBuffer(buffers[i]) }
-      args.Buffers[i] = buffers[i]
-      args.Offsets[i] = offsets[i]
+      args.BuffersOffsets[i] = BufferOffset(buffers[i], offsets[i])
     }
     cmdBuf := CommandBuffers[commandBuffer]
     mapPos := as!u32(len(cmdBuf.BufferCommands.vkCmdBindVertexBuffers))
@@ -196,14 +195,14 @@ vkCmdDrawIndexedArgs {
   u32 FirstInstance
 }
 
-@server_disabled
+@relaxed_dependency
 sub void readCoherentMemoryInBoundIndexBuffer() {
   lastDraw := lastDrawInfo()
   indexBuffer := lastDraw.BoundIndexBuffer.BoundBuffer.Buffer
   readCoherentMemoryInBuffer(indexBuffer)
 }
 
-@spy_disabled
+@strict_dependency
 sub void readBoundIndexBuffer(u32 indexCount, u32 firstIndex) {
   // Loop through the index buffer, and find the low and high
   // vertices. Then read all of the applicable vertex buffers.
@@ -271,7 +270,7 @@ cmd void vkCmdDrawIndexed(
   u32          Stride
 }
 
-@spy_disabled
+@strict_dependency
 sub void readIndirectDrawBuffer(VkBuffer buf, VkDeviceSize offset, u32 drawCount, u32 stride) {
   if !(buf in Buffers) {
     vkErrorInvalidBuffer(buf)
@@ -484,12 +483,12 @@ sub  ref!DynamicStateSet unpackDynamicState(ref!DynamicData data) {
   return obj
 }
 
-@spy_disabled
+@strict_dependency
 sub void readComputeState() {
   readPushConstants(VK_PIPELINE_BIND_POINT_COMPUTE)
 }
 
-@spy_disabled
+@strict_dependency
 sub void readDrawState() {
   info := lastDrawInfo()
   pipeline := info.GraphicsPipeline

--- a/gapis/api/vulkan/api/pipeline.api
+++ b/gapis/api/vulkan/api/pipeline.api
@@ -869,7 +869,7 @@ cmd void vkCmdBindPipeline(
 
 @internal class vkCmdSetViewportArgs {
   u32                   FirstViewport
-  map!(u32, VkViewport) Viewports
+  dense_map!(u32, VkViewport) Viewports
 }
 
 sub void dovkCmdSetViewport(ref!vkCmdSetViewportArgs args) {
@@ -907,7 +907,7 @@ cmd void vkCmdSetViewport(
 
 @internal class vkCmdSetScissorArgs {
   u32                 FirstScissor
-  map!(u32, VkRect2D) Scissors
+  dense_map!(u32, VkRect2D) Scissors
 }
 
 sub void dovkCmdSetScissor(ref!vkCmdSetScissorArgs args) {

--- a/gapis/api/vulkan/api/renderpass_framebuffer.api
+++ b/gapis/api/vulkan/api/renderpass_framebuffer.api
@@ -51,7 +51,7 @@
   @unused ref!VulkanDebugMarkerInfo DebugInfo
 }
 
-@spy_disabled
+@strict_dependency
 sub void registerFramebufferUser(ref!ImageViewObject view, VkFramebuffer vkFb, u32 attachment) {
   if !(vkFb in view.FramebufferUsers) {
     f := view.FramebufferUsers[vkFb]
@@ -266,7 +266,7 @@ vkCmdBeginRenderPassArgs {
   VkRenderPass            RenderPass
   VkFramebuffer           Framebuffer
   VkRect2D                RenderArea
-  map!(u32, VkClearValue) ClearValues
+  dense_map!(u32, VkClearValue) ClearValues
 }
 
 sub void dovkCmdBeginRenderPass(ref!vkCmdBeginRenderPassArgs args) {
@@ -459,7 +459,7 @@ sub void storeImageAttachment(u32 attachmentID) {
   }
 }
 
-@spy_disabled
+@strict_dependency
 sub void useRenderPass() {
   // read and write InRenderPass to ensure dependencies between render pass commands
   _ = lastDrawInfo().InRenderPass

--- a/gapis/api/vulkan/api/synchronization.api
+++ b/gapis/api/vulkan/api/synchronization.api
@@ -619,7 +619,7 @@ sub void processBarriers(VkPipelineStageFlags             srcStageMask,
   }
 }
 
-@spy_disabled
+@strict_dependency
 sub void processMemoryBarriers(VkPipelineStageFlags       srcStageMask,
                                VkPipelineStageFlags       dstStageMask,
                                map!(u32, VkMemoryBarrier) memoryBarriers) {
@@ -641,7 +641,7 @@ sub void processMemoryBarriers(VkPipelineStageFlags       srcStageMask,
   }
 }
 
-@spy_disabled
+@strict_dependency
 sub void processBufferBarriers(VkPipelineStageFlags             srcStageMask,
                                VkPipelineStageFlags             dstStageMask,
                                map!(u32, VkBufferMemoryBarrier) bufferBarriers) {
@@ -655,7 +655,7 @@ sub void processBufferBarriers(VkPipelineStageFlags             srcStageMask,
   }
 }
 
-@spy_disabled
+@strict_dependency
 sub void processImageBarrier(VkImageMemoryBarrier v, ref!ImageObject image) {
   if v.oldLayout != VK_IMAGE_LAYOUT_UNDEFINED {
     readImageSubresource(image, v.subresourceRange)

--- a/gapis/api/vulkan/command_buffer_rebuilder.go
+++ b/gapis/api/vulkan/command_buffer_rebuilder.go
@@ -275,16 +275,22 @@ func rebuildVkCmdBindVertexBuffers(
 	s *api.GlobalState,
 	d VkCmdBindVertexBuffersArgsʳ) (func(), api.Cmd, error) {
 
-	for i, c := 0, d.Buffers().Len(); i < c; i++ {
-		buf := d.Buffers().Get(uint32(i))
+	buffers := []VkBuffer{}
+	offsets := []VkDeviceSize{}
+	for i := 0; i < d.BuffersOffsets().Len(); i++ {
+		bufOffset := d.BuffersOffsets().Get(uint32(i))
+		buf := d.BuffersOffsets().Get(uint32(i)).Buffer()
+		buffers = append(buffers, buf)
+		offsets = append(offsets, bufOffset.Offset())
 		if !GetState(s).Buffers().Contains(buf) {
 			return nil, nil, fmt.Errorf("Cannot find Buffer %v", buf)
 		}
 	}
 
-	bufferData, _ := unpackMap(ctx, s, d.Buffers())
-	offsetData, _ := unpackMap(ctx, s, d.Offsets())
+	bufferData := s.AllocDataOrPanic(ctx, buffers)
+	offsetData := s.AllocDataOrPanic(ctx, offsets)
 
+	
 	return func() {
 			bufferData.Free()
 			offsetData.Free()


### PR DESCRIPTION
This renames server_disabled/spy_disabled, to allow us to
define which subroutines need to be called for dependency
graph generation or not. This is really what they are trying
to describe.