### PR TITLE
Add dependencies between draw calls

### DIFF
--- a/gapis/api/gles/api/draw_commands.api
+++ b/gapis/api/gles/api/draw_commands.api
@@ -67,6 +67,7 @@ cmd void glDrawArrays(GLenum draw_mode, GLint first_index, GLsizei indices_count
   ctx := GetContext()
   ReadVertexArrays(ctx, as!u32(first_index), as!u32(indices_count), 1)
   WriteGPUFramebufferData(ctx)
+  DrawCommandDependencies(ctx)
 }
 
 @if(Version.GLES31)
@@ -82,6 +83,7 @@ cmd void glDrawArraysIndirect(GLenum draw_mode, const void* indirect) {
   // TODO: INVALID_OPERATION error if the command would source data beyond the end of the buffer object.
   // TODO: CheckEQ(as!u64(indirect) % 4, 0)
   WriteGPUFramebufferData(ctx)
+  DrawCommandDependencies(ctx)
 }
 
 @if(Version.GLES30)
@@ -102,6 +104,7 @@ sub void DrawArraysInstanced(GLenum draw_mode, GLint first_index, GLsizei indice
   ctx := GetContext()
   ReadVertexArrays(ctx, as!u32(first_index), as!u32(indices_count), as!u32(instance_count))
   WriteGPUFramebufferData(ctx)
+  DrawCommandDependencies(ctx)
 }
 
 sub void DrawElements(ref!Context    ctx,
@@ -145,6 +148,7 @@ sub void DrawElements(ref!Context    ctx,
     }
   }
   WriteGPUFramebufferData(ctx)
+  DrawCommandDependencies(ctx)
 }
 
 @if(Version.GLES10)
@@ -195,6 +199,7 @@ cmd void glDrawElementsIndirect(GLenum draw_mode, GLenum indices_type, const voi
   // TODO: INVALID_OPERATION error if the command would source data beyond the end of the buffer object.
   // TODO: CheckEQ(as!u64(indirect) % 4, 0)
   WriteGPUFramebufferData(ctx)
+  DrawCommandDependencies(ctx)
 }
 
 @if(Version.GLES30)
@@ -304,7 +309,7 @@ sub void PrimitiveBoundingBox(GLfloat minX, GLfloat minY, GLfloat minZ, GLfloat 
   ctx.Rasterization.PrimitiveBoundingBox.Max = Vec4f(maxX, maxY, maxZ, maxW)
 }
 
