### PR TITLE
Make cmd/gapid prefer java in JAVA_HOME over PATH

### DIFF
--- a/cmd/gapid/main.go
+++ b/cmd/gapid/main.go
@@ -182,16 +182,16 @@ func (c *config) locateVM() error {
 		return nil
 	}
 
-	if java, err := exec.LookPath(c.javaExecutable()); err == nil && checkVM(java, true) {
-		c.vm = java
-		return nil
-	}
-
 	if home := os.Getenv("JAVA_HOME"); home != "" {
 		if java := c.javaInHome(home); checkVM(java, true) {
 			c.vm = java
 			return nil
 		}
+	}
+
+	if java, err := exec.LookPath(c.javaExecutable()); err == nil && checkVM(java, true) {
+		c.vm = java
+		return nil
 	}
 
 	if runtime.GOOS == "linux" {


### PR DESCRIPTION
The cmd/gapid command that starts gapic should prefer the java found in JAVA_HOME over the one in PATH.

Yet, setting JAVA_HOME to java 11 leads to Bazel using it for the build, which fails with:
```
/com/google/gapid/proto/service/GapidGrpc.java:23: error: package javax.annotation does not exist
```

Because javax.annotation package has been dropped in java 11.

So we need to conditionnally depend on javax.annotation:javax.annotation-api when compiling with java >= 11, see:
https://stackoverflow.com/questions/48204141/replacements-for-deprecated-jpms-modules-with-java-ee-apis/48204154#48204154

@pmuetschard is there a way to do a such conditional dependency based on java version in Bazel?

Aim to fix #2878 