### PR TITLE
Fix condition on shader cross-compilation

### DIFF
--- a/cmd/gapit/benchmark.go
+++ b/cmd/gapit/benchmark.go
@@ -512,9 +512,9 @@ func (verb *benchmarkVerb) Run(ctx context.Context, flags flag.FlagSet) error {
 		for _, types := range resources.GetTypes() {
 			for ii, v := range types.GetResources() {
 				if (types.Type == api.ResourceType_TextureResource ||
-						types.Type == api.ResourceType_ShaderResource ||
-						types.Type == api.ResourceType_ProgramResource) &&
-						ii < 30 {
+					types.Type == api.ResourceType_ShaderResource ||
+					types.Type == api.ResourceType_ProgramResource) &&
+					ii < 30 {
 					gotResources.Add(1)
 					go func(id *path.ID) {
 						defer gotResources.Done()

--- a/gapis/api/gles/find_issues.go
+++ b/gapis/api/gles/find_issues.go
@@ -170,7 +170,7 @@ func (t *findIssues) Transform(ctx context.Context, id api.CmdID, cmd api.Cmd, o
 			return
 		}
 
-		if t.targetVersion.IsES {
+		if !t.targetVersion.IsES {
 			// Check we are able to convert this GLES shader to desktop GL.
 			opts := shadertools.ConvertOptions{
 				ShaderType:        st,


### PR DESCRIPTION
A GLES shader must be cross-compiled to a GL shader only when the target
is *not* a GLES target.