### PR TITLE
Fix for descriptors if we cannot parse the SPIR-V module.

### DIFF
--- a/gapis/api/vulkan/state_rebuilder.go
+++ b/gapis/api/vulkan/state_rebuilder.go
@@ -2193,7 +2193,6 @@ func (sb *stateBuilder) createRenderPass(rp RenderPassObjectʳ) {
 }
 
 func (sb *stateBuilder) createShaderModule(sm ShaderModuleObjectʳ) {
-	sbExtra := sm.Descriptors().Get().Clone(sb.newState.Arena, api.CloneContext{})
 	csm := sb.cb.VkCreateShaderModule(
 		sm.Device(),
 		sb.MustAllocReadData(NewVkShaderModuleCreateInfo(sb.ta,
@@ -2207,7 +2206,10 @@ func (sb *stateBuilder) createShaderModule(sm ShaderModuleObjectʳ) {
 		sb.MustAllocWriteData(sm.VulkanHandle()).Ptr(),
 		VkResult_VK_SUCCESS,
 	)
-	csm.Extras().Add(sbExtra)
+	if !sm.Descriptors().IsNil() {
+		sbExtra := sm.Descriptors().Get().Clone(sb.newState.Arena, api.CloneContext{})
+		csm.Extras().Add(sbExtra)
+	}
 	sb.write(csm)
 }
 


### PR DESCRIPTION
We would fail to re-create the state in this case.