### PR TITLE
Use the new system settings driven layer system to trace.

### DIFF
--- a/core/os/android/BUILD.bazel
+++ b/core/os/android/BUILD.bazel
@@ -22,11 +22,13 @@ go_library(
         "device.go",
         "doc.go",
         "installed_package.go",
+        "layers.go",
     ],
     embed = [":android_go_proto"],
     importpath = "github.com/google/gapid/core/os/android",
     visibility = ["//visibility:public"],
     deps = [
+        "//core/app:go_default_library",
         "//core/log:go_default_library",
         "//core/os/device:go_default_library",
         "//core/os/device/bind:go_default_library",

--- a/core/os/android/adb/commands.go
+++ b/core/os/android/adb/commands.go
@@ -186,6 +186,34 @@ func (b *binding) SetSystemProperty(ctx context.Context, name, value string) err
 	return nil
 }
 
+// SystemSetting returns the system setting with the given namespaced key.
+func (b *binding) SystemSetting(ctx context.Context, namespace, key string) (string, error) {
+	res, err := b.Shell("settings", "get", namespace, key).Call(ctx)
+	if err != nil {
+		return "", log.Errf(ctx, err, "settings get returned error: \n%s", err.Error())
+	}
+	return res, nil
+}
+
+// SetSystemSetting sets the system setting with with the given namespaced key
+// to value.
+func (b *binding) SetSystemSetting(ctx context.Context, namespace, key, value string) error {
+	res, err := b.Shell("settings", "put", namespace, key, value).Call(ctx)
+	if err != nil {
+		return log.Errf(ctx, nil, "settings put returned error: \n%s", res)
+	}
+	return nil
+}
+
+// DeleteSystemSetting removes the system setting with with the given namespaced key.
+func (b *binding) DeleteSystemSetting(ctx context.Context, namespace, key string) error {
+	res, err := b.Shell("settings", "delete", namespace, key).Call(ctx)
+	if err != nil {
+		return log.Errf(ctx, nil, "settings delete returned error: \n%s", res)
+	}
+	return nil
+}
+
 // TempFile creates a temporary file on the given Device. It returns the
 // path to the file, and a function that can be called to clean it up.
 func (b *binding) TempFile(ctx context.Context) (string, func(ctx context.Context), error) {

--- a/core/os/android/device.go
+++ b/core/os/android/device.go
@@ -79,10 +79,18 @@ type Device interface {
 	NativeBridgeABI(ctx context.Context, abi *device.ABI) *device.ABI
 	// ForceStop stops the everything associated with the given package.
 	ForceStop(ctx context.Context, pkg string) error
-	// SystemProperty returns the system property in string
+	// SystemProperty returns the system property in string.
 	SystemProperty(ctx context.Context, name string) (string, error)
-	// SetSystemProperty sets the system property with the given string value
+	// SetSystemProperty sets the system property with the given string value.
 	SetSystemProperty(ctx context.Context, name, value string) error
+	// SystemSetting returns the system setting with the given namespaced key.
+	SystemSetting(ctx context.Context, namespace, key string) (string, error)
+	// SetSystemSetting sets the system setting with with the given namespaced
+	// key to value.
+	SetSystemSetting(ctx context.Context, namespace, key, value string) error
+	// DeleteSystemSetting removes the system setting with with the given
+	// namespaced key.
+	DeleteSystemSetting(ctx context.Context, namespace, key string) error
 }
 
 // LogcatMessage represents a single logcat message.

--- a/core/os/android/layers.go
+++ b/core/os/android/layers.go
@@ -1,0 +1,78 @@
+// Copyright (C) 2019 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package android
+
+import (
+	"context"
+
+	"github.com/google/gapid/core/app"
+	"github.com/google/gapid/core/log"
+)
+
+const eglLayersExt = "EGL_ANDROID_GLES_layers"
+
+// SupportsLayersViaSystemSettings returns whether the given device supports
+// loading GLES and Vulkan layers via the system settings.
+func SupportsLayersViaSystemSettings(d Device) bool {
+	// TODO: this currently looks for the EGL extension that advertises the
+	// GLES layer loading capability. Technically, the extension could be
+	// absent, but the device could still support loading Vulkan layers via
+	// the settings. There doesn't appear to be a way to detect Vulkan support
+	// and we currently assume a device either supports both, or none.
+	exts := d.Instance().GetConfiguration().GetDrivers().GetOpengl().GetExtensions()
+	for _, ext := range exts {
+		if ext == eglLayersExt {
+			return true
+		}
+	}
+	return false
+}
+
+// SetupLayer initializes d to use either a Vulkan or GLES layer from layerPkg
+// limited to the app with package appPkg using the system settings and returns
+// a cleanup to remove the layer settings.
+func SetupLayer(ctx context.Context, d Device, appPkg, layerPkg, layer string, vulkan bool) (app.Cleanup, error) {
+	var cleanup app.Cleanup
+
+	// pushSetting changes a device property for the duration of the trace.
+	pushSetting := func(ns, key, val string) error {
+		cleanup = cleanup.Then(func(ctx context.Context) {
+			log.D(ctx, "Removing setting %v", key)
+			d.DeleteSystemSetting(ctx, ns, key)
+		})
+		return d.SetSystemSetting(ctx, ns, key, val)
+	}
+
+	if err := pushSetting("global", "enable_gpu_debug_layers", "1"); err != nil {
+		return cleanup.Invoke(ctx), err
+	}
+	if err := pushSetting("global", "gpu_debug_app", appPkg); err != nil {
+		return cleanup.Invoke(ctx), err
+	}
+	if err := pushSetting("global", "gpu_debug_layer_app", layerPkg); err != nil {
+		return cleanup.Invoke(ctx), err
+	}
+	if vulkan {
+		if err := pushSetting("global", "gpu_debug_layers", layer); err != nil {
+			return cleanup.Invoke(ctx), err
+		}
+	} else {
+		if err := pushSetting("global", "gpu_debug_layers_gles", layer); err != nil {
+			return cleanup.Invoke(ctx), err
+		}
+	}
+
+	return cleanup, nil
+}

--- a/core/os/device/deviceinfo/cc/android/egl_lite.h
+++ b/core/os/device/deviceinfo/cc/android/egl_lite.h
@@ -53,6 +53,7 @@ const EGLint EGL_OPENGL_ES_API = 0x30A0;
 const EGLNativeDisplayType EGL_DEFAULT_DISPLAY = nullptr;
 const EGLContext EGL_NO_CONTEXT = 0;
 const EGLDisplay EGL_NO_DISPLAY = 0;
+const EGLSurface EGL_NO_SURFACE = 0;
 
 typedef EGLBoolean (*PFNEGLBINDAPI)(EGLenum api);
 typedef EGLBoolean (*PFNEGLCHOOSECONFIG)(EGLDisplay display,
@@ -77,5 +78,6 @@ typedef EGLSurface (*PFNEGLCREATEPBUFFERSURFACE)(EGLDisplay display,
                                                  EGLConfig config,
                                                  const EGLint* attrib_list);
 typedef const char* (*PFNEGLQUERYSTRING)(EGLDisplay display, EGLint name);
+typedef EGLBoolean (*PFNEGLRELEASETHREAD)();
 
 #endif  // GAPID_CORE_OS_DEVICEINFO_ANDROID_EGL_LITE

--- a/core/os/device/deviceinfo/cc/android/egl_lite.h
+++ b/core/os/device/deviceinfo/cc/android/egl_lite.h
@@ -42,6 +42,7 @@ const EGLint EGL_CONFIG_ID = 0x3028;
 const EGLint EGL_SURFACE_TYPE = 0x3033;
 const EGLint EGL_NONE = 0x3038;
 const EGLint EGL_RENDERABLE_TYPE = 0x3040;
+const EGLint EGL_EXTENSIONS = 0x3055;
 const EGLint EGL_HEIGHT = 0x3056;
 const EGLint EGL_WIDTH = 0x3057;
 const EGLint EGL_SWAP_BEHAVIOR = 0x3093;
@@ -51,6 +52,7 @@ const EGLint EGL_OPENGL_ES_API = 0x30A0;
 
 const EGLNativeDisplayType EGL_DEFAULT_DISPLAY = nullptr;
 const EGLContext EGL_NO_CONTEXT = 0;
+const EGLDisplay EGL_NO_DISPLAY = 0;
 
 typedef EGLBoolean (*PFNEGLBINDAPI)(EGLenum api);
 typedef EGLBoolean (*PFNEGLCHOOSECONFIG)(EGLDisplay display,
@@ -74,5 +76,6 @@ typedef EGLint (*PFNEGLGETERROR)();
 typedef EGLSurface (*PFNEGLCREATEPBUFFERSURFACE)(EGLDisplay display,
                                                  EGLConfig config,
                                                  const EGLint* attrib_list);
+typedef const char* (*PFNEGLQUERYSTRING)(EGLDisplay display, EGLint name);
 
 #endif  // GAPID_CORE_OS_DEVICEINFO_ANDROID_EGL_LITE

--- a/core/os/device/deviceinfo/cc/android/query.cpp
+++ b/core/os/device/deviceinfo/cc/android/query.cpp
@@ -156,14 +156,20 @@ void destroyContext() {
     return;
   }
 
+  auto eglMakeCurrent = reinterpret_cast<PFNEGLMAKECURRENT>(
+      core::GetGlesProcAddress("eglMakeCurrent"));
   auto eglDestroyContext = reinterpret_cast<PFNEGLDESTROYCONTEXT>(
       core::GetGlesProcAddress("eglDestroyContext"));
   auto eglDestroySurface = reinterpret_cast<PFNEGLDESTROYSURFACE>(
       core::GetGlesProcAddress("eglDestroySurface"));
   auto eglTerminate = reinterpret_cast<PFNEGLTERMINATE>(
       core::GetGlesProcAddress("eglTerminate"));
+  auto eglReleaseThread = reinterpret_cast<PFNEGLRELEASETHREAD>(
+      core::GetGlesProcAddress("eglReleaseThread"));
 
   if (gContext.mContext) {
+    eglMakeCurrent(gContext.mDisplay, EGL_NO_SURFACE, EGL_NO_SURFACE,
+                   EGL_NO_CONTEXT);
     eglDestroyContext(gContext.mDisplay, gContext.mContext);
     gContext.mContext = 0;
   }
@@ -172,6 +178,7 @@ void destroyContext() {
     gContext.mSurface = 0;
   }
   if (gContext.mDisplay) {
+    eglReleaseThread();
     eglTerminate(gContext.mDisplay);
     gContext.mDisplay = nullptr;
   }

--- a/core/os/device/deviceinfo/cc/gl.cpp
+++ b/core/os/device/deviceinfo/cc/gl.cpp
@@ -92,6 +92,8 @@ void glDriver(device::OpenGLDriver* driver) {
       maxtransformfeedbackseparateattribs);
   driver->set_max_transform_feedback_interleaved_components(
       maxtransformfeedbackinterleavedcomponents);
+
+  glDriverPlatform(driver);
 }
 
 }  // namespace query

--- a/core/os/device/deviceinfo/cc/linux/query.cpp
+++ b/core/os/device/deviceinfo/cc/linux/query.cpp
@@ -294,4 +294,6 @@ int osMinor() { return 0; }
 
 int osPoint() { return 0; }
 
+void glDriverPlatform(device::OpenGLDriver*) {}
+
 }  // namespace query

