### PR TITLE
Don't build libinterceptor from source by default.

### DIFF
--- a/gapii/apk/BUILD.bazel
+++ b/gapii/apk/BUILD.bazel
@@ -23,7 +23,10 @@ android_native(
 android_native(
     name = "interceptor",
     visibility = ["//visibility:public"],
-    deps = ["//gapii/interceptor-lib/cc:libinterceptor"],
+    deps = select({
+        "//tools/build:libinterceptor-from-source": ["//gapii/interceptor-lib/cc:libinterceptor"],
+        "//conditions:default": ["@libinterceptor//:libinterceptor"],
+    }),
 )
 
 android_native(

--- a/tools/build/BUILD.bazel
+++ b/tools/build/BUILD.bazel
@@ -101,6 +101,14 @@ config_setting(
     },
 )
 
+config_setting(
+    name = "libinterceptor-from-source",
+    define_values = {
+        "LIBINTERCEPTOR_FROM_SOURCE": "1",
+    },
+    visibility = ["//visibility:public"],
+)
+
 cc_library(
     name = "jni",
     hdrs = [

--- a/tools/build/third_party/libinterceptor.BUILD
+++ b/tools/build/third_party/libinterceptor.BUILD
@@ -1,0 +1,24 @@
+# Copyright (C) 2019 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cc_library(
+    name = "libinterceptor",
+    srcs = select({
+        "@gapid//tools/build:android-armeabi-v7a": ["armeabi-v7a/libinterceptor.so"],
+        "@gapid//tools/build:android-arm64-v8a": ["arm64-v8a/libinterceptor.so"],
+        "@gapid//tools/build:android-x86": ["x86/libinterceptor.so"],
+    }),
+    linkstatic = 1,
+    visibility = ["//visibility:public"],
+)

--- a/tools/build/workspace.bzl
+++ b/tools/build/workspace.bzl
@@ -226,6 +226,15 @@ def gapid_dependencies(android = True, mingw = True, locals = {}):
             actual = "@androidndk//:toolchain-libcpp",
         )
 
+        maybe_repository(
+            http_archive,
+            name = "libinterceptor",
+            locals = locals,
+            url = "https://github.com/google/gapid/releases/download/libinterceptor-v1.0/libinterceptor.zip",
+            build_file = "@gapid//tools/build/third_party:libinterceptor.BUILD",
+            sha256 = "307e0e3ec7451a244811b4edf21453d55d1e90a5f868a73dc42d4975ef74aec9",
+        )
+
     if mingw:
         cc_configure()
 


### PR DESCRIPTION
It can be built from source like this:
`$ bazel build --define LIBINTERCEPTOR_FROM_SOURCE=1 ...`

I've extracted the libinterceptor.so files from the APKs from the latest continuous linux build (/placer/prod/home/kokoro-dedicated/build_artifacts/prod/gapid/linux/continuous/730/20190517-133732/), zipped them and uploaded them to our release page. Feel free to verify the SHAs.