-// WriteGPUFramebufferData updates the data of the given FramebufferAttachment.
+// WriteGPUFramebufferAttachment updates the data of the given FramebufferAttachment.
 sub void WriteGPUFramebufferAttachment(FramebufferAttachment a) {
   numViews := a.NumViews
   for view in (0 .. numViews) {
@@ -320,8 +325,7 @@ sub void WriteGPUFramebufferAttachment(FramebufferAttachment a) {
   }
 }
 
-// WriteGPUFramebufferData updates the data of currently bound framebuffer
-// textures.
+// WriteGPUFramebufferData updates the data of currently bound framebuffer textures.
 sub void WriteGPUFramebufferData(ref!Context ctx) {
   fb := ctx.Bound.DrawFramebuffer
   for _, _, a in fb.ColorAttachments {
@@ -335,3 +339,63 @@ sub void WriteGPUFramebufferData(ref!Context ctx) {
 // This is typically done to read the result of a render-to-texture.
 @internal
 extern u8[] ReadGPUTextureData(ref!Texture texture, GLint level, GLint layer)
+
+//////////////////
+// Dependencies //
+//////////////////
+
+// ReadFramebufferAttachment creates a read on this FramebufferAttachment.
+sub void ReadFramebufferAttachment(FramebufferAttachment a) {
+  switch (a.Type) {
+    case GL_FRAMEBUFFER_DEFAULT, GL_RENDERBUFFER: {
+      read(a.Renderbuffer.Image.Data)
+    }
+    case GL_TEXTURE: {
+      read(a.Texture.Image.Data)
+    }
+    case GL_NONE: {
+      // nothing to do
+    }
+  }
+}
+
+// WriteFramebufferAttachment creates a write on this FramebufferAttachment.
+sub void WriteFramebufferAttachment(FramebufferAttachment a) {
+  switch (a.Type) {
+    case GL_FRAMEBUFFER_DEFAULT, GL_RENDERBUFFER: {
+      write(a.Renderbuffer.Image.Data)
+    }
+    case GL_TEXTURE: {
+      write(a.Texture.Image.Data)
+    }
+    case GL_NONE: {
+      // nothing to do
+    }
+  }
+}
+
+// DrawCommandDependencies creates relevant dependencies of draw commands.
+sub void DrawCommandDependencies(ref!Context ctx) {
+  read_fb := ctx.Bound.ReadFramebuffer
+  draw_fb := ctx.Bound.DrawFramebuffer
+
+  _ = ctx.Rasterization.Viewport
+
+  if ctx.Pixel.Stencil.Test == GL_TRUE {
+    ReadFramebufferAttachment(read_fb.StencilAttachment)
+  }
+
+  if ctx.Pixel.Depth.Test == GL_TRUE {
+    ReadFramebufferAttachment(read_fb.DepthAttachment)
+  }
+
+  // The program execution read uniforms
+  for _, _, u in ctx.Bound.Program.UniformLocations {
+    read(u.Values)
+  }
+
+  for _, _, a in draw_fb.ColorAttachments {
+    ReadFramebufferAttachment(a)
+    WriteFramebufferAttachment(a)
+  }
+}

--- a/gapis/api/gles/api/egl.api
+++ b/gapis/api/gles/api/egl.api
@@ -361,6 +361,20 @@ cmd EGLBoolean eglSurfaceAttrib(EGLDisplay display,
 @custom
 ///http://www.khronos.org/registry/egl/sdk/docs/man/html/eglSwapBuffers.xhtml
 cmd EGLBoolean eglSwapBuffers(EGLDisplay display, void* surface) {
+
+  // eglSwapBuffers leaves buffer contents undefined, so there cannot
+  // be dependencies on framebuffer attachement values across
+  // eglSwapBuffers.
+  // TODO(hevrard): there is a possible dependency  on color buffer
+  // if EGL_SWAP_BEHAVIOR == EGL_BUFFER_PRESERVED
+  ctx := GetContext()
+  fb := ctx.Bound.DrawFramebuffer
+  for _, _, a in fb.ColorAttachments {
+      WriteFramebufferAttachment(a)
+  }
+  WriteFramebufferAttachment(fb.DepthAttachment)
+  WriteFramebufferAttachment(fb.StencilAttachment)
+
   return ?
 }
 

--- a/gapis/api/gles/api/framebuffer.api
+++ b/gapis/api/gles/api/framebuffer.api
@@ -298,25 +298,18 @@ cmd void glClear(GLbitfield mask) {
   if (GL_COLOR_BUFFER_BIT in mask) {
     _ = ctx.Pixel.ColorClearValue
     for _, _, a in fb.ColorAttachments {
-      WriteGPUFramebufferAttachment(a)
+      WriteFramebufferAttachment(a)
     }
   }
 
   if (GL_DEPTH_BUFFER_BIT in mask) {
     _ = ctx.Pixel.DepthClearValue
-    WriteGPUFramebufferAttachment(fb.DepthAttachment)
+    WriteFramebufferAttachment(fb.DepthAttachment)
   }
 
   if (GL_STENCIL_BUFFER_BIT in mask) {
     _ = ctx.Pixel.StencilClearValue
-    WriteGPUFramebufferAttachment(fb.StencilAttachment)
-  }
-
-  // TODO: use(Clearing.ClearColor) when mask[GL_COLOR_BUFFER_BIT] == true
-  if (GL_COLOR_BUFFER_BIT in mask) {
-    // color := BoundFramebuffers[GL_FRAMEBUFFER].Attachments[GL_COLOR_ATTACHMENT0]
-    // error("Attempting to clear missing color buffer") if !exists(color)
-    // modifies(color.Levels[0].Data) // COMPILATION ERROR
+    WriteFramebufferAttachment(fb.StencilAttachment)
   }
 }
 

--- a/gapis/api/gles/api/programs_and_shaders.api
+++ b/gapis/api/gles/api/programs_and_shaders.api
@@ -496,6 +496,7 @@ cmd void glBindProgramPipeline(PipelineId pipeline) {
 cmd void glCompileShader(ShaderId shader) {
   ctx := GetContext()
   s := GetShaderOrError(shader)
+  _ = s.Source
   ApplyCompileShaderExtra(s, GetCompileShaderExtra(ctx, s, null))
 }
 
@@ -1276,7 +1277,9 @@ cmd GLboolean glIsShader(ShaderId shader) {
 @doc("https://www.khronos.org/opengles/sdk/docs/man32/html/glLinkProgram.xhtml", Version.GLES32)
 cmd void glLinkProgram(ProgramId program) {
   p := GetProgramOrError(program)
-
+  for _, _, attributeLocation in p.AttributeBindings {
+    _ = attributeLocation
+  }
   ctx := GetContext()
   ApplyLinkProgramExtra(p, GetLinkProgramExtra(ctx, p, null))
 }


### PR DESCRIPTION
These dependencies are enough to do relevant dead-code elimination on
a simple spinning cube app.

I introduce DrawCommandDependencies() which is distinct from the existing WriteGPUFramebufferData(), as this latter one is used to eventually call
ReadGPUTextureData(), such that renderings to textures are obtained with a replay.
I prefered to keep the logic separated.

Once the dependency graph is in place, we want to get rid of ReadGPUTextureData(),
as we will know if a replay is needed based on the dependency graph.

There is still a lot to do, but I would like to proceed with incremental PR,
one at a time.
