### PR TITLE
Added a -gapir-nofallback flag.

### DIFF
--- a/cmd/gapit/common.go
+++ b/cmd/gapit/common.go
@@ -269,6 +269,10 @@ func getDevice(ctx context.Context, client client.Client, capture *path.Capture,
 		return selected, nil
 	}
 
+	if flags.NoFallback {
+		return nil, log.Err(ctx, nil, "Could not find the requested device.")
+	}
+
 	log.W(ctx, "No compatible devices found. Attempting to use the first device anyway...")
 
 	paths, err = client.GetDevices(ctx)

--- a/cmd/gapit/flags.go
+++ b/cmd/gapit/flags.go
@@ -104,7 +104,8 @@ type (
 	}
 	GapirFlags struct {
 		DeviceFlags
-		Args string `help:"_The arguments to be passed to gapir"`
+		NoFallback bool   `help:"Do not fallback to another device if the requested one could not be found"`
+		Args       string `help:"_The arguments to be passed to gapir"`
 	}
 	GapiiFlags struct {
 		DeviceFlags


### PR DESCRIPTION
This will prevent GAPIR from falling back to a default
device if the given device could not be found.

Fixes #2589.