### PR TITLE
Fix the interception layers vkGetInstanceProcAddr. 

### DIFF
--- a/gapis/api/vulkan/api/properties_features_requirements.api
+++ b/gapis/api/vulkan/api/properties_features_requirements.api
@@ -902,6 +902,9 @@ sub void GetImageMemoryRequirements2(
           ext := as!VkImagePlaneMemoryRequirementsInfo*(next.Ptr)[0]
           plane.Val = as!u32(ext.planeAspect)
         }
+        case VK_STRUCTURE_TYPE_MEMORY_DEDICATED_REQUIREMENTS: {
+          _ = as!VkMemoryDedicatedRequirements*(next.Ptr)[0]
+        }
       }
       next.Ptr = as!VulkanStructHeader*(next.Ptr)[0].PNext
     }
@@ -936,6 +939,8 @@ sub void GetImageMemoryRequirements2(
             RequiresDedicatedAllocation:  ext.requiresDedicatedAllocation,
           )
           as!VkMemoryDedicatedRequirements*(next.Ptr)[0] = ext
+        }
+        case VK_STRUCTURE_TYPE_IMAGE_PLANE_MEMORY_REQUIREMENTS_INFO: {
         }
       }
       next.Ptr = as!VulkanStructHeader*(next.Ptr)[0].PNext

--- a/gapis/api/vulkan/templates/vk_spy_helpers.cpp.tmpl
+++ b/gapis/api/vulkan/templates/vk_spy_helpers.cpp.tmpl
@@ -84,7 +84,7 @@ gapii::VkExtensionProperties *pProperties) {
 namespace gapii {
 PFN_vkVoidFunction VulkanSpy::SpyOverride_vkGetInstanceProcAddr(VkInstance instance, const char* pName) {
     {{range $c := AllCommands $}}
-        {{if (Macro "IsIndirected" "Command" $c "IndirectOn" "VkInstance")}}
+        {{if (or (Macro "IsIndirected" "Command" $c "IndirectOn" "VkInstance") (Macro "IsIndirected" "Command" $c "IndirectOn" "VkDevice"))}}
             {{$name := Macro "CmdName" $c}}
             if(!strcmp(pName, "{{$name}}"))
               return reinterpret_cast<PFN_vkVoidFunction>(gapii::{{$name}});


### PR DESCRIPTION
`vkGetInstanceProcAddr` should return function pointers even for device functions. The spec requires these returned functions to do the dispatch based on the passed device. Since we already do that, we can simply return a pointer to all valid VK functions in our `vkGetInstanceProcAddr`.

Fixes #2755