### PR TITLE
Make dead-code-elimination remove glUseProgram() duplicates

### DIFF
--- a/gapis/api/gles/api/programs_and_shaders.api
+++ b/gapis/api/gles/api/programs_and_shaders.api
@@ -2380,9 +2380,11 @@ cmd void glUseProgram(ProgramId program) {
   } else {
     p := GetProgramOrError(program)
     if p.LinkStatus == GL_FALSE { glErrorInvalidOperation() }
-    AdjustProgramUseCount(p, +1)
-    AdjustProgramUseCount(ctx.Bound.Program, -1)
-    ctx.Bound.Program = p
+    if p != ctx.Bound.Program {
+      AdjustProgramUseCount(p, +1)
+      AdjustProgramUseCount(ctx.Bound.Program, -1)
+      ctx.Bound.Program = p
+    }
   }
 }
 


### PR DESCRIPTION
When glUseProgram() is called with the same program id as the
currently bound one, do not write on ctx.Bound.Program to avoid an
unnecessary dependency.