### PR TITLE
gapit dump_resources: include shader type in file extension

### DIFF
--- a/cmd/gapit/dump_shaders.go
+++ b/cmd/gapit/dump_shaders.go
@@ -90,7 +90,8 @@ func (verb *dumpShadersVerb) Run(ctx context.Context, flags flag.FlagSet) error 
 				}
 
 				shaderSource := resourceData.(*api.ResourceData).GetShader().GetSource()
-				filename := file.SanitizePath(v.GetHandle())
+				shaderType := resourceData.(*api.ResourceData).GetShader().GetType()
+				filename := file.SanitizePath(v.GetHandle() + "." + shaderType.Extension())
 				f, err := os.Create(filename)
 				if err != nil {
 					log.E(ctx, "Could open file to write %s %v", v.GetHandle(), err)

--- a/gapis/api/service.go
+++ b/gapis/api/service.go
@@ -62,3 +62,26 @@ func (t Pipeline_Type) Format(f fmt.State, c rune) {
 func (t StageType) Format(f fmt.State, c rune) {
 	fmt.Fprint(f, strings.Title(strings.ToLower(t.String())))
 }
+
+func (x ShaderType) Extension() string {
+	switch x {
+	case ShaderType_Vertex:
+		return "vert"
+	case ShaderType_Geometry:
+		return "geom"
+	case ShaderType_TessControl:
+		return "tessc"
+	case ShaderType_TessEvaluation:
+		return "tesse"
+	case ShaderType_Fragment:
+		return "frag"
+	case ShaderType_Compute:
+		return "comp"
+	case ShaderType_Spirv:
+		return "spvasm"
+	case ShaderType_SpirvBinary:
+		return "spv"
+	default:
+		return "unknown"
+	}
+}


### PR DESCRIPTION
It can be useful to know the type of dumped shaders. This simple change adds the type as an extension. E.g. "Shader<2><125>.Fragment".