### PR TITLE
Replay frame delimiters for EGL

### DIFF
--- a/gapir/cc/android/gles_renderer.cpp
+++ b/gapir/cc/android/gles_renderer.cpp
@@ -36,6 +36,7 @@ class GlesRendererImpl : public GlesRenderer {
   virtual void bind(bool resetViewportScissor) override;
   virtual void unbind() override;
   virtual void* createExternalImage(uint32_t texture) override;
+  virtual bool frameDelimiter() override;
   virtual const char* name() override;
   virtual const char* extensions() override;
   virtual const char* vendor() override;
@@ -203,6 +204,15 @@ void* GlesRendererImpl::createExternalImage(uint32_t texture) {
   return mApi.mFunctionStubs.eglCreateImageKHR(
       mDisplay, mContext, EGL_GL_TEXTURE_2D_KHR,
       (EGLClientBuffer)(uint64_t)texture, nullptr);
+}
+
+bool GlesRendererImpl::frameDelimiter() {
+  if (mSurface != nullptr) {
+    eglSwapBuffers(mDisplay, mSurface);
+    EGL_CHECK_ERROR("Failed to swap buffers");
+    return true;
+  }
+  return false;
 }
 
 const char* GlesRendererImpl::name() {

--- a/gapir/cc/context.cpp
+++ b/gapir/cc/context.cpp
@@ -201,6 +201,26 @@ void Context::registerCallbacks(Interpreter* interpreter) {
                                });
 
   interpreter->registerBuiltin(
+      Gles::INDEX, Builtins::ReplayFrameDelimiter,
+      [this](uint32_t label, Stack* stack, bool) {
+        uint32_t id = stack->pop<uint32_t>();
+        if (stack->isValid()) {
+          GAPID_INFO("[%u]replayFrameDelimiter(%u)", label, id);
+          auto found = mGlesRenderers.find(id);
+          if (found == mGlesRenderers.end()) {
+            GAPID_ERROR("replayFrameDelimiter has no renderer at ID: %u", id);
+            return false;
+          }
+          found->second->frameDelimiter();
+          return true;
+        } else {
+          GAPID_WARNING(
+              "[%u]Error during calling function replayFrameDelimiter", label);
+          return false;
+        }
+      });
+
+  interpreter->registerBuiltin(
       Gles::INDEX, Builtins::ReplayCreateRenderer,
       [this](uint32_t label, Stack* stack, bool) {
         uint32_t id = stack->pop<uint32_t>();

--- a/gapir/cc/gles_renderer.h
+++ b/gapir/cc/gles_renderer.h
@@ -76,6 +76,9 @@ class GlesRenderer : public Renderer {
 
   // Creates an external image backed by the given texture.
   virtual void* createExternalImage(uint32_t texture) { return nullptr; }
+
+  // Perform a call that acts as a frame delimiter, typically swapBuffers
+  virtual bool frameDelimiter() { return true; }
 };
 
 inline GlesRenderer::Backbuffer::Format::Format()

--- a/gapis/api/gles/api/egl.api
+++ b/gapis/api/gles/api/egl.api
@@ -357,15 +357,15 @@ cmd EGLBoolean eglSurfaceAttrib(EGLDisplay display,
   return ? // TODO
 }
 
-@no_replay
 @frame_start
+@custom
 ///http://www.khronos.org/registry/egl/sdk/docs/man/html/eglSwapBuffers.xhtml
 cmd EGLBoolean eglSwapBuffers(EGLDisplay display, void* surface) {
   return ?
 }
 
-@no_replay
 @frame_start
+@no_replay
 ///https://www.khronos.org/registry/egl/extensions/KHR/EGL_KHR_swap_buffers_with_damage.txt
 cmd EGLBoolean eglSwapBuffersWithDamageKHR(EGLDisplay dpy,
                                            EGLSurface surface,

--- a/gapis/api/gles/synthetic.api
+++ b/gapis/api/gles/synthetic.api
@@ -38,6 +38,10 @@ cmd void replayChangeBackbuffer(u32     rendererID,
 @synthetic
 cmd EGLImageKHR replayCreateExternalImage(u32 rendererID, TextureId texture) { return ? }
 
+// replayFrameDelimiter replay a call that acts as a frame delimiter, e.g. eglSwapBuffers()
+@synthetic
+cmd void replayFrameDelimiter(u32 rendererID) { }
+
 @synthetic
 cmd void startTimer(u8 index) { }
 


### PR DESCRIPTION
When export_replay creates a standalone APK to replay a trace, we want
to be able to trace the replay itself, and we want to detect frame
delimiters during this tracing. Hence the replay of EGL frame
delimiters.