### PR TITLE
Improve resource cache prefetch logging

### DIFF
--- a/gapir/cc/resource_cache.cpp
+++ b/gapir/cc/resource_cache.cpp
@@ -28,10 +28,12 @@ size_t ResourceCache::prefetch(const Resource* res, size_t count,
   size_t res_sum = 0;
   std::vector<Resource> uncached;
   uncached.reserve(count);
+  size_t alreadyCached = 0;
 
   for (size_t i = 0; i < count; i++) {
     const auto& r = res[i];
     if (hasCache(r)) {
+      alreadyCached++;
       continue;
     }
     if (res_sum + r.size > totalCacheSize()) {
@@ -40,7 +42,10 @@ size_t ResourceCache::prefetch(const Resource* res, size_t count,
     uncached.push_back(r);
     res_sum += r.size;
   }
-  GAPID_INFO("Prefetch %zu out of %zu resources...", uncached.size(), count);
+  GAPID_INFO(
+      "Prefetching %zu new uncached resources (%zu / %zu resources will be in "
+      "cache after prefetch)...",
+      uncached.size(), uncached.size() + alreadyCached, count);
   ResourceLoadingBatch bat;
   auto fetchBatch = [&bat, fetcher, this]() {
     auto fetched =


### PR DESCRIPTION
Make it more obvious when the prefetching did not prefetch everything as
a result of some data already existing in the cache; vs not prefetching
everything because it would overflow the cache memory limit.