### PR TITLE
Correctly set the target/min SDK API.

### DIFF
--- a/gapidapk/android/apk/AndroidManifest.xml.in
+++ b/gapidapk/android/apk/AndroidManifest.xml.in
@@ -21,7 +21,7 @@
     >
 
     <uses-sdk
-        android:minSdkVersion="16"
+        android:minSdkVersion="21"
         android:targetSdkVersion="26" />
 
     <application

--- a/tools/build/rules/AndroidManifest.xml
+++ b/tools/build/rules/AndroidManifest.xml
@@ -18,7 +18,7 @@
     package="com.google.android.gapid.gapii">
 
     <uses-sdk
-        android:minSdkVersion="16"
+        android:minSdkVersion="21"
         android:targetSdkVersion="26" />
 
 </manifest>

--- a/tools/build/workspace.bzl
+++ b/tools/build/workspace.bzl
@@ -199,14 +199,14 @@ def gapid_dependencies(android = True, mingw = True, locals = {}):
             native.android_sdk_repository,
             name = "androidsdk",
             locals = locals,
-            api_level = 26,
+            api_level = 26, # This is the target API
         )
 
         maybe_repository(
             native.android_ndk_repository,
             name = "androidndk",
             locals = locals,
-            api_level = 26,
+            api_level = 21, # This is the minimum API
         )
 
         maybe_repository(


### PR DESCRIPTION
Sigh. For the NDK rule, the API level is really the minimum API level, since that's what will be linked against, while for the SDK, it's the target API. Our native code requires API level 21 (5.0 Lollipop), so updated the manifests as well.

Fixes #2389