### PR TITLE
Revert "Have GAPIT display commands by context handle (#3014)"

### DIFF
--- a/cmd/gapit/common.go
+++ b/cmd/gapit/common.go
@@ -47,30 +47,16 @@ import (
 
 func (f CommandFilterFlags) commandFilter(ctx context.Context, client service.Service, p *path.Capture) (*path.CommandFilter, error) {
 	filter := &path.CommandFilter{}
-	if f.Context >= 0 || f.ContextName != "" {
+	if f.Context >= 0 {
 		boxedContexts, err := client.Get(ctx, p.Contexts().Path(), nil)
 		if err != nil {
 			return nil, log.Err(ctx, err, "Failed to load the contexts")
 		}
-		contexts := boxedContexts.(*service.Contexts).List
-
-		for i, c := range contexts {
-			boxedContext, err := client.Get(ctx, p.Context(c.ID.ID()).Path(), nil)
-			if err != nil {
-				return nil, log.Errf(ctx, err, "Failed to load context at index %d", i)
-			}
-			context := boxedContext.(*service.Context)
-			if f.Context >= 0 && f.Context == int(context.Handle) {
-				filter.Context = c.ID
-				return filter, nil
-			}
-			if f.ContextName != "" && f.ContextName == context.Name {
-				filter.Context = c.ID
-				return filter, nil
-			}
+		contexts := boxedContexts.(*service.Contexts)
+		if n := len(contexts.List); f.Context >= n {
+			return nil, log.Errf(ctx, err, "Context %d is out of range [0..%d]", f.Context, n-1)
 		}
-
-		return nil, log.Errf(ctx, err, "Could not find context %d", f.Context)
+		filter.Context = contexts.List[f.Context].ID
 	}
 	return filter, nil
 }

--- a/cmd/gapit/flags.go
+++ b/cmd/gapit/flags.go
@@ -95,8 +95,7 @@ type (
 		CaptureID bool `help:"if true then interpret the capture file argument as a capture ID that is already loaded in gapis"`
 	}
 	CommandFilterFlags struct {
-		Context     int    `help:"Filter to the i'th context."`
-		ContextName string `help:"Filter by context name."`
+		Context int `help:"Filter to the i'th context."`
 	}
 	ObservationFlags struct {
 		Ranges            bool `help:"if true then display the read and write ranges made by each command."`

--- a/gapis/api/context.go
+++ b/gapis/api/context.go
@@ -30,8 +30,6 @@ type Context interface {
 
 	// ID returns the context's unique identifier
 	ID() ContextID
-
-	Handle() uint32
 }
 
 // ContextInfo is describes a Context.
@@ -40,7 +38,6 @@ type Context interface {
 type ContextInfo struct {
 	Path              *path.Context
 	ID                ContextID
-	Handle            uint32
 	API               ID
 	NumCommandsByType map[reflect.Type]int
 	Name              string

--- a/gapis/api/gles/context.go
+++ b/gapis/api/gles/context.go
@@ -38,10 +38,6 @@ func (c Contextʳ) ID() api.ContextID {
 	return api.ContextID(id.OfString(fmt.Sprintf("GLES Context %v", c.Identifier())))
 }
 
-func (c Contextʳ) Handle() uint32 {
-	return uint32(c.Identifier())
-}
-
 // API returns the GLES API.
 func (c Contextʳ) API() api.API {
 	return API{}

--- a/gapis/api/vulkan/vulkan.go
+++ b/gapis/api/vulkan/vulkan.go
@@ -77,10 +77,6 @@ func (VulkanContext) API() api.API {
 	return API{}
 }
 
-func (VulkanContext) Handle() uint32 {
-	return 1
-}
-
 func (API) Context(ctx context.Context, s *api.GlobalState, thread uint64) api.Context {
 	return VulkanContext{}
 }

--- a/gapis/resolve/contexts.go
+++ b/gapis/resolve/contexts.go
@@ -149,7 +149,6 @@ func (r *ContextListResolvable) Resolve(ctx context.Context) (interface{}, error
 		out[i] = &api.ContextInfo{
 			Path:              r.Capture.Context(id.ID(c.ctx.ID())),
 			ID:                c.ctx.ID(),
-			Handle:            c.ctx.Handle(),
 			API:               c.ctx.API().ID(),
 			NumCommandsByType: c.cnts,
 			Name:              name,

--- a/gapis/resolve/service.go
+++ b/gapis/resolve/service.go
@@ -38,7 +38,6 @@ func internalToService(v interface{}) (interface{}, error) {
 			Name:     v.Name,
 			API:      path.NewAPI(id.ID(v.API)),
 			Priority: uint32(v.Priority),
-			Handle:   v.Handle,
 		}, nil
 	default:
 		return v, nil

--- a/gapis/service/service.proto
+++ b/gapis/service/service.proto
@@ -979,8 +979,6 @@ message Context {
   path.API API = 2;
   // The estimated importance for the context. 0 = lowest priority.
   uint32 priority = 3;
-  // The context ID. Always 1 for Vulkan
-  uint32 handle = 4;
 }
 
 // CommandTree represents a command tree hierarchy.


### PR DESCRIPTION
This reverts commit d6588a085ba1d8238ac986d34d90bb1cfcd06eef.

Fixes #3064

This change breaks a lot of tools (gapit video, screenshot, etc). I am reverting for now