### PR TITLE
Clear the global `PhysicalDevices` map on `vkDestroyInstance`.

### DIFF
--- a/gapis/api/vulkan/api/instance.api
+++ b/gapis/api/vulkan/api/instance.api
@@ -72,6 +72,9 @@ cmd void vkDestroyInstance(
     VkInstance                   instance,
     AllocationCallbacks          pAllocator) {
   delete(Instances, instance)
+  for _, device, _ in PhysicalDevices {
+    delete(PhysicalDevices, device)
+  }
 }
 
 @indirect("VkInstance")


### PR DESCRIPTION
A mapping is maintained in the values of this map that maps physical devices to instances. If a driver uses the same id for physical devices between two instances, this mapping is not updated and will point to destroyed instances.