### PR TITLE
Fix a bug in notification instruction

### DIFF
--- a/gapir/cc/context.cpp
+++ b/gapir/cc/context.cpp
@@ -799,8 +799,8 @@ bool Context::stopTimer(Stack* stack, bool pushReturn) {
 
 bool Context::sendNotificationData(Stack* stack) {
   const uint32_t count = stack->pop<uint32_t>();
-  const void* address = stack->pop<const void*>();
   const uint32_t id = stack->pop<uint32_t>();
+  const void* address = stack->pop<const void*>();
   auto label = mInterpreter->getLabel();
 
   if (!stack->isValid()) {

--- a/gapis/api/vulkan/find_issues.go
+++ b/gapis/api/vulkan/find_issues.go
@@ -271,7 +271,7 @@ func (t *findIssues) Flush(ctx context.Context, out transform.Writer) {
 		delete(t.reportCallbacks, inst)
 	}
 	out.MutateAndWrite(ctx, api.CmdNoID, cb.Custom(func(ctx context.Context, s *api.GlobalState, b *builder.Builder) error {
-		return b.RegisterNotificationReader(func(n gapir.Notification) {
+		return b.RegisterNotificationReader(builder.IssuesNotificationID, func(n gapir.Notification) {
 			vkApi := API{}
 			eMsg := n.GetErrorMsg()
 			if eMsg == nil {
@@ -296,7 +296,7 @@ func (t *findIssues) Flush(ctx context.Context, out transform.Writer) {
 			issue.Error = fmt.Errorf("%s", msg)
 			issue.Severity = service.Severity(uint32(eMsg.GetSeverity()))
 			t.issues = append(t.issues, issue)
-		}, builder.IssuesNotificationID)
+		})
 	}))
 	t.AddNotifyInstruction(ctx, out, func() interface{} { return t.issues })
 }

--- a/gapis/api/vulkan/query_timestamps.go
+++ b/gapis/api/vulkan/query_timestamps.go
@@ -426,7 +426,7 @@ func (t *queryTimestamps) GetQueryResults(ctx context.Context,
 		b.ReserveMemory(tmp.Range())
 		notificationID := b.GetNotificationID()
 		b.Notification(notificationID, value.ObservedPointer(tmp.Address()), buflen)
-		return b.RegisterNotificationReader(func(n gapir.Notification) {
+		return b.RegisterNotificationReader(notificationID, func(n gapir.Notification) {
 			d := n.GetData()
 			data := d.GetData()
 			byteOrder := s.MemoryLayout.GetEndian()
@@ -463,7 +463,7 @@ func (t *queryTimestamps) GetQueryResults(ctx context.Context,
 					Timestamps: &timestamps,
 				},
 			})
-		}, notificationID)
+		})
 	}))
 	queryPoolInfo.writeIndex = 0
 	tmp.Free()

--- a/gapis/replay/asm/instructions.go
+++ b/gapis/replay/asm/instructions.go
@@ -376,14 +376,14 @@ type Notification struct {
 }
 
 func (a Notification) Encode(r value.PointerResolver, w binary.Writer) error {
-	if err := encodePush(protocol.Type_Uint32, a.ID, w); err != nil {
-		return err
-	}
 	ty, val, onStack := a.Source.Get(r)
 	if !onStack {
 		if err := encodePush(ty, val, w); err != nil {
 			return err
 		}
+	}
+	if err := encodePush(protocol.Type_Uint32, a.ID, w); err != nil {
+		return err
 	}
 	if err := encodePush(protocol.Type_Uint32, a.Size, w); err != nil {
 		return err

--- a/gapis/replay/builder/builder.go
+++ b/gapis/replay/builder/builder.go
@@ -642,8 +642,7 @@ func (b *Builder) GetNotificationID() uint64 {
 
 // RegisterNotificationReader registers a notification reader for a specific notificationID. Returns error
 // if the notificationID has already been registered.
-func (b *Builder) RegisterNotificationReader(reader NotificationReader, notificationID uint64) error {
-	fmt.Printf("Regitster notification ID %v", notificationID)
+func (b *Builder) RegisterNotificationReader(notificationID uint64, reader NotificationReader) error {
 	if _, ok := b.notificationReaders[notificationID]; ok {
 		return fmt.Errorf("notificationID %d already registered", notificationID)
 	}


### PR DESCRIPTION
The order to pop the stack is invalid if the address of the data
has been remapped to absolute address. This is because during remap
the address will be on the top of the stack before calling
the `sendNotificationData`.