### PR TITLE
Fixed export_replay to  work with ADB devices.

### DIFF
--- a/core/os/device/bind/device.go
+++ b/core/os/device/bind/device.go
@@ -53,4 +53,6 @@ type Device interface {
 	IsDirectory(ctx context.Context, path string) (bool, error)
 	// GetWorkingDirectory returns the directory that this device considers CWD
 	GetWorkingDirectory(ctx context.Context) (string, error)
+	// CanTrace returns true if this device can be used to take a trace
+	CanTrace() bool
 }

--- a/core/os/device/bind/simple.go
+++ b/core/os/device/bind/simple.go
@@ -44,6 +44,9 @@ func (b *Simple) String() string {
 	return b.To.Serial
 }
 
+// CanTrace returns true if this device can be used to take a trace
+func (b *Simple) CanTrace() bool { return true }
+
 // Instance implements the Device interface returning the Information in the To field.
 func (b *Simple) Instance() *device.Instance { return b.To }
 

--- a/gapis/server/export_replay.go
+++ b/gapis/server/export_replay.go
@@ -35,6 +35,14 @@ import (
 	"github.com/google/gapid/gapis/service/path"
 )
 
+type mockDevice struct {
+	bind.Simple
+}
+
+func (*mockDevice) CanTrace() bool {
+	return false
+}
+
 func exportReplay(ctx context.Context, c *path.Capture, d *path.Device, out string, opts *service.ExportReplayOptions) error {
 	cap, err := capture.ResolveGraphicsFromPath(ctx, c)
 
@@ -42,7 +50,8 @@ func exportReplay(ctx context.Context, c *path.Capture, d *path.Device, out stri
 		instance := *cap.Header.Device
 		instance.Name = "mock-" + instance.Name
 		instance.GenID()
-		dev := &bind.Simple{To: &instance}
+		dev := &mockDevice{}
+		dev.To = &instance
 		bind.GetRegistry(ctx).AddDevice(ctx, dev)
 		d = path.NewDevice(dev.Instance().ID.ID())
 	}

--- a/gapis/trace/manager.go
+++ b/gapis/trace/manager.go
@@ -46,6 +46,9 @@ func New(ctx context.Context) *Manager {
 }
 
 func (m *Manager) createTracer(ctx context.Context, dev bind.Device) {
+	if !dev.CanTrace() {
+		return
+	}
 	deviceID := dev.Instance().ID.ID()
 	log.I(ctx, "New trace scheduler for device: %v %v", deviceID, dev.Instance().Name)
 	m.mutex.Lock()
@@ -58,6 +61,9 @@ func (m *Manager) createTracer(ctx context.Context, dev bind.Device) {
 }
 
 func (m *Manager) destroyTracer(ctx context.Context, dev bind.Device) {
+	if !dev.CanTrace() {
+		return
+	}
 	deviceID := dev.Instance().ID.ID()
 	log.I(ctx, "Destroying trace scheduler for device: %v", deviceID)
 	m.mutex.Lock()


### PR DESCRIPTION
Our tracing system was trying to initialize the trace device
which is a mock device. This obviously won't work for a mock
device. Instead, make sure that the Mock devices are not allowed
to trace.

Fixed #2592