### PR TITLE
JNI Library Bazel Rule

### DIFF
--- a/gapic/src/platform/BUILD.bazel
+++ b/gapic/src/platform/BUILD.bazel
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("//tools/build:rules.bzl", "jni_library")
+
 java_library(
     name = "platform",
     srcs = select({
@@ -21,7 +23,7 @@ java_library(
     }),
     resource_strip_prefix = "gapic/src/platform/",
     resources = select({
-        "//tools/build:linux": [":liblinux_glcanvas.so"],
+        "//tools/build:linux": [":liblinux_glcanvas"],
         "//conditions:default": [],
     }),
     visibility = ["//visibility:public"],
@@ -31,31 +33,13 @@ java_library(
     ],
 )
 
-cc_binary(
-    name = "liblinux_glcanvas.so",
-    srcs = [
-        "jni.h",
-        "jni_md.h",
-        "linux/glcanvas.cc",
-    ],
-    includes = ["."],
+jni_library(
+    name = "liblinux_glcanvas",
+    srcs = ["linux/glcanvas.cc"],
     linkopts = [
         "-lGL",
         "-lX11",
     ],
-    linkshared = 1,
-)
-
-genrule(
-    name = "copy_jni.h",
-    srcs = ["@bazel_tools//tools/jdk:jni_header"],
-    outs = ["jni.h"],
-    cmd = "cp -f $< $@",
-)
-
-genrule(
-    name = "copy_jni_md.h",
-    srcs = ["@bazel_tools//tools/jdk:jni_md_header-linux"],
-    outs = ["jni_md.h"],
-    cmd = "cp -f $< $@",
+    visibility = ["//visibility:private"],
+    exports = "linux/glcanvas.exports",
 )

--- a/gapic/src/platform/linux/glcanvas.exports
+++ b/gapic/src/platform/linux/glcanvas.exports
@@ -1,0 +1,1 @@
+Java_com_google_gapid_glcanvas_GlCanvas_createContext0

--- a/tools/build/BUILD.bazel
+++ b/tools/build/BUILD.bazel
@@ -100,3 +100,31 @@ config_setting(
         "NO_ANDROID": "1",
     },
 )
+
+cc_library(
+    name = "jni",
+    hdrs = [
+        "jni.h",
+        "jni_md.h",
+    ],
+    includes = ["."],
+    visibility = ["//visibility:public"],
+)
+
+genrule(
+    name = "copy_jni.h",
+    srcs = ["@bazel_tools//tools/jdk:jni_header"],
+    outs = ["jni.h"],
+    cmd = "cp -f $< $@",
+)
+
+genrule(
+    name = "copy_jni_md.h",
+    srcs = select({
+        ":linux": ["@bazel_tools//tools/jdk:jni_md_header-linux"],
+        ":windows": ["@bazel_tools//tools/jdk:jni_md_header-windows"],
+        ":darwin": ["@bazel_tools//tools/jdk:jni_md_header-darwin"],
+    }),
+    outs = ["jni_md.h"],
+    cmd = "cp -f $< $@",
+)

--- a/tools/build/rules.bzl
+++ b/tools/build/rules.bzl
@@ -19,6 +19,7 @@ load("//tools/build/rules:common.bzl", "generate", "copy", "copy_to", "copy_tree
 load("//tools/build/rules:dynlib.bzl", "android_dynamic_library", "cc_dynamic_library")
 load("//tools/build/rules:embed.bzl", "embed")
 load("//tools/build/rules:filehash.bzl", "filehash")
+load("//tools/build/rules:jni.bzl", "jni_library")
 load("//tools/build/rules:gapil.bzl", "api_library", "api_template")
 load("//tools/build/rules:go.bzl", "go_stripped_binary")
 load("//tools/build/rules:grpc.bzl", "java_grpc_library")

--- a/tools/build/rules/dynlib.bzl
+++ b/tools/build/rules/dynlib.bzl
@@ -55,7 +55,10 @@ def cc_dynamic_library(name, exports = "", visibility = ["//visibility:private"]
         name = name + ".so",
         srcs = [":" + name + "_syms"],
         deps = deps + [name + ".ldscript"],
-        linkopts = linkopts + ["-Wl,--version-script", "$(location " + name + ".ldscript)"],
+        linkopts = linkopts + [
+            "-Wl,--version-script", "$(location " + name + ".ldscript)",
+            "-Wl,-z,defs",
+        ],
         linkshared = 1,
         visibility = ["//visibility:private"],
         **kwargs

--- a/tools/build/rules/jni.bzl
+++ b/tools/build/rules/jni.bzl
@@ -1,0 +1,31 @@
+# Copyright (C) 2019 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load(":dynlib.bzl", "cc_dynamic_library")
+
+def jni_library(name, exports = "", **kwargs):
+    deps = kwargs.pop("deps", default = []) + ["//tools/build:jni"]
+    native.cc_library(
+        name = name + "_lib",
+        deps = deps,
+        **kwargs
+    )
+
+    cc_dynamic_library(
+        name = name,
+        exports = exports,
+        linkopts = ["-z noexecstack"],
+        visibility = kwargs.get("visibility"),
+        deps = [":" + name + "_lib"],
+    )


### PR DESCRIPTION
Also causes the linking of a `cc_dynamic_library` to fail if it would result in a library with undefined symbols.