### PR TITLE
Automatically unlock device screen when possible

### DIFF
--- a/core/os/android/adb/adb_data_test.go
+++ b/core/os/android/adb/adb_data_test.go
@@ -33,28 +33,26 @@ List of devices attached
 adb server version (36) doesn't match this client (35); killing...
 * daemon not running. starting it now on port 5037 *
 * daemon started successfully *
-debug_device             unknown
-debug_device2            unknown
-dumpsys_device           offline
-error_device             device
-install_device           unauthorized
-invalid_device           unknown
-lockscreen_off_device    offline
-lockscreen_on_device     device
-logcat_device            unauthorized
-no_pgrep_no_ps_device    unknown
-no_pgrep_ok_ps_device    offline
-ok_pgrep_no_ps_device    device
-ok_pgrep_ok_ps_device    unauthorized
-production_device        unknown
-pull_device              offline
-push_device              device
-rooted_device            unauthorized
-run_device               unknown
-screen_off_device        offline
-screen_doze_device       offline
-screen_unready_device    offline
-screen_on_device         device
+debug_device                unknown
+debug_device2               unknown
+dumpsys_device              offline
+error_device                device
+install_device              unauthorized
+invalid_device              unknown
+logcat_device               unauthorized
+no_pgrep_no_ps_device       unknown
+no_pgrep_ok_ps_device       offline
+ok_pgrep_no_ps_device       device
+ok_pgrep_ok_ps_device       unauthorized
+production_device           unknown
+pull_device                 offline
+push_device                 device
+rooted_device               unauthorized
+run_device                  unknown
+screen_off_locked_device    offline
+screen_off_unlocked_device  offline
+screen_on_locked_device     offline
+screen_on_unlocked_device   device
 `)
 	emptyDevices = stub.RespondTo(adbPath.System()+` devices`, `
 List of devices attached
