### PR TITLE
Sort the dependency graph.

### DIFF
--- a/gapis/resolve/dependencygraph2/dependency_graph.go
+++ b/gapis/resolve/dependencygraph2/dependency_graph.go
@@ -76,6 +76,26 @@ type NodeID uint32
 
 const NodeNoID = NodeID(math.MaxUint32)
 
+// NodeIDSorter is a structure to use for sorting NodeIDs in the sort package
+type NodeIDSorter struct {
+	Nodes []NodeID
+}
+
+// Len returns the length of the node list
+func (s *NodeIDSorter) Len() int {
+	return len(s.Nodes)
+}
+
+// Less returns trus if the elements at index i are less than j
+func (s *NodeIDSorter) Less(i, j int) bool {
+	return s.Nodes[i] < s.Nodes[j]
+}
+
+// Swap swaps the locations of 2 nodes in the list
+func (s *NodeIDSorter) Swap(i, j int) {
+	s.Nodes[i], s.Nodes[j] = s.Nodes[j], s.Nodes[i]
+}
+
 // DependencyGraph stores the dependencies among api calls and memory observations,
 type DependencyGraph interface {
 

--- a/gapis/resolve/dependencygraph2/dependency_graph_test.go
+++ b/gapis/resolve/dependencygraph2/dependency_graph_test.go
@@ -16,6 +16,7 @@ package dependencygraph2
 
 import (
 	"context"
+	"sort"
 	"testing"
 
 	"github.com/google/gapid/core/assert"
@@ -139,6 +140,13 @@ func TestBuilder(t *testing.T) {
 	b.OnEndCmd(ctx, 2, TestCmd{})
 	addNode(2)
 	eg.setDependencies(getNodeID(2), []NodeID{getNodeID(0), getNodeID(1)})
+
+	// Sort the dependencies here. They are returned by iterating over
+	// a map. Their order has no functional effect, just makes the
+	// test deterministic.
+	for i := range b.graphBuilder.GetGraph().dependenciesFrom {
+		sort.Sort(&NodeIDSorter{b.graphBuilder.GetGraph().dependenciesFrom[i]})
+	}
 
 	// eg.Paths = b.graph.Paths
 	assert.To(t).For("Reading struct should depend on writes to fields after last write to struct (0)").That(


### PR DESCRIPTION
This sorts the dependencies in the graph just for the
puposes of test. This removes the flake from the test.