### PR TITLE
Fix for #3083. OnDiskResourceCache now prefetches all data up front.

### DIFF
--- a/gapir/cc/on_disk_resource_cache.cpp
+++ b/gapir/cc/on_disk_resource_cache.cpp
@@ -78,7 +78,9 @@ std::unique_ptr<ResourceCache> OnDiskResourceCache::create(
 }
 
 OnDiskResourceCache::OnDiskResourceCache(const std::string& path, bool cleanUp)
-    : mArchive(path + "resources"), mCleanUp(cleanUp) {}
+    : ResourceCache(ResourceCache::PrefetchMode::IMMEDIATE_PREFETCH),
+      mArchive(path + "resources"),
+      mCleanUp(cleanUp) {}
 
 bool OnDiskResourceCache::putCache(const Resource& resource, const void* data) {
   return mArchive.write(resource.getID(), data, resource.getSize());

--- a/gapir/cc/on_disk_resource_cache.h
+++ b/gapir/cc/on_disk_resource_cache.h
@@ -40,7 +40,6 @@ class OnDiskResourceCache : public ResourceCache {
   // not readable or it can't be created then returns the fall back provider.
   static std::unique_ptr<ResourceCache> create(const std::string& path,
                                                bool cleanUp);
-
   virtual ~OnDiskResourceCache() {
 #if TARGET_OS == GAPID_OS_LINUX || TARGET_OS == GAPID_OS_OSX
     if (mCleanUp) {

--- a/gapir/cc/resource_cache.cpp
+++ b/gapir/cc/resource_cache.cpp
@@ -37,6 +37,13 @@ void ResourceCache::setPrefetch(const Resource* resources, size_t count,
   }
 
   mFetcher = std::move(fetcher);
+
+  if (mPrefetchMode == PrefetchMode::IMMEDIATE_PREFETCH && count > 0) {
+    auto fetch = anticipateNextResources(resources[0], unusedSize());
+    if (fetch.size() > 0) {
+      prefetchImpl(&fetch[0], fetch.size());
+    }
+  }
 }
 
 std::vector<Resource> ResourceCache::anticipateNextResources(

--- a/gapir/cc/resource_cache.h
+++ b/gapir/cc/resource_cache.h
@@ -29,6 +29,11 @@ namespace gapir {
 // ResourceCache is an abstract base class for caching resources.
 class ResourceCache {
  public:
+  enum class PrefetchMode { DEFERRED_PREFETCH, IMMEDIATE_PREFETCH };
+
+ public:
+  ResourceCache(PrefetchMode mode = PrefetchMode::DEFERRED_PREFETCH)
+      : mPrefetchMode(mode) {}
   virtual ~ResourceCache() {}
 
   // putCache caches the given resource and its data. Returns true if caching
@@ -66,6 +71,8 @@ class ResourceCache {
   virtual size_t prefetchImpl(const Resource* res, size_t count);
 
  private:
+  PrefetchMode mPrefetchMode;
+
   std::vector<Resource> mResources;
   std::map<ResourceId, std::vector<Resource>::iterator> mResourceIterators;
 


### PR DESCRIPTION
Andrew: Does this do what you need from the disk cache? You didn't give me repro steps for bug 3083 and I'm not sure the disk cache is even used on Android where I have been testing GAPID so far.

Let me know if this works or if there is something I'm missing and still need to patch up.