### PR TITLE
Fix GAPIR Android app termination

### DIFF
--- a/cmd/gapir/cc/main.cpp
+++ b/cmd/gapir/cc/main.cpp
@@ -380,7 +380,8 @@ void android_main(struct android_app* app) {
     int events;
     const int timeoutMilliseconds = 1000;
     struct android_poll_source* source;
-    while (ALooper_pollAll(timeoutMilliseconds, &fdesc, &events, (void**)&source) >= 0) {
+    while (ALooper_pollAll(timeoutMilliseconds, &fdesc, &events,
+                           (void**)&source) >= 0) {
       // process this event
       if (source) {
         source->process(app, source);


### PR DESCRIPTION
After calling ANativeActivity_finish(), the native app should keep on
polling events and only terminate when app->destroyRequested becomes
true.

This ensure a proper termination of the GAPIR app on Android.