### PR TITLE
Fix frame token device and instance extensions

### DIFF
--- a/gapis/api/vulkan/vulkan.api
+++ b/gapis/api/vulkan/vulkan.api
@@ -213,7 +213,6 @@ sub ref!ExtensionSet supportedInstanceExtensions() {
   supported.ExtensionNames["VK_KHR_external_semaphore_capabilities"] = true
   supported.ExtensionNames["VK_KHR_external_fence_capabilities"] = true
   supported.ExtensionNames["VK_GGP_stream_descriptor_surface"] = true
-  supported.ExtensionNames["VK_GGP_frame_token"] = true
   return supported
 }
 
@@ -236,7 +235,6 @@ sub ref!ExtensionSet supportedDeviceExtensions() {
   supported.ExtensionNames["VK_KHR_maintenance1"] = true
   supported.ExtensionNames["VK_KHR_maintenance2"] = true
   supported.ExtensionNames["VK_KHR_maintenance3"] = true
-  supported.ExtensionNames["VK_GGP_stream_descriptor_surface"] = true
   supported.ExtensionNames["VK_GGP_frame_token"] = true
   supported.ExtensionNames["VK_AMD_draw_indirect_count"] = true
   supported.ExtensionNames["VK_KHR_draw_indirect_count"] = true


### PR DESCRIPTION
VK_GGP_frame_token was listed as both an instance and device
extension. It is now only a device extension.

VK_GGP_stream_descriptor_surface was listed as a device and instance
extension. It is now only an instance extension.

Tests: Captured Hello GGP