### PR TITLE
Complete EXT_texture_sRGB_decode support

### DIFF
--- a/gapis/api/gles/api/textures_and_samplers.api
+++ b/gapis/api/gles/api/textures_and_samplers.api
@@ -78,8 +78,11 @@ class Texture {
   @unused GLuint ImmutableLevels         = 0
   @unused string Label
 
-  // EXT/texture_filter_anisotropic
+  // EXT_texture_filter_anisotropic
   GLfloat MaxAnisotropy = 1.0
+
+  // EXT_texture_sRGB_decode
+  GLenum DecodeSRGB = GL_DECODE_EXT
 
   // GL_OES_EGL_image
   // EGL image which is used as storage for this texture.
@@ -150,8 +153,11 @@ class Sampler {
   GLenum         CompareFunc  = GL_LEQUAL
   @unused string Label
 
-  // EXT/texture_filter_anisotropic
+  // EXT_texture_filter_anisotropic
   GLfloat MaxAnisotropy = 1.0
+
+  // EXT_texture_sRGB_decode
+  GLenum DecodeSRGB = GL_DECODE_EXT
 }
 
 @internal
@@ -1082,6 +1088,10 @@ sub void GetSamplerParameterv!T(SamplerId sampler, GLenum pname, T* params) {
     case GL_TEXTURE_MAX_ANISOTROPY_EXT: {
       params[0] = as!T(s.MaxAnisotropy)
     }
+    @if(Extension.GL_EXT_texture_sRGB_decode)
+    case GL_TEXTURE_SRGB_DECODE_EXT: {
+      params[0] = as!T(s.DecodeSRGB)
+    }
     default: {
       glErrorInvalidEnum(pname)
     }
@@ -1308,6 +1318,10 @@ sub void GetTexParameter!T(GLenum target, GLenum parameter, T* params) {
     case GL_TEXTURE_MAX_ANISOTROPY_EXT: {
       params[0] = as!T(t.MaxAnisotropy)
     }
+    @if(Extension.GL_EXT_texture_sRGB_decode)
+    case GL_TEXTURE_SRGB_DECODE_EXT: {
+      params[0] = as!T(t.DecodeSRGB)
+    }
     default: {
       glErrorInvalidEnum(parameter)
     }
@@ -1458,6 +1472,17 @@ sub void SamplerParameterv!T(SamplerId sampler, GLenum pname, T params) {
       // because it is written for GLES2, but samplers were introduced in GLES3).
       // However, it is used and supported in practice (which is reasonable).
       s.MaxAnisotropy = as!GLfloat(params[0])
+    }
+    @if(Extension.GL_EXT_texture_sRGB_decode)
+    case GL_TEXTURE_SRGB_DECODE_EXT: {
+      decode := as!GLenum(params[0])
+      switch (decode) {
+        case GL_DECODE_EXT, GL_SKIP_DECODE_EXT: { /* fine */ }
+        default:                     {
+          glErrorInvalidEnum(decode)
+        }
+      }
+      s.DecodeSRGB = decode
     }
     default: {
       glErrorInvalidEnum(pname)
@@ -1783,7 +1808,14 @@ sub void TexParameterv!T(GLenum target, GLenum pname, T params) {
     }
     @if(Extension.GL_EXT_texture_sRGB_decode)
     case GL_TEXTURE_SRGB_DECODE_EXT: {
-      // TODO: DECODE_EXT, SKIP_DECODE_EXT
+      decode := as!GLenum(params[0])
+      switch (decode) {
+        case GL_DECODE_EXT, GL_SKIP_DECODE_EXT: { /* fine */ }
+        default:                     {
+          glErrorInvalidEnum(decode)
+        }
+      }
+      t.DecodeSRGB = decode
     }
     default: {
       glErrorInvalidEnum(pname)

--- a/gapis/api/gles/links.go
+++ b/gapis/api/gles/links.go
@@ -112,6 +112,16 @@ func (o RenderbufferId) Link(ctx context.Context, p path.Node, r *path.ResolveCo
 	return i.Field("Renderbuffers").MapIndex(o), nil
 }
 
+// Link returns the link to the sampler object in the state block.
+// If nil, nil is returned then the path cannot be followed.
+func (o SamplerId) Link(ctx context.Context, p path.Node, r *path.ResolveConfig) (path.Node, error) {
+	i, c, err := objects(ctx, p, r)
+	if i == nil || !c.Objects().Samplers().Contains(o) {
+		return nil, err
+	}
+	return i.Field("Samplers").MapIndex(o), nil
+}
+
 // Link returns the link to the shader object in the state block.
 // If nil, nil is returned then the path cannot be followed.
 func (o ShaderId) Link(ctx context.Context, p path.Node, r *path.ResolveConfig) (path.Node, error) {

--- a/gapis/api/gles/state_builder.go
+++ b/gapis/api/gles/state_builder.go
@@ -956,6 +956,7 @@ func (sb *stateBuilder) textureObject(ctx context.Context, t Textureʳ) {
 	parami(GLenum_GL_TEXTURE_SWIZZLE_G, GLint(t.SwizzleG()), GLint(defaults.SwizzleG()))
 	parami(GLenum_GL_TEXTURE_SWIZZLE_R, GLint(t.SwizzleR()), GLint(defaults.SwizzleR()))
 	parami(GLenum_GL_DEPTH_STENCIL_TEXTURE_MODE, GLint(t.DepthStencilTextureMode()), GLint(defaults.DepthStencilTextureMode()))
+	parami(GLenum_GL_TEXTURE_SRGB_DECODE_EXT, GLint(t.DecodeSRGB()), GLint(defaults.DecodeSRGB()))
 	if t.MaxLod() != defaults.MaxLod() {
 		write(ctx, cb.GlTexParameterf(target, GLenum_GL_TEXTURE_MAX_LOD, t.MaxLod()))
 	}
@@ -989,6 +990,9 @@ func (sb *stateBuilder) samplerObject(ctx context.Context, s Samplerʳ) {
 		write(ctx, cb.GlSamplerParameterfv(id, GLenum_GL_TEXTURE_BORDER_COLOR, sb.readsData(ctx, s.BorderColor()))) // GLES32
 	} else if !s.BorderColorI().EqualTo(0, 0, 0, 0) {
 		write(ctx, cb.GlSamplerParameterIiv(id, GLenum_GL_TEXTURE_BORDER_COLOR, sb.readsData(ctx, s.BorderColorI()))) // GLES32
+	}
+	if s.DecodeSRGB() != GLenum_GL_DECODE_EXT {
+		write(ctx, cb.GlSamplerParameteri(id, GLenum_GL_TEXTURE_SRGB_DECODE_EXT, GLint(s.DecodeSRGB())))
 	}
 }
 


### PR DESCRIPTION
Adds a new field in texture and sampler objects to store whether SRGB texture sampling should disable the otherwise implicit conversion to linear color. Also handles this field in state reconstruction.