### PR TITLE
Get tests building again.

### DIFF
--- a/gapil/compiler/plugins/replay/replay_test.go
+++ b/gapil/compiler/plugins/replay/replay_test.go
@@ -319,7 +319,7 @@ func (t test) run(ctx context.Context) (succeeded bool) {
 
 	ctx = database.Put(ctx, database.NewInMemory(ctx))
 
-	c := &capture.Capture{}
+	c := &capture.GraphicsCapture{}
 
 	processor := gapil.NewProcessor()
 	processor.Loader = gapil.NewDataLoader([]byte(t.src))

--- a/gapir/cc/interpreter_test.cpp
+++ b/gapir/cc/interpreter_test.cpp
@@ -43,9 +43,8 @@ class InterpreterTest : public ::testing::Test {
   virtual void SetUp() {
     std::vector<uint32_t> memorySizes = {MEMORY_SIZE};
     mMemoryManager.reset(new MemoryManager(memorySizes));
-    auto callback = [](Interpreter*, uint8_t) { return false; };
-    mInterpreter.reset(new Interpreter(crash_handler, mMemoryManager.get(),
-                                       STACK_SIZE, std::move(callback)));
+    mInterpreter.reset(
+        new Interpreter(crash_handler, mMemoryManager.get(), STACK_SIZE));
   }
 
   core::CrashHandler crash_handler;

--- a/gapir/cc/replay_request_test.cpp
+++ b/gapir/cc/replay_request_test.cpp
@@ -58,7 +58,7 @@ TEST(ReplayRequestTestStatic, Create) {
   std::unique_ptr<MemoryManager> memoryManager(new MemoryManager(memorySizes));
 
   auto replayRequest =
-      ReplayRequest::create(mock_srv.get(), memoryManager.get());
+      ReplayRequest::create(mock_srv.get(), "id", memoryManager.get());
 
   EXPECT_THAT(replayRequest, NotNull());
 
@@ -82,7 +82,7 @@ TEST(ReplayRequestTestStatic, CreateErrorGet) {
   std::unique_ptr<MemoryManager> memoryManager(new MemoryManager(memorySizes));
 
   auto replayRequest =
-      ReplayRequest::create(mock_srv.get(), memoryManager.get());
+      ReplayRequest::create(mock_srv.get(), "payload_id", memoryManager.get());
 
   EXPECT_EQ(nullptr, replayRequest);
 }

--- a/gapis/api/gles/compat_test.go
+++ b/gapis/api/gles/compat_test.go
@@ -53,7 +53,12 @@ func TestGlVertexAttribPointerCompatTest(t *testing.T) {
 
 	h := &capture.Header{ABI: device.AndroidARMv7a}
 	ml := h.ABI.MemoryLayout
-	capturePath, err := capture.New(ctx, a, "test", h, nil, []api.Cmd{})
+	cap, err := capture.NewGraphicsCapture(ctx, a, "test", h, nil, []api.Cmd{})
+	if err != nil {
+		panic(err)
+	}
+
+	capturePath, err := cap.Path(ctx)
 	if err != nil {
 		panic(err)
 	}

--- a/gapis/api/gles/dead_code_elimination_test.go
+++ b/gapis/api/gles/dead_code_elimination_test.go
@@ -225,14 +225,19 @@ func TestDeadCommandRemoval(t *testing.T) {
 		cmds := append(prologue, testCmds...)
 
 		h := &capture.Header{ABI: device.WindowsX86_64}
-		capturePath, err := capture.New(ctx, a, name, h, nil, cmds)
+		cap, err := capture.NewGraphicsCapture(ctx, a, name, h, nil, cmds)
+		if err != nil {
+			panic(err)
+		}
+		capturePath, err := cap.Path(ctx)
 		if err != nil {
 			panic(err)
 		}
 		ctx = capture.Put(ctx, capturePath)
 
 		// First verify the commands mutate without errors
-		c, _ := capture.Resolve(ctx)
+		uc, _ := capture.Resolve(ctx)
+		c := uc.(*capture.GraphicsCapture)
 		s := c.NewState(ctx)
 		err = api.ForeachCmd(ctx, cmds, func(ctx context.Context, id api.CmdID, cmd api.Cmd) error {
 			if err := cmd.Mutate(ctx, id, s, nil, nil); err != nil {

--- a/gapis/capture/capture_test.go
+++ b/gapis/capture/capture_test.go
@@ -33,8 +33,12 @@ func TestCaptureExportImport(t *testing.T) {
 	ctx = database.Put(ctx, database.NewInMemory(ctx))
 	header := &capture.Header{ABI: device.WindowsX86_64}
 	cmds := []api.Cmd{test.Cmds.A, test.Cmds.B}
-	p, err := capture.New(ctx, arena.New(), "test", header, nil, cmds)
+	c, err := capture.NewGraphicsCapture(ctx, arena.New(), "test", header, nil, cmds)
 	if !assert.For(ctx, "capture.New").ThatError(err).Succeeded() {
+		return
+	}
+	p, err := c.Path(ctx)
+	if !assert.For(ctx, "capture.Path").ThatError(err).Succeeded() {
 		return
 	}
 	ctx = capture.Put(ctx, p)
@@ -56,5 +60,5 @@ func TestCaptureExportImport(t *testing.T) {
 		return
 	}
 
-	assert.For(ctx, "got").That(ic.Commands).CustomDeepEquals(cmds, test.Cmds.IgnoreArena)
+	assert.For(ctx, "got").That(ic.(*capture.GraphicsCapture).Commands).CustomDeepEquals(cmds, test.Cmds.IgnoreArena)
 }

--- a/gapis/capture/graphics.go
+++ b/gapis/capture/graphics.go
@@ -66,6 +66,11 @@ func (g *GraphicsCapture) Name() string {
 	return g.name
 }
 
+// Path returns the path of this capture in the database.
+func (g *GraphicsCapture) Path(ctx context.Context) (*path.Capture, error) {
+	return New(ctx, g)
+}
+
 type InitialState struct {
 	Memory []api.CmdObservation
 	APIs   map[api.API]api.State

--- a/gapis/replay/builder/builder_test.go
+++ b/gapis/replay/builder/builder_test.go
@@ -155,7 +155,7 @@ func TestCommitCommand(t *testing.T) {
 			},
 		},
 	} {
-		b := New(device.Little32)
+		b := New(device.Little32, nil)
 		test.f(b)
 		assert.For(ctx, test.name).ThatSlice(b.instructions).Equals(test.expected)
 	}
@@ -201,7 +201,7 @@ func TestRevertCommand(t *testing.T) {
 			},
 		},
 	} {
-		b := New(device.Little32)
+		b := New(device.Little32, nil)
 		test.f(b)
 
 		assert.For(ctx, test.name).ThatSlice(b.instructions).Equals(test.expected)
@@ -233,7 +233,7 @@ func TestRevertPostbackCommand(t *testing.T) {
 		},
 	} {
 		ctx := log.Enter(ctx, test.name)
-		b := New(device.Little32)
+		b := New(device.Little32, nil)
 		test.f(b)
 		assert.For(ctx, "inst").ThatSlice(b.instructions).Equals(test.expected)
 	}
@@ -317,7 +317,7 @@ func TestMapMemory(t *testing.T) {
 		},
 	} {
 		ctx := log.Enter(ctx, test.name)
-		b := New(device.Little32)
+		b := New(device.Little32, nil)
 		test.f(b)
 		assert.For(ctx, "inst").ThatSlice(b.instructions).Equals(test.expected)
 	}

--- a/gapis/resolve/get_set_test.go
+++ b/gapis/resolve/get_set_test.go
@@ -42,11 +42,15 @@ func newPathTest(ctx context.Context) *path.Capture {
 		cb.CmdTypeMix(1, 15, 25, 35, 45, 55, 65, 75, 85, 95, 105, false, test.Voidᵖ(0x87654321), 3),
 		cb.PrimeState(test.U8ᵖ(0x89abcdef)),
 	}
-	p, err := capture.New(ctx, a, "test", h, nil, cmds)
+	p, err := capture.NewGraphicsCapture(ctx, a, "test", h, nil, cmds)
 	if err != nil {
 		log.F(ctx, true, "Couldn't create capture: %v", err)
 	}
-	return p
+	path, err := p.Path(ctx)
+	if err != nil {
+		log.F(ctx, true, "Couldn't get capture path: %v", err)
+	}
+	return path
 }
 
 func TestGet(t *testing.T) {

--- a/gapis/resolve/state_tree_test.go
+++ b/gapis/resolve/state_tree_test.go
@@ -197,7 +197,11 @@ func TestStateTreeNode(t *testing.T) {
 	ctx := log.Testing(t)
 	ctx = database.Put(ctx, database.NewInMemory(ctx))
 	header := capture.Header{ABI: device.AndroidARM64v8a}
-	c, err := capture.New(ctx, arena.New(), "test-capture", &header, nil, []api.Cmd{})
+	cap, err := capture.NewGraphicsCapture(ctx, arena.New(), "test-capture", &header, nil, []api.Cmd{})
+	if err != nil {
+		panic(err)
+	}
+	c, err := cap.Path(ctx)
 	if err != nil {
 		panic(err)
 	}

--- a/test/integration/gles/replay/gles_test.go
+++ b/test/integration/gles/replay/gles_test.go
@@ -91,7 +91,7 @@ func maybeExportCapture(ctx context.Context, c *path.Capture) {
 	}
 	cap, err := capture.ResolveFromPath(ctx, c)
 	assert.For(ctx, "err").ThatError(err).Succeeded()
-	f, err := os.Create(filepath.Join(*exportCaptures, cap.Name+".gfxtrace"))
+	f, err := os.Create(filepath.Join(*exportCaptures, cap.Name()+".gfxtrace"))
 	assert.For(ctx, "err").ThatError(err).Succeeded()
 	defer f.Close()
 	err = capture.Export(ctx, c, f)
@@ -118,11 +118,12 @@ func mergeCaptures(ctx context.Context, captures ...*path.Capture) *path.Capture
 	for i, path := range captures {
 		c, err := capture.ResolveFromPath(ctx, path)
 		assert.For(ctx, "err").ThatError(err).Succeeded()
-		lists = append(lists, c.Commands)
-		remainingCmds += len(c.Commands)
+		gc := c.(*capture.GraphicsCapture)
+		lists = append(lists, gc.Commands)
+		remainingCmds += len(gc.Commands)
 		threads = append(threads, uint64(0x10000+i))
 		if i == 0 {
-			d = c.Header.Device
+			d = gc.Header.Device
 		}
 	}
 

--- a/test/integration/gles/snippets/builder.go
+++ b/test/integration/gles/snippets/builder.go
@@ -73,11 +73,15 @@ func (b *Builder) Capture(ctx context.Context, name string) *path.Capture {
 		Device: b.device,
 		ABI:    b.abi,
 	}
-	out, err := capture.New(ctx, b.CB.Arena, name, h, nil, b.Cmds)
+	out, err := capture.NewGraphicsCapture(ctx, b.CB.Arena, name, h, nil, b.Cmds)
 	if err != nil {
 		panic(err)
 	}
-	return out
+	path, err := out.Path(ctx)
+	if err != nil {
+		panic(err)
+	}
+	return path
 }
 
 func (b *Builder) newID() uint {

--- a/test/integration/replay/BUILD.bazel
+++ b/test/integration/replay/BUILD.bazel
@@ -36,14 +36,7 @@ go_test(
     ],
     deps = [
         "//core/app:go_default_library",
-        "//core/data/binary:go_default_library",
         "//core/event/task:go_default_library",
-        "//core/log:go_default_library",
-        "//core/os/device/bind:go_default_library",
-        "//gapir/client:go_default_library",
-        "//gapis/database:go_default_library",
         "//gapis/replay/builder:go_default_library",
-        "//gapis/replay/executor:go_default_library",
-        "//gapis/replay/value:go_default_library",
     ],
 )

--- a/test/integration/replay/postback_test.go
+++ b/test/integration/replay/postback_test.go
@@ -18,19 +18,11 @@ import (
 	"context"
 	"flag"
 	"os"
-	"reflect"
 	"testing"
 
 	"github.com/google/gapid/core/app"
-	"github.com/google/gapid/core/data/binary"
 	"github.com/google/gapid/core/event/task"
-	"github.com/google/gapid/core/log"
-	"github.com/google/gapid/core/os/device/bind"
-	gapir "github.com/google/gapid/gapir/client"
-	"github.com/google/gapid/gapis/database"
 	"github.com/google/gapid/gapis/replay/builder"
-	"github.com/google/gapid/gapis/replay/executor"
-	"github.com/google/gapid/gapis/replay/value"
 )
 
 func TestMain(m *testing.M) {
@@ -39,77 +31,83 @@ func TestMain(m *testing.M) {
 	code := m.Run()
 	cancel()
 	app.WaitForCleanup(ctx)
-	os.Exit(code)
+	_ = code
+	//os.Exit(code)
+	os.Exit(-1)
 }
 
 func doReplay(t *testing.T, f func(*builder.Builder)) error {
-	ctx := log.Testing(t)
+	// TODO(awoloszyn): Fix this replay test. The executor API
+	//   has changed, and uses a background connection,
+	//   which is not exposed.
+	/*
+		ctx := log.Testing(t)
 
-	r := bind.NewRegistry()
-	ctx = bind.PutRegistry(ctx, r)
+		r := bind.NewRegistry()
+		ctx = bind.PutRegistry(ctx, r)
 
-	ctx = database.Put(ctx, database.NewInMemory(ctx))
+		ctx = database.Put(ctx, database.NewInMemory(ctx))
 
-	device := bind.Host(ctx)
-	client := gapir.New(ctx)
-	abi := device.Instance().GetConfiguration().PreferredABI(nil)
-	os := device.Instance().GetConfiguration().GetOS()
-	connection, err := client.Connect(ctx, device, abi)
-	if err != nil {
-		t.Errorf("Failed to connect to '%v': %v", device, err)
-		return err
-	}
+		device := bind.Host(ctx)
+		client := gapir.New(ctx)
+		abi := device.Instance().GetConfiguration().PreferredABI(nil)
+		os := device.Instance().GetConfiguration().GetOS()
+		connection, err := client.Connect(ctx, device, abi)
+		if err != nil {
+			t.Errorf("Failed to connect to '%v': %v", device, err)
+			return err
+		}
 
-	b := builder.New(abi.MemoryLayout, nil)
+		b := builder.New(abi.MemoryLayout, nil)
 
-	f(b)
+		f(b)
 
-	payload, decoder, notification, err := b.Build(ctx)
-	if err != nil {
-		t.Errorf("Build failed with error: %v", err)
-		return err
-	}
+		payload, decoder, notification, err := b.Build(ctx)
+		if err != nil {
+			t.Errorf("Build failed with error: %v", err)
+			return err
+		}
 
-	err = executor.Execute(ctx, payload, decoder, notification, connection, abi.MemoryLayout, os)
-	if err != nil {
-		t.Errorf("Executor failed with error: %v", err)
-		return err
-	}
-
+		err = replay.Execute(ctx, payload, decoder, notification, connection, abi.MemoryLayout, os)
+		if err != nil {
+			t.Errorf("Executor failed with error: %v", err)
+			return err
+		}
+	*/
 	return nil
 }
 
 func TestPostbackString(t *testing.T) {
-	expected := "γειά σου κόσμος"
+	/*	expected := "γειά σου κόσμος"
 
-	done := make(chan struct{})
+		done := make(chan struct{})
 
-	if doReplay(t, func(b *builder.Builder) {
-		ptr := b.String(expected)
-		b.Post(ptr, uint64(len(expected)), func(r binary.Reader, err error) {
-			defer close(done)
-			if err != nil {
-				t.Errorf("Postback returned error: %v", err)
-				return
-			}
-			data := make([]byte, len(expected))
-			r.Data(data)
-			err = r.Error()
-			if err != nil {
-				t.Errorf("Postback returned error: %v", err)
-				return
-			}
-			if expected != string(data) {
-				t.Errorf("Postback data was not as expected. Expected: %v. Got: %v", expected, data)
-			}
-		})
-	}) == nil {
-		<-done
-	}
+		if doReplay(t, func(b *builder.Builder) {
+			ptr := b.String(expected)
+			b.Post(ptr, uint64(len(expected)), func(r binary.Reader, err error) {
+				defer close(done)
+				if err != nil {
+					t.Errorf("Postback returned error: %v", err)
+					return
+				}
+				data := make([]byte, len(expected))
+				r.Data(data)
+				err = r.Error()
+				if err != nil {
+					t.Errorf("Postback returned error: %v", err)
+					return
+				}
+				if expected != string(data) {
+					t.Errorf("Postback data was not as expected. Expected: %v. Got: %v", expected, data)
+				}
+			})
+		}) == nil {
+			<-done
+		}*/
 }
 
 func TestMultiPostback(t *testing.T) {
-	done := make(chan struct{})
+	/*done := make(chan struct{})
 
 	if doReplay(t, func(b *builder.Builder) {
 		ptr := b.AllocateTemporaryMemory(8)
@@ -173,4 +171,5 @@ func TestMultiPostback(t *testing.T) {
 	}) == nil {
 		<-done
 	}
+	*/
 }


### PR DESCRIPTION
All tests except for depedencygraph2 tests are building.
I have 7 failures on my machine with these tests.
I have had to disable "postback_test.go" since it now relies
on internal APIs. It will fail until we fix it properly.