### PR TITLE
Cannot edit shaders that were created before the start of MEC (#1821)

### DIFF
--- a/gapis/resolve/resources.go
+++ b/gapis/resolve/resources.go
@@ -62,7 +62,6 @@ func (r *ResourcesResolvable) Resolve(ctx context.Context) (interface{}, error) 
 	state := c.NewUninitializedState(ctx).ReserveMemory(ranges)
 	state.OnResourceCreated = func(res api.Resource) {
 		currentCmdResourceCount++
-		seen[res] = len(seen)
 		context := currentAPI.Context(ctx, state, currentThread)
 		tr := trackedResource{
 			resource: res,
@@ -72,6 +71,7 @@ func (r *ResourcesResolvable) Resolve(ctx context.Context) (interface{}, error) 
 			created:  currentCmdIndex,
 		}
 		resources = append(resources, tr)
+		seen[res] = len(resources) - 1
 		resourceTypes[tr.id.String()] = res.ResourceType(ctx)
 	}
 	state.OnResourceAccessed = func(r api.Resource) {


### PR DESCRIPTION
When performing a MEC, state reconstruction "linearisation"
creates new resources. This means there are more than zero
resources in existence when the first "real" commands are issued.
GAPIS's ResourcesResolvable does a fake replay of the driver's shadow
state to get the creation, read, modification and deletion points of a
capture's various resources. This is used to discover which resource
should be edited when the user modifies a shader in the UI. The bug was
caused by an error in the bookkeeping performed while computing these
access points for the various resources, when the "fake replay" began
with more than zero resources in existence. A mapping of resource ->
int, indexing a flat array of resources was being updated with the wrong
integer for a freshly created resource. This commit changes the map
creation to insert correct indexes for newly created resources.