### PR TITLE
Fix compilation issue in transformer/injector_test.go

### DIFF
--- a/gapis/api/transform/recorder.go
+++ b/gapis/api/transform/recorder.go
@@ -44,6 +44,14 @@ func (r *Recorder) MutateAndWrite(ctx context.Context, id api.CmdID, cmd api.Cmd
 	r.CmdsAndIDs = append(r.CmdsAndIDs, CmdAndID{cmd, id})
 }
 
+// Required to implement Writer interface
+func (r *Recorder) NotifyPreLoop(ctx context.Context) {
+}
+
+// Required to implement Writer interface
+func (r *Recorder) NotifyPostLoop(ctx context.Context) {
+}
+
 // CmdAndID is a pair of api.Cmd and api.CmdID
 type CmdAndID struct {
 	Cmd api.Cmd


### PR DESCRIPTION
The new two methods added to the Writer interface broken the test build. This fixes that issue.