### PR TITLE
Fix logging by using vprint() style log function

### DIFF
--- a/core/cc/log.cpp
+++ b/core/cc/log.cpp
@@ -144,7 +144,7 @@ void Logger::vlogf(unsigned level, const char* src_file, unsigned src_line,
       // There is no va_list version of __android_log_assert(), hence the
       // message pre-formatting in this case.
       char buf[2048];
-      vsnprintf(buf, sizeof(buf), format, args);
+      vsnprintf(buf, sizeof(buf), ss.str().c_str(), args);
       __android_log_assert(nullptr, "GAPID", "%s", buf);
       break;
     case LOG_LEVEL_ERROR:

--- a/core/cc/log.cpp
+++ b/core/cc/log.cpp
@@ -160,7 +160,8 @@ void Logger::vlogf(unsigned level, const char* src_file, unsigned src_line,
       __android_log_vprint(ANDROID_LOG_DEBUG, "GAPID", ss.str().c_str(), args);
       break;
     case LOG_LEVEL_VERBOSE:
-      __android_log_vprint(ANDROID_LOG_VERBOSE, "GAPID", ss.str().c_str(), args);
+      __android_log_vprint(ANDROID_LOG_VERBOSE, "GAPID", ss.str().c_str(),
+                           args);
       break;
     default:
       break;

--- a/core/cc/log.cpp
+++ b/core/cc/log.cpp
@@ -129,32 +129,38 @@ void Logger::vlogf(unsigned level, const char* src_file, unsigned src_line,
   }
 #else   // TARGET_OS != GAPID_OS_ANDROID
 
+  // Note that we use "GAPID" as the logcat tag, rather than mInstance.mSystem,
+  // in order to easily filter all GAPID-related logcat. The mInstance.mSystem
+  // is still present in the message.
+
   std::stringstream ss;
+  if (mInstance.mSystem != nullptr && strlen(mInstance.mSystem) > 0) {
+    ss << mInstance.mSystem << " ";
+  }
   ss << "[" << src_file << ":" << src_line << "] " << format;
 
   switch (level) {
     case LOG_LEVEL_FATAL:
-      __android_log_assert(nullptr, mInstance.mSystem, ss.str().c_str(), args);
+      // There is no va_list version of __android_log_assert(), hence the
+      // message pre-formatting in this case.
+      char buf[2048];
+      vsnprintf(buf, sizeof(buf), format, args);
+      __android_log_assert(nullptr, "GAPID", "%s", buf);
       break;
     case LOG_LEVEL_ERROR:
-      __android_log_print(ANDROID_LOG_ERROR, mInstance.mSystem,
-                          ss.str().c_str(), args);
+      __android_log_vprint(ANDROID_LOG_ERROR, "GAPID", ss.str().c_str(), args);
       break;
     case LOG_LEVEL_WARNING:
-      __android_log_print(ANDROID_LOG_WARN, mInstance.mSystem, ss.str().c_str(),
-                          args);
+      __android_log_vprint(ANDROID_LOG_WARN, "GAPID", ss.str().c_str(), args);
       break;
     case LOG_LEVEL_INFO:
-      __android_log_print(ANDROID_LOG_INFO, mInstance.mSystem, ss.str().c_str(),
-                          args);
+      __android_log_vprint(ANDROID_LOG_INFO, "GAPID", ss.str().c_str(), args);
       break;
     case LOG_LEVEL_DEBUG:
-      __android_log_print(ANDROID_LOG_DEBUG, mInstance.mSystem,
-                          ss.str().c_str(), args);
+      __android_log_vprint(ANDROID_LOG_DEBUG, "GAPID", ss.str().c_str(), args);
       break;
     case LOG_LEVEL_VERBOSE:
-      __android_log_print(ANDROID_LOG_VERBOSE, mInstance.mSystem,
-                          ss.str().c_str(), args);
+      __android_log_vprint(ANDROID_LOG_VERBOSE, "GAPID", ss.str().c_str(), args);
       break;
     default:
       break;

--- a/gapii/cc/spy.cpp
+++ b/gapii/cc/spy.cpp
@@ -104,6 +104,7 @@ namespace gapii {
 Spy* Spy::get() {
   std::lock_guard<std::recursive_mutex> lock(gMutex);
   if (!gSpy) {
+    GAPID_LOGGER_INIT(LOG_LEVEL_INFO, "gapii", nullptr);
     GAPID_INFO("Constructing spy...");
     gSpy.reset(new Spy());
     GAPID_INFO("Registering spy symbols...");


### PR DESCRIPTION
Also revert to using "GAPID" as the logcat tag for all logging on Android.

The va_list was passed to __android_log_print, whereas the __android_log_vprint (note the "v") must be used. The compiler did not complain as __android_log_print is a variadic function, which accepts any type for its variadic args.