### PR TITLE
 Don't rely on context cancelation to release a Vulkan device.

### DIFF
--- a/core/app/BUILD.bazel
+++ b/core/app/BUILD.bazel
@@ -19,6 +19,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "atexit.go",
+        "cleanup.go",
         "default_version.go",
         "doc.go",
         "flags.go",

--- a/core/app/cleanup.go
+++ b/core/app/cleanup.go
@@ -1,0 +1,43 @@
+// Copyright (C) 2019 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package app
+
+import "context"
+
+// Cleanup is a function that is invoked at a later time to perform the cleanup.
+type Cleanup func(ctx context.Context)
+
+// Then combines two clean up functions into a single cleanup function.
+func (c Cleanup) Then(next Cleanup) Cleanup {
+	if c == nil {
+		return next
+	}
+	if next == nil {
+		return c
+	}
+	return func(ctx context.Context) {
+		c(ctx)
+		next(ctx)
+	}
+}
+
+// Invoke invokes the possibly nil cleanup safely. Returns a nil Cleanup, so
+// this can be chained when invoking the cleanup as part of the error handling.
+func (c Cleanup) Invoke(ctx context.Context) Cleanup {
+	if c != nil {
+		c(ctx)
+	}
+	return nil
+}

--- a/core/os/device/remotessh/BUILD.bazel
+++ b/core/os/device/remotessh/BUILD.bazel
@@ -24,6 +24,7 @@ go_library(
     importpath = "github.com/google/gapid/core/os/device/remotessh",
     visibility = ["//visibility:public"],
     deps = [
+        "//core/app:go_default_library",
         "//core/app/crash:go_default_library",
         "//core/app/layout:go_default_library",
         "//core/event/task:go_default_library",

--- a/core/os/device/remotessh/commands.go
+++ b/core/os/device/remotessh/commands.go
@@ -26,6 +26,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/google/gapid/core/app"
 	"github.com/google/gapid/core/app/crash"
 	"github.com/google/gapid/core/event/task"
 	"github.com/google/gapid/core/log"
@@ -150,7 +151,7 @@ func (b binding) destroyPosixDirectory(ctx context.Context, dir string) {
 	_, _ = b.Shell("rm", "-rf", dir).Call(ctx)
 }
 
-func (b binding) createPosixTempDirectory(ctx context.Context) (string, func(context.Context), error) {
+func (b binding) createPosixTempDirectory(ctx context.Context) (string, app.Cleanup, error) {
 	dir, err := b.Shell("mktemp", "-d").Call(ctx)
 	if err != nil {
 		return "", nil, err
@@ -158,13 +159,13 @@ func (b binding) createPosixTempDirectory(ctx context.Context) (string, func(con
 	return dir, func(ctx context.Context) { b.destroyPosixDirectory(ctx, dir) }, nil
 }
 
-func (b binding) createWindowsTempDirectory(ctx context.Context) (string, func(ctx context.Context), error) {
+func (b binding) createWindowsTempDirectory(ctx context.Context) (string, app.Cleanup, error) {
 	return "", nil, fmt.Errorf("Windows remote targets are not yet supported.")
 }
 
 // MakeTempDir creates a temporary directory on the remote machine. It returns the
 // full path, and a function that can be called to clean up the directory.
-func (b binding) MakeTempDir(ctx context.Context) (string, func(ctx context.Context), error) {
+func (b binding) MakeTempDir(ctx context.Context) (string, app.Cleanup, error) {
 	switch b.os {
 	case device.Linux, device.OSX:
 		return b.createPosixTempDirectory(ctx)

--- a/core/os/device/remotessh/device.go
+++ b/core/os/device/remotessh/device.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	"github.com/golang/protobuf/jsonpb"
+	"github.com/google/gapid/core/app"
 	"github.com/google/gapid/core/app/layout"
 	"github.com/google/gapid/core/event/task"
 	"github.com/google/gapid/core/log"
@@ -47,7 +48,7 @@ type Device interface {
 	PushFile(ctx context.Context, sourcePath, destPath string) error
 	// MakeTempDir makes a temporary directory, and returns the
 	// path, as well as a function to call to clean it up.
-	MakeTempDir(ctx context.Context) (string, func(ctx context.Context), error)
+	MakeTempDir(ctx context.Context) (string, app.Cleanup, error)
 	// WriteFile writes the given file into the given location on the remote device
 	WriteFile(ctx context.Context, contents io.Reader, mode os.FileMode, destPath string) error
 	// DefaultReplayCacheDir returns the default path for replay resource caches

--- a/core/vulkan/loader/BUILD.bazel
+++ b/core/vulkan/loader/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
     importpath = "github.com/google/gapid/core/vulkan/loader",
     visibility = ["//visibility:public"],
     deps = [
+        "//core/app:go_default_library",
         "//core/app/layout:go_default_library",
         "//core/os/device:go_default_library",
         "//core/os/device/bind:go_default_library",

--- a/gapir/client/session.go
+++ b/gapir/client/session.go
@@ -137,7 +137,7 @@ func (s *session) newRemote(ctx context.Context, d remotessh.Device, abi *device
 	if err != nil {
 		return err
 	}
-	s.onClose(func() { sessionCleanup(ctx) })
+	s.onClose(func() { sessionCleanup.Invoke(ctx) })
 
 	parser := func(severity log.Severity) io.WriteCloser {
 		h := log.GetHandler(ctx)
@@ -220,7 +220,7 @@ func (s *session) newHost(ctx context.Context, d bind.Device, abi *device.ABI, l
 	if err != nil {
 		return err
 	}
-	s.onClose(func() { cleanup(ctx) })
+	s.onClose(func() { cleanup.Invoke(ctx) })
 
 	parser := func(severity log.Severity) io.WriteCloser {
 		h := log.GetHandler(ctx)

--- a/gapis/trace/BUILD.bazel
+++ b/gapis/trace/BUILD.bazel
@@ -25,6 +25,7 @@ go_library(
     importpath = "github.com/google/gapid/gapis/trace",
     visibility = ["//visibility:public"],
     deps = [
+        "//core/app:go_default_library",
         "//core/context/keys:go_default_library",
         "//core/data/id:go_default_library",
         "//core/event/task:go_default_library",

--- a/gapis/trace/android/BUILD.bazel
+++ b/gapis/trace/android/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
     importpath = "github.com/google/gapid/gapis/trace/android",
     visibility = ["//visibility:public"],
     deps = [
+        "//core/app:go_default_library",
         "//core/log:go_default_library",
         "//core/os/android:go_default_library",
         "//core/os/android/adb:go_default_library",

--- a/gapis/trace/android/trace.go
+++ b/gapis/trace/android/trace.go
@@ -473,11 +473,11 @@ func (t *androidTracer) SetupTrace(ctx context.Context, o *service.TraceOptions)
 			t.b.TurnScreenOff(ctx)
 		})
 	}
+
 	log.I(ctx, "Starting with options %+v", tracer.GapiiOptions(o))
-	process, err := gapii.Start(ctx, pkg, a, tracer.GapiiOptions(o))
+	process, gapiiCleanup, err := gapii.Start(ctx, pkg, a, tracer.GapiiOptions(o))
 	if err != nil {
 		return ret, cleanup.Invoke(ctx), err
 	}
-
-	return process, cleanup, nil
+	return process, cleanup.Then(gapiiCleanup), nil
 }

--- a/gapis/trace/desktop/BUILD.bazel
+++ b/gapis/trace/desktop/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
     importpath = "github.com/google/gapid/gapis/trace/desktop",
     visibility = ["//visibility:public"],
     deps = [
+        "//core/app:go_default_library",
         "//core/os/device:go_default_library",
         "//core/os/device/bind:go_default_library",
         "//core/os/process:go_default_library",

--- a/gapis/trace/trace.go
+++ b/gapis/trace/trace.go
@@ -20,6 +20,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/google/gapid/core/app"
 	"github.com/google/gapid/core/event/task"
 	"github.com/google/gapid/core/log"
 	gapii "github.com/google/gapid/gapii/client"
@@ -31,7 +32,7 @@ import (
 func Trace(ctx context.Context, device *path.Device, start task.Signal, stop task.Signal, options *service.TraceOptions, written *int64) error {
 	gapiiOpts := tracer.GapiiOptions(options)
 	var process tracer.Process
-	cleanup := func() {}
+	var cleanup app.Cleanup
 	mgr := GetManager(ctx)
 	if device == nil {
 		return log.Errf(ctx, nil, "Invalid device path")
@@ -57,7 +58,7 @@ func Trace(ctx context.Context, device *path.Device, start task.Signal, stop tas
 	if err != nil {
 		return log.Errf(ctx, err, "Could not start trace")
 	}
-	defer cleanup()
+	defer cleanup.Invoke(ctx)
 
 	os.MkdirAll(filepath.Dir(options.ServerLocalSavePath), 0755)
 	file, err := os.Create(options.ServerLocalSavePath)

--- a/gapis/trace/tracer/BUILD.bazel
+++ b/gapis/trace/tracer/BUILD.bazel
@@ -23,6 +23,7 @@ go_library(
     importpath = "github.com/google/gapid/gapis/trace/tracer",
     visibility = ["//visibility:public"],
     deps = [
+        "//core/app:go_default_library",
         "//core/event/task:go_default_library",
         "//core/os/device/bind:go_default_library",
         "//gapii/client:go_default_library",

--- a/gapis/trace/tracer/tracer.go
+++ b/gapis/trace/tracer/tracer.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"io"
 
+	"github.com/google/gapid/core/app"
 	"github.com/google/gapid/core/event/task"
 	"github.com/google/gapid/core/os/device/bind"
 	gapii "github.com/google/gapid/gapii/client"
@@ -63,7 +64,7 @@ type Tracer interface {
 	// SetupTrace starts the application on the device, and causes it to wait
 	// for the trace to be started. It returns the process that was created, as
 	// well as a function that can be used to clean up the device
-	SetupTrace(ctx context.Context, o *service.TraceOptions) (Process, func(), error)
+	SetupTrace(ctx context.Context, o *service.TraceOptions) (Process, app.Cleanup, error)
 
 	// GetDevice returns the device associated with this tracer
 	GetDevice() bind.Device


### PR DESCRIPTION
This is an old bug that got exasperated recently. The context was never cancelled if the trace "finished" on its own - i.e. it was bounded by the number of frames captures or the app exited/crashed. Recently, a user request to stop tracing was also changed to not cancel the context either, causing the device to be released even less often. (It appears the context may sometimes get cancelled on gapis exit.)

Fixes #2622