### PR TITLE
Don't dispose tabs when moving between folders.

### DIFF
--- a/gapic/src/main/com/google/gapid/GraphicsTraceView.java
+++ b/gapic/src/main/com/google/gapid/GraphicsTraceView.java
@@ -167,7 +167,7 @@ public class GraphicsTraceView extends Composite implements MainWindow.MainView 
           tabs.showTab(type);
           hiddenTabs.remove(type);
         } else {
-          tabs.removeTab(type);
+          tabs.disposeTab(type);
           hiddenTabs.add(type);
         }
         models.settings.hiddenTabs =

--- a/gapic/src/main/com/google/gapid/widgets/TabComposite.java
+++ b/gapic/src/main/com/google/gapid/widgets/TabComposite.java
@@ -255,8 +255,8 @@ public class TabComposite extends Composite {
     group.addTabToLargestFolder(info);
   }
 
-  public boolean removeTab(Object id) {
-    if (group.removeTab(id)) {
+  public boolean disposeTab(Object id) {
+    if (group.disposeTab(id)) {
       group.merge();
       return true;
     }
@@ -335,7 +335,7 @@ public class TabComposite extends Composite {
 
     public abstract boolean showTab(Object id);
     public abstract void addTabToLargestFolder(TabInfo tab);
-    public abstract boolean removeTab(Object id);
+    public abstract boolean disposeTab(Object id);
 
     public abstract void setBounds(Set<Control> controls, int x, int y, int w, int h);
 
@@ -417,9 +417,9 @@ public class TabComposite extends Composite {
     }
 
     @Override
-    public boolean removeTab(Object id) {
+    public boolean disposeTab(Object id) {
       for (Element child : children) {
-        if (child.removeTab(id)) {
+        if (child.disposeTab(id)) {
           return true;
         }
       }
@@ -814,10 +814,11 @@ public class TabComposite extends Composite {
     }
 
     @Override
-    public boolean removeTab(Object id) {
+    public boolean disposeTab(Object id) {
       for (Tab tab : tabs) {
         if (Objects.equals(tab.info.id, id)) {
           removeTab(tab);
+          tab.control.dispose();
           return true;
         }
       }
@@ -881,7 +882,6 @@ public class TabComposite extends Composite {
         current = tabs.isEmpty() ? null : tabs.get(0).control;
         requestLayout();
       }
-      tab.control.dispose();
       redrawBar();
     }
 


### PR DESCRIPTION
In #2860, a change was added that disposed the tabs when they are removed, however, the same function is called when moving tabs between folders. This change renames the "removeTab" function used when complety removing a tab to "disposeTab" to make it more clear that the tab's control will be disposed. This function removes and then disposes the tab, while the removeTab function was changed back to not dispose the control.

Fixes #2869