--- a/core/os/device/deviceinfo/cc/osx/query.mm
+++ b/core/os/device/deviceinfo/cc/osx/query.mm
@@ -166,4 +166,6 @@ int osMinor() { return gContext.mOsVersion.minorVersion; }
 
 int osPoint() { return gContext.mOsVersion.patchVersion; }
 
+void glDriverPlatform(device::OpenGLDriver*) {}
+
 }  // namespace query

--- a/core/os/device/deviceinfo/cc/query.h
+++ b/core/os/device/deviceinfo/cc/query.h
@@ -135,7 +135,10 @@ const char* gpuVendor();
 
 const char* instanceName();
 
+// This queries the platform independent GL things.
 void glDriver(device::OpenGLDriver*);
+// This queries the platform depended GL things.
+void glDriverPlatform(device::OpenGLDriver*);
 
 device::OSKind osKind();
 const char* osName();

--- a/core/os/device/deviceinfo/cc/windows/query.cpp
+++ b/core/os/device/deviceinfo/cc/windows/query.cpp
@@ -235,4 +235,6 @@ int osMinor() { return gContext.mOsVersion.dwMinorVersion; }
 
 int osPoint() { return gContext.mOsVersion.dwBuildNumber; }
 
+void glDriverPlatform(device::OpenGLDriver*) {}
+
 }  // namespace query

