### PR TITLE
Resources cleanup

### DIFF
--- a/cmd/gapit/dump_shaders.go
+++ b/cmd/gapit/dump_shaders.go
@@ -91,7 +91,7 @@ func (verb *dumpShadersVerb) Run(ctx context.Context, flags flag.FlagSet) error 
 
 				shaderSource := resourceData.(*api.ResourceData).GetShader().GetSource()
 				shaderType := resourceData.(*api.ResourceData).GetShader().GetType()
-				filename := file.SanitizePath(v.GetHandle() + "." + shaderType.Extension())
+				filename := file.SanitizePath(v.GetID().ID().String() + "." + shaderType.Extension())
 				f, err := os.Create(filename)
 				if err != nil {
 					log.E(ctx, "Could open file to write %s %v", v.GetHandle(), err)

--- a/cmd/gapit/flags.go
+++ b/cmd/gapit/flags.go
@@ -216,7 +216,7 @@ type (
 	ReplaceResourceFlags struct {
 		Gapis                GapisFlags
 		Gapir                GapirFlags
-		Handle               string `help:"required. handle of the resource to replace"`
+		Handle               string `help:"required. handle or ID of the resource to replace"`
 		ResourcePath         string `help:"file path for the new resource"`
 		At                   int    `help:"command index to replace the resource(s) at"`
 		UpdateResourceBinary string `help:"shaders only. binary to run for every shader; consumes resource data from standard input and writes to standard output"`

--- a/cmd/gapit/replace_resource.go
+++ b/cmd/gapit/replace_resource.go
@@ -89,7 +89,8 @@ func (verb *replaceResourceVerb) Run(ctx context.Context, flags flag.FlagSet) er
 	switch {
 	case verb.Handle != "":
 		matchedResource, err := resources.FindSingle(func(t api.ResourceType, r service.Resource) bool {
-			return t == api.ResourceType_ShaderResource && strings.Contains(r.GetHandle(), verb.Handle)
+			return t == api.ResourceType_ShaderResource &&
+				(strings.Contains(r.GetHandle(), verb.Handle) || strings.Contains(r.GetID().ID().String(), verb.Handle))
 		})
 		if err != nil {
 			return err

--- a/gapic/src/main/com/google/gapid/views/ShaderView.java
+++ b/gapic/src/main/com/google/gapid/views/ShaderView.java
@@ -696,22 +696,19 @@ public class ShaderView extends Composite
    */
   private static class Type implements ShaderPanel.UpdateShader {
     public final API.ResourceType type;
-    public final String selectMessage;
     public final ShaderPanel.UpdateShader onSourceEdited;
 
-    public Type(
-        API.ResourceType type, String selectMessage, ShaderPanel.UpdateShader onSourceEdited) {
+    public Type(API.ResourceType type, ShaderPanel.UpdateShader onSourceEdited) {
       this.type = type;
-      this.selectMessage = selectMessage;
       this.onSourceEdited = onSourceEdited;
     }
 
     public static Type shader(ShaderPanel.UpdateShader onSourceEdited) {
-      return new Type(API.ResourceType.ShaderResource, Messages.SELECT_SHADER, onSourceEdited);
+      return new Type(API.ResourceType.ShaderResource, onSourceEdited);
     }
 
     public static Type program() {
-      return new Type(API.ResourceType.ProgramResource, Messages.SELECT_PROGRAM, null);
+      return new Type(API.ResourceType.ProgramResource, null);
     }
 
     @Override

--- a/gapic/src/main/com/google/gapid/views/ShaderView.java
+++ b/gapic/src/main/com/google/gapid/views/ShaderView.java
@@ -340,7 +340,7 @@ public class ShaderView extends Composite
       MenuItem contextFilterSelector = new MenuItem(searchBox.getNestedMenu(), SWT.CHECK);
       contextFilterSelector.setText("Include all contexts");
       contextFilterSelector.addListener(SWT.Selection, e -> updateContextFilter(contextFilterSelector.getSelection()));
-      contextFilterSelector.setSelection(false);
+      contextFilterSelector.setSelection(true);
 
       shaderViewer = createShaderSelector(treeViewerContainer);
       shaderViewer.getTree().setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));

--- a/gapis/resolve/resources.go
+++ b/gapis/resolve/resources.go
@@ -150,7 +150,7 @@ func (r trackedResource) asService(p *path.Capture) *service.Resource {
 	out := &service.Resource{
 		ID:       path.NewID(r.id),
 		Context:  r.context,
-		Handle:   r.resource.ResourceHandle() + fmt.Sprintf("<%d>", r.created),
+		Handle:   r.resource.ResourceHandle(),
 		Label:    r.resource.ResourceLabel(),
 		Order:    r.resource.Order(),
 		Accesses: make([]*path.Command, len(r.accesses)),


### PR DESCRIPTION
 - No longer put the command id into the handle
 - Fix a warning in the UI code
 - Make the "show shaders/programs form all contexts" on by default
 - Use a proper table in the shader/program view