### PR TITLE
Fix screen state logic for devices without NFC.

### DIFF
--- a/core/os/android/adb/adb_data_test.go
+++ b/core/os/android/adb/adb_data_test.go
@@ -107,29 +107,37 @@ Packages:
 `),
 
 		// Screen state queries
-		stub.RespondTo(adbPath.System()+` -s screen_off_locked_device shell dumpsys nfc`, `
-mState=on
-mIsZeroClickRequested=false
-mScreenState=OFF_LOCKED
-mTechMask: default
+		stub.RespondTo(adbPath.System()+` -s screen_off_locked_device shell dumpsys window policy`, `
+mHasSoftInput=true
+mAwake=false
+mScreenOnEarly=true mScreenOnFully=true
+mDockLayer=268435456 mStatusBarLayer=-1
+mShowingDream=false mDreamingLockscreen=true mDreamingSleepToken=null
+mFocusedWindow=Window{7f1fdc4 u0 com.google.gapid.gltests/com.google.gapid.gltests.MainActivity}
 ...`),
-		stub.RespondTo(adbPath.System()+` -s screen_off_unlocked_device shell dumpsys nfc`, `
-mState=on
-mIsZeroClickRequested=false
-mScreenState=OFF_UNLOCKED
-mTechMask: default
+		stub.RespondTo(adbPath.System()+` -s screen_off_unlocked_device shell dumpsys window policy`, `
+mHomePressed=false
+mAwake=falsemScreenOnEarly=true mScreenOnFully=true
+mKeyguardDrawComplete=true mWindowManagerDrawComplete=true
+mDockLayer=268435456 mStatusBarLayer=0
+mShowingDream=false mShowingLockscreen=false mDreamingSleepToken=null
+mStatusBar=Window{5033a83 u0 StatusBar} isStatusBarKeyguard=false
 ...`),
-		stub.RespondTo(adbPath.System()+` -s screen_on_locked_device shell dumpsys nfc`, `
-mState=on
-mIsZeroClickRequested=false
-mScreenState=ON_LOCKED
-mTechMask: default
+		stub.RespondTo(adbPath.System()+` -s screen_on_locked_device shell dumpsys window policy`, `
+mHasSoftInput=true
+mAwake=true
+mScreenOnEarly=true mScreenOnFully=true
+mDockLayer=268435456 mStatusBarLayer=-1
+mShowingDream=false mDreamingLockscreen=true mDreamingSleepToken=null
+mFocusedWindow=Window{7f1fdc4 u0 com.google.gapid.gltests/com.google.gapid.gltests.MainActivity}
 ...`),
-		stub.RespondTo(adbPath.System()+` -s screen_on_unlocked_device shell dumpsys nfc`, `
-mState=on
-mIsZeroClickRequested=false
-mScreenState=ON_UNLOCKED
-mTechMask: default
+		stub.RespondTo(adbPath.System()+` -s screen_on_unlocked_device shell dumpsys window policy`, `
+mHomePressed=false
+mAwake=truemScreenOnEarly=true mScreenOnFully=true
+mKeyguardDrawComplete=true mWindowManagerDrawComplete=true
+mDockLayer=268435456 mStatusBarLayer=0
+mShowingDream=false mShowingLockscreen=false mDreamingSleepToken=null
+mStatusBar=Window{5033a83 u0 StatusBar} isStatusBarKeyguard=false
 ...`),
 
 		// Pid queries.

--- a/gapii/client/adb.go
+++ b/gapii/client/adb.go
@@ -80,9 +80,8 @@ func Start(ctx context.Context, p *android.InstalledPackage, a *android.Activity
 	log.I(ctx, "Unlocking device screen")
 	unlocked, err := d.UnlockScreen(ctx)
 	if err != nil {
-		return nil, nil, log.Err(ctx, err, "Error when trying to unlock device screen")
-	}
-	if !unlocked {
+		log.W(ctx, "Failed to determine lock state: %s", err)
+	} else if !unlocked {
 		return nil, nil, log.Err(ctx, nil, "Please unlock your device screen: GAPID can automatically unlock the screen only when no PIN/password/pattern is needed")
 	}
 

--- a/gapis/perfetto/android/trace.go
+++ b/gapis/perfetto/android/trace.go
@@ -57,9 +57,8 @@ func Start(ctx context.Context, d adb.Device, a *android.ActivityAction, opts *s
 	log.I(ctx, "Unlocking device screen")
 	unlocked, err := d.UnlockScreen(ctx)
 	if err != nil {
-		return nil, log.Err(ctx, err, "Error when trying to unlock device screen")
-	}
-	if !unlocked {
+		log.W(ctx, "Failed to determine lock state: %s", err)
+	} else if !unlocked {
 		return nil, log.Err(ctx, nil, "Please unlock your device screen: GAPID can automatically unlock the screen only when no PIN/password/pattern is needed")
 	}
 


### PR DESCRIPTION
Don't use the NFC service to determine screen state, as there are devices that don't have NFC, which will cause the "dumpsys nfc" command to fail.

Fixes #2736 