### PR TITLE
Ignore OpenGL deprecation warnings on latest OSX.

### DIFF
--- a/core/os/device/deviceinfo/cc/BUILD.bazel
+++ b/core/os/device/deviceinfo/cc/BUILD.bazel
@@ -17,7 +17,10 @@ load("//tools/build:rules.bzl", "android_dynamic_library", "cc_copts", "mm_libra
 mm_library(
     name = "darwin_query",
     srcs = glob(["osx/*.mm"]),
-    copts = cc_copts(),
+    copts = cc_copts() + [
+        # Avoid OpenGL deprecation error.
+        "-DGL_SILENCE_DEPRECATION",
+    ],
     copy_hdrs = ["query.h"],
     deps = ["//core/os/device:device_cc_proto"],
 )

--- a/gapir/cc/BUILD.bazel
+++ b/gapir/cc/BUILD.bazel
@@ -57,7 +57,12 @@ mm_library(
         ":gles_h",
         ":vulkan_h",
     ],
-    copts = cc_copts(),
+    copts = cc_copts() + [
+        # Avoid OpenGL deprecation error.
+        "-DGL_SILENCE_DEPRECATION",
+        # Avoid NSOpenGLContext.setView deprecation error.
+        "-Wno-deprecated-declarations",
+    ],
     deps = [
         "//core/cc",
     ],


### PR DESCRIPTION
Fixes #2495