### PR TITLE
 Fix reading of depth textures/buffers in ODR.

### DIFF
--- a/core/cc/gl/formats.cpp
+++ b/core/cc/gl/formats.cpp
@@ -93,7 +93,7 @@ bool getDepthStencilFormat(int d, int s, uint32_t& depth, uint32_t& stencil) {
           stencil = GL_DEPTH24_STENCIL8;
           return true;
         case 32:
-          depth = GL_DEPTH24_STENCIL8;
+          depth = GL_DEPTH32F_STENCIL8;
           stencil = GL_DEPTH32F_STENCIL8;
           return true;
       }

--- a/gapis/api/gles/api/egl.api
+++ b/gapis/api/gles/api/egl.api
@@ -433,11 +433,12 @@ cmd EGLImageKHR eglCreateImageKHR(EGLDisplay      display,
       eglImage.Extra = info
       for i in 0 .. max!u32(info.LayerCount, 1) {
         image := new!Image(
-          Width:        as!GLsizei(info.Width),
-          Height:       as!GLsizei(info.Height),
-          SizedFormat:  sf,
-          DataFormat:   sfInfo.UnsizedFormat,
-          DataType:     sfInfo.DataType,
+          Width:          as!GLsizei(info.Width),
+          Height:         as!GLsizei(info.Height),
+          SizedFormat:    sf,
+          InternalFormat: sf,
+          DataFormat:     sfInfo.UnsizedFormat,
+          DataType:       sfInfo.DataType,
         )
         size := uncompressedImageSize(image.Width, image.Height, image.DataFormat, image.DataType)
         image.Data = make!u8(size)

--- a/gapis/api/gles/api/image_format.api
+++ b/gapis/api/gles/api/image_format.api
@@ -459,7 +459,7 @@ sub GLenum GetSizedFormatFromTuple(GLenum unsizedFormat, GLenum type) {
     @if(Extension.GL_OES_depth_texture)
     case GL_DEPTH_COMPONENT: switch type {
       case GL_UNSIGNED_SHORT: GL_DEPTH_COMPONENT16
-      case GL_UNSIGNED_INT: GL_DEPTH_COMPONENT32
+      case GL_UNSIGNED_INT: GL_DEPTH_COMPONENT24
       default: GL_NONE
     }
     @if(Extension.GL_OES_packed_depth_stencil)

--- a/gapis/api/gles/api/textures_and_samplers.api
+++ b/gapis/api/gles/api/textures_and_samplers.api
@@ -124,6 +124,12 @@ class Image {
   //   (sizedFormat, GL_NONE) - Compressed data.
   @unused GLenum DataFormat
   @unused GLenum DataType
+
+  // The internal format as specified by the application. It may be
+  // the same as SizedFormat, if the application requested a sized
+  // format, but may be unsized and different from SizedFormat, or
+  // GL_NONE for compressed textures and non texture images.
+  @unused GLenum InternalFormat
 }
 
 @internal
@@ -446,6 +452,7 @@ sub void TexImage(TexImageFlags  flags,
           Samples: samples,
           FixedSampleLocations: fixedsamplelocations,
           SizedFormat: sfBox.SizedFormat,
+          InternalFormat: sized_format,
           DataFormat: data_format,
           DataType: data_type))
       }
@@ -1031,6 +1038,7 @@ cmd void glGenerateMipmap(GLenum target) {
             Width: max!GLsizei(1, width),
             Height: max!GLsizei(1, height),
             SizedFormat: base.SizedFormat,
+            InternalFormat: base.InternalFormat,
             DataFormat: base.DataFormat,
             DataType: base.DataType)
           // Set state first so that the command below knowns image size.

--- a/gapis/api/gles/gles.go
+++ b/gapis/api/gles/gles.go
@@ -231,13 +231,13 @@ func GetFramebufferAttachmentInfoByID(
 	}
 
 	fbai, err := s.getFramebufferAttachmentInfo(thread, fb, glAtt)
-	if fbai.format == 0 {
+	if fbai.sizedFormat == 0 {
 		return api.FramebufferAttachmentInfo{}, fmt.Errorf("No format set")
 	}
 	if err != nil {
 		return api.FramebufferAttachmentInfo{}, err
 	}
-	fmt, ty := getUnsizedFormatAndType(fbai.format)
+	fmt, ty := getUnsizedFormatAndType(fbai.sizedFormat)
 	f, err := getImageFormat(fmt, ty)
 	if err != nil {
 		return api.FramebufferAttachmentInfo{}, err

--- a/gapis/api/gles/read_framebuffer.go
+++ b/gapis/api/gles/read_framebuffer.go
@@ -108,7 +108,7 @@ func postFBData(ctx context.Context,
 		res(nil, &service.ErrDataUnavailable{Reason: messages.ErrFramebufferUnavailable()})
 		return
 	}
-	if fbai.format == 0 {
+	if fbai.sizedFormat == 0 {
 		log.W(ctx, "Failed to read framebuffer after cmd %v: no image format", id)
 		res(nil, &service.ErrDataUnavailable{Reason: messages.ErrFramebufferUnavailable()})
 		return
@@ -134,7 +134,7 @@ func postFBData(ctx context.Context,
 	defer t.revert(ctx)
 	t.glBindFramebuffer_Read(ctx, fb)
 
-	unsizedFormat, ty := getUnsizedFormatAndType(fbai.format)
+	unsizedFormat, ty := getUnsizedFormatAndType(fbai.sizedFormat)
 
 	imgFmt, err := getImageFormat(unsizedFormat, ty)
 	if err != nil {
@@ -227,7 +227,7 @@ func postFBData(ctx context.Context,
 		}
 
 		mutateAndWriteEach(ctx, out, dID,
-			cb.GlRenderbufferStorage(GLenum_GL_RENDERBUFFER, fbai.format, GLsizei(inW), GLsizei(inH)),
+			cb.GlRenderbufferStorage(GLenum_GL_RENDERBUFFER, fbai.sizedFormat, GLsizei(inW), GLsizei(inH)),
 			cb.GlFramebufferRenderbuffer(GLenum_GL_DRAW_FRAMEBUFFER, attachment, GLenum_GL_RENDERBUFFER, renderbufferID),
 			cb.GlBlitFramebuffer(0, 0, GLint(inW), GLint(inH), 0, 0, GLint(inW), GLint(inH), bufferBits, GLenum_GL_NEAREST),
 		)
@@ -264,7 +264,7 @@ func postFBData(ctx context.Context,
 		}
 
 		mutateAndWriteEach(ctx, out, dID,
-			cb.GlRenderbufferStorage(GLenum_GL_RENDERBUFFER, fbai.format, GLsizei(outW), GLsizei(outH)),
+			cb.GlRenderbufferStorage(GLenum_GL_RENDERBUFFER, fbai.sizedFormat, GLsizei(outW), GLsizei(outH)),
 			cb.GlFramebufferRenderbuffer(GLenum_GL_DRAW_FRAMEBUFFER, attachment, GLenum_GL_RENDERBUFFER, renderbufferID),
 			cb.GlBlitFramebuffer(0, 0, GLint(inW), GLint(inH), 0, 0, GLint(outW), GLint(outH), bufferBits, sampling),
 		)
@@ -272,7 +272,7 @@ func postFBData(ctx context.Context,
 	}
 
 	if hasDepth && version.IsES {
-		copyDepthToColorGLES(ctx, dID, thread, s, out, t, fbai.format, inW, inH)
+		copyDepthToColorGLES(ctx, dID, thread, s, out, t, fbai, inW, inH)
 	}
 
 	if needFBQuery {

--- a/gapis/api/gles/state.go
+++ b/gapis/api/gles/state.go
@@ -22,10 +22,13 @@ import (
 
 // fbai is the result getFramebufferAttachmentInfo.
 type fbai struct {
-	width        uint32
-	height       uint32
-	format       GLenum // sized
-	multisampled bool
+	width          uint32
+	height         uint32
+	sizedFormat    GLenum
+	internalFormat GLenum // These are GL_NONE, unless the attachement is a texture
+	format         GLenum // that was initialized with a buffer of this internal
+	ty             GLenum // format, format and type.
+	multisampled   bool
 }
 
 func attachmentToEnum(a api.FramebufferAttachment) (GLenum, error) {
@@ -93,7 +96,7 @@ func (s *State) getFramebufferAttachmentInfo(thread uint64, fb FramebufferId, at
 				t.ID(), a.TextureLevel(), a.TextureLayer())
 		}
 		multisampled := l.Samples() > 0
-		return fbai{uint32(l.Width()), uint32(l.Height()), l.SizedFormat(), multisampled}, nil
+		return fbai{uint32(l.Width()), uint32(l.Height()), l.SizedFormat(), l.InternalFormat(), l.DataFormat(), l.DataType(), multisampled}, nil
 	case GLenum_GL_RENDERBUFFER:
 		r := a.Renderbuffer()
 		l := r.Image()
@@ -101,7 +104,7 @@ func (s *State) getFramebufferAttachmentInfo(thread uint64, fb FramebufferId, at
 			return fbai{}, fmt.Errorf("Renderbuffer %v does not have any image date", r.ID())
 		}
 		multisampled := l.Samples() > 0
-		return fbai{uint32(l.Width()), uint32(l.Height()), l.SizedFormat(), multisampled}, nil
+		return fbai{uint32(l.Width()), uint32(l.Height()), l.SizedFormat(), GLenum_GL_NONE, GLenum_GL_NONE, GLenum_GL_NONE, multisampled}, nil
 	default:
 		return fbai{}, fmt.Errorf("Unknown framebuffer attachment type %T", a.Type())
 	}


### PR DESCRIPTION
Depth textures, and framebuffers backed by depth textures, that where created with an unsized internal format require special handling when read back from the GPU. For example, when blitting a FB, the source and target formats will have to match and thus have to both be created with a sized or unsized internal format.

Fixes #2584