### PR TITLE
Disables the new warning added by GCC 8.

### DIFF
--- a/gapii/cc/vulkan_extras.cpp
+++ b/gapii/cc/vulkan_extras.cpp
@@ -717,7 +717,7 @@ uint32_t VulkanSpy::SpyOverride_vkEnumerateInstanceLayerProperties(
     return VkResult::VK_INCOMPLETE;
   }
   *pCount = 1;
-  memset(pProperties, 0x00, sizeof(*pProperties));
+  pProperties = {nullptr};
   strcpy((char*)pProperties->mlayerName, "GraphicsSpy");
   pProperties->mspecVersion = VK_VERSION_MAJOR(1) | VK_VERSION_MINOR(0) | 5;
   pProperties->mimplementationVersion = 1;
@@ -735,7 +735,7 @@ uint32_t VulkanSpy::SpyOverride_vkEnumerateDeviceLayerProperties(
     return VkResult::VK_INCOMPLETE;
   }
   *pCount = 1;
-  memset(pProperties, 0x00, sizeof(*pProperties));
+  pProperties = {nullptr};
   strcpy((char*)pProperties->mlayerName, "GraphicsSpy");
   pProperties->mspecVersion = VK_VERSION_MAJOR(1) | VK_VERSION_MINOR(0) | 5;
   pProperties->mimplementationVersion = 1;

--- a/gapil/runtime/cc/map.inc
+++ b/gapil/runtime/cc/map.inc
@@ -336,6 +336,12 @@ void Map<K, V, DENSE>::Allocation::clear_for_delete() {
     count = 0;
 }
 
+// The warning "Wclass-memaccess" added with GCC 8+ is raised by memset.
+#if defined __GNUC__ && __GNUC__ >= 8
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wclass-memaccess"
+#endif
+
 template<typename K, typename V, bool DENSE>
 void Map<K, V, DENSE>::Allocation::clear_keep() {
     auto elems = els();
@@ -350,10 +356,15 @@ void Map<K, V, DENSE>::Allocation::clear_keep() {
                 --count;
         }
     }
+
     memset(elems, 0x00, sizeof(*elems) * capacity);
     count = 0;
 }
 
 }  // namespace gapil
+
+#if defined __GNUC__ && __GNUC__ >= 8
+#pragma GCC diagnostic pop
+#endif
 
 #endif  // __GAPIL_RUNTIME_MAP_INC__

--- a/kokoro/linux-test/test.sh
+++ b/kokoro/linux-test/test.sh
@@ -24,12 +24,12 @@ curl -L -k -O -s https://github.com/bazelbuild/bazel/releases/download/0.25.1/ba
 mkdir bazel
 bash bazel-0.25.1-installer-linux-x86_64.sh --prefix=$PWD/bazel
 
-# Get GCC 7
+# Get GCC 8
 sudo rm /etc/apt/sources.list.d/cuda.list*
 sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
 sudo apt-get -q update
-sudo apt-get -qy install gcc-7 g++-7
-export CC=/usr/bin/gcc-7
+sudo apt-get -qy install gcc-8 g++-8
+export CC=/usr/bin/gcc-8
 
 cd $SRC
 BUILD_SHA=${KOKORO_GITHUB_COMMIT:-$KOKORO_GITHUB_PULL_REQUEST_COMMIT}

--- a/kokoro/linux/build.sh
+++ b/kokoro/linux/build.sh
@@ -24,12 +24,12 @@ curl -L -k -O -s https://github.com/bazelbuild/bazel/releases/download/0.25.1/ba
 mkdir bazel
 bash bazel-0.25.1-installer-linux-x86_64.sh --prefix=$PWD/bazel
 
-# Get GCC 7
+# Get GCC 8
 sudo rm /etc/apt/sources.list.d/cuda.list*
 sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
 sudo apt-get -q update
-sudo apt-get -qy install gcc-7 g++-7
-export CC=/usr/bin/gcc-7
+sudo apt-get -qy install gcc-8 g++-8
+export CC=/usr/bin/gcc-8
 
 # Get the Android NDK
 curl -L -k -O -s https://dl.google.com/android/repository/android-ndk-r18b-linux-x86_64.zip

--- a/tools/build/third_party/glslang.BUILD
+++ b/tools/build/third_party/glslang.BUILD
@@ -44,7 +44,13 @@ cc_library(
     copts = cc_copts() + [
         "-DNV_EXTENSIONS",
         "-Wno-unused-variable",
-    ],
+    ] + select({
+        "@gapid//tools/build:linux": [
+            "-Wno-error=class-memaccess",  # TODO(#3100): Remove this when glslang fixes the bug
+            "-Wno-maybe-uninitialized",
+        ],
+        "//conditions:default": [],
+    }),
     include_prefix = "third_party/glslang",
     linkopts = select({
         "@gapid//tools/build:windows": [],

--- a/tools/build/third_party/perfetto/perfetto.BUILD
+++ b/tools/build/third_party/perfetto/perfetto.BUILD
@@ -25,6 +25,7 @@ _COPTS_BASE = cc_copts() + [
     "-DNDEBUG",
 ] + select({
     "@gapid//tools/build:windows": ["-D__STDC_FORMAT_MACROS"],
+    "@gapid//tools/build:linux": ["-Wno-error=class-memaccess"],  # TODO(#3099): Remove this when perfetto fixes the bug
     "//conditions:default": [],
 })
 


### PR DESCRIPTION
This is a workaround for GCC 8 update.

Summary: There is a new warning added with GCC 8 and it will break the build when gcc updated to lastest version. This is a workaround by disabling the particular warning. I believe that we should not merge this at all and make a proper fix about it because the new warning is actually a meaningful one(in my opinion). This pr is for if someones machine randomly updates as mine, they can just copy this pr and continue to be able to build until the issue fixed for real.