### PR TITLE
Have GAPIT display commands by context handle

### DIFF
--- a/cmd/gapit/common.go
+++ b/cmd/gapit/common.go
@@ -47,7 +47,7 @@ import (
 
 func (f CommandFilterFlags) commandFilter(ctx context.Context, client service.Service, p *path.Capture) (*path.CommandFilter, error) {
 	filter := &path.CommandFilter{}
-	if f.Context >= 0 {
+	if f.Context >= 0 || f.ContextName != "" {
 		boxedContexts, err := client.Get(ctx, p.Contexts().Path(), nil)
 		if err != nil {
 			return nil, log.Err(ctx, err, "Failed to load the contexts")
@@ -60,7 +60,11 @@ func (f CommandFilterFlags) commandFilter(ctx context.Context, client service.Se
 				return nil, log.Errf(ctx, err, "Failed to load context at index %d", i)
 			}
 			context := boxedContext.(*service.Context)
-			if f.Context == int(context.Handle) {
+			if f.Context >= 0 && f.Context == int(context.Handle) {
+				filter.Context = c.ID
+				return filter, nil
+			}
+			if f.ContextName != "" && f.ContextName == context.Name {
 				filter.Context = c.ID
 				return filter, nil
 			}

--- a/cmd/gapit/flags.go
+++ b/cmd/gapit/flags.go
@@ -95,7 +95,8 @@ type (
 		CaptureID bool `help:"if true then interpret the capture file argument as a capture ID that is already loaded in gapis"`
 	}
 	CommandFilterFlags struct {
-		Context int `help:"Filter to the i'th context."`
+		Context     int    `help:"Filter to the i'th context."`
+		ContextName string `help:"Filter by context name."`
 	}
 	ObservationFlags struct {
 		Ranges            bool `help:"if true then display the read and write ranges made by each command."`

--- a/gapis/api/context.go
+++ b/gapis/api/context.go
@@ -30,6 +30,8 @@ type Context interface {
 
 	// ID returns the context's unique identifier
 	ID() ContextID
+
+	Handle() uint32
 }
 
 // ContextInfo is describes a Context.
@@ -38,6 +40,7 @@ type Context interface {
 type ContextInfo struct {
 	Path              *path.Context
 	ID                ContextID
+	Handle            uint32
 	API               ID
 	NumCommandsByType map[reflect.Type]int
 	Name              string

--- a/gapis/api/gles/context.go
+++ b/gapis/api/gles/context.go
@@ -38,6 +38,10 @@ func (c Contextʳ) ID() api.ContextID {
 	return api.ContextID(id.OfString(fmt.Sprintf("GLES Context %v", c.Identifier())))
 }
 
+func (c Contextʳ) Handle() uint32 {
+	return uint32(c.Identifier())
+}
+
 // API returns the GLES API.
 func (c Contextʳ) API() api.API {
 	return API{}

--- a/gapis/api/vulkan/vulkan.go
+++ b/gapis/api/vulkan/vulkan.go
@@ -77,6 +77,10 @@ func (VulkanContext) API() api.API {
 	return API{}
 }
 
+func (VulkanContext) Handle() uint32 {
+	return 1
+}
+
 func (API) Context(ctx context.Context, s *api.GlobalState, thread uint64) api.Context {
 	return VulkanContext{}
 }

--- a/gapis/resolve/contexts.go
+++ b/gapis/resolve/contexts.go
@@ -149,6 +149,7 @@ func (r *ContextListResolvable) Resolve(ctx context.Context) (interface{}, error
 		out[i] = &api.ContextInfo{
 			Path:              r.Capture.Context(id.ID(c.ctx.ID())),
 			ID:                c.ctx.ID(),
+			Handle:            c.ctx.Handle(),
 			API:               c.ctx.API().ID(),
 			NumCommandsByType: c.cnts,
 			Name:              name,

--- a/gapis/resolve/service.go
+++ b/gapis/resolve/service.go
@@ -38,6 +38,7 @@ func internalToService(v interface{}) (interface{}, error) {
 			Name:     v.Name,
 			API:      path.NewAPI(id.ID(v.API)),
 			Priority: uint32(v.Priority),
+			Handle:   v.Handle,
 		}, nil
 	default:
 		return v, nil

--- a/gapis/service/service.proto
+++ b/gapis/service/service.proto
@@ -979,6 +979,8 @@ message Context {
   path.API API = 2;
   // The estimated importance for the context. 0 = lowest priority.
   uint32 priority = 3;
+  // The context ID. 0 or 1 for GLES. 1 for Vulkan
+  uint32 handle = 4;
 }
 
 // CommandTree represents a command tree hierarchy.

--- a/gapis/service/service.proto
+++ b/gapis/service/service.proto
@@ -979,7 +979,7 @@ message Context {
   path.API API = 2;
   // The estimated importance for the context. 0 = lowest priority.
   uint32 priority = 3;
-  // The context ID. 0 or 1 for GLES. 1 for Vulkan
+  // The context ID. Always 1 for Vulkan
   uint32 handle = 4;
 }
 


### PR DESCRIPTION
Instead of "commands -context i" request the i'th
context in the list, have it request the context
with handle/name i.