### PR TITLE
Make Android Perfetto tracing work on Windows.

### DIFF
--- a/core/os/android/adb/perfetto.go
+++ b/core/os/android/adb/perfetto.go
@@ -16,8 +16,8 @@ package adb
 
 import (
 	"bufio"
-	"bytes"
 	"context"
+	"encoding/base64"
 	"io"
 	"strings"
 
@@ -56,8 +56,8 @@ func (b *binding) StartPerfettoTrace(ctx context.Context, config *perfetto_pb.Tr
 		}
 	})
 
-	process, err := b.Shell("perfetto", "-c", "-", "-o", out).
-		Read(bytes.NewReader(data)).
+	process, err := b.Shell("base64", "-d", "|", "perfetto", "-c", "-", "-o", out).
+		Read(strings.NewReader(base64.StdEncoding.EncodeToString(data))).
 		Capture(stdout, stdout).
 		Start(ctx)
 	if err != nil {


### PR DESCRIPTION
Passing the binary data via adb doesn't quite work on Windows, so encode the proto to base64 to make it go safely through adb.