### PR TITLE
Stop passing the GAPID version as a compiler flag.

### DIFF
--- a/cmd/gapir/cc/BUILD.bazel
+++ b/cmd/gapir/cc/BUILD.bazel
@@ -16,7 +16,7 @@ load("//tools/build:rules.bzl", "android_dynamic_library", "cc_copts", "cc_strip
 
 cc_library(
     name = "cc",
-    srcs = ["main.cpp"],
+    srcs = ["main.cpp"] + ["//core/cc:version"],
     copts = cc_copts(),
     deps = [
         "//gapir/cc:gapir",

--- a/cmd/gapir/cc/main.cpp
+++ b/cmd/gapir/cc/main.cpp
@@ -31,6 +31,7 @@
 #include "core/cc/socket_connection.h"
 #include "core/cc/supported_abis.h"
 #include "core/cc/target.h"
+#include "core/cc/version.h"
 
 #include <signal.h>
 #include <stdio.h>

--- a/core/cc/BUILD.bazel
+++ b/core/cc/BUILD.bazel
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("//:version.bzl", "gapid_version")
 load("//tools/build:rules.bzl", "cc_copts")
 
 cc_library(
@@ -57,6 +58,13 @@ cc_library(
         "@breakpad",
         "@cityhash",
     ],
+)
+
+gapid_version(
+    name = "version",
+    out = "version.h",
+    template = "version.h.in",
+    visibility = ["//visibility:public"],
 )
 
 cc_test(

--- a/core/cc/version.h.in
+++ b/core/cc/version.h.in
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef GAPID_VERSION_AND_BUILD
+#define GAPID_VERSION_AND_BUILD \
+  "@GAPID_VERSION_MAJOR@."      \
+  "@GAPID_VERSION_MINOR@."      \
+  "@GAPID_VERSION_POINT@."      \
+  "@GAPID_BUILD_SHA@"
+#endif

--- a/tools/build/rules/cc.bzl
+++ b/tools/build/rules/cc.bzl
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@gapid//:version.bzl", "version_define_copts")
 load("@gapid//tools/build/rules:common.bzl", "copy_exec")
 load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
 
@@ -26,7 +25,7 @@ _ANDROID_COPTS = [
 
 # This should probably all be done by fixing the toolchains...
 def cc_copts():
-    return version_define_copts() + ["-Werror"] + select({
+    return ["-Werror"] + select({
         "@gapid//tools/build:linux": ["-DTARGET_OS_LINUX"],
         "@gapid//tools/build:darwin": ["-DTARGET_OS_OSX"],
         "@gapid//tools/build:windows": ["-DTARGET_OS_WINDOWS"],

--- a/version.bzl
+++ b/version.bzl
@@ -23,12 +23,6 @@ GAPID_VERSION_POINT="0"
 GAPID_BUILD_NUMBER="$(GAPID_BUILD_NUMBER)"
 GAPID_BUILD_SHA="$(GAPID_BUILD_SHA)"
 
-def version():
-    return "{}.{}.{}:{}".format(GAPID_VERSION_MAJOR, GAPID_VERSION_MINOR, GAPID_VERSION_POINT, GAPID_BUILD_SHA)
-
-def version_define_copts():
-    return ["-DGAPID_VERSION_AND_BUILD=\\\"" + version() + "\\\""]
-
 def _gapid_version(ctx):
     ctx.actions.expand_template(
         template = ctx.file.template,


### PR DESCRIPTION
Instead, generate a .h file with the version, so we don't rebuild every C++ target when the version changes and it is more clear, where we actually depend on the version.