### PR TITLE
 Use an explicit stop signal to stop a trace.

### DIFF
--- a/cmd/gapit/benchmark.go
+++ b/cmd/gapit/benchmark.go
@@ -888,20 +888,20 @@ func (verb *benchmarkVerb) doTrace(ctx context.Context, client client.Client, tr
 	if err != nil {
 		return err
 	}
-	defer handler.Dispose()
+	defer handler.Dispose(ctx)
 
 	defer app.AddInterruptHandler(func() {
-		handler.Dispose()
+		handler.Dispose(ctx)
 	})()
 
-	status, err := handler.Initialize(options)
+	status, err := handler.Initialize(ctx, options)
 	if err != nil {
 		return err
 	}
 	verb.traceInitializedTime = time.Now()
 
 	return task.Retry(ctx, 0, time.Second*3, func(ctx context.Context) (retry bool, err error) {
-		status, err = handler.Event(service.TraceEvent_Status)
+		status, err = handler.Event(ctx, service.TraceEvent_Status)
 		if err == io.EOF {
 			return true, nil
 		}

--- a/cmd/gapit/trace.go
+++ b/cmd/gapit/trace.go
@@ -213,13 +213,13 @@ func (verb *traceVerb) Run(ctx context.Context, flags flag.FlagSet) error {
 	if err != nil {
 		return err
 	}
-	defer handler.Dispose()
+	defer handler.Dispose(ctx)
 
 	defer app.AddInterruptHandler(func() {
-		handler.Dispose()
+		handler.Dispose(ctx)
 	})()
 
-	status, err := handler.Initialize(options)
+	status, err := handler.Initialize(ctx, options)
 	if err != nil {
 		return err
 	}
@@ -228,7 +228,7 @@ func (verb *traceVerb) Run(ctx context.Context, flags flag.FlagSet) error {
 	handlerInstalled := false
 
 	return task.Retry(ctx, 0, time.Second*3, func(ctx context.Context) (retry bool, err error) {
-		status, err = handler.Event(service.TraceEvent_Status)
+		status, err = handler.Event(ctx, service.TraceEvent_Status)
 		if err == io.EOF {
 			return true, nil
 		}
@@ -247,11 +247,11 @@ func (verb *traceVerb) Run(ctx context.Context, flags flag.FlagSet) error {
 					if options.DeferStart {
 						println("Press enter to start capturing...")
 						_, _ = reader.ReadString('\n')
-						_, _ = handler.Event(service.TraceEvent_Begin)
+						_, _ = handler.Event(ctx, service.TraceEvent_Begin)
 					}
 					println("Press enter to stop capturing...")
 					_, _ = reader.ReadString('\n')
-					handler.Event(service.TraceEvent_Stop)
+					handler.Event(ctx, service.TraceEvent_Stop)
 				})
 				handlerInstalled = true
 			}

--- a/gapis/client/client.go
+++ b/gapis/client/client.go
@@ -458,7 +458,7 @@ func (c *client) Trace(ctx context.Context) (service.TraceHandler, error) {
 	return &traceHandler{res}, nil
 }
 
-func (t *traceHandler) Initialize(opts *service.TraceOptions) (*service.StatusResponse, error) {
+func (t *traceHandler) Initialize(ctx context.Context, opts *service.TraceOptions) (*service.StatusResponse, error) {
 	err := t.conn.Send(
 		&service.TraceRequest{
 			Action: &service.TraceRequest_Initialize{
@@ -475,7 +475,7 @@ func (t *traceHandler) Initialize(opts *service.TraceOptions) (*service.StatusRe
 	return res.GetStatus(), nil
 }
 
-func (t *traceHandler) Event(evt service.TraceEvent) (*service.StatusResponse, error) {
+func (t *traceHandler) Event(ctx context.Context, evt service.TraceEvent) (*service.StatusResponse, error) {
 	err := t.conn.Send(
 		&service.TraceRequest{
 			Action: &service.TraceRequest_QueryEvent{
@@ -492,7 +492,7 @@ func (t *traceHandler) Event(evt service.TraceEvent) (*service.StatusResponse, e
 	return res.GetStatus(), nil
 }
 
-func (t *traceHandler) Dispose() {
+func (t *traceHandler) Dispose(ctx context.Context) {
 	t.conn.CloseSend()
 }
 

--- a/gapis/server/grpc.go
+++ b/gapis/server/grpc.go
@@ -587,7 +587,7 @@ func (s *grpcServer) Trace(conn service.Gapid_TraceServer) error {
 	if err != nil {
 		return err
 	}
-	defer t.Dispose()
+	defer t.Dispose(ctx)
 
 	for {
 		req, err := conn.Recv()
@@ -600,7 +600,7 @@ func (s *grpcServer) Trace(conn service.Gapid_TraceServer) error {
 
 		switch r := req.Action.(type) {
 		case *service.TraceRequest_Initialize:
-			resp, err := t.Initialize(r.Initialize)
+			resp, err := t.Initialize(ctx, r.Initialize)
 			if err := service.NewError(err); err != nil {
 				r := service.TraceResponse{Res: &service.TraceResponse_Error{
 					Error: err,
@@ -610,7 +610,7 @@ func (s *grpcServer) Trace(conn service.Gapid_TraceServer) error {
 			}
 			conn.Send(&service.TraceResponse{Res: &service.TraceResponse_Status{Status: resp}})
 		case *service.TraceRequest_QueryEvent:
-			resp, err := t.Event(r.QueryEvent)
+			resp, err := t.Event(ctx, r.QueryEvent)
 			if err := service.NewError(err); err != nil {
 				r := service.TraceResponse{Res: &service.TraceResponse_Error{
 					Error: err,

--- a/gapis/service/service.go
+++ b/gapis/service/service.go
@@ -176,9 +176,9 @@ type Service interface {
 }
 
 type TraceHandler interface {
-	Initialize(*TraceOptions) (*StatusResponse, error)
-	Event(TraceEvent) (*StatusResponse, error)
-	Dispose()
+	Initialize(context.Context, *TraceOptions) (*StatusResponse, error)
+	Event(context.Context, TraceEvent) (*StatusResponse, error)
+	Dispose(context.Context)
 }
 
 // FindHandler is the handler of found items using Service.Find.

--- a/gapis/trace/trace.go
+++ b/gapis/trace/trace.go
@@ -28,7 +28,7 @@ import (
 	"github.com/google/gapid/gapis/trace/tracer"
 )
 
-func Trace(ctx context.Context, device *path.Device, start task.Signal, options *service.TraceOptions, written *int64) error {
+func Trace(ctx context.Context, device *path.Device, start task.Signal, stop task.Signal, options *service.TraceOptions, written *int64) error {
 	gapiiOpts := tracer.GapiiOptions(options)
 	var process tracer.Process
 	cleanup := func() {}
@@ -71,7 +71,7 @@ func Trace(ctx context.Context, device *path.Device, start task.Signal, options 
 		ctx, _ = task.WithTimeout(ctx, time.Duration(options.Duration)*time.Second)
 	}
 
-	_, err = process.Capture(ctx, start, file, written)
+	_, err = process.Capture(ctx, start, stop, file, written)
 	return err
 }
 

--- a/gapis/trace/tracer/tracer.go
+++ b/gapis/trace/tracer/tracer.go
@@ -42,8 +42,10 @@ type Process interface {
 	// Capture connects to this trace and waits for a capture to be delivered.
 	// It copies the capture into the supplied writer.
 	// If the process was started with the DeferStart flag, then tracing will wait
-	// until s is fired.
-	Capture(ctx context.Context, s task.Signal, w io.Writer, written *int64) (size int64, err error)
+	// until start is fired.
+	// Capturing will stop when the stop signal is fired (clean stop) or the
+	// context is cancelled (abort).
+	Capture(ctx context.Context, start task.Signal, stop task.Signal, w io.Writer, written *int64) (size int64, err error)
 }
 
 // Tracer is an option interface that a bind.Device can implement.


### PR DESCRIPTION
Instead of canceling the context, use an explicit signal to notify the tracer to stop the trace. This way tracers can perform actions after the stop to cleanup/finalize the trace that would otherwise fail on a canceled context.