### PR TITLE
Continuous Synchronous Prefetch

### DIFF
--- a/cmd/gapir/cc/main.cpp
+++ b/cmd/gapir/cc/main.cpp
@@ -57,6 +57,8 @@
 using namespace core;
 using namespace gapir;
 
+const size_t RAM_CACHE_SIZE = 256ul * 1024ul * 1024ul;
+
 namespace {
 
 enum ReplayMode {
@@ -64,18 +66,6 @@ enum ReplayMode {
   kConflict,       // Impossible combination of command line arguments.
   kReplayServer,   // Run gapir as a server.
   kReplayArchive,  // Replay an exported archive.
-};
-
-std::vector<uint32_t> memorySizes {
-// If we are on desktop, we can try more memory
-#if TARGET_OS != GAPID_OS_ANDROID
-  3 * 1024 * 1024 * 1024U,  // 3GB
-#endif
-      2 * 1024 * 1024 * 1024U,  // 2GB
-      1 * 1024 * 1024 * 1024U,  // 1GB
-      512 * 1024 * 1024U,       // 512MB
-      256 * 1024 * 1024U,       // 256MB
-      128 * 1024 * 1024U,       // 128MB
 };
 
 struct Options {
@@ -478,7 +468,8 @@ static int replayArchive(core::CrashHandler* crashHandler,
                          std::unique_ptr<ResourceCache> resourceCache,
                          gapir::ReplayService* replayArchiveService) {
   // The directory consists an archive(resources.{index,data}) and payload.bin.
-  MemoryManager memoryManager(memorySizes);
+  MemoryManager memoryManager;
+
   std::unique_ptr<ResourceLoader> resLoader =
       CachedResourceLoader::create(resourceCache.get(), nullptr);
 
@@ -669,8 +660,8 @@ void android_main(struct android_app* app) {
   std::string socket_file_path = internal_data_path + "/" + std::string(pipe);
   std::string uri = std::string("unix://") + socket_file_path;
   std::unique_ptr<Server> server = nullptr;
-  MemoryManager memoryManager(memorySizes);
-  auto cache = InMemoryResourceCache::create(memoryManager.getTopAddress());
+  MemoryManager memoryManager;
+  auto cache = InMemoryResourceCache::create(RAM_CACHE_SIZE);
   std::mutex lock;
   PrewarmData data;
 
@@ -787,7 +778,7 @@ std::unique_ptr<ResourceCache> createCache(
     const Options::OnDiskCache& onDiskCacheOpts, MemoryManager* memoryManager) {
 #if TARGET_OS == GAPID_OS_LINUX || TARGET_OS == GAPID_OS_OSX
   if (!onDiskCacheOpts.enabled) {
-    return InMemoryResourceCache::create(memoryManager->getTopAddress());
+    return InMemoryResourceCache::create(RAM_CACHE_SIZE);
   }
   auto onDiskCachePath = std::string(onDiskCacheOpts.path);
   bool cleanUpOnDiskCache = onDiskCacheOpts.cleanUp;
@@ -802,14 +793,14 @@ std::unique_ptr<ResourceCache> createCache(
         "No disk cache path specified and no $TMPDIR environment variable "
         "defined for temporary on-disk cache, fallback to use in-memory "
         "cache.");
-    return InMemoryResourceCache::create(memoryManager->getTopAddress());
+    return InMemoryResourceCache::create(RAM_CACHE_SIZE);
   }
   auto onDiskCache =
       OnDiskResourceCache::create(onDiskCachePath, cleanUpOnDiskCache);
   if (onDiskCache == nullptr) {
     GAPID_WARNING(
         "On-disk cache creation failed, fallback to use in-memory cache");
-    return InMemoryResourceCache::create(memoryManager->getTopAddress());
+    return InMemoryResourceCache::create(RAM_CACHE_SIZE);
   }
   GAPID_INFO("On-disk cache created at %s", onDiskCachePath.c_str());
   if (cleanUpOnDiskCache || useTempCacheFolder) {
@@ -856,7 +847,7 @@ std::unique_ptr<ResourceCache> createCache(
   }
 #endif  // TARGET_OS == GAPID_OS_LINUX || TARGET_OS == GAPID_OS_OSX
   // Just use the in-memory cache
-  return InMemoryResourceCache::create(memoryManager->getTopAddress());
+  return InMemoryResourceCache::create(RAM_CACHE_SIZE);
 }
 }  // namespace
 
@@ -883,7 +874,7 @@ static int startServer(core::CrashHandler* crashHandler, Options opts) {
     fclose(file);
   }
 
-  MemoryManager memoryManager(memorySizes);
+  MemoryManager memoryManager;
 
   // If the user does not assign a port to use, get a free TCP port from OS.
   const char local_host_name[] = "127.0.0.1";

--- a/gapir/cc/android/asset_resource_cache.cpp
+++ b/gapir/cc/android/asset_resource_cache.cpp
@@ -112,15 +112,14 @@ bool AssetResourceCache::putCache(const Resource &resource, const void *data) {
 }
 
 bool AssetResourceCache::hasCache(const Resource &resource) {
-  return (mRecords.find(resource.id) != mRecords.end());
+  return (mRecords.find(resource.getID()) != mRecords.end());
 }
 
 bool AssetResourceCache::loadCache(const Resource &resource, void *data) {
-  std::unordered_map<std::string, AssetRecord>::const_iterator it;
-  it = mRecords.find(resource.id);
+  std::unordered_map<std::string, AssetRecord>::const_iterator it =
+      mRecords.find(resource.getID());
   if (it == mRecords.end()) {
-    GAPID_FATAL("AssetResourceCache::loadCache() cannot find resource: %s",
-                resource.id.c_str());
+    return false;
   }
 
   AssetRecord record = it->second;

--- a/gapir/cc/android/asset_resource_cache.h
+++ b/gapir/cc/android/asset_resource_cache.h
@@ -43,6 +43,11 @@ class AssetResourceCache : public ResourceCache {
   virtual size_t totalCacheSize() const override {
     return std::numeric_limits<size_t>::max();
   }
+
+  virtual size_t unusedSize() const override {
+    return std::numeric_limits<size_t>::max();
+  }
+
   // Do not support resize.
   virtual bool resize(size_t newSize) override { return true; };
 

--- a/gapir/cc/cached_resource_loader.cpp
+++ b/gapir/cc/cached_resource_loader.cpp
@@ -39,7 +39,7 @@ bool CachedResourceLoader::loadBatch(const ResourceLoadingBatch& bat) {
   for (const auto r : bat.resources()) {
     mCache->putCache(r,
                      reinterpret_cast<const uint8_t*>(res->data()) + readSize);
-    readSize += r.size;
+    readSize += r.getSize();
   }
   const uint8_t* src = reinterpret_cast<const uint8_t*>(res->data());
   for (const auto dsp : bat.dstsAndSizes()) {
@@ -53,7 +53,7 @@ bool CachedResourceLoader::load(const Resource* resources, size_t count,
                                 void* target, size_t targetSize) {
   size_t totalSize = 0;
   for (size_t i = 0; i < count; i++) {
-    totalSize += resources[i].size;
+    totalSize += resources[i].getSize();
   }
   if (targetSize < totalSize) {
     return false;  // Not enough space
@@ -64,10 +64,8 @@ bool CachedResourceLoader::load(const Resource* resources, size_t count,
   for (size_t i = 0; i < count; i++) {
     const auto& r = resources[i];
     // Check cache first
-    if (mCache->hasCache(r)) {
-      bool cache_load_success = mCache->loadCache(r, static_cast<void*>(dst));
-      GAPID_ASSERT(cache_load_success);
-      dst += r.size;
+    if (mCache->loadCache(r, static_cast<void*>(dst))) {
+      dst += r.getSize();
       continue;
     }
     // Not in cache, batch for fetching.
@@ -83,7 +81,7 @@ bool CachedResourceLoader::load(const Resource* resources, size_t count,
         return false;
       }
     }
-    dst += r.size;
+    dst += r.getSize();
   }
   if (batch.size() != 0) {
     if (!loadBatch(batch)) {

--- a/gapir/cc/context.cpp
+++ b/gapir/cc/context.cpp
@@ -108,15 +108,13 @@ bool Context::initialize(const std::string& id) {
 }
 
 void Context::prefetch(ResourceCache* cache) const {
-  auto cacheSize = static_cast<uint32_t>(mMemoryManager->getFreeSpace());
-  cache->resize(cacheSize);
   auto resources = mReplayRequest->getResources();
   if (resources.size() == 0) {
     return;
   }
 
   auto tempLoader = PassThroughResourceLoader::create(mSrv);
-  cache->prefetch(resources.data(), resources.size(), tempLoader.get());
+  cache->setPrefetch(resources.data(), resources.size(), std::move(tempLoader));
 }
 
 bool Context::interpret(bool cleanup) {
@@ -749,8 +747,8 @@ bool Context::loadResource(Stack* stack) {
 
   const auto& resource = mReplayRequest->getResources()[resourceId];
 
-  if (!mResourceLoader->load(&resource, 1, address, resource.size)) {
-    GAPID_WARNING("Can't load resource: %s", resource.id.c_str());
+  if (!mResourceLoader->load(&resource, 1, address, resource.getSize())) {
+    GAPID_WARNING("Can't load resource: %s", resource.getID().c_str());
     return false;
   }
 

--- a/gapir/cc/grpc_replay_service.cpp
+++ b/gapir/cc/grpc_replay_service.cpp
@@ -102,8 +102,8 @@ std::unique_ptr<ReplayService::Resources> GrpcReplayService::getResources(
   res.set_allocated_resource_request(new replay_service::ResourceRequest());
   size_t totalSize = 0;
   for (size_t i = 0; i < resCount; i++) {
-    res.mutable_resource_request()->add_ids(resources[i].id);
-    totalSize += resources[i].size;
+    res.mutable_resource_request()->add_ids(resources[i].getID());
+    totalSize += resources[i].getSize();
   }
   res.mutable_resource_request()->set_expected_total_size(totalSize);
   mGrpcStream->Write(res);

--- a/gapir/cc/in_memory_resource_cache.h
+++ b/gapir/cc/in_memory_resource_cache.h
@@ -35,163 +35,44 @@ class InMemoryResourceCache : public ResourceCache {
  public:
   // Creates a new in-memory cache with the given fallback provider and base
   // address. The initial cache size is 0 byte.
-  static std::unique_ptr<InMemoryResourceCache> create(void* buffer);
+  static std::unique_ptr<InMemoryResourceCache> create(size_t memoryLimit);
 
-  // destructor
+  InMemoryResourceCache(size_t memoryLimit);
   ~InMemoryResourceCache();
 
   // ResourceCache interface implementation
-  virtual bool putCache(const Resource& res, const void* resData) override;
-  virtual bool hasCache(const Resource& res) override;
-  virtual bool loadCache(const Resource& res, void* target) override;
-  virtual size_t totalCacheSize() const override { return mBufferSize; }
-  virtual bool resize(size_t newSize) override;
-  virtual void dump(FILE*) override;
+  virtual bool putCache(const Resource& res,
+                        const void* resData) override final;
+  virtual bool hasCache(const Resource& res) override final;
+  virtual bool loadCache(const Resource& res, void* target) override final;
+  virtual size_t totalCacheSize() const override final;
+  virtual size_t unusedSize() const override final;
+  virtual bool resize(size_t newSize) override final;
+  virtual void dump(FILE* file) override final;
 
-  virtual void clear();
+  void clear();
 
  protected:
-  // A doubly-linked list data structure representing a chunk of memory in the
-  // cache.
-  struct Block {
-    inline Block();
-    inline Block(size_t offset, size_t size);
-    inline Block(size_t offset, size_t size, const ResourceId& id);
+  std::map<unsigned int, std::pair<Resource, std::shared_ptr<char> > >::iterator
+  findCache(const Resource& res);
+  bool evictLeastRecentlyUsed();
 
-    inline ~Block();
-
-    inline void linkAfter(Block* other);
-    inline void linkBefore(Block* other);
-    inline void unlink();
-    inline bool isFree() const;
-    inline size_t end() const;
-
-    size_t offset;  // offset in bytes from mBuffer.
-    size_t size;    // size in bytes. May wrap-around the cache buffer.
-    ResourceId id;
-    Block* next;
-    Block* prev;
-  };
-
-  // free evicts the cache entry for block, transforming it into a free block.
-  void free(Block* block);
-
-  // foreach_block calls cb for each block, starting with first.
-  void foreach_block(Block* first, const std::function<void(Block*)>& cb);
-
-  // destroy frees, unlinks and deletes the block, returning the next block.
-  Block* destroy(Block* block);
-
-  // first returns the block with the lowest offset.
-  Block* first();
-
-  // last returns the block with the highest offset.
-  Block* last();
+  bool loadCacheMiss(const Resource& res, void* target);
 
  private:
-  // constructor
-  InMemoryResourceCache(void* buffer);
+  std::unordered_map<ResourceId, unsigned int> mResourceIndex;
+  std::map<unsigned int, std::pair<Resource, std::shared_ptr<char> > >
+      mResources;
 
-  // put adds the the resource to the cache.
-  // size must be less or equal to mBufferSize.
-  void put(const ResourceId& id, size_t size, const uint8_t* data);
+  size_t mMemoryLimit;
+  size_t mMemoryUse;
 
-  // A pointer to the next block to be used for a resource allocation.
-  // While filling the cache, mHead will point to the first free block. Once
-  // the cache is full it will point to an existing cache entry that will be
-  // next to be evicted.
-  Block* mHead;
+  unsigned int mIDGenerator;
 
-  // A map of cached resource identifiers to offsets on mBuffer.
-  std::unordered_map<ResourceId, size_t> mCache;
-
-  // The top address and the size of the memory used for caching.
-  // This memory region is owned by the memory manager class, not by the cache
-  // itself.
-  uint8_t* mBuffer;
-  size_t mBufferSize;
+  unsigned int mHits = 0;
+  unsigned int mCacheHits = 0;
+  unsigned int mCacheAccesses = 0;
 };
-
-inline InMemoryResourceCache::Block::Block()
-    : offset(0), size(0), next(this), prev(this) {}
-inline InMemoryResourceCache::Block::Block(size_t offset_, size_t size_)
-    : offset(offset_), size(size_), next(this), prev(this) {}
-inline InMemoryResourceCache::Block::Block(size_t offset_, size_t size_,
-                                           const ResourceId& id_)
-    : offset(offset_), size(size_), id(id_), next(this), prev(this) {}
-
-inline InMemoryResourceCache::Block::~Block() {
-  GAPID_ASSERT(next == this && prev == this);
-}
-
-inline void InMemoryResourceCache::Block::linkAfter(Block* other) {
-  GAPID_ASSERT(next == this && prev == this);
-  next = other->next;
-  prev = other;
-  next->prev = this;
-  prev->next = this;
-}
-
-inline void InMemoryResourceCache::Block::linkBefore(Block* other) {
-  GAPID_ASSERT(next == this && prev == this);
-  next = other;
-  prev = other->prev;
-  next->prev = this;
-  prev->next = this;
-}
-
-inline void InMemoryResourceCache::Block::unlink() {
-  GAPID_ASSERT(next != this && prev != this);
-  next->prev = prev;
-  prev->next = next;
-  next = this;
-  prev = this;
-}
-
-inline bool InMemoryResourceCache::Block::isFree() const {
-  return id.size() == 0;
-}
-
-inline size_t InMemoryResourceCache::Block::end() const {
-  return offset + size;
-}
-
-inline void InMemoryResourceCache::free(Block* block) {
-  mCache.erase(block->id);
-  block->id = ResourceId();
-}
-
-inline void InMemoryResourceCache::foreach_block(
-    Block* first, const std::function<void(Block*)>& cb) {
-  std::vector<Block*> blocks;
-  cb(first);
-  for (Block* block = first->next; block != first; block = block->next) {
-    cb(block);
-  }
-}
-
-inline InMemoryResourceCache::Block* InMemoryResourceCache::destroy(
-    Block* block) {
-  Block* next = block->next;
-  if (mHead == block) {
-    mHead = next;
-  }
-  free(block);
-  block->unlink();
-  delete block;
-  return next;
-}
-
-inline InMemoryResourceCache::Block* InMemoryResourceCache::first() {
-  return last()->next;
-}
-
-inline InMemoryResourceCache::Block* InMemoryResourceCache::last() {
-  Block* block = mHead;
-  for (; block->next->offset > block->offset; block = block->next) {
-  }
-  return block;
-}
 
 }  // namespace gapir
 

--- a/gapir/cc/memory_manager.cpp
+++ b/gapir/cc/memory_manager.cpp
@@ -22,31 +22,7 @@
 #include <utility>
 #include <vector>
 
-//                 mMemory[0]
-//   ┏━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━┓
-//   ┃             ┃                        ┃
-//   ┃             ┃                        ┃
-//   ┃             ┃                        ┃
-//   ┃             ┃         volatile       ┃
-//   ┃   mMemory   ┃          memory        ┃
-//   ┃             ┃                        ┃
-//   ┃             ┃                        ┨
-//   ┃             ┣━━━━━━━━━━━━━━━━━━━━━━━━┨
-//   ┃             ┃                        ┃
-//   ┃             ┃        in-memory       ┃
-//   ┃             ┃        resource        ┃
-//   ┃             ┃          cache         ┃
-//   ┃             ┃                        ┃
-//   ┗━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━━━━━━━━━━┛
-//                 mMemory[mSize]
-
 namespace gapir {
-
-namespace {
-// Expected driver memory overhead to be left free as a factor of allocated
-// managed memory.
-const float kDriverOverheadFactor = 0.3f;
-}  // namespace
 
 template <typename T>
 MemoryManager::MemoryRange<T>::MemoryRange() : base(nullptr), size(0) {}
@@ -55,41 +31,24 @@ template <typename T>
 MemoryManager::MemoryRange<T>::MemoryRange(T* base, uint32_t size)
     : base(base), size(size) {}
 
-MemoryManager::MemoryManager(const std::vector<uint32_t>& sizeList)
-    : mConstantMemory(nullptr, 0) {
-  for (auto size : sizeList) {
-    // Try over-allocating to leave at least (size * kDriverOverheadFactor) free
-    // bytes.
-    mSize = static_cast<uint32_t>(size * (1 + kDriverOverheadFactor));
-    mMemory.reset(new (std::nothrow) uint8_t[mSize]);
-    if (mMemory) {
-      // Free the over-allocation first, then attempt allocating the (smaller)
-      // original size.
-      mMemory.reset();
-      mSize = size;
-      mMemory.reset(new (std::nothrow) uint8_t[mSize]);
-      break;
-    }
-    GAPID_DEBUG("Failed to allocate %u bytes of volatile memory, continuing...",
-                size);
-  }
-
-  if (!mMemory) {
-    GAPID_FATAL("Couldn't allocate any volatile memory size.");
-  }
-
-  GAPID_DEBUG("Base address: %p", mMemory.get());
-  setVolatileMemory(mSize);
-}
+MemoryManager::MemoryManager()
+    : mMemory(nullptr),
+      mOpcodeMemory(nullptr, 0),
+      mConstantMemory(nullptr, 0),
+      mVolatileMemory(nullptr, 0) {}
 
 bool MemoryManager::setVolatileMemory(uint32_t size) {
-  if (size > mSize) {
-    return false;
+  mMemory.reset(new (std::nothrow) uint8_t[size]);
+
+  if (mMemory == nullptr) {
+    GAPID_FATAL("MemoryManager::setVolatileMemory - ALLOCATION FAILED");
   }
 
   mVolatileMemory = {&mMemory[0], size};
+
   GAPID_DEBUG("Volatile range: [%p,%p]", mVolatileMemory.base,
               mVolatileMemory.base + mVolatileMemory.size - 1);
+
   return true;
 }
 

--- a/gapir/cc/memory_manager.h
+++ b/gapir/cc/memory_manager.h
@@ -39,7 +39,7 @@ class MemoryManager {
   // list provided, while keeping at least size * kOverheadFactor free bytes for
   // possible driver overhead allocations. Stopping after the first successful
   // allocation and cause a fatal error if none of the sizes could be allocated.
-  explicit MemoryManager(const std::vector<uint32_t>& sizeList);
+  MemoryManager();
 
   // Sets the size of the replay data.
   void setReplayData(const uint8_t* constantMemoryBase,
@@ -54,13 +54,10 @@ class MemoryManager {
   // Returns the size and the base address of the different memory regions
   // managed by the memory manager
   void* getBaseAddress() const { return mMemory.get(); }
-  void* getTopAddress() const { return mMemory.get() + mSize; }
-  uint32_t getFreeSpace() const { return mSize - mVolatileMemory.size; }
 
   const void* getOpcodeAddress() const { return mOpcodeMemory.base; }
   const void* getConstantAddress() const { return mConstantMemory.base; }
   void* getVolatileAddress() const { return mVolatileMemory.base; }
-  uint32_t getSize() const { return mSize; }
   uint32_t getOpcodeSize() const { return mOpcodeMemory.size; }
   uint32_t getConstantSize() const { return mConstantMemory.size; }
   uint32_t getVolatileSize() const { return mVolatileMemory.size; }
@@ -127,9 +124,8 @@ class MemoryManager {
   // memory layout used
   uint8_t* align(uint8_t* addr) const;
 
-  // The size and the base address of the memory block managed by the memory
+  // The base address of the memory block managed by the memory
   // manager. This pointer owns the allocated memory
-  uint32_t mSize;
   std::unique_ptr<uint8_t[]> mMemory;
 
   // The size and base address of the opcode memory. This opcode memory

--- a/gapir/cc/on_disk_resource_cache.cpp
+++ b/gapir/cc/on_disk_resource_cache.cpp
@@ -81,15 +81,15 @@ OnDiskResourceCache::OnDiskResourceCache(const std::string& path, bool cleanUp)
     : mArchive(path + "resources"), mCleanUp(cleanUp) {}
 
 bool OnDiskResourceCache::putCache(const Resource& resource, const void* data) {
-  return mArchive.write(resource.id, data, resource.size);
+  return mArchive.write(resource.getID(), data, resource.getSize());
 }
 
 bool OnDiskResourceCache::hasCache(const Resource& resource) {
-  return mArchive.contains(resource.id);
+  return mArchive.contains(resource.getID());
 }
 
 bool OnDiskResourceCache::loadCache(const Resource& resource, void* data) {
-  return mArchive.read(resource.id, data, resource.size);
+  return mArchive.read(resource.getID(), data, resource.getSize());
 }
 
 }  // namespace gapir

--- a/gapir/cc/on_disk_resource_cache.h
+++ b/gapir/cc/on_disk_resource_cache.h
@@ -59,6 +59,9 @@ class OnDiskResourceCache : public ResourceCache {
   virtual size_t totalCacheSize() const override {
     return std::numeric_limits<size_t>::max();
   }
+  virtual size_t unusedSize() const override {
+    return std::numeric_limits<size_t>::max();
+  }
   // Do not support resize.
   virtual bool resize(size_t newSize) override { return true; };
 

--- a/gapir/cc/resource.cpp
+++ b/gapir/cc/resource.cpp
@@ -19,30 +19,35 @@
 namespace gapir {
 bool ResourceLoadingBatch::append(const Resource& res, uint8_t* dst) {
   size_t n = mDstsAndSizes.size();
+
   // Always includes the first resource.
   if (n == 0) {
     mResources.push_back(res);
-    mDstsAndSizes.emplace_back(std::make_pair(dst, res.size));
-    mSize += res.size;
+    mDstsAndSizes.emplace_back(std::make_pair(dst, res.getSize()));
+    mSize += res.getSize();
     return true;
   }
+
   // Returns false if exceeds the maximum size.
-  if (mSize + res.size > kMultipleResourcesSizeLimit) {
+  if (mSize + res.getSize() > kMultipleResourcesSizeLimit) {
     return false;
   }
+
   // If the resource destination is contiguous to the last one, expend the
   // last chunk.
   if (dst == mDstsAndSizes[n - 1].first + mDstsAndSizes[n - 1].second) {
     mResources.push_back(res);
-    mDstsAndSizes[n - 1].second += res.size;
-    mSize += res.size;
+    mDstsAndSizes[n - 1].second += res.getSize();
+    mSize += res.getSize();
     return true;
   }
+
   // The resource destination is not contigous to the last one, create
   // new chunk.
   mResources.push_back(res);
-  mDstsAndSizes.emplace_back(std::make_pair(dst, res.size));
-  mSize += res.size;
+  mDstsAndSizes.emplace_back(std::make_pair(dst, res.getSize()));
+  mSize += res.getSize();
+
   return true;
 }
 

--- a/gapir/cc/resource.h
+++ b/gapir/cc/resource.h
@@ -28,19 +28,24 @@ typedef std::string ResourceId;
 
 // Resource represent a requestable blob of data from the server.
 struct Resource {
-  Resource() : id(), size(0) {}
-  Resource(ResourceId id_, uint32_t size_) : id(id_), size(size_) {}
-  Resource(const Resource& other) : id(other.id), size(other.size) {}
-  Resource(Resource&& other) : id(other.id), size(other.size) {}
+  Resource() : mID(), mSize(0) {}
+  Resource(ResourceId id, uint32_t size) : mID(id), mSize(size) {}
+  Resource(const Resource& other) : mID(other.mID), mSize(other.mSize) {}
+  Resource(Resource&& other) : mID(other.mID), mSize(other.mSize) {}
+
   Resource& operator=(const Resource& other) = default;
   Resource& operator=(Resource&& other) = default;
 
   bool operator==(const Resource& other) const {
-    return id == other.id && size == other.size;
+    return mID == other.mID && mSize == other.mSize;
   }
 
-  ResourceId id;
-  uint32_t size;
+  uint32_t getSize() const { return mSize; }
+  ResourceId getID() const { return mID; }
+
+ private:
+  ResourceId mID;
+  uint32_t mSize;
 };
 
 // ResourceLoadingBatch is a helper class to group resources and their loading
@@ -61,6 +66,7 @@ class ResourceLoadingBatch {
     return mDstsAndSizes;
   }
   size_t size() const { return mSize; }
+
   // Clear resets the ResourceLoadingBatch.
   void clear() {
     mResources.clear();

--- a/gapir/cc/resource_cache.h
+++ b/gapir/cc/resource_cache.h
@@ -43,15 +43,34 @@ class ResourceCache {
   virtual bool loadCache(const Resource& res, void* target) = 0;
   // size returns the total size in bytes that can be used for caching.
   virtual size_t totalCacheSize() const = 0;
+  // returns the unused capacity of the cache in bytes.
+  virtual size_t unusedSize() const = 0;
   // resize adjust the total size in bytes that can be used for this cache.
+  // this does not actually resize the cache upwards, it can only be used to
+  // ensure the cache uses no more than newSize bytes on return. Please note the
+  // cache may later resize upwards again.
   virtual bool resize(size_t newSize) = 0;
-  // prefetch get the resources data through the given loader, and put as much
-  // as possble resource data in cache. Returns the number of resources put in
-  // cache.
-  virtual size_t prefetch(const Resource* res, size_t count,
-                          ResourceLoader* fetcher);
+  // set the anticipated resources and access order, so that on cache misses,
+  // the cache can fetch not only the missing resource, but also an anticipated
+  // lookahead. also fills any free space in the cache with the first N
+  // resources that fit in storage.
+  size_t setPrefetch(const Resource* res, size_t count,
+                     std::unique_ptr<ResourceLoader> fetcher);
   // debug print the internal state.
   virtual void dump(FILE*) {}
+
+ protected:
+  std::vector<Resource> anticipateNextResources(const Resource& resource,
+                                                size_t bytesToFetch);
+
+  virtual size_t prefetchImpl(const Resource* res, size_t count,
+                              bool allowEviction = false);
+
+ private:
+  std::vector<Resource> mResources;
+  std::map<ResourceId, std::vector<Resource>::iterator> mResourceIterators;
+
+  std::unique_ptr<ResourceLoader> mFetcher;
 };
 
 }  // namespace gapir

--- a/gapir/cc/resource_loader.h
+++ b/gapir/cc/resource_loader.h
@@ -76,7 +76,7 @@ class PassThroughResourceLoader : public ResourceLoader {
     }
     size_t requestSize = 0;
     for (size_t i = 0; i < count; i++) {
-      requestSize += resources[i].size;
+      requestSize += resources[i].getSize();
     }
     if (requestSize > size) {
       return false;  // not enough space.


### PR DESCRIPTION

    Continuous Synchronous Prefetch
    
    Change the InMemoryResourceCache and base class ResourceCache to use a
    transparent cache design. Simply instead of calling if(hasCache())
    loadCache() else xxx(); you instead call if(!loadCache()) xxx(); This allows us
    to count cache misses, as well as allowing us to later make the cache
    thread safe (not done as part of this work). Further, modify both
    classes so that a cache miss no longer requires the caller to fetch the
    missing resource and insert it into the cache, but instead this functionality is
    built directly into the cache. When a cache miss happens, additionally,
    if the resource is known to the cache from a previous call to
    setPrefetch() then not only will the missing resource be fetched into
    the cache transparently, but also a speculated prefetch of anticipated future
    resources will be performed to attempt to minimise future cache misses.
    Finally, the Pseudo-LRU policy of the old cache is replaced by a true
    LRU policy.
