### PR TITLE
 Log API commands to atrace during replay.

### DIFF
--- a/gapis/api/templates/specific_gfx_api.cpp.tmpl
+++ b/gapis/api/templates/specific_gfx_api.cpp.tmpl
@@ -40,6 +40,10 @@
 ¶
   #define __STDC_FORMAT_MACROS
   #include <inttypes.h>
+
+#if TARGET_OS == GAPID_OS_ANDROID
+#include <android/trace.h>
+#endif  // TARGET_OS == GAPID_OS_ANDROID
 ¶
   {{$api := Title (Global "API")}}
 
@@ -133,6 +137,10 @@
     if (stack->isValid()) {
       GAPID_DEBUG({{Template "C++.PrintfCommandCallWithLabel" $}});
 
+      #if TARGET_OS == GAPID_OS_ANDROID
+      ATrace_beginSection("{{$name}}");
+      #endif  // TARGET_OS == GAPID_OS_ANDROID
+
       {{if GetAnnotation $ "indirect"}}
         {{$args := (GetAnnotation $ "indirect").Arguments}}
         {{$elem := (index $.CallParameters 0).Name}}
@@ -183,6 +191,11 @@
       } else {
         GAPID_ERROR("Attempted to call unsupported function {{$name}}");
       }
+
+      #if TARGET_OS == GAPID_OS_ANDROID
+      ATrace_endSection();
+      #endif  // TARGET_OS == GAPID_OS_ANDROID
+
       return true;
     } else {
       GAPID_ERROR("Error during calling function {{$name}}");

--- a/kokoro/linux/build.sh
+++ b/kokoro/linux/build.sh
@@ -30,8 +30,10 @@ sudo apt-get -q update
 sudo apt-get -qy install gcc-7 g++-7
 export CC=/usr/bin/gcc-7
 
-# Setup environment.
-export ANDROID_NDK_HOME=/opt/android-ndk-r16b
+# Get the Android NDK
+curl -L -k -O -s https://dl.google.com/android/repository/android-ndk-r18b-linux-x86_64.zip
+unzip android-ndk-r18b-linux-x86_64.zip
+export ANDROID_NDK_HOME=$PWD/android-ndk-r18b
 
 cd $SRC
 BUILD_SHA=${KOKORO_GITHUB_COMMIT:-$KOKORO_GITHUB_PULL_REQUEST_COMMIT}

--- a/kokoro/macos/build.sh
+++ b/kokoro/macos/build.sh
@@ -24,10 +24,10 @@ curl -L -k -O -s https://dl.google.com/android/repository/tools_r25.2.3-macosx.z
 mkdir android
 unzip -q tools_r25.2.3-macosx.zip -d android
 echo y | ./android/tools/bin/sdkmanager build-tools\;26.0.1 platforms\;android-26
-curl -L -k -O -s https://dl.google.com/android/repository/android-ndk-r16b-darwin-x86_64.zip
-unzip -q android-ndk-r16b-darwin-x86_64.zip -d android
+curl -L -k -O -s https://dl.google.com/android/repository/android-ndk-r18b-darwin-x86_64.zip
+unzip -q android-ndk-r18b-darwin-x86_64.zip -d android
 export ANDROID_HOME=$PWD/android
-export ANDROID_NDK_HOME=$PWD/android/android-ndk-r16b
+export ANDROID_NDK_HOME=$PWD/android/android-ndk-r18b
 
 # Get bazel.
 curl -L -k -O -s https://github.com/bazelbuild/bazel/releases/download/0.25.1/bazel-0.25.1-installer-darwin-x86_64.sh

--- a/kokoro/windows/build.bat
+++ b/kokoro/windows/build.bat
@@ -25,9 +25,9 @@ set JAVA_HOME=c:\Program Files\Java\jdk1.8.0_144
 REM Install the Android SDK components and NDK.
 set ANDROID_HOME=%LOCALAPPDATA%\Android\Sdk
 echo y | %ANDROID_HOME%\tools\bin\sdkmanager build-tools;26.0.1 platforms;android-26
-wget -q https://dl.google.com/android/repository/android-ndk-r16b-windows-x86_64.zip
-unzip -q android-ndk-r16b-windows-x86_64.zip
-set ANDROID_NDK_HOME=%CD%\android-ndk-r16b
+wget -q https://dl.google.com/android/repository/android-ndk-r18b-windows-x86_64.zip
+unzip -q android-ndk-r18b-windows-x86_64.zip
+set ANDROID_NDK_HOME=%CD%\android-ndk-r18b
 
 REM Install WiX Toolset.
 wget -q https://github.com/wixtoolset/wix3/releases/download/wix311rtm/wix311-binaries.zip

--- a/tools/build/workspace.bzl
+++ b/tools/build/workspace.bzl
@@ -211,7 +211,7 @@ def gapid_dependencies(android = True, mingw = True, locals = {}):
             native.android_ndk_repository,
             name = "androidndk",
             locals = locals,
-            api_level = 21, # This is the minimum API
+            api_level = 23, # This is the minimum API
         )
 
         maybe_repository(


### PR DESCRIPTION
atrace requires API level 23 (M) in the NDK, which means this would make M required for on-device-replay.