### PR TITLE
Fixes for multi-process applications.

### DIFF
--- a/core/cc/BUILD.bazel
+++ b/core/cc/BUILD.bazel
@@ -49,7 +49,10 @@ cc_library(
     linkopts = select({
         "//tools/build:linux": ["-ldl"],
         "//tools/build:darwin": [],
-        "//tools/build:windows": ["-lws2_32"],
+        "//tools/build:windows": [
+            "-lws2_32",
+            "-lshlwapi",
+        ],
         # Android.
         "//conditions:default": ["-ldl"],
     }),

--- a/core/cc/posix/process_name.cpp
+++ b/core/cc/posix/process_name.cpp
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2019 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <libgen.h>
+#include <unistd.h>
+#include <cstring>
+#include <string>
+
+namespace core {
+static const size_t MAX_PATH = 4096;
+
+std::string get_process_name() {
+  char mp[MAX_PATH + 1];
+  memset(mp, 0, MAX_PATH + 1);
+  ssize_t len = readlink("/proc/self/exe", mp, MAX_PATH);
+  if (len <= 0) {
+    return "";
+  }
+  return basename(mp);
+}
+
+}  // namespace core

--- a/core/cc/process_name.h
+++ b/core/cc/process_name.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2019 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef CORE_PROCESS_NAME_H_
+#define CORE_PROCESS_NAME_H_
+
+#include <string>
+
+namespace core {
+std::string get_process_name();
+}  // namespace core
+
+#endif  // CORE_PROCESS_NAME_H_

--- a/core/cc/windows/process_name.cpp
+++ b/core/cc/windows/process_name.cpp
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2019 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <Shlwapi.h>
+#include <string>
+namespace core {
+
+std::string get_process_name() {
+  char modulename[MAX_PATH + 1];
+  memset(modulename, 0, MAX_PATH + 1);
+  if (GetModuleFileNameA(NULL, modulename, MAX_PATH) == 0) {
+    return "";
+  }
+  return PathFindFileNameA(modulename);
+}
+
+}  // namespace core

--- a/gapii/cc/connection_header.h
+++ b/gapii/cc/connection_header.h
@@ -55,6 +55,22 @@ class ConnectionHeader {
   // on success or false on error.
   bool read(core::StreamReader* reader);
 
+  void read_dummy() {
+    mMagic[0] = 's';
+    mMagic[1] = 'p';
+    mMagic[2] = 'y';
+    mMagic[3] = '0';
+    mVersion = 1;
+    mObserveFrameFrequency = 0;
+    mObserveDrawFrequency = 0;
+    mStartFrame = -1;
+    mNumFrames = 0;
+    mAPIs = 0;
+    mFlags = 0;
+    mGvrHandle = 0;
+    mLibInterceptorPath[0] = '\0';
+  }
+
   uint8_t mMagic[4];                // 's', 'p', 'y', '0'
   uint32_t mVersion;                // 1
   uint32_t mObserveFrameFrequency;  // non-zero == enabled.


### PR DESCRIPTION
Some applications launch child processes, and those child
processes are the ones we are actually trying to trace.

This works as long as the parent process does not use a graphics
api. However i nthe case where the parent does this caused
us to attach to the parent.

This change allows an environment variable to be set
that will force gapii to effectively stifle itself if
it is attached to the wrong process.

GAPID_CAPTURE_PROCESS_NAME=my_process_name

gapii is still attached to the process, but does not try
and connect to gapis, nor does it write anything out.