### PR TITLE
Fix memory tracker destructor logic

### DIFF
--- a/core/memory_tracker/cc/posix/memory_tracker.inc
+++ b/core/memory_tracker/cc/posix/memory_tracker.inc
@@ -15,6 +15,7 @@
  */
 
 #include <functional>
+
 namespace gapii {
 namespace track_memory {
 


### PR DESCRIPTION
DisableMemoryTrackerImpl() used to loop over the tracking_ranges_ map
using an iterator, yet it calls UntrackRangeImpl() which itselft also
uses an iterator on tracking_ranges_ map to erase the element, and
this does not play well with the iteration in
DisableMemoryTrackerImpl() loop. Hence we avoid using iterators to
loop over tracking_ranges_ in DisableMemoryTrackerImpl().