### PR TITLE
Gracefully fail when context argument is out of range

### DIFF
--- a/cmd/gapit/common.go
+++ b/cmd/gapit/common.go
@@ -45,14 +45,15 @@ import (
 func (f CommandFilterFlags) commandFilter(ctx context.Context, client service.Service, p *path.Capture) (*path.CommandFilter, error) {
 	filter := &path.CommandFilter{}
 	if f.Context >= 0 {
-		contexts, err := client.Get(ctx, p.Contexts().Path(), nil)
+		boxedContexts, err := client.Get(ctx, p.Contexts().Path(), nil)
 		if err != nil {
 			return nil, log.Err(ctx, err, "Failed to load the contexts")
 		}
-		if n := len(contexts.(*service.Contexts).List); f.Context >= n {
+		contexts := boxedContexts.(*service.Contexts)
+		if n := len(contexts.List); f.Context >= n {
 			return nil, log.Errf(ctx, err, "Context %d is out of range [0..%d]", f.Context, n-1)
 		}
-		filter.Context = contexts.(*service.Contexts).List[f.Context].ID
+		filter.Context = contexts.List[f.Context].ID
 	}
 	return filter, nil
 }

--- a/cmd/gapit/common.go
+++ b/cmd/gapit/common.go
@@ -49,7 +49,14 @@ func (f CommandFilterFlags) commandFilter(ctx context.Context, client service.Se
 		if err != nil {
 			return nil, log.Err(ctx, err, "Failed to load the contexts")
 		}
-		filter.Context = contexts.(*service.Contexts).List[f.Context].ID
+		numContexts := len(contexts.(*service.Contexts).List)
+		// f.Context is an ID, so it must be strictly inferior to numContexts
+		if f.Context < numContexts {
+			filter.Context = contexts.(*service.Contexts).List[f.Context].ID
+		} else {
+			msg := fmt.Sprintf("Context %d is out of range [0..%d]", f.Context, numContexts-1)
+			return nil, log.Err(ctx, err, msg)
+		}
 	}
 	return filter, nil
 }

--- a/cmd/gapit/common.go
+++ b/cmd/gapit/common.go
@@ -54,8 +54,7 @@ func (f CommandFilterFlags) commandFilter(ctx context.Context, client service.Se
 		if f.Context < numContexts {
 			filter.Context = contexts.(*service.Contexts).List[f.Context].ID
 		} else {
-			msg := fmt.Sprintf("Context %d is out of range [0..%d]", f.Context, numContexts-1)
-			return nil, log.Err(ctx, err, msg)
+			return nil, log.Errf(ctx, err, "Context %d is out of range [0..%d]", f.Context, numContexts-1)
 		}
 	}
 	return filter, nil

--- a/cmd/gapit/common.go
+++ b/cmd/gapit/common.go
@@ -49,13 +49,10 @@ func (f CommandFilterFlags) commandFilter(ctx context.Context, client service.Se
 		if err != nil {
 			return nil, log.Err(ctx, err, "Failed to load the contexts")
 		}
-		numContexts := len(contexts.(*service.Contexts).List)
-		// f.Context is an ID, so it must be strictly inferior to numContexts
-		if f.Context < numContexts {
-			filter.Context = contexts.(*service.Contexts).List[f.Context].ID
-		} else {
-			return nil, log.Errf(ctx, err, "Context %d is out of range [0..%d]", f.Context, numContexts-1)
+		if n := len(contexts.(*service.Contexts).List); f.Context >= n {
+			return nil, log.Errf(ctx, err, "Context %d is out of range [0..%d]", f.Context, n-1)
 		}
+		filter.Context = contexts.(*service.Contexts).List[f.Context].ID
 	}
 	return filter, nil
 }


### PR DESCRIPTION
Fix #2679 