@@ -108,45 +106,31 @@ Packages:
     flags=[ DEBUGGABLE HAS_CODE ALLOW_CLEAR_USER_DATA ALLOW_BACKUP ]
 `),
 
-		// Screen on / off / doze / unready queries.
-		stub.RespondTo(adbPath.System()+` -s screen_off_device shell dumpsys power`, `
-POWER MANAGER (dumpsys power)
-  mScreenBrightnessBoostInProgress=false
-  mDisplayReady=true
-  mHoldingWakeLockSuspendBlocker=false
-Display Power: state=OFF`),
-		stub.RespondTo(adbPath.System()+` -s screen_doze_device shell dumpsys power`, `
-POWER MANAGER (dumpsys power)
-  mScreenBrightnessBoostInProgress=false
-  mDisplayReady=true
-  mHoldingWakeLockSuspendBlocker=false
-Display Power: state=DOZE`),
-		stub.RespondTo(adbPath.System()+` -s screen_unready_device shell dumpsys power`, `
-POWER MANAGER (dumpsys power)
-  mScreenBrightnessBoostInProgress=false
-  mDisplayReady=false
-  mHoldingWakeLockSuspendBlocker=false
-Display Power: state=ON`),
-		stub.RespondTo(adbPath.System()+` -s screen_on_device shell dumpsys power`, `
-POWER MANAGER (dumpsys power)
-  mScreenBrightnessBoostInProgress=false
-  mDisplayReady=true
-  mHoldingWakeLockSuspendBlocker=false
-Display Power: state=ON`),
-
-		// Lockscreen on / off queries.
-		stub.RespondTo(adbPath.System()+` -s lockscreen_off_device shell dumpsys activity activities`, `
-ACTIVITY MANAGER ACTIVITIES (dumpsys activity activities)
-  isHomeRecentsComponent=true  KeyguardController:
-    mKeyguardShowing=false
-    mAodShowing=false
-    mKeyguardGoingAway=false`),
-		stub.RespondTo(adbPath.System()+` -s lockscreen_on_device shell dumpsys activity activities`, `
-ACTIVITY MANAGER ACTIVITIES (dumpsys activity activities)
-  isHomeRecentsComponent=true  KeyguardController:
-    mKeyguardShowing=true
-    mAodShowing=false
-    mKeyguardGoingAway=false`),
+		// Screen state queries
+		stub.RespondTo(adbPath.System()+` -s screen_off_locked_device shell dumpsys nfc`, `
+mState=on
+mIsZeroClickRequested=false
+mScreenState=OFF_LOCKED
+mTechMask: default
+...`),
+		stub.RespondTo(adbPath.System()+` -s screen_off_unlocked_device shell dumpsys nfc`, `
+mState=on
+mIsZeroClickRequested=false
+mScreenState=OFF_UNLOCKED
+mTechMask: default
+...`),
+		stub.RespondTo(adbPath.System()+` -s screen_on_locked_device shell dumpsys nfc`, `
+mState=on
+mIsZeroClickRequested=false
+mScreenState=ON_LOCKED
+mTechMask: default
+...`),
+		stub.RespondTo(adbPath.System()+` -s screen_on_unlocked_device shell dumpsys nfc`, `
+mState=on
+mIsZeroClickRequested=false
+mScreenState=ON_UNLOCKED
+mTechMask: default
+...`),
 
 		// Pid queries.
 		stub.Regex(`adb -s ok_pgrep_\S*device shell pgrep .* com.google.foo`, stub.Respond("")),

--- a/core/os/android/adb/screen_test.go
+++ b/core/os/android/adb/screen_test.go
@@ -24,55 +24,28 @@ import (
 func TestScreenState(t_ *testing.T) {
 	ctx := log.Testing(t_)
 
-	d := mustConnect(ctx, "screen_off_device")
-	res, err := d.IsScreenOn(ctx)
-	assert.For(ctx, "ScreenOn").That(res).Equals(false)
-	assert.For(ctx, "err").ThatError(err).Succeeded()
-	err = d.TurnScreenOn(ctx)
+	d := mustConnect(ctx, "screen_off_locked_device")
+	res, err := d.UnlockScreen(ctx)
+	assert.For(ctx, "UnlockScreen").That(res).Equals(false)
 	assert.For(ctx, "err").ThatError(err).Succeeded()
 
-	d = mustConnect(ctx, "screen_doze_device")
-	res, err = d.IsScreenOn(ctx)
-	assert.For(ctx, "ScreenOn").That(res).Equals(false)
-	assert.For(ctx, "err").ThatError(err).Succeeded()
-	err = d.TurnScreenOn(ctx)
+	d = mustConnect(ctx, "screen_off_unlocked_device")
+	res, err = d.UnlockScreen(ctx)
+	assert.For(ctx, "UnlockScreen").That(res).Equals(false)
 	assert.For(ctx, "err").ThatError(err).Succeeded()
 
-	d = mustConnect(ctx, "screen_unready_device")
-	res, err = d.IsScreenOn(ctx)
-	assert.For(ctx, "ScreenOn").That(res).Equals(false)
-	assert.For(ctx, "err").ThatError(err).Succeeded()
-	err = d.TurnScreenOn(ctx)
+	d = mustConnect(ctx, "screen_on_locked_device")
+	res, err = d.UnlockScreen(ctx)
+	assert.For(ctx, "UnlockScreen").That(res).Equals(false)
 	assert.For(ctx, "err").ThatError(err).Succeeded()
 
-	d = mustConnect(ctx, "screen_on_device")
-	res, err = d.IsScreenOn(ctx)
-	assert.For(ctx, "ScreenOn").That(res).Equals(true)
-	assert.For(ctx, "err").ThatError(err).Succeeded()
-	err = d.TurnScreenOff(ctx)
+	d = mustConnect(ctx, "screen_on_unlocked_device")
+	res, err = d.UnlockScreen(ctx)
+	assert.For(ctx, "UnlockScreen").That(res).Equals(true)
 	assert.For(ctx, "err").ThatError(err).Succeeded()
 
 	d = mustConnect(ctx, "invalid_device")
-	res, err = d.IsScreenOn(ctx)
-	assert.For(ctx, "err").ThatError(err).Failed()
-	err = d.TurnScreenOn(ctx)
-	assert.For(ctx, "err").ThatError(err).Failed()
-}
-
-func TestLockscreenScreenState(t_ *testing.T) {
-	ctx := log.Testing(t_)
-
-	d := mustConnect(ctx, "lockscreen_off_device")
-	res, err := d.IsShowingLockscreen(ctx)
-	assert.For(ctx, "LockscreenShowing").That(res).Equals(false)
-	assert.For(ctx, "err").ThatError(err).Succeeded()
-
-	d = mustConnect(ctx, "lockscreen_on_device")
-	res, err = d.IsShowingLockscreen(ctx)
-	assert.For(ctx, "LockscreenShowing").That(res).Equals(true)
-	assert.For(ctx, "err").ThatError(err).Succeeded()
-
-	d = mustConnect(ctx, "invalid_device")
-	res, err = d.IsShowingLockscreen(ctx)
+	res, err = d.UnlockScreen(ctx)
+	assert.For(ctx, "UnlockScreen").That(res).Equals(false)
 	assert.For(ctx, "err").ThatError(err).Failed()
 }

--- a/core/os/android/device.go
+++ b/core/os/android/device.go
@@ -64,14 +64,8 @@ type Device interface {
 	InstalledPackages(ctx context.Context) (InstalledPackages, error)
 	// InstalledPackage returns information about a single installed package on the device.
 	InstalledPackage(ctx context.Context, name string) (*InstalledPackage, error)
-	// IsScreenOn returns true if the device's screen is currently on.
-	IsScreenOn(ctx context.Context) (bool, error)
-	// TurnScreenOn turns the device's screen on.
-	TurnScreenOn(ctx context.Context) error
-	// TurnScreenOff turns the device's screen off.
-	TurnScreenOff(ctx context.Context) error
-	// IsShowingLockscreen returns true if the device's lockscreen is currently showing.
-	IsShowingLockscreen(ctx context.Context) (bool, error)
+	// UnlockScreen returns true if it managed to turn on and unlock the screen.
+	UnlockScreen(ctx context.Context) (bool, error)
 	// Logcat writes all logcat messages reported by the device to the chan msgs,
 	// blocking until the context is stopped.
 	Logcat(ctx context.Context, msgs chan<- LogcatMessage) error

--- a/core/os/android/keycodes.proto
+++ b/core/os/android/keycodes.proto
@@ -17,6 +17,8 @@ syntax = "proto3";
 package android;
 option go_package = "github.com/google/gapid/core/os/android";
 
+// See authoritative list at:
+// https://android.googlesource.com/platform/frameworks/base/+/master/core/java/android/view/KeyEvent.java
 enum KeyCode {
   Unknown = 0;
   SoftLeft = 1;
@@ -229,4 +231,18 @@ enum KeyCode {
   Calendar = 208;
   Music = 209;
   Calculator = 210;
+  ZenkakuHankaku = 211;
+  Eisu = 212;
+  Muhenkan = 213;
+  Henkan = 214;
+  KatakanaHiragana = 215;
+  Yen = 216;
+  Ro = 217;
+  Kana = 218;
+  Assist = 219;
+  BrightnessDown = 220;
+  BrightnessUp = 221;
+  MediaAudioTrack = 222;
+  Sleep = 223;
+  Wakeup = 224;
 }

--- a/gapii/client/adb.go
+++ b/gapii/client/adb.go
@@ -77,18 +77,13 @@ func Start(ctx context.Context, p *android.InstalledPackage, a *android.Activity
 
 	ctx = log.V{"abi": abi.Name}.Bind(ctx)
 
-	log.I(ctx, "Turning device screen on")
-	if err := d.TurnScreenOn(ctx); err != nil {
-		return nil, nil, log.Err(ctx, err, "Couldn't turn device screen on")
-	}
-
-	log.I(ctx, "Checking for lockscreen")
-	locked, err := d.IsShowingLockscreen(ctx)
+	log.I(ctx, "Unlocking device screen")
+	unlocked, err := d.UnlockScreen(ctx)
 	if err != nil {
-		log.W(ctx, "Couldn't determine lockscreen state: %v", err)
+		return nil, nil, log.Err(ctx, err, "Error when trying to unlock device screen")
 	}
-	if locked {
-		return nil, nil, log.Err(ctx, nil, "Cannot trace app on locked device")
+	if !unlocked {
+		return nil, nil, log.Err(ctx, nil, "Please unlock your device screen: GAPID can automatically unlock the screen only when no PIN/password/pattern is needed")
 	}
 
 	port, err := adb.LocalFreeTCPPort()

--- a/gapis/perfetto/android/trace.go
+++ b/gapis/perfetto/android/trace.go
@@ -54,18 +54,13 @@ func Start(ctx context.Context, d adb.Device, a *android.ActivityAction, opts *s
 		}.Bind(ctx)
 	}
 
-	log.I(ctx, "Turning device screen on")
-	if err := d.TurnScreenOn(ctx); err != nil {
-		return nil, log.Err(ctx, err, "Couldn't turn device screen on")
-	}
-
-	log.I(ctx, "Checking for lockscreen")
-	locked, err := d.IsShowingLockscreen(ctx)
+	log.I(ctx, "Unlocking device screen")
+	unlocked, err := d.UnlockScreen(ctx)
 	if err != nil {
-		log.W(ctx, "Couldn't determine lockscreen state: %v", err)
+		return nil, log.Err(ctx, err, "Error when trying to unlock device screen")
 	}
-	if locked {
-		return nil, log.Err(ctx, nil, "Cannot trace app on locked device")
+	if !unlocked {
+		return nil, log.Err(ctx, nil, "Please unlock your device screen: GAPID can automatically unlock the screen only when no PIN/password/pattern is needed")
 	}
 
 	if a != nil {

--- a/gapis/trace/android/trace.go
+++ b/gapis/trace/android/trace.go
@@ -474,12 +474,6 @@ func (t *androidTracer) SetupTrace(ctx context.Context, o *service.TraceOptions)
 		}
 	}
 
-	if wasScreenOn, _ := t.b.IsScreenOn(ctx); !wasScreenOn {
-		cleanup = cleanup.Then(func(ctx context.Context) {
-			t.b.TurnScreenOff(ctx)
-		})
-	}
-
 	var process tracer.Process
 	if o.Type == service.TraceType_Perfetto {
 		process, err = perfetto.Start(ctx, t.b, a, o)


### PR DESCRIPTION
This is a refactor of the device screen unlock logic, to simplify it down to two functions:

- UnlockScreen() which tries to get the screen on and unlocked

- IsScreenUnlocked() which returns true if the screen is on and unlocked

When the screen cannot be automatically unlocked, the new error message clearly tells the user to unlock the device screen.

Along the way, this removes the feature of putting back the screen off if it was off before tracing. I argue this was hardly desirable in any case.

Fixes #2747