### PR TITLE
Some improvements to the tracer package

### DIFF
--- a/gapic/src/main/com/google/gapid/views/TracerDialog.java
+++ b/gapic/src/main/com/google/gapid/views/TracerDialog.java
@@ -459,6 +459,10 @@ public class TracerDialog {
             config.getMidExecutionCaptureSupport() != Service.FeatureStatus.NotSupported;
         fromBeginning.setEnabled(mec);
         fromBeginning.setSelection(!mec || !settings.traceMidExecution);
+
+        boolean ext = config != null && config.getCanEnableUnsupportedExtensions();
+        hideUnknownExtensions.setEnabled(ext);
+        hideUnknownExtensions.setSelection(!ext || settings.traceHideUnknownExtensions);
       }
 
       private void updateDevicesDropDown(Settings settings) {

--- a/gapis/resolve/resolve.go
+++ b/gapis/resolve/resolve.go
@@ -69,15 +69,7 @@ func DeviceTraceConfiguration(ctx context.Context, p *path.DeviceTraceConfigurat
 		HasCache:             c.HasCache,
 		CanSpecifyEnv:        c.CanSpecifyEnv,
 		PreferredRootUri:     c.PreferredRootUri,
-		Apis:                 make([]*service.DeviceAPITraceConfiguration, len(c.Apis)),
-	}
-
-	for i, opt := range c.Apis {
-		config.Apis[i] = &service.DeviceAPITraceConfiguration{
-			Api:                        opt.APIName,
-			CanDisablePcs:              opt.CanDisablePCS,
-			MidExecutionCaptureSupport: opt.MidExecutionCaptureSupport,
-		}
+		Apis:                 c.Apis,
 	}
 	return config, nil
 }

