### PR TITLE
Make the vulkan.api file publicly visible

### DIFF
--- a/gapis/api/vulkan/BUILD.bazel
+++ b/gapis/api/vulkan/BUILD.bazel
@@ -29,6 +29,12 @@ filegroup(
     visibility = ["//visibility:public"],
 )
 
+filegroup(
+    name = "api_file",
+    srcs = ["vulkan.api"],
+    visibility = ["//visibility:public"],
+)
+
 api_library(
     name = "api",
     api = "vulkan.api",


### PR DESCRIPTION
This allows other Bazel builds to reference the file.