### PR TITLE
gapit: print capture id when loading a capture

### DIFF
--- a/cmd/gapit/common.go
+++ b/cmd/gapit/common.go
@@ -197,6 +197,8 @@ func getGapisAndLoadCapture(ctx context.Context, gapisFlags GapisFlags, gapirFla
 		}
 	}
 
+	log.I(ctx, "Loaded capture; id: %s", capture.ID)
+
 	return client, capture, nil
 }
 

--- a/cmd/gapit/flags.go
+++ b/cmd/gapit/flags.go
@@ -185,6 +185,7 @@ type (
 		AllowIncompleteFrame   bool   `help:"_Make a group for incomplete frames"`
 		Observations           ObservationFlags
 		CommandFilterFlags
+		CaptureFileFlags
 	}
 	ReplaceResourceFlags struct {
 		Gapis                GapisFlags

--- a/cmd/gapit/screenshot.go
+++ b/cmd/gapit/screenshot.go
@@ -65,8 +65,6 @@ func (verb *screenshotVerb) Run(ctx context.Context, flags flag.FlagSet) error {
 	}
 	defer client.Close()
 
-	log.I(ctx, "Getting screenshot from capture id: %s", capture.ID)
-
 	device, err := getDevice(ctx, client, capture, verb.Gapir)
 	if err != nil {
 		return err


### PR DESCRIPTION
Also refactor `gapit commands` to use `getGapisAndLoadCapture`.