--- a/gapis/resolve/resolve.go
+++ b/gapis/resolve/resolve.go
@@ -56,22 +56,7 @@ func Device(ctx context.Context, p *path.Device, r *path.ResolveConfig) (*device
 
 // DeviceTraceConfiguration resolves and returns the trace config for a device.
 func DeviceTraceConfiguration(ctx context.Context, p *path.DeviceTraceConfiguration, r *path.ResolveConfig) (*service.DeviceTraceConfiguration, error) {
-	c, err := trace.TraceConfiguration(ctx, p.Device)
-
-	if err != nil {
-		return nil, err
-	}
-
-	config := &service.DeviceTraceConfiguration{
-		ServerLocalPath:      c.ServerLocalPath,
-		CanSpecifyCwd:        c.CanSpecifyCwd,
-		CanUploadApplication: c.CanUploadApplication,
-		HasCache:             c.HasCache,
-		CanSpecifyEnv:        c.CanSpecifyEnv,
-		PreferredRootUri:     c.PreferredRootUri,
-		Apis:                 c.Apis,
-	}
-	return config, nil
+	return trace.TraceConfiguration(ctx, p.Device)
 }
 
 // ImageInfo resolves and returns the ImageInfo from the path p.

--- a/gapis/server/BUILD.bazel
+++ b/gapis/server/BUILD.bazel
@@ -57,7 +57,6 @@ go_library(
         "//gapis/service/path:go_default_library",
         "//gapis/stringtable:go_default_library",
         "//gapis/trace:go_default_library",
-        "//gapis/trace/tracer:go_default_library",
         "@com_github_golang_protobuf//proto:go_default_library",
         "@com_github_google_go_github//github:go_default_library",
         "@org_golang_google_grpc//:go_default_library",

--- a/gapis/server/server.go
+++ b/gapis/server/server.go
@@ -55,7 +55,6 @@ import (
 	"github.com/google/gapid/gapis/service/path"
 	"github.com/google/gapid/gapis/stringtable"
 	"github.com/google/gapid/gapis/trace"
-	"github.com/google/gapid/gapis/trace/tracer"
 
 	"github.com/google/go-github/github"
 
@@ -547,32 +546,6 @@ func (s *server) FindTraceTargets(ctx context.Context, req *service.FindTraceTar
 	return out, nil
 }
 
-func optionsToTraceOptions(opts *service.TraceOptions) tracer.TraceOptions {
-	return tracer.TraceOptions{
-		URI:                   opts.GetUri(),
-		UploadApplication:     opts.GetUploadApplication(),
-		Port:                  opts.GetPort(),
-		ClearCache:            opts.ClearCache,
-		APIs:                  opts.Apis,
-		WriteFile:             opts.ServerLocalSavePath,
-		AdditionalFlags:       opts.AdditionalCommandLineArgs,
-		CWD:                   opts.Cwd,
-		Environment:           opts.Environment,
-		Duration:              opts.Duration,
-		ObserveFrameFrequency: opts.ObserveFrameFrequency,
-		ObserveDrawFrequency:  opts.ObserveDrawFrequency,
-		StartFrame:            opts.StartFrame,
-		FramesToCapture:       opts.FramesToCapture,
-		DisablePCS:            opts.DisablePcs,
-		RecordErrorState:      opts.RecordErrorState,
-		DeferStart:            opts.DeferStart,
-		NoBuffer:              opts.NoBuffer,
-		HideUnknownExtensions: opts.HideUnknownExtensions,
-		StoreTimestamps:       opts.RecordTraceTimes,
-		PipeName:              opts.PipeName,
-	}
-}
-
 // traceHandler implements the TraceHandler interface
 // It wraps all of the state for a trace operation
 type traceHandler struct {
@@ -594,9 +567,8 @@ func (r *traceHandler) Initialize(opts *service.TraceOptions) (*service.StatusRe
 		return nil, log.Errf(r.ctx, nil, "Error initialize a running trace")
 	}
 	r.initialized = true
-	tracerOptions := optionsToTraceOptions(opts)
 	go func() {
-		r.err = trace.Trace(r.ctx, opts.Device, r.startSignal, &tracerOptions, &r.bytesWritten)
+		r.err = trace.Trace(r.ctx, opts.Device, r.startSignal, opts, &r.bytesWritten)
 		r.done = true
 		r.doneSignalFunc(r.ctx)
 	}()

--- a/gapis/service/service.proto
+++ b/gapis/service/service.proto
@@ -1138,6 +1138,8 @@ message DeviceAPITraceConfiguration {
   bool can_disable_pcs = 2;
   // Does this API support MEC.
   FeatureStatus mid_execution_capture_support = 3;
+  // Whether unsupported extensions can be enabled.
+  bool can_enable_unsupported_extensions = 4;
 }
 
 // GetTimestampsRequest is the request send to server to get the timestamps for

--- a/gapis/trace/BUILD.bazel
+++ b/gapis/trace/BUILD.bazel
@@ -32,6 +32,7 @@ go_library(
         "//core/os/device:go_default_library",
         "//core/os/device/bind:go_default_library",
         "//gapii/client:go_default_library",
+        "//gapis/service:go_default_library",
         "//gapis/service/path:go_default_library",
         "//gapis/trace/android:go_default_library",
         "//gapis/trace/desktop:go_default_library",

--- a/gapis/trace/android/BUILD.bazel
+++ b/gapis/trace/android/BUILD.bazel
@@ -29,6 +29,7 @@ go_library(
         "//gapidapk:go_default_library",
         "//gapidapk/pkginfo:go_default_library",
         "//gapii/client:go_default_library",
+        "//gapis/service:go_default_library",
         "//gapis/trace/tracer:go_default_library",
     ],
 )

--- a/gapis/trace/android/trace.go
+++ b/gapis/trace/android/trace.go
@@ -410,7 +410,7 @@ func (t *androidTracer) FindTraceTargets(ctx context.Context, str string) ([]*tr
 	return nodes, nil
 }
 
-func (t *androidTracer) SetupTrace(ctx context.Context, o *tracer.TraceOptions) (*gapii.Process, func(), error) {
+func (t *androidTracer) SetupTrace(ctx context.Context, o *tracer.TraceOptions) (tracer.Process, func(), error) {
 	var err error
 	cleanup := func() {}
 	var pkg *android.InstalledPackage

--- a/gapis/trace/android/trace.go
+++ b/gapis/trace/android/trace.go
@@ -93,44 +93,25 @@ func NewTracer(dev bind.Device) tracer.Tracer {
 	return &androidTracer{dev.(adb.Device), nil, 1.0, time.Time{}}
 }
 
-// IsServerLocal returns true if all paths on this device can be server-local
-func (t *androidTracer) IsServerLocal() bool {
-	return false
-}
-
-func (t *androidTracer) CanSpecifyCWD() bool {
-	return false
-}
-
-func (t *androidTracer) CanSpecifyEnv() bool {
-	return false
-}
-
-func (t *androidTracer) CanUploadApplication() bool {
-	return true
-}
-
-func (t *androidTracer) HasCache() bool {
-	return true
-}
-
-func (t *androidTracer) CanUsePortFile() bool {
-	return false
-}
-
-func (t *androidTracer) PreferredRootUri(ctx context.Context) (string, error) {
-	return "", nil
-}
-
-func (t *androidTracer) APITraceOptions(ctx context.Context) []*service.DeviceAPITraceConfiguration {
-	options := make([]*service.DeviceAPITraceConfiguration, 0, 2)
+// TraceConfiguration returns the device's supported trace configuration.
+func (t *androidTracer) TraceConfiguration(ctx context.Context) (*service.DeviceTraceConfiguration, error) {
+	apis := make([]*service.DeviceAPITraceConfiguration, 0, 2)
 	if t.b.Instance().GetConfiguration().GetDrivers().GetOpengl().GetVersion() != "" {
-		options = append(options, tracer.GLESTraceOptions())
+		apis = append(apis, tracer.GLESTraceOptions())
 	}
 	if len(t.b.Instance().GetConfiguration().GetDrivers().GetVulkan().GetPhysicalDevices()) > 0 {
-		options = append(options, tracer.VulkanTraceOptions())
+		apis = append(apis, tracer.VulkanTraceOptions())
 	}
-	return options
+
+	return &service.DeviceTraceConfiguration{
+		Apis:                 apis,
+		ServerLocalPath:      false,
+		CanSpecifyCwd:        false,
+		CanUploadApplication: true,
+		CanSpecifyEnv:        false,
+		PreferredRootUri:     "",
+		HasCache:             true,
+	}, nil
 }
 
 func (t *androidTracer) GetTraceTargetNode(ctx context.Context, uri string, iconDensity float32) (*tracer.TraceTargetTreeNode, error) {

--- a/gapis/trace/android/trace.go
+++ b/gapis/trace/android/trace.go
@@ -36,6 +36,7 @@ import (
 	"github.com/google/gapid/gapidapk"
 	"github.com/google/gapid/gapidapk/pkginfo"
 	gapii "github.com/google/gapid/gapii/client"
+	"github.com/google/gapid/gapis/service"
 	"github.com/google/gapid/gapis/trace/tracer"
 )
 
@@ -121,8 +122,8 @@ func (t *androidTracer) PreferredRootUri(ctx context.Context) (string, error) {
 	return "", nil
 }
 
-func (t *androidTracer) APITraceOptions(ctx context.Context) []tracer.APITraceOptions {
-	options := make([]tracer.APITraceOptions, 0, 2)
+func (t *androidTracer) APITraceOptions(ctx context.Context) []*service.DeviceAPITraceConfiguration {
+	options := make([]*service.DeviceAPITraceConfiguration, 0, 2)
 	if t.b.Instance().GetConfiguration().GetDrivers().GetOpengl().GetVersion() != "" {
 		options = append(options, tracer.GLESTraceOptions())
 	}

--- a/gapis/trace/desktop/BUILD.bazel
+++ b/gapis/trace/desktop/BUILD.bazel
@@ -25,6 +25,7 @@ go_library(
         "//core/os/process:go_default_library",
         "//core/vulkan/loader:go_default_library",
         "//gapii/client:go_default_library",
+        "//gapis/service:go_default_library",
         "//gapis/trace/tracer:go_default_library",
     ],
 )

--- a/gapis/trace/desktop/trace.go
+++ b/gapis/trace/desktop/trace.go
@@ -193,7 +193,7 @@ func (t *DesktopTracer) GetTraceTargetNode(ctx context.Context, uri string, icon
 	return tttn, nil
 }
 
-func (t *DesktopTracer) SetupTrace(ctx context.Context, o *tracer.TraceOptions) (tracer.Process, func(), error) {
+func (t *DesktopTracer) SetupTrace(ctx context.Context, o *service.TraceOptions) (tracer.Process, func(), error) {
 	env, err := t.b.GetEnv(ctx)
 	if err != nil {
 		return nil, nil, err
@@ -205,17 +205,17 @@ func (t *DesktopTracer) SetupTrace(ctx context.Context, o *tracer.TraceOptions) 
 		return nil, nil, err
 	}
 	r := regexp.MustCompile("'.+'|\".+\"|\\S+")
-	args := r.FindAllString(o.AdditionalFlags, -1)
+	args := r.FindAllString(o.AdditionalCommandLineArgs, -1)
 
 	for _, x := range o.Environment {
 		env.Add(x)
 	}
 
-	boundPort, err := process.StartOnDevice(ctx, o.URI, process.StartOptions{
+	boundPort, err := process.StartOnDevice(ctx, o.GetUri(), process.StartOptions{
 		Env:        env,
 		Args:       args,
 		PortFile:   portFile,
-		WorkingDir: o.CWD,
+		WorkingDir: o.Cwd,
 		Device:     t.b,
 	})
 
@@ -224,6 +224,6 @@ func (t *DesktopTracer) SetupTrace(ctx context.Context, o *tracer.TraceOptions) 
 		panic(err)
 		return nil, nil, err
 	}
-	process := &gapii.Process{Port: boundPort, Device: t.b, Options: o.GapiiOptions()}
+	process := &gapii.Process{Port: boundPort, Device: t.b, Options: tracer.GapiiOptions(o)}
 	return process, func() { cleanup(ctx) }, nil
 }

--- a/gapis/trace/desktop/trace.go
+++ b/gapis/trace/desktop/trace.go
@@ -28,6 +28,7 @@ import (
 	"github.com/google/gapid/core/os/process"
 	"github.com/google/gapid/core/vulkan/loader"
 	gapii "github.com/google/gapid/gapii/client"
+	"github.com/google/gapid/gapis/service"
 	"github.com/google/gapid/gapis/trace/tracer"
 )
 
@@ -101,8 +102,8 @@ func (t *DesktopTracer) SplitPath(p string) (string, string) {
 	}
 }
 
-func (t *DesktopTracer) APITraceOptions(ctx context.Context) []tracer.APITraceOptions {
-	options := make([]tracer.APITraceOptions, 0, 1)
+func (t *DesktopTracer) APITraceOptions(ctx context.Context) []*service.DeviceAPITraceConfiguration {
+	options := make([]*service.DeviceAPITraceConfiguration, 0, 1)
 	if len(t.b.Instance().GetConfiguration().GetDrivers().GetVulkan().GetPhysicalDevices()) > 0 {
 		options = append(options, tracer.VulkanTraceOptions())
 	}

--- a/gapis/trace/desktop/trace.go
+++ b/gapis/trace/desktop/trace.go
@@ -202,7 +202,7 @@ func (t *DesktopTracer) GetTraceTargetNode(ctx context.Context, uri string, icon
 	return tttn, nil
 }
 
-func (t *DesktopTracer) SetupTrace(ctx context.Context, o *tracer.TraceOptions) (*gapii.Process, func(), error) {
+func (t *DesktopTracer) SetupTrace(ctx context.Context, o *tracer.TraceOptions) (tracer.Process, func(), error) {
 	env, err := t.b.GetEnv(ctx)
 	if err != nil {
 		return nil, nil, err

--- a/gapis/trace/trace.go
+++ b/gapis/trace/trace.go
@@ -23,6 +23,7 @@ import (
 	"github.com/google/gapid/core/event/task"
 	"github.com/google/gapid/core/log"
 	gapii "github.com/google/gapid/gapii/client"
+	"github.com/google/gapid/gapis/service"
 	"github.com/google/gapid/gapis/service/path"
 	"github.com/google/gapid/gapis/trace/tracer"
 )
@@ -71,13 +72,13 @@ func Trace(ctx context.Context, device *path.Device, start task.Signal, options 
 }
 
 type TraceConfig struct {
-	ServerLocalPath      bool                     // Are the paths server-local for this tracer
-	CanSpecifyCwd        bool                     // Does it make sense to specify a CWD for this device
-	CanUploadApplication bool                     // Does this device support app upload
-	CanSpecifyEnv        bool                     // Does this device support environment variables
-	HasCache             bool                     // Does this device have a clearable cache
-	PreferredRootUri     string                   // What URI is the preferred root
-	Apis                 []tracer.APITraceOptions // API specific tracing options
+	ServerLocalPath      bool                                   // Are the paths server-local for this tracer
+	CanSpecifyCwd        bool                                   // Does it make sense to specify a CWD for this device
+	CanUploadApplication bool                                   // Does this device support app upload
+	CanSpecifyEnv        bool                                   // Does this device support environment variables
+	HasCache             bool                                   // Does this device have a clearable cache
+	PreferredRootUri     string                                 // What URI is the preferred root
+	Apis                 []*service.DeviceAPITraceConfiguration // API specific tracing options
 }
 
 func TraceConfiguration(ctx context.Context, device *path.Device) (*TraceConfig, error) {

--- a/gapis/trace/trace.go
+++ b/gapis/trace/trace.go
@@ -28,7 +28,7 @@ import (
 )
 
 func Trace(ctx context.Context, device *path.Device, start task.Signal, options *tracer.TraceOptions, written *int64) error {
-	var process *gapii.Process
+	var process tracer.Process
 	cleanup := func() {}
 	var err error
 	mgr := GetManager(ctx)

--- a/gapis/trace/tracer/BUILD.bazel
+++ b/gapis/trace/tracer/BUILD.bazel
@@ -23,6 +23,7 @@ go_library(
     importpath = "github.com/google/gapid/gapis/trace/tracer",
     visibility = ["//visibility:public"],
     deps = [
+        "//core/event/task:go_default_library",
         "//core/os/device/bind:go_default_library",
         "//gapii/client:go_default_library",
         "//gapis/service:go_default_library",

--- a/gapis/trace/tracer/default_api_trace_options.go
+++ b/gapis/trace/tracer/default_api_trace_options.go
@@ -19,19 +19,19 @@ import (
 )
 
 // VulkanTraceOptions returns the default trace options for Vulkan.
-func VulkanTraceOptions() APITraceOptions {
-	return APITraceOptions{
-		APIName:                    "Vulkan",
-		CanDisablePCS:              false,
+func VulkanTraceOptions() *service.DeviceAPITraceConfiguration {
+	return &service.DeviceAPITraceConfiguration{
+		Api:                        "Vulkan",
+		CanDisablePcs:              false,
 		MidExecutionCaptureSupport: service.FeatureStatus_Supported,
 	}
 }
 
 // GLESTraceOptions returns the default trace options for GLES.
-func GLESTraceOptions() APITraceOptions {
-	return APITraceOptions{
-		APIName:                    "OpenGLES",
-		CanDisablePCS:              true,
+func GLESTraceOptions() *service.DeviceAPITraceConfiguration {
+	return &service.DeviceAPITraceConfiguration{
+		Api:                        "OpenGLES",
+		CanDisablePcs:              true,
 		MidExecutionCaptureSupport: service.FeatureStatus_Experimental,
 	}
 }

--- a/gapis/trace/tracer/default_api_trace_options.go
+++ b/gapis/trace/tracer/default_api_trace_options.go
@@ -21,17 +21,19 @@ import (
 // VulkanTraceOptions returns the default trace options for Vulkan.
 func VulkanTraceOptions() *service.DeviceAPITraceConfiguration {
 	return &service.DeviceAPITraceConfiguration{
-		Api:                        "Vulkan",
-		CanDisablePcs:              false,
-		MidExecutionCaptureSupport: service.FeatureStatus_Supported,
+		Api:                            "Vulkan",
+		CanDisablePcs:                  false,
+		MidExecutionCaptureSupport:     service.FeatureStatus_Supported,
+		CanEnableUnsupportedExtensions: true,
 	}
 }
 
 // GLESTraceOptions returns the default trace options for GLES.
 func GLESTraceOptions() *service.DeviceAPITraceConfiguration {
 	return &service.DeviceAPITraceConfiguration{
-		Api:                        "OpenGLES",
-		CanDisablePcs:              true,
-		MidExecutionCaptureSupport: service.FeatureStatus_Experimental,
+		Api:                            "OpenGLES",
+		CanDisablePcs:                  true,
+		MidExecutionCaptureSupport:     service.FeatureStatus_Experimental,
+		CanEnableUnsupportedExtensions: false,
 	}
 }

--- a/gapis/trace/tracer/tracer.go
+++ b/gapis/trace/tracer/tracer.go
@@ -24,14 +24,6 @@ import (
 	"github.com/google/gapid/gapis/service"
 )
 
-// APITraceOptions represents API-sepcific trace options for a given
-// device.
-type APITraceOptions struct {
-	APIName                    string                // APIName is the name of the API in question
-	CanDisablePCS              bool                  // Does it make sense for this API to disable PCS
-	MidExecutionCaptureSupport service.FeatureStatus // Does this API support MEC
-}
-
 // TraceTargetTreeNode represents a node in the traceable application
 // Tree
 type TraceTargetTreeNode struct {
@@ -100,7 +92,7 @@ type Tracer interface {
 	PreferredRootUri(ctx context.Context) (string, error)
 
 	// TraceOptions returns API-specific trace options for this device
-	APITraceOptions(ctx context.Context) []APITraceOptions
+	APITraceOptions(ctx context.Context) []*service.DeviceAPITraceConfiguration
 	// GetTraceTargetNode returns a TraceTargetTreeNode for the given URI
 	// on the device
 	GetTraceTargetNode(ctx context.Context, uri string, iconDensity float32) (*TraceTargetTreeNode, error)

--- a/gapis/trace/tracer/tracer.go
+++ b/gapis/trace/tracer/tracer.go
@@ -77,22 +77,8 @@ type Process interface {
 // Tracer is an option interface that a bind.Device can implement.
 // If it exists, it is used to set up and connect to a tracing application.
 type Tracer interface {
-	// IsServerLocal returns true if all paths on this device can be server-local
-	IsServerLocal() bool
-	// CanSpecifyCWD returns true if this device has the concept of a CWD
-	CanSpecifyCWD() bool
-	// CanUploadApplication returns true if an application can be uploaded to this device
-	CanUploadApplication() bool
-	// HasCache returns true if the device has an appliction cache that can be cleared
-	HasCache() bool
-	// CanSpecifyEnv() returns true if you can specify environment variables for the tracer
-	CanSpecifyEnv() bool
-
-	// PreferredRootUri returns the preferred path to search URIs
-	PreferredRootUri(ctx context.Context) (string, error)
-
-	// TraceOptions returns API-specific trace options for this device
-	APITraceOptions(ctx context.Context) []*service.DeviceAPITraceConfiguration
+	// TraceConfiguration returns the device's supported trace configuration.
+	TraceConfiguration(ctx context.Context) (*service.DeviceTraceConfiguration, error)
 	// GetTraceTargetNode returns a TraceTargetTreeNode for the given URI
 	// on the device
 	GetTraceTargetNode(ctx context.Context, uri string, iconDensity float32) (*TraceTargetTreeNode, error)


### PR DESCRIPTION
- Adds an abstraction around gapii.Process in the tracer, that will allow a tracer to return a different type of Process that may not require connecting to a port, for example.
- Dump some proto <-> go struct conversion code and just use the protos.
- Correctly disable/check the "hide unsupported extension" setting in the trace dialog.