### PR TITLE
Update read/write to have relevant dependency for textured cube app

### DIFF
--- a/gapis/api/gles/api/draw_commands.api
+++ b/gapis/api/gles/api/draw_commands.api
@@ -345,6 +345,7 @@ extern u8[] ReadGPUTextureData(ref!Texture texture, GLint level, GLint layer)
 //////////////////
 
 // ReadFramebufferAttachment creates a read on this FramebufferAttachment.
+@spy_disabled
 sub void ReadFramebufferAttachment(FramebufferAttachment a) {
   switch (a.Type) {
     case GL_FRAMEBUFFER_DEFAULT, GL_RENDERBUFFER: {
@@ -360,6 +361,7 @@ sub void ReadFramebufferAttachment(FramebufferAttachment a) {
 }
 
 // WriteFramebufferAttachment creates a write on this FramebufferAttachment.
+@spy_disabled
 sub void WriteFramebufferAttachment(FramebufferAttachment a) {
   switch (a.Type) {
     case GL_FRAMEBUFFER_DEFAULT, GL_RENDERBUFFER: {
@@ -403,6 +405,7 @@ sub void DependencyReadTexture(ref!Texture texture) {
 }
 
 // DrawCommandDependencies creates relevant dependencies of draw commands.
+@spy_disabled
 sub void DrawCommandDependencies(ref!Context ctx) {
   read_fb := ctx.Bound.ReadFramebuffer
   draw_fb := ctx.Bound.DrawFramebuffer

--- a/gapis/api/gles/api/draw_commands.api
+++ b/gapis/api/gles/api/draw_commands.api
@@ -375,6 +375,7 @@ sub void WriteFramebufferAttachment(FramebufferAttachment a) {
 }
 
 // DependencyReadTexture read all relevant fields of texture to create dependencies
+@spy_disabled
 sub void DependencyReadTexture(ref!Texture texture) {
   read(texture.Image.Data)
 

--- a/gapis/api/gles/api/draw_commands.api
+++ b/gapis/api/gles/api/draw_commands.api
@@ -374,6 +374,33 @@ sub void WriteFramebufferAttachment(FramebufferAttachment a) {
   }
 }
 
+// DependencyReadTexture read all relevant fields of texture to create dependencies
+sub void DependencyReadTexture(ref!Texture texture) {
+  read(texture.Image.Data)
+
+  // Sampling may be affected by all these parameters
+  _ = texture.SwizzleR
+  _ = texture.SwizzleG
+  _ = texture.SwizzleB
+  _ = texture.SwizzleA
+  _ = texture.BorderColor
+  _ = texture.BorderColorI
+  _ = texture.MinFilter
+  _ = texture.MagFilter
+  _ = texture.WrapS
+  _ = texture.WrapT
+  _ = texture.WrapR
+  _ = texture.MinLod
+  _ = texture.MaxLod
+  _ = texture.BaseLevel
+  _ = texture.MaxLevel
+  _ = texture.DepthStencilTextureMode
+  _ = texture.CompareMode
+  _ = texture.CompareFunc
+  _ = texture.MaxAnisotropy
+  _ = texture.DecodeSRGB
+}
+
 // DrawCommandDependencies creates relevant dependencies of draw commands.
 sub void DrawCommandDependencies(ref!Context ctx) {
   read_fb := ctx.Bound.ReadFramebuffer
@@ -389,9 +416,17 @@ sub void DrawCommandDependencies(ref!Context ctx) {
     ReadFramebufferAttachment(read_fb.DepthAttachment)
   }
 
-  // The program execution read uniforms
   for _, _, u in ctx.Bound.Program.UniformLocations {
+
+    // The program execution reads uniform values
     read(u.Values)
+
+    // Sampler uniform refers to a texture
+    texture_target := GetTextureTargetFromSamplerType(u.Type)
+    if texture_target != GL_NONE {
+      DependencyReadTexture(GetBoundTextureForUnit(ctx.Objects.TextureUnits[as!TextureUnitId(u.Value[0])], texture_target))
+    }
+
   }
 
   for _, _, a in draw_fb.ColorAttachments {

--- a/gapis/api/gles/api/textures_and_samplers.api
+++ b/gapis/api/gles/api/textures_and_samplers.api
@@ -494,6 +494,9 @@ sub void TexImage(TexImageFlags  flags,
       }
     }
   }
+
+  // Dependency reads
+  _ = ctx.Other.Unpack.Alignment
 }
 
 sub void UpdateImageData(ref!Image      dst_image,
@@ -655,7 +658,12 @@ sub ref!Texture GetOrCreateTexture(GLenum target, TextureId texture, ref!Texture
         ctx.Objects.Textures[texture] = new!Texture(ID: texture)
       }
     }
-    ctx.Objects.GeneratedNames.Textures[texture] = true
+
+    // Dependency: set GeneratedNames.Textures[texture] only if it has not
+    // been set previously by glGenTexture()
+    if !ctx.Objects.GeneratedNames.Textures[texture] {
+      ctx.Objects.GeneratedNames.Textures[texture] = true
+    }
 
     // Set or check the kind of the texture
     t := ctx.Objects.Textures[texture]


### PR DESCRIPTION
This change updates read/write such that dead code elimintation keeps
the relevant commands for frames of a simple textured spinning cube
app.