### PR TITLE
Add scissor test dependency to glClear

### DIFF
--- a/gapis/api/gles/api/draw_commands.api
+++ b/gapis/api/gles/api/draw_commands.api
@@ -439,14 +439,6 @@ sub void DrawCommandDependencies(ref!Context ctx) {
     }
   }
 
-  scissorState := ctx.Pixel.Scissor
-  if scissorState.Test == GL_TRUE {
-    _ = scissorState.Box.X
-    _ = scissorState.Box.Y
-    _ = scissorState.Box.Width
-    _ = scissorState.Box.Height
-  }
-
   for _, _, u in ctx.Bound.Program.UniformLocations {
 
     // The program execution reads uniform values
@@ -463,5 +455,19 @@ sub void DrawCommandDependencies(ref!Context ctx) {
   for _, _, a in draw_fb.ColorAttachments {
     ReadFramebufferAttachment(a)
     WriteFramebufferAttachment(a)
+  }
+
+  SharedDrawClearCommandDependencies(ctx)
+}
+
+// SharedDrawClearCommandDependencies creates relevant dependencies which are shared between draw and clear commands.
+@spy_disabled
+sub void SharedDrawClearCommandDependencies(ref!Context ctx) {
+  scissorState := ctx.Pixel.Scissor
+  if scissorState.Test == GL_TRUE {
+    _ = scissorState.Box.X
+    _ = scissorState.Box.Y
+    _ = scissorState.Box.Width
+    _ = scissorState.Box.Height
   }
 }

--- a/gapis/api/gles/api/framebuffer.api
+++ b/gapis/api/gles/api/framebuffer.api
@@ -311,6 +311,8 @@ cmd void glClear(GLbitfield mask) {
     _ = ctx.Pixel.StencilClearValue
     WriteFramebufferAttachment(fb.StencilAttachment)
   }
+
+  SharedDrawClearCommandDependencies(ctx)
 }
 
 @clear


### PR DESCRIPTION
Create SharedDrawClearCommandDependencies to abstract dependency reads
that are shared between draw and clear commands.