### PR TITLE
Homogenize Arm ABI naming

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -86,8 +86,8 @@ copy_to(
         ],
     }),
     rename = {
-        "armeabi-v7a.apk": "gapid-armeabi.apk",
-        "arm64-v8a.apk": "gapid-aarch64.apk",
+        "armeabi-v7a.apk": "gapid-armeabi-v7a.apk",
+        "arm64-v8a.apk": "gapid-arm64-v8a.apk",
         "x86.apk": "gapid-x86.apk",
     },
     to = "pkg",

--- a/cmd/regres/main.go
+++ b/cmd/regres/main.go
@@ -59,8 +59,8 @@ type stats struct {
 	FileSizes            struct { // in bytes
 		LibGAPII                   int `name:"libgapii"`
 		LibVkLayerVirtualSwapchain int `name:"libVkLayer_VirtualSwapchain"`
-		GAPIDAarch64APK            int `name:"gapid-aarch64"`
-		GAPIDArmeabi64APK          int `name:"gapid-armeabi"`
+		GAPIDARMv8aAPK             int `name:"gapid-arm64-v8a"`
+		GAPIDARMv7aAPK             int `name:"gapid-armeabi-v7a"`
 		GAPIDX86APK                int `name:"gapid-x86"`
 		GAPID                      int `name:"gapid"`
 		GAPIR                      int `name:"gapir"`
@@ -139,8 +139,8 @@ func run(ctx context.Context) error {
 		}{
 			{filepath.Join(pkgDir, "lib", dllExt("libgapii")), &r.FileSizes.LibGAPII},
 			{filepath.Join(pkgDir, "lib", dllExt("libVkLayer_VirtualSwapchain")), &r.FileSizes.LibVkLayerVirtualSwapchain},
-			{filepath.Join(pkgDir, "gapid-aarch64.apk"), &r.FileSizes.GAPIDAarch64APK},
-			{filepath.Join(pkgDir, "gapid-armeabi.apk"), &r.FileSizes.GAPIDArmeabi64APK},
+			{filepath.Join(pkgDir, "gapid-armeabi-v7a.apk"), &r.FileSizes.GAPIDARMv7aAPK},
+			{filepath.Join(pkgDir, "gapid-arm64-v8a.apk"), &r.FileSizes.GAPIDARMv8aAPK},
 			{filepath.Join(pkgDir, "gapid-x86.apk"), &r.FileSizes.GAPIDX86APK},
 			{filepath.Join(pkgDir, exeExt("gapid")), &r.FileSizes.GAPID},
 			{filepath.Join(pkgDir, exeExt("gapir")), &r.FileSizes.GAPIR},

--- a/core/app/layout/layout.go
+++ b/core/app/layout/layout.go
@@ -96,8 +96,8 @@ func LibraryName(lib LibraryType, abi *device.ABI) string {
 }
 
 var abiToApk = map[device.Architecture]string{
-	device.ARMv7a: "gapid-armeabi.apk",
-	device.ARMv8a: "gapid-aarch64.apk",
+	device.ARMv7a: "gapid-armeabi-v7a.apk",
+	device.ARMv8a: "gapid-arm64-v8a.apk",
 	device.X86:    "gapid-x86.apk",
 }
 

--- a/core/os/device/abi.go
+++ b/core/os/device/abi.go
@@ -17,9 +17,6 @@ package device
 var (
 	UnknownABI = abi("unknown", UnknownOS, UnknownArchitecture, &MemoryLayout{})
 
-	// AndroidARM defaults to v7a which is the lowest that we support.
-	AndroidARM = abi("armeabi", Android, ARMv7a, Little32)
-
 	AndroidARMv7a   = abi("armeabi-v7a", Android, ARMv7a, ARMv7aLayout)
 	AndroidARM64v8a = abi("arm64-v8a", Android, ARMv8a, ARM64v8aLayout)
 	AndroidX86      = abi("x86", Android, X86, X86IA32Layout)

--- a/core/os/device/deviceinfo/cc/android/query.cpp
+++ b/core/os/device/deviceinfo/cc/android/query.cpp
@@ -51,7 +51,7 @@ void abiByName(const std::string name, device::ABI* abi) {
   abi->set_name(name);
   abi->set_os(device::Android);
 
-  if (name == "armeabi" || name == "armeabi-v7a") {
+  if (name == "armeabi-v7a") {
     // http://infocenter.arm.com/help/topic/com.arm.doc.ihi0042f/IHI0042F_aapcs.pdf
     // 4 DATA TYPES AND ALIGNMENT
     auto memory_layout = new device::MemoryLayout();
@@ -312,7 +312,7 @@ bool createContext() {
 
   if (gContext.mSupportedABIs.size() > 0) {
     auto primaryABI = gContext.mSupportedABIs[0];
-    if (primaryABI == "armeabi" || primaryABI == "armeabi-v7a") {
+    if (primaryABI == "armeabi-v7a") {
       gContext.mCpuArchitecture = device::ARMv7a;
     } else if (primaryABI == "arm64-v8a") {
       gContext.mCpuArchitecture = device::ARMv8a;
@@ -435,7 +435,7 @@ int numABIs() { return gContext.mSupportedABIs.size(); }
 device::ABI* currentABI() {
   device::ABI* out = new device::ABI();
 #if defined(__arm__)
-  abiByName("armeabi", out);
+  abiByName("armeabi-v7a", out);
 #elif defined(__aarch64__)
   abiByName("arm64-v8a", out);
 #elif defined(__i686__)

--- a/gapidapk/android/apk/BUILD.bazel
+++ b/gapidapk/android/apk/BUILD.bazel
@@ -27,14 +27,14 @@ gapid_apk(
     name = "armeabi-v7a",
     abi = "armeabi-v7a",
     libs = _NATIVE_LIBRARIES,
-    pkg = "armeabi",
+    pkg = "armeabiv7a",
 )
 
 gapid_apk(
     name = "arm64-v8a",
     abi = "arm64-v8a",
     libs = _NATIVE_LIBRARIES,
-    pkg = "aarch64",
+    pkg = "arm64v8a",
 )
 
 gapid_apk(

--- a/gapidapk/gapidapk.go
+++ b/gapidapk/gapidapk.go
@@ -164,8 +164,7 @@ func EnsureInstalled(ctx context.Context, d adb.Device, abi *device.ABI) (*APK, 
 // gapid.apk must be installed for this path to be valid.
 func (a APK) LibsPath(abi *device.ABI) string {
 	switch {
-	case abi.SameAs(device.AndroidARM),
-		abi.SameAs(device.AndroidARMv7a):
+	case abi.SameAs(device.AndroidARMv7a):
 		return a.path + "/lib/arm"
 	case abi.SameAs(device.AndroidARM64v8a):
 		return a.path + "/lib/arm64"
@@ -188,11 +187,10 @@ func (a APK) LibInterceptorPath(abi *device.ABI) string {
 
 func pkgName(abi *device.ABI) string {
 	switch {
-	case abi.SameAs(device.AndroidARM),
-		abi.SameAs(device.AndroidARMv7a):
-		return "com.google.android.gapid.armeabi"
+	case abi.SameAs(device.AndroidARMv7a):
+		return "com.google.android.gapid.armeabiv7a"
 	case abi.SameAs(device.AndroidARM64v8a):
-		return "com.google.android.gapid.aarch64"
+		return "com.google.android.gapid.arm64v8a"
 	default:
 		return fmt.Sprintf("com.google.android.gapid.%v", abi.Name)
 	}

--- a/test/robot/go_robot_go.sh
+++ b/test/robot/go_robot_go.sh
@@ -129,8 +129,8 @@ function pack_local() {
   cp bazel-bin/pkg/gapir ${BUILD_BOT_DIR}/gapid/
   cp bazel-bin/pkg/gapis ${BUILD_BOT_DIR}/gapid/
   cp bazel-bin/pkg/gapit ${BUILD_BOT_DIR}/gapid/
-  cp bazel-bin/pkg/gapid-aarch64.apk ${BUILD_BOT_DIR}/gapid/android-armv8a/
-  cp bazel-bin/pkg/gapid-armeabi.apk ${BUILD_BOT_DIR}/gapid/android-armv7a/
+  cp bazel-bin/pkg/gapid-arm64-v8a.apk ${BUILD_BOT_DIR}/gapid/android-armv8a/
+  cp bazel-bin/pkg/gapid-armeabi-v7a.apk ${BUILD_BOT_DIR}/gapid/android-armv7a/
   cp bazel-bin/pkg/gapid-x86.apk ${BUILD_BOT_DIR}/gapid/android-x86/
   if [[ -z "$(git status -z | tr -d \0)" ]]; then
     BUILD_BOT_CL="$(git log --pretty="format:%H" -1 .)"

--- a/test/robot/replay/client.go
+++ b/test/robot/replay/client.go
@@ -62,8 +62,8 @@ func (c *client) onDeviceAdded(ctx context.Context, host *device.Instance, targe
 		defer func() {
 			// HACK: kill gapid.apk manually for now as subsequent reports/replays may freeze the app.
 			// Remove when https://github.com/google/gapid/issues/1666 is fixed.
-			target.Shell("am", "force-stop", "com.google.android.gapid.aarch64").Run(ctx)
-			target.Shell("am", "force-stop", "com.google.android.gapid.armeabi").Run(ctx)
+			target.Shell("am", "force-stop", "com.google.android.gapid.arm64v8a").Run(ctx)
+			target.Shell("am", "force-stop", "com.google.android.gapid.armeabiv7a").Run(ctx)
 		}()
 		defer job.UnlockDevice(ctx, target)
 		if target.Status(ctx) != bind.Status_Online {

--- a/test/robot/report/client.go
+++ b/test/robot/report/client.go
@@ -62,8 +62,8 @@ func (c *client) onDeviceAdded(ctx context.Context, host *device.Instance, targe
 		defer func() {
 			// HACK: kill gapid.apk manually for now as subsequent reports/replays may freeze the app.
 			// Remove when https://github.com/google/gapid/issues/1666 is fixed.
-			target.Shell("am", "force-stop", "com.google.android.gapid.aarch64").Run(ctx)
-			target.Shell("am", "force-stop", "com.google.android.gapid.armeabi").Run(ctx)
+			target.Shell("am", "force-stop", "com.google.android.gapid.arm64v8a").Run(ctx)
+			target.Shell("am", "force-stop", "com.google.android.gapid.armeabiv7a").Run(ctx)
 		}()
 		defer job.UnlockDevice(ctx, target)
 		if target.Status(ctx) != bind.Status_Online {


### PR DESCRIPTION
Fix #2677 

Naming should now be armeabi-v7a and arm64-v8a everywhere, unless in Android package names which do not tolerate hypens, thus package names are armeabiv7a and arm64v8a.
