### PR TITLE
Remove some randomness from replays

### DIFF
--- a/gapis/api/gles/compat.go
+++ b/gapis/api/gles/compat.go
@@ -1343,8 +1343,8 @@ func compatMultiviewDraw(ctx context.Context, id api.CmdID, cmd api.Cmd, out tra
 }
 
 func (fb Framebufferʳ) ForEachAttachment(action func(GLenum, FramebufferAttachment)) {
-	for i, a := range fb.ColorAttachments().All() {
-		action(GLenum_GL_COLOR_ATTACHMENT0+GLenum(i), a)
+	for _, i := range fb.ColorAttachments().Keys() {
+		action(GLenum_GL_COLOR_ATTACHMENT0+GLenum(i), fb.ColorAttachments().Get(i))
 	}
 	action(GLenum_GL_DEPTH_ATTACHMENT, fb.DepthAttachment())
 	action(GLenum_GL_STENCIL_ATTACHMENT, fb.StencilAttachment())
@@ -1376,7 +1376,8 @@ func disableUnusedAttribArrays(ctx context.Context, t *tweaker) {
 		}
 	}
 
-	for l, arr := range t.c.Bound().VertexArray().VertexAttributeArrays().All() {
+	for _, l := range t.c.Bound().VertexArray().VertexAttributeArrays().Keys() {
+		arr := t.c.Bound().VertexArray().VertexAttributeArrays().Get(l)
 		if arr.Enabled() == GLboolean_GL_TRUE && l < AttributeLocation(len(used)) && !used[l] {
 			t.glDisableVertexAttribArray(ctx, l)
 		}

--- a/gapis/api/gles/tweaker.go
+++ b/gapis/api/gles/tweaker.go
@@ -200,8 +200,8 @@ func (t *tweaker) makeVertexArray(ctx context.Context, enabledLocations ...Attri
 		// GLES 2.0 does not have Vertex Array Objects, but the state is fairly simple.
 		vao := t.c.Bound().VertexArray()
 		// Disable all vertex attribute arrays
-		for location, origVertexAttrib := range vao.VertexAttributeArrays().All() {
-			if origVertexAttrib.Enabled() == GLboolean_GL_TRUE {
+		for _, location := range vao.VertexAttributeArrays().Keys() {
+			if vao.VertexAttributeArrays().Get(location).Enabled() == GLboolean_GL_TRUE {
 				t.doAndUndo(ctx,
 					t.cb.GlDisableVertexAttribArray(location),
 					t.cb.GlEnableVertexAttribArray(location))


### PR DESCRIPTION
In a few locations, iterate over maps in a deterministic order, rather than go's default random order, in order to ensure the order of commands is always the same between replays.