### PR TITLE
GLES API: Init framebuffer image data with proper slices

### DIFF
--- a/gapis/api/gles/api/framebuffer.api
+++ b/gapis/api/gles/api/framebuffer.api
@@ -1141,6 +1141,7 @@ sub void RenderbufferStorageMultisample(GLenum target, GLsizei samples, GLenum i
     DataFormat: sizedFormatInfo.UnsizedFormat,
     DataType: sizedFormatInfo.DataType,
   )
+  rb.Image.Data = make!u8(uncompressedImageSize(width, height, sizedFormatInfo.UnsizedFormat, sizedFormatInfo.DataType))
 }
 
 @if(Version.GLES10)

--- a/gapis/api/gles/gles.api
+++ b/gapis/api/gles/gles.api
@@ -744,22 +744,31 @@ sub void ApplyDynamicContextState(ref!Context ctx, ref!DynamicContextState dynam
   if (dynamicState != null) {
     backbuffer := ctx.Objects.Framebuffers[0]
 
+    width := dynamicState.BackbufferWidth
+    height := dynamicState.BackbufferHeight
+
+    colorFmtInfo := GetSizedFormatInfo(dynamicState.BackbufferColorFmt)
     backbuffer.ColorAttachments[0].Renderbuffer.Image = new!Image(
       Width: dynamicState.BackbufferWidth,
       Height: dynamicState.BackbufferHeight,
       SizedFormat: dynamicState.BackbufferColorFmt,
+      Data: make!u8(uncompressedImageSize(width, height, colorFmtInfo.UnsizedFormat, colorFmtInfo.DataType)),
     )
 
+    depthFmtInfo := GetSizedFormatInfo(dynamicState.BackbufferDepthFmt)
     backbuffer.DepthAttachment.Renderbuffer.Image = new!Image(
       Width: dynamicState.BackbufferWidth,
       Height: dynamicState.BackbufferHeight,
       SizedFormat: dynamicState.BackbufferDepthFmt,
+      Data: make!u8(uncompressedImageSize(width, height, depthFmtInfo.UnsizedFormat, depthFmtInfo.DataType)),
     )
 
+    stencilFmtInfo := GetSizedFormatInfo(dynamicState.BackbufferStencilFmt)
     backbuffer.StencilAttachment.Renderbuffer.Image = new!Image(
       Width: dynamicState.BackbufferWidth,
       Height: dynamicState.BackbufferHeight,
       SizedFormat: dynamicState.BackbufferStencilFmt,
+      Data: make!u8(uncompressedImageSize(width, height, stencilFmtInfo.UnsizedFormat, stencilFmtInfo.DataType)),
     )
 
     if resetViewportScissor {

--- a/gapis/api/gles/gles.api
+++ b/gapis/api/gles/gles.api
@@ -747,29 +747,32 @@ sub void ApplyDynamicContextState(ref!Context ctx, ref!DynamicContextState dynam
     width := dynamicState.BackbufferWidth
     height := dynamicState.BackbufferHeight
 
-    colorFmtInfo := GetSizedFormatInfo(dynamicState.BackbufferColorFmt)
     backbuffer.ColorAttachments[0].Renderbuffer.Image = new!Image(
       Width: dynamicState.BackbufferWidth,
       Height: dynamicState.BackbufferHeight,
       SizedFormat: dynamicState.BackbufferColorFmt,
-      Data: make!u8(uncompressedImageSize(width, height, colorFmtInfo.UnsizedFormat, colorFmtInfo.DataType)),
     )
+    colorFmtInfo := GetSizedFormatInfo(dynamicState.BackbufferColorFmt)
+    colorImageSize := uncompressedImageSize(width, height, colorFmtInfo.UnsizedFormat, colorFmtInfo.DataType)
+    backbuffer.ColorAttachments[0].Renderbuffer.Image.Data = make!u8(colorImageSize)
 
-    depthFmtInfo := GetSizedFormatInfo(dynamicState.BackbufferDepthFmt)
     backbuffer.DepthAttachment.Renderbuffer.Image = new!Image(
       Width: dynamicState.BackbufferWidth,
       Height: dynamicState.BackbufferHeight,
       SizedFormat: dynamicState.BackbufferDepthFmt,
-      Data: make!u8(uncompressedImageSize(width, height, depthFmtInfo.UnsizedFormat, depthFmtInfo.DataType)),
     )
+    depthFmtInfo := GetSizedFormatInfo(dynamicState.BackbufferDepthFmt)
+    depthImageSize := uncompressedImageSize(width, height, depthFmtInfo.UnsizedFormat, depthFmtInfo.DataType)
+    backbuffer.DepthAttachment.Renderbuffer.Image.Data = make!u8(depthImageSize)
 
-    stencilFmtInfo := GetSizedFormatInfo(dynamicState.BackbufferStencilFmt)
     backbuffer.StencilAttachment.Renderbuffer.Image = new!Image(
       Width: dynamicState.BackbufferWidth,
       Height: dynamicState.BackbufferHeight,
       SizedFormat: dynamicState.BackbufferStencilFmt,
-      Data: make!u8(uncompressedImageSize(width, height, stencilFmtInfo.UnsizedFormat, stencilFmtInfo.DataType)),
     )
+    stencilFmtInfo := GetSizedFormatInfo(dynamicState.BackbufferStencilFmt)
+    stencilImageSize := uncompressedImageSize(width, height, stencilFmtInfo.UnsizedFormat, stencilFmtInfo.DataType)
+    backbuffer.StencilAttachment.Renderbuffer.Image.Data = make!u8(stencilImageSize)
 
     if resetViewportScissor {
       ctx.Pixel.Scissor.Box.Width = dynamicState.BackbufferWidth


### PR DESCRIPTION
This is a first PR for a series of GLES dependency graph related PRs.