### PR TITLE
Add support for template generated go and cpp file

### DIFF
--- a/cmd/gofuse/main.go
+++ b/cmd/gofuse/main.go
@@ -152,6 +152,7 @@ func run() error {
 		return filepath.Join(fusedRoot, "src", trimUpTo(rel(projectRoot, path), "github.com"))
 	})
 
+	// Get ".go" files generated from templates.
 	templateGenedGofiles := collect(binOut, always).ifTrue(and(
 		isFile,
 		contains(filepath.Join("github.com", "google", "gapid")).not(),
@@ -160,6 +161,7 @@ func run() error {
 		return filepath.Join(fusedRoot, "src", "github.com", "google", "gapid", rel(binOut, path))
 	})
 
+	// Get ".cpp" and ".h" files generated from templates.
 	templateGenedCppfiles := collect(binOut, always).ifTrue(and(
 		isFile,
 		contains(filepath.Join("github.com", "google", "gapid")).not(),

--- a/cmd/gofuse/main.go
+++ b/cmd/gofuse/main.go
@@ -152,6 +152,22 @@ func run() error {
 		return filepath.Join(fusedRoot, "src", trimUpTo(rel(projectRoot, path), "github.com"))
 	})
 
+	templateGenedGofiles := collect(binOut, always).ifTrue(and(
+		isFile,
+		contains(filepath.Join("github.com", "google", "gapid")).not(),
+		hasSuffix(".go"),
+	)).mapping(func(path string) string {
+		return filepath.Join(fusedRoot, "src", "github.com", "google", "gapid", rel(binOut, path))
+	})
+
+	templateGenedCppfiles := collect(binOut, always).ifTrue(and(
+		isFile,
+		contains(filepath.Join("github.com", "google", "gapid")).not(),
+		or(hasSuffix(".cpp"), hasSuffix(".h")),
+	)).mapping(func(path string) string {
+		return filepath.Join(fusedRoot, "src", "github.com", "google", "gapid", rel(binOut, path))
+	})
+
 	// Collect all the external package file mappings.
 
 	// After resolving symlinks, bazel-gapid/external points to:
@@ -190,7 +206,7 @@ func run() error {
 	}
 
 	// Every mapping we're going to deal with.
-	allMappings := join(srcMapping, genfilesMappingOut, binMappingOut, extMapping)
+	allMappings := join(srcMapping, genfilesMappingOut, binMappingOut, templateGenedGofiles, templateGenedCppfiles, extMapping)
 
 	// Remove all existing symlinks in the fused directory that are not part of the
 	// mappings. This may never happen if the OS automatically deletes deleted


### PR DESCRIPTION
gofuse now seems can not collect the apic compiled files, trying to update the gofuse to collect them. 