### PR TITLE
Disable the horizontal mouse wheel in the Perfetto view.

### DIFF
--- a/gapic/src/main/com/google/gapid/perfetto/TraceView.java
+++ b/gapic/src/main/com/google/gapid/perfetto/TraceView.java
@@ -68,6 +68,9 @@ public class TraceView extends Composite
         }
       }
     });
+    canvas.addListener(SWT.MouseHorizontalWheel, e -> {
+      e.doit = false;
+    });
     canvas.getHorizontalBar().addListener(SWT.Selection, e -> {
       TimeSpan trace = state.getTraceTime();
       int sel = canvas.getHorizontalBar().getSelection();


### PR DESCRIPTION
This makes the UI work better with (Mac) trackpads.