### PR TITLE
Macos Bazel Fixes

### DIFF
--- a/tools/build/rules/cc.bzl
+++ b/tools/build/rules/cc.bzl
@@ -54,6 +54,8 @@ def _strip_impl(ctx):
         flags = ["--strip-unneeded", "-p"]
     elif cc_toolchain.cpu == "darwin_x86_64":
         flags = ["-x"]
+    elif cc_toolchain.cpu == "darwin":
+        fail("Please install Xcode and setup the path using xcode-select. You need Xcode, the CLI tools are not enough.")
     else:
         fail("Unhandled CPU type in strip rule: " + cc_toolchain.cpu)
 

--- a/tools/build/rules/mm.bzl
+++ b/tools/build/rules/mm.bzl
@@ -15,13 +15,13 @@
 load(":common.bzl", "copy")
 
 def _filter_headers_impl(ctx):
-    outs = depset()
+    outs = []
     for src in ctx.files.srcs:
         path = src.short_path
         if path.endswith(".h") or path.endswith(".inc"):
             outs += [src]
     return struct(
-        files = outs,
+        files = depset(outs),
     )
 
 filter_headers = rule(


### PR DESCRIPTION
- Get MacOS building using latest bazel.
- Show a better error if trying to build without Xcode/only the CLI tools.