--- a/gapidapk/gapidapk.go
+++ b/gapidapk/gapidapk.go
@@ -66,7 +66,7 @@ func ensureInstalled(ctx context.Context, d adb.Device, abi *device.ABI) (*APK, 
 		return nil, log.Errf(ctx, nil, "Device does not support requested abi: %v", abi.Name)
 	}
 
-	name := pkgName(abi)
+	name := PackageName(abi)
 
 	log.I(ctx, "Examining gapid.apk on host...")
 	apkPath, err := layout.GapidApk(ctx, abi)
@@ -172,20 +172,30 @@ func (a APK) LibsPath(abi *device.ABI) string {
 	return a.path + "/lib/" + abi.Name
 }
 
-// LibGAPIIPath returns the path on the Android device to libgapii.so.
+// LibGAPIIPath returns the path on the Android device to the GAPII dynamic
+// library file.
 // gapid.apk must be installed for this path to be valid.
 func (a APK) LibGAPIIPath(abi *device.ABI) string {
-	return a.LibsPath(abi) + "/libgapii.so"
+	return a.LibsPath(abi) + "/" + LibGAPIIName
 }
 
-// LibInterceptorPath returns the path on the Android device to
-// libinterceptor.so.
+// LibInterceptorPath returns the path on the Android device to the
+// interceptor dynamic library file.
 // gapid.apk must be installed for this path to be valid.
 func (a APK) LibInterceptorPath(abi *device.ABI) string {
-	return a.LibsPath(abi) + "/libinterceptor.so"
+	return a.LibsPath(abi) + "/" + LibInterceptorName
 }
 
