### PR TITLE
Split test targets to work around Kokoro OOM

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -198,8 +198,131 @@ copy_to(
 )
 
 test_suite(
+    name = "tests-core",
+    tests = [
+        "//core/app/analytics:go_default_test",
+        "//core/app/auth:go_default_test",
+        "//core/app/benchmark:go_default_test",
+        "//core/app/crash/reporting:go_default_test",
+        "//core/app/flags:go_default_test",
+        "//core/assert:go_default_test",
+        "//core/cc:tests",
+        "//core/codegen:go_default_test",
+        "//core/context/keys:go_default_test",
+        "//core/data:go_default_test",
+        "//core/data/binary:go_default_test",
+        "//core/data/compare:go_default_test",
+        "//core/data/deep:go_default_test",
+        "//core/data/dictionary:go_default_test",
+        "//core/data/endian:go_default_test",
+        "//core/data/generic:go_default_test",
+        "//core/data/id:go_default_test",
+        "//core/data/pack:go_default_test",
+        "//core/data/slice:go_default_test",
+        "//core/event/task:go_default_test",
+        "//core/fault:go_default_test",
+        "//core/fault/stacktrace:go_default_test",
+        "//core/fault/stacktrace/crunch:go_default_test",
+        "//core/git:go_default_test",
+        "//core/image:go_default_test",
+        "//core/java/jdbg:go_default_test",
+        "//core/java/jdwp:go_default_test",
+        "//core/langsvr:go_default_test",
+        "//core/log:go_default_test",
+        "//core/math/f16:go_default_test",
+        "//core/math/f32:go_default_test",
+        "//core/math/f64:go_default_test",
+        "//core/math/interval:go_default_test",
+        "//core/math/sint:go_default_test",
+        "//core/memory/arena:go_default_test",
+        "//core/memory/arena/cc:tests",
+        "//core/memory_tracker/cc:tests",
+        "//core/net:go_default_test",
+        "//core/net/grpcutil:go_default_test",
+        "//core/os/android/adb:go_default_test",
+        "//core/os/android/binaryxml:go_default_test",
+        "//core/os/android/manifest:go_default_test",
+        "//core/os/device:go_default_test",
+        "//core/os/device/host:go_default_test",
+        "//core/os/device/remotessh:go_default_test",
+        "//core/os/file:go_default_test",
+        "//core/os/flock:go_default_test",
+        "//core/os/shell:go_default_test",
+        "//core/os/shell/stub:go_default_test",
+        "//core/stream:go_default_test",
+        "//core/stream/fmts:go_default_test",
+        "//core/text:go_default_test",
+        "//core/text/cases:go_default_test",
+        "//core/text/parse:go_default_test",
+    ],
+)
+
+test_suite(
+    name = "tests-gapil",
+    tests = [
+        "//gapil/analysis:go_default_test",
+        "//gapil/bapi:go_default_test",
+        "//gapil/compiler:go_default_test",
+        "//gapil/compiler/mangling/c:go_default_test",
+        "//gapil/compiler/mangling/ia64:go_default_test",
+        "//gapil/compiler/plugins/encoder/test:go_default_test",
+        "//gapil/compiler/plugins/replay:go_default_test",
+        "//gapil/fuzz:go_default_test",
+        "//gapil/parser:go_default_test",
+        "//gapil/resolver:go_default_test",
+        "//gapil/runtime/cc:tests",
+        "//gapil/semantic:go_default_test",
+        "//gapil/template:go_default_test",
+        "//gapil/validate:go_default_test",
+    ],
+)
+
+test_suite(
+    name = "tests-gapis",
+    tests = [
+        "//gapis/api:go_default_test",
+        "//gapis/api/gles:go_default_test",
+        "//gapis/api/test:go_default_test",
+        "//gapis/api/transform:go_default_test",
+        "//gapis/api/vulkan:go_default_test",
+        "//gapis/capture:go_default_test",
+        "//gapis/memory:go_default_test",
+        "//gapis/replay/asm:go_default_test",
+        "//gapis/replay/builder:go_default_test",
+        "//gapis/replay/scheduler:go_default_test",
+        "//gapis/resolve:go_default_test",
+        "//gapis/resolve/dependencygraph:go_default_test",
+        "//gapis/resolve/dependencygraph2:go_default_test",
+        "//gapis/resolve/dependencygraph2/graph_visualization:go_default_test",
+        "//gapis/service/box:go_default_test",
+        "//gapis/shadertools:go_default_test",
+        "//gapis/shadertools/cc:tests",
+        "//gapis/stringtable/minidown/parser:go_default_test",
+        "//gapis/stringtable/minidown/scanner:go_default_test",
+        "//gapis/stringtable/parser:go_default_test",
+        "//gapis/vertex:go_default_test",
+    ],
+)
+
+test_suite(
+    name = "tests-gapir",
+    tests = [
+        "//gapir/cc:tests",
+    ],
+)
+
+test_suite(
+    name = "tests-general",
+    tests = [
+        "//test/integration/gles/replay:go_default_test",
+        "//test/integration/replay:go_default_test",
+        "//test/integration/service:go_default_test",
+        "//test/robot/stash/grpc:go_default_test",
+    ],
+)
+
+test_suite(
     name = "tests",
-    # bazel query --output label 'kind(".*_test rule", //...)'
     tests = [
         # __BEGIN_TESTS
         "//core/app/analytics:go_default_test",

--- a/kokoro/linux-test/test.sh
+++ b/kokoro/linux-test/test.sh
@@ -33,11 +33,21 @@ export CC=/usr/bin/gcc-7
 cd $SRC
 BUILD_SHA=${KOKORO_GITHUB_COMMIT:-$KOKORO_GITHUB_PULL_REQUEST_COMMIT}
 
-echo $(date): Tests started.
-$BUILD_ROOT/bazel/bin/bazel \
-    --output_base="${TMP}/bazel_out" \
-    test tests -c opt --config symbols \
-    --define GAPID_BUILD_NUMBER="$KOKORO_BUILD_NUMBER" \
-    --define GAPID_BUILD_SHA="$BUILD_SHA" \
-    --test_tag_filters=-needs_gpu
-echo $(date): Tests completed.
+function test {
+    echo $(date): Starting test for $@...
+    $BUILD_ROOT/bazel/bin/bazel \
+        --output_base="${TMP}/bazel_out" \
+        test -c opt --config symbols \
+        --define GAPID_BUILD_NUMBER="$KOKORO_BUILD_NUMBER" \
+        --define GAPID_BUILD_SHA="$BUILD_SHA" \
+        --test_tag_filters=-needs_gpu \
+        $@
+    echo $(date): Tests completed.
+}
+
+# Running all the tests in one go leads to an out-of-memory error on Kokoro, hence the division in smaller test sets
+test tests-core
+test tests-gapis
+test tests-gapir
+test tests-gapil
+test tests-general


### PR DESCRIPTION
Separate tests into different logical groups to prevent to hit memory limit in CI.