### PR TITLE
Added a needs_gpu test tag.

### DIFF
--- a/test/integration/gles/replay/BUILD.bazel
+++ b/test/integration/gles/replay/BUILD.bazel
@@ -69,6 +69,7 @@ go_test(
     tags = [
         "integration",
         "manual",
+        "needs_gpu",
     ],
     deps = [
         "//core/assert:go_default_library",

--- a/test/integration/service/BUILD.bazel
+++ b/test/integration/service/BUILD.bazel
@@ -25,7 +25,10 @@ go_test(
     name = "go_default_test",
     srcs = ["service_test.go"],
     embed = [":go_default_library"],
-    tags = ["integration"],
+    tags = [
+        "integration",
+        "needs_gpu",
+    ],
     deps = [
         "//core/app/auth:go_default_library",
         "//core/assert:go_default_library",


### PR DESCRIPTION
This adds a needs_gpu test tag to those tests that cannot
run without OpenGL being available.