### PR TITLE
Grab all of `dumpsys window` to determine screen state.

### DIFF
--- a/core/os/android/adb/screen.go
+++ b/core/os/android/adb/screen.go
@@ -44,7 +44,7 @@ var lockStateRegex = regexp.MustCompile("(?:mDreamingLockscreen|mShowingLockscre
 
 // getScreenState returns the screen state
 func (b *binding) getScreenState(ctx context.Context) (int, error) {
-	res, err := b.Shell("dumpsys", "window", "policy").Call(ctx)
+	res, err := b.Shell("dumpsys", "window").Call(ctx)
 	if err != nil {
 		return -1, err
 	}


### PR DESCRIPTION
The fields we're interested in have moved from the policy section to the display section in more recent Android builds.