### PR TITLE
Fix calculation of frame count for gapit trim

### DIFF
--- a/cmd/gapit/trim.go
+++ b/cmd/gapit/trim.go
@@ -114,7 +114,7 @@ func (verb *trimVerb) eofEvents(ctx context.Context, capture *path.Capture, clie
 func (verb *trimVerb) getDCERequest(eofEvents []*service.Event, p *path.Capture) []*path.Command {
 	frameCount := verb.Frames.Count
 	if frameCount < 0 {
-		frameCount = len(eofEvents) - verb.Frames.Start + 1
+		frameCount = len(eofEvents) - verb.Frames.Start
 	}
 	dceRequest := make([]*path.Command, 0, frameCount+len(verb.ExtraCommands))
 	for i := 0; i < frameCount; i++ {


### PR DESCRIPTION
The frame count is from the Start index, included, to the end of
eofEvents. In the extreme case of Start being index zero,
frameCount should be equal to len(eofEvents), so the '+ 1' was
erroneous (perhaps due to forgetting Start is an index value).

Fix #2608 