### PR TITLE
Fix effect of pointer[n] for n > 0.

### DIFF
--- a/gapil/resolver/expression.go
+++ b/gapil/resolver/expression.go
@@ -346,7 +346,7 @@ func index(rv *resolver, in *ast.Index) semantic.Expression {
 			// pointer[n]
 			r := &semantic.BinaryOp{LHS: n, Operator: ast.OpSlice, RHS: n + 1}
 			slice := &semantic.PointerRange{AST: in, Pointer: object, Type: at.Slice, Range: r}
-			out := &semantic.SliceIndex{AST: in, Slice: slice, Type: at.Slice, Index: n}
+			out := &semantic.SliceIndex{AST: in, Slice: slice, Type: at.Slice, Index: semantic.Uint64Value(0)}
 			rv.mappings.Add(in, out)
 			return out
 		}


### PR DESCRIPTION
Pointer[n] was incorrectly getting translated to
slice(n, n+1)[n], instead of slice(n, n+1)[0].