### PR TITLE
Fix error handling in gapis Set grpc primitive

### DIFF
--- a/gapis/client/client.go
+++ b/gapis/client/client.go
@@ -109,6 +109,9 @@ func (c *client) Set(ctx context.Context, p *path.Any, v interface{}, r *path.Re
 	if err != nil {
 		return nil, err
 	}
+	if err := res.GetError(); err != nil {
+		return nil, err.Get()
+	}
 	return res.GetPath(), nil
 }
 


### PR DESCRIPTION
The client must check the result GetError() in addition to the regular
error return value.