### PR TITLE
Work around instance issues in a new way.

### DIFF
--- a/gapir/cc/context.cpp
+++ b/gapir/cc/context.cpp
@@ -506,6 +506,22 @@ void Context::registerCallbacks(Interpreter* interpreter) {
       });
 
   interpreter->registerBuiltin(
+      Vulkan::INDEX, Builtins::ReplayDestroyVkInstance,
+      [this](uint32_t label, Stack* stack, bool) {
+        GAPID_DEBUG("[%u]replayDestroyVkInstance()", label);
+        if (mVulkanRenderer != nullptr) {
+          auto* api = mVulkanRenderer->getApi<Vulkan>();
+          return api->replayDestroyVkInstance(stack);
+        } else {
+          GAPID_WARNING(
+              "[%u]replayDestroyVkInstance called without a bound Vulkan "
+              "renderer",
+              label);
+          return false;
+        }
+      });
+
+  interpreter->registerBuiltin(
       Vulkan::INDEX, Builtins::ReplayUnregisterVkInstance,
       [this](uint32_t label, Stack* stack, bool) {
         GAPID_DEBUG("[%u]replayUnregisterVkInstance()", label);

--- a/gapir/cc/linux/vulkan_renderer.cpp
+++ b/gapir/cc/linux/vulkan_renderer.cpp
@@ -33,23 +33,7 @@ class VulkanRendererImpl : public VulkanRenderer {
   Vulkan mApi;
 };
 
-VulkanRendererImpl::VulkanRendererImpl() {
-  mApi.resolve();
-  // Create a dummy instance renderer that never gets cleaned up.
-  // This works around some driver bugs.
-  // See https://github.com/google/gapid/issues/1899
-  auto create_info = Vulkan::VkInstanceCreateInfo{
-      Vulkan::VkStructureType::VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO,
-      nullptr,
-      0,
-      nullptr,
-      0,
-      nullptr,
-      0,
-      nullptr};
-  Vulkan::VkInstance inst;
-  mApi.mFunctionStubs.vkCreateInstance(&create_info, nullptr, &inst);
-}
+VulkanRendererImpl::VulkanRendererImpl() { mApi.resolve(); }
 
 VulkanRendererImpl::~VulkanRendererImpl() {}
 

--- a/gapir/cc/vulkan_gfx_api.inc
+++ b/gapir/cc/vulkan_gfx_api.inc
@@ -60,6 +60,10 @@ bool replayRegisterVkInstance(Stack* stack);
 // The instance is popped from the top of the stack.
 bool replayUnregisterVkInstance(Stack* stack);
 
+// Builtin function for destroying the VkInstance.
+// This is used because we have to leak an instance.
+bool replayDestroyVkInstance(Stack* stack);
+
 // Builtin function for creating device-level function pointers.
 // From the top of the stack, pop three arguments sequentially:
 // - pointer to the VkDeviceCreateInfo struct for this device,

--- a/gapis/api/templates/vulkan_gfx_api_extras.tmpl
+++ b/gapis/api/templates/vulkan_gfx_api_extras.tmpl
@@ -89,6 +89,7 @@
     return queues;
   }
 ¶
+  static Vulkan::VkInstance leakInstance = 0;
   »}  // anonymous namespace
 ¶
 bool Vulkan::replayCreateVkInstanceImpl(Stack* stack,
@@ -146,8 +147,14 @@ bool Vulkan::replayCreateVkInstanceImpl(Stack* stack,
   stack->push(&new_info);
   stack->push(pAllocator);
   stack->push(pInstance);
+
   if (callVkCreateInstance(~0, stack, true)) {
     *result = stack->pop<uint32_t>();
+    if (*result == VK_SUCCESS) {
+      if (leakInstance == 0) {
+        leakInstance = *pInstance;
+      }
+    }
     return true;
   }
   *result = VkResult::VK_ERROR_INITIALIZATION_FAILED;
@@ -218,6 +225,24 @@ bool Vulkan::replayCreateVkDeviceImpl(Stack* stack, size_val physicalDevice,
       return true;
     } else {
       GAPID_WARNING("Error during calling function replayRegisterVkInstance");
+      return false;
+    }
+  }
+¶
+  bool Vulkan::replayDestroyVkInstance(Stack* stack) {
+    auto pAllocator = stack->pop<VkAllocationCallbacks const*>();
+    auto instance = static_cast<size_val>(stack->pop<size_val>());
+    if (stack->isValid()) {
+      // Leak this first instance. This is to work around a driver bug.
+      // See https://github.com/google/gapid/issues/1899
+      if (instance == leakInstance) {
+        return true;
+      }
+      stack->push<size_val>(static_cast<size_val>(instance));
+      stack->push<VkAllocationCallbacks const*>(pAllocator);
+      return callVkDestroyInstance(~0, stack, false);
+    } else {
+      GAPID_WARNING("Error during calling function replayDestroyVkInstance");
       return false;
     }
   }

--- a/gapis/api/vulkan/custom_replay.go
+++ b/gapis/api/vulkan/custom_replay.go
@@ -276,8 +276,10 @@ func (a *VkCreateInstance) Mutate(ctx context.Context, id api.CmdID, s *api.Glob
 
 func (a *VkDestroyInstance) Mutate(ctx context.Context, id api.CmdID, s *api.GlobalState, b *builder.Builder, w api.StateWatcher) error {
 	cb := CommandBuilder{Thread: a.Thread(), Arena: s.Arena}
-	// Call the underlying vkDestroyInstance() and do the observation.
-	err := a.mutate(ctx, id, s, b, w)
+	hijack := cb.ReplayDestroyVkInstance(a.Instance(), a.PAllocator())
+	hijack.Extras().MustClone(a.Extras().All()...)
+	err := hijack.Mutate(ctx, id, s, b, w)
+
 	if b == nil || err != nil {
 		return err
 	}

--- a/gapis/api/vulkan/synthetic.api
+++ b/gapis/api/vulkan/synthetic.api
@@ -31,6 +31,18 @@ cmd VkResult replayCreateVkInstance(
 }
 
 @synthetic
+cmd void replayDestroyVkInstance(
+    VkInstance                   instance,
+    AllocationCallbacks          pAllocator) {
+  // NOTE: The logic for this function should be identical to the one of
+  // vkDestroyInstance() in vulkan.api. Change both together
+  delete(Instances, instance)
+  for _, device, _ in PhysicalDevices {
+    delete(PhysicalDevices, device)
+  }
+}
+
+@synthetic
 cmd VkResult ReplayCreateVkDevice(
     VkPhysicalDevice             physicalDevice,
     const VkDeviceCreateInfo*    pCreateInfo,


### PR DESCRIPTION
Some drivers will fail if you have 2 instances that have
different ApplicationName/EngineName values attached to them.

To work around this (yet another) issue, we leak the first instance
that was ever created.