### PR TITLE
Make the tests build and pass again.

### DIFF
--- a/core/app/crash/reporting/encoder_test.go
+++ b/core/app/crash/reporting/encoder_test.go
@@ -32,7 +32,7 @@ func TestEncoder(t *testing.T) {
 		osVersion:  "10",
 	}.encodeStacktrace("foo1.bar 10:20\nfoo2.bar 20:30")
 	if assert.For(ctx, "err").ThatError(err).Succeeded() {
-		assert.For(ctx, "ty").ThatString(ty).Equals("multipart/form-data; boundary=" + multipartBoundary)
+		assert.For(ctx, "ty").ThatString(ty).Equals("multipart/form-data; boundary=\"" + multipartBoundary + "\"")
 		bytes, err := ioutil.ReadAll(r)
 		if assert.For(ctx, "ReadAll").ThatError(err).Succeeded() {
 			expect := "--" + multipartBoundary + "\r\n" +

--- a/core/fault/stacktrace/stacktrace_test.go
+++ b/core/fault/stacktrace/stacktrace_test.go
@@ -72,7 +72,7 @@ var (
 		fun: nested3,
 		expect: []string{
 			"⇒ core/fault/stacktrace/stacktrace_test.go@36:nested1",
-			"⇒ core/fault/stacktrace/stacktrace_test.go@35:nested2",
+			"⇒ core/fault/stacktrace/stacktrace_test.go@34:nested3",
 			"⇒ core/fault/stacktrace/stacktrace_test.go@34:nested3",
 			"⇒ core/fault/stacktrace/stacktrace_test.go@39:init.0",
 		},

--- a/gapis/api/test/test_types.api
+++ b/gapis/api/test/test_types.api
@@ -56,3 +56,8 @@ class Complex {
   ref!TestList             Cycle
   map!(u32, ref!NestedRef) NestedRefs
 }
+
+enum TestEnum {
+  FOO = 1,
+  BAR = 2,
+}


### PR DESCRIPTION
They were failing due to the upgrades to golang and the splitting of the api generated go files.