### PR TITLE
Do not run device info provider on too old Android versions

### DIFF
--- a/core/os/android/adb/device.go
+++ b/core/os/android/adb/device.go
@@ -167,11 +167,14 @@ func newDevice(ctx context.Context, serial string, status bind.Status) (*binding
 		}
 	}
 
-	devInfoProvidersMutex.Lock()
-	defer devInfoProvidersMutex.Unlock()
-	for _, f := range devInfoProviders {
-		if err := f(ctx, d); err != nil {
-			return nil, err
+	// Run device info providers only if the API is supported
+	if d.To.Configuration.OS != nil && d.To.Configuration.OS.APIVersion >= device.AndroidMinimalSupportedAPIVersion {
+		devInfoProvidersMutex.Lock()
+		defer devInfoProvidersMutex.Unlock()
+		for _, f := range devInfoProviders {
+			if err := f(ctx, d); err != nil {
+				return nil, err
+			}
 		}
 	}
 

--- a/core/os/device/android.go
+++ b/core/os/device/android.go
@@ -16,6 +16,8 @@ package device
 
 import "fmt"
 
+const AndroidMinimalSupportedAPIVersion = 23
+
 // AndroidOS returns the full OS structure for the supplied android os version.
 func AndroidOS(major, minor, point int32) *OS {
 	os := &OS{


### PR DESCRIPTION
Fix #3036 