-func pkgName(abi *device.ABI) string {
+const (
+	// LibGAPIIName is the name of the GAPII dynamic library file.
+	LibGAPIIName = "libgapii.so"
+
+	// LibInterceptorName is the name of the interceptor dynamic library file.
+	LibInterceptorName = "libinterceptor.so"
+)
+
+// PackageName returns the full package name of the GAPID apk for the given ABI.
+func PackageName(abi *device.ABI) string {
 	switch {
 	case abi.SameAs(device.AndroidARMv7a):
 		return "com.google.android.gapid.armeabiv7a"

--- a/gapidapk/gapidapk.go
+++ b/gapidapk/gapidapk.go
@@ -192,6 +192,9 @@ const (
 
 	// LibInterceptorName is the name of the interceptor dynamic library file.
 	LibInterceptorName = "libinterceptor.so"
+
+	// GraphicsSpyLayerName is the name of the graphics spy layer.
+	GraphicsSpyLayerName = "GraphicsSpy"
 )
 
 // PackageName returns the full package name of the GAPID apk for the given ABI.
@@ -203,5 +206,14 @@ func PackageName(abi *device.ABI) string {
 		return "com.google.android.gapid.arm64v8a"
 	default:
 		return fmt.Sprintf("com.google.android.gapid.%v", abi.Name)
+	}
+}
+
+// LayerName returns the name of the layer to use for Vulkan vs GLES.
+func LayerName(vulkan bool) string {
+	if vulkan {
+		return GraphicsSpyLayerName
+	} else {
+		return LibGAPIIName
 	}
 }

--- a/gapii/cc/android/gles_layer.cpp
+++ b/gapii/cc/android/gles_layer.cpp
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2019 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "gapii/cc/gles_exports.h"
+#include "gapii/cc/spy.h"
+
+#include "core/cc/get_gles_proc_address.h"
+
+namespace {
+
+typedef void* (*PFNEGLGETNEXTLAYERPROCADDRESS)(void*, const char*);
+
+PFNEGLGETNEXTLAYERPROCADDRESS g_next_layer_proc_addr = nullptr;
+void* g_layer_id = nullptr;
+
+void* get_next_gles_proc_address(const char* name) {
+  return g_next_layer_proc_addr(g_layer_id, name);
+}
+
+}  // anonymous namespace
+
+extern "C" {
+
+void AndroidGLESLayer_Initialize(
+    void* layer_id, PFNEGLGETNEXTLAYERPROCADDRESS get_next_layer_proc_address) {
+  GAPID_INFO("GLES Layer: InitializeLayer(%p, %p)", layer_id,
+             get_next_layer_proc_address);
+  g_layer_id = layer_id;
+  g_next_layer_proc_addr = get_next_layer_proc_address;
+  core::GetGlesProcAddress = &get_next_gles_proc_address;
+}
+
+void* AndroidGLESLayer_GetProcAddress(const char* name, void* next) {
+  GAPID_DEBUG("GLES Layer: GetProcAddress(%s, %p)", name, next);
+  for (int i = 0; gapii::kGLESExports[i].mName != NULL; ++i) {
+    if (strcmp(name, gapii::kGLESExports[i].mName) == 0) {
+      return gapii::kGLESExports[i].mFunc;
+    }
+  }
+  GAPID_WARNING("Unhandled GLES function '%s'", name);
+  return next;
+}
+
+}  // extern "C"

--- a/gapii/cc/gapii_android.exports
+++ b/gapii/cc/gapii_android.exports
@@ -1,4 +1,6 @@
 JNI_OnLoad
+AndroidGLESLayer_GetProcAddress
+AndroidGLESLayer_Initialize
 gapid_vkGetDeviceProcAddr
 gapid_vkGetInstanceProcAddr
 gapid_vkEnumerateInstanceLayerProperties

--- a/gapis/api/gles/templates/api_exports.cpp.tmpl
+++ b/gapis/api/gles/templates/api_exports.cpp.tmpl
@@ -94,8 +94,8 @@ Symbol kGLESExports[] = {
       {{$name := Macro "CmdName" $c}}
       {{$imports := print (Title (Global "API")) "Spy::imports()"}}
       EXPORT {{Template "C++.ReturnType" $c}} STDCALL {{$name}}({{Template "C++.CallParameters" $c}}) {
-        Spy* s = Spy::get();
         GAPID_DEBUG({{Template "C++.PrintfCommandCall" $c}});
+        Spy* s = Spy::get();
         auto spy_ctx = s->enter("{{$name}}", GlesAPI);
         {{if not (IsVoid $c.Return.Type)}}auto _result_ = §{{end}}
         s->{{$name}}({{Macro "C++.CallArguments" $c | Strings "spy_ctx" | JoinWith ", "}});


### PR DESCRIPTION
For GLES, if layers are supported, no longer use JDWP and libinterceptor to trace, but the layers instead.

For Vulkan use the system settings to setup the layer, rather than the global system property and skip the JDWP interception to modify the classpath.

Since we no longer require JDWP when using the new layers, we will no longer require apps to be marked debuggable on non-rooted device and tracing will work on apps marked profilable.