### PR TITLE
Replay Status Enhancements

### DIFF
--- a/cmd/gapit/status.go
+++ b/cmd/gapit/status.go
@@ -301,7 +301,7 @@ func (verb *statusVerb) Run(ctx context.Context, flags flag.FlagSet) error {
 					maxMemoryUsage = tu.TotalHeap
 				}
 				currentMemoryUsage = tu.TotalHeap
-			}, func(tu *service.ReplayStatus) {
+			}, func(tu *service.ReplayUpdate) {
 				replayTotalInstrs = tu.TotalInstrs
 				replayFinishedInstrs = tu.FinishedInstrs
 			})

--- a/core/app/status/listener.go
+++ b/core/app/status/listener.go
@@ -19,8 +19,6 @@ import (
 	"fmt"
 	"runtime"
 	"sync"
-
-	"github.com/google/gapid/core/data/id"
 )
 
 var listeners = map[int]Listener{}
@@ -62,7 +60,7 @@ type Listener interface {
 	OnMemorySnapshot(context.Context, runtime.MemStats)
 	OnTaskBlock(context.Context, *Task)
 	OnTaskUnblock(context.Context, *Task)
-	OnReplayStatusUpdate(context.Context, uint64, uint32, uint32, id.ID)
+	OnReplayStatusUpdate(context.Context, *Replay, uint64, uint32, uint32)
 }
 
 // Unregister is the function returned by RegisterListener and is used to
@@ -142,10 +140,10 @@ func onMemorySnapshot(ctx context.Context, snapshot runtime.MemStats) {
 	}
 }
 
-func onReplayStatusUpdate(ctx context.Context, label uint64, total_instrs uint32, finished_instrs uint32, deviceID id.ID) {
+func onReplayStatusUpdate(ctx context.Context, r *Replay, label uint64, totalInstrs, finishedInstrs uint32) {
 	listenerMutex.RLock()
 	defer listenerMutex.RUnlock()
 	for _, l := range listeners {
-		l.OnReplayStatusUpdate(ctx, label, total_instrs, finished_instrs, deviceID)
+		l.OnReplayStatusUpdate(ctx, r, label, totalInstrs, finishedInstrs)
 	}
 }

--- a/core/app/status/logger.go
+++ b/core/app/status/logger.go
@@ -19,7 +19,6 @@ import (
 	"runtime"
 	"time"
 
-	"github.com/google/gapid/core/data/id"
 	"github.com/google/gapid/core/log"
 )
 
@@ -76,6 +75,6 @@ func (l statusLogger) OnMemorySnapshot(ctx context.Context, stats runtime.MemSta
 	log.I(ctx, "Memory %+v bytes", stats.Alloc)
 }
 
-func (l statusLogger) OnReplayStatusUpdate(ctx context.Context, label uint64, total_instrs uint32, finished_instrs uint32, deviceID id.ID) {
-	log.I(ctx, "Replay Status: label: %v, total instructions: %v, finished instructions: %v, device ID: %v.", label, total_instrs, finished_instrs, deviceID)
+func (l statusLogger) OnReplayStatusUpdate(ctx context.Context, r *Replay, label uint64, totalInstrs, finishedInstrs uint32) {
+	log.I(ctx, "Replay Status: started: %v finished: %v label: %v, total instructions: %v, finished instructions: %v.", r.Started(), r.Finished(), label, totalInstrs, finishedInstrs)
 }

--- a/core/app/status/tracer.go
+++ b/core/app/status/tracer.go
@@ -23,8 +23,6 @@ import (
 	"runtime"
 	"sync"
 	"time"
-
-	"github.com/google/gapid/core/data/id"
 )
 
 const (
@@ -99,7 +97,7 @@ func (s *statusTracer) OnTaskStart(ctx context.Context, t *Task) {
 func (s *statusTracer) OnTaskProgress(ctx context.Context, t *Task) {}
 func (s *statusTracer) OnTaskBlock(ctx context.Context, t *Task)    {}
 func (s *statusTracer) OnTaskUnblock(ctx context.Context, t *Task)  {}
-func (s *statusTracer) OnReplayStatusUpdate(ctx context.Context, label uint64, total_instrs uint32, finished_instrs uint32, deviceID id.ID) {
+func (s *statusTracer) OnReplayStatusUpdate(ctx context.Context, r *Replay, label uint64, totalInstrs, finishedInstrs uint32) {
 }
 
 func (s *statusTracer) OnTaskFinish(ctx context.Context, t *Task) {

--- a/gapic/src/main/com/google/gapid/MainWindow.java
+++ b/gapic/src/main/com/google/gapid/MainWindow.java
@@ -34,12 +34,10 @@ import com.google.gapid.models.Analytics.View;
 import com.google.gapid.models.Capture;
 import com.google.gapid.models.CommandStream;
 import com.google.gapid.models.CommandStream.CommandIndex;
-import com.google.gapid.models.Devices;
 import com.google.gapid.models.Models;
 import com.google.gapid.models.Settings;
 import com.google.gapid.proto.service.Service;
 import com.google.gapid.proto.service.Service.ClientAction;
-import com.google.gapid.proto.service.path.Path;
 import com.google.gapid.server.Client;
 import com.google.gapid.util.Loadable.Message;
 import com.google.gapid.util.MacApplication;
@@ -148,7 +146,7 @@ public class MainWindow extends ApplicationWindow {
     watchForUpdates(client, models);
 
     showLoadingMessage("Tracking server status...");
-    trackServerStatus(client, models.devices);
+    trackServerStatus(client);
 
     showLoadingMessage("Ready! Please open or capture a trace file.");
   }
@@ -163,8 +161,7 @@ public class MainWindow extends ApplicationWindow {
     });
   }
 
-  private void trackServerStatus(Client client, Devices devices) {
-
+  private void trackServerStatus(Client client) {
     new StatusWatcher(client, new StatusWatcher.Listener() {
       @Override
       public void onStatus(String status) {
@@ -177,8 +174,8 @@ public class MainWindow extends ApplicationWindow {
       }
 
       @Override
-      public void onReplayProgress(long label, int totalInstrs, int finishedInstrs, Path.Device replayDevice ) {
-        scheduleIfNotDisposed(statusBar, () -> statusBar.setReplayStatus(label, totalInstrs, finishedInstrs, replayDevice, devices));
+      public void onReplayProgress(String status) {
+        scheduleIfNotDisposed(statusBar, () -> statusBar.setReplayStatus(status));
       }
     });
   }
@@ -255,7 +252,7 @@ public class MainWindow extends ApplicationWindow {
     manager.add(createEditMenu(models, widgets));
     manager.add(createGotoMenu(models));
     manager.add(createViewMenu());
-    manager.add(createHelpMenu(client, models, widgets));
+    manager.add(createHelpMenu(models, widgets));
     manager.updateAll(true);
   }
 
@@ -354,7 +351,7 @@ public class MainWindow extends ApplicationWindow {
     return manager;
   }
 
-  private MenuManager createHelpMenu(Client client, Models models, Widgets widgets) {
+  private MenuManager createHelpMenu(Models models, Widgets widgets) {
     MenuManager manager = new MenuManager("&Help");
     manager.add(MenuItems.HelpOnlineHelp.create(() -> showHelp(models.analytics)));
     manager.add(MenuItems.HelpAbout.create(

--- a/gapic/src/main/com/google/gapid/util/StatusWatcher.java
+++ b/gapic/src/main/com/google/gapid/util/StatusWatcher.java
@@ -96,7 +96,7 @@ public class StatusWatcher {
     listener.onHeap(update.getTotalHeap());
   }
 
-  private void onReplayUpdate(Service.ReplayStatus update) {
+  private void onReplayUpdate(Service.ReplayUpdate update) {
     listener.onReplayProgress(update.getLabel(), update.getTotalInstrs(),
         update.getFinishedInstrs(), update.getDevice());
   }

--- a/gapic/src/main/com/google/gapid/views/StatusBar.java
+++ b/gapic/src/main/com/google/gapid/views/StatusBar.java
@@ -23,8 +23,6 @@ import static com.google.gapid.widgets.Widgets.withLayoutData;
 import static com.google.gapid.widgets.Widgets.withMargin;
 import static com.google.gapid.widgets.Widgets.withSpacing;
 
-import com.google.gapid.models.Devices;
-import com.google.gapid.proto.service.path.Path;
 import com.google.gapid.widgets.Theme;
 
 import org.eclipse.swt.SWT;
@@ -39,7 +37,6 @@ import org.eclipse.swt.widgets.Canvas;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Link;
-import org.eclipse.swt.widgets.ProgressBar;
 
 /**
  * Displays status information at the bottom of the main window.
@@ -51,7 +48,7 @@ public class StatusBar extends Composite {
   private final HeapStatus heap;
   private final Label serverPrefix;
   private final Label server;
-  private final ProgressBar replayProgressBar;
+  private final Label replay;
   private final Link notification;
   private Runnable onNotificationClick = null;
 
@@ -78,10 +75,10 @@ public class StatusBar extends Composite {
     heap = new HeapStatus(memoryStatus, theme);
     withLayoutData(new Label(memoryStatus, SWT.SEPARATOR | SWT.VERTICAL), new RowData(SWT.DEFAULT, 1));
 
-    Label hintLabel = createLabel(replayStatus, "Replay:");
-    replayProgressBar = new ProgressBar(replayStatus, SWT.HORIZONTAL | SWT.SMOOTH);
-    withLayoutData(new Label(replayStatus, SWT.SEPARATOR | SWT.VERTICAL),
-        new RowData(SWT.DEFAULT, hintLabel.computeSize(SWT.DEFAULT, SWT.DEFAULT).y));
+    createLabel(replayStatus, "Replay:");
+    replay = createLabel(replayStatus, "");
+    withLayoutData(new Label(replayStatus, SWT.SEPARATOR | SWT.VERTICAL), new RowData(SWT.DEFAULT, 1));
+    replayStatus.setVisible(false);
 
     serverPrefix = createLabel(serverStatus, "");
     server = createLabel(serverStatus, "");
@@ -118,16 +115,9 @@ public class StatusBar extends Composite {
     layout();
   }
 
-  public void setReplayStatus(long label, int totalInstrs, int finishedInstrs, Path.Device replayDevice, Devices devices) {
-    // Check for simultaneous replay from multiple devices.
-    // Compare the ID from notification and the ID from current client's device selection.
-    Path.Device selectedDevice = devices.getReplayDevicePath();
-    boolean shouldShowUpdate = replayDevice != null && selectedDevice != null
-        && replayDevice.getID().getData().equals(selectedDevice.getID().getData());
-    if (shouldShowUpdate) {
-      replayProgressBar.setMaximum(totalInstrs);
-      replayProgressBar.setSelection(finishedInstrs);
-    }
+  public void setReplayStatus(String text) {
+    replayStatus.setVisible(true);
+    replay.setText(text);
     layout();
   }
 

--- a/gapis/client/client.go
+++ b/gapis/client/client.go
@@ -186,7 +186,7 @@ func (c *client) Profile(
 }
 
 func (c *client) Status(
-	ctx context.Context, snapshotInterval time.Duration, statusUpdateFrequency time.Duration, f func(*service.TaskUpdate), m func(*service.MemoryStatus), rs func(t *service.ReplayStatus)) error {
+	ctx context.Context, snapshotInterval time.Duration, statusUpdateFrequency time.Duration, f func(*service.TaskUpdate), m func(*service.MemoryStatus), rs func(t *service.ReplayUpdate)) error {
 
 	req := &service.ServerStatusRequest{MemorySnapshotInterval: float32(snapshotInterval.Seconds()), StatusUpdateFrequency: float32(statusUpdateFrequency.Seconds())}
 

--- a/gapis/replay/batch.go
+++ b/gapis/replay/batch.go
@@ -53,7 +53,7 @@ func findABI(ml *device.MemoryLayout, abis []*device.ABI) *device.ABI {
 	return nil
 }
 
-func (m *manager) batch(ctx context.Context, e []scheduler.Executable, b scheduler.Batch) {
+func (m *manager) batch(ctx context.Context, r *status.Replay, e []scheduler.Executable, b scheduler.Batch) {
 	batch := b.Key.(batchKey)
 
 	ctx = PutDevice(ctx, path.NewDevice(batch.device))
@@ -83,7 +83,7 @@ func (m *manager) batch(ctx context.Context, e []scheduler.Executable, b schedul
 		}.Bind(ctx)
 		log.I(ctx, "Replay for %d requests", len(e))
 
-		return m.execute(ctx, d, batch.device, batch.capture, batch.config, batch.generator, requests)
+		return m.execute(ctx, d, r, batch.device, batch.capture, batch.config, batch.generator, requests)
 	}()
 
 	if err != nil {
@@ -228,6 +228,7 @@ func (r *InitialPayloadResolvable) Resolve(
 func (m *manager) execute(
 	ctx context.Context,
 	d bind.Device,
+	r *status.Replay,
 	deviceID, captureID id.ID,
 	cfg Config,
 	generator Generator,
@@ -355,7 +356,7 @@ func (m *manager) execute(
 		return log.Err(ctx, err, "Failed to build replay payload")
 	}
 
-	err = b.RegisterReplayStatusReader(ctx, deviceID)
+	err = b.RegisterReplayStatusReader(ctx, r)
 	if err != nil {
 		return log.Err(ctx, err, "Failed to register replay status notification reader.")
 	}

--- a/gapis/replay/builder/builder.go
+++ b/gapis/replay/builder/builder.go
@@ -660,15 +660,15 @@ func (b *Builder) RegisterNotificationReader(notificationID uint64, reader Notif
 
 // RegisterReplayStatusReader create and register a NotificationReader, which is used to decode and handle
 // replay status information sent from GAPIR.
-func (b *Builder) RegisterReplayStatusReader(ctx context.Context, deviceID id.ID) error {
+func (b *Builder) RegisterReplayStatusReader(ctx context.Context, r *status.Replay) error {
 	reader := func(n gapir.Notification) {
-		r := n.GetReplayStatus()
-		label := r.GetLabel()
-		total_instrs := r.GetTotalInstrs()
-		finished_instrs := r.GetFinishedInstrs()
+		s := n.GetReplayStatus()
+		label := s.GetLabel()
+		totalInstrs := s.GetTotalInstrs()
+		finishedInstrs := s.GetFinishedInstrs()
 
-		log.D(ctx, "Replay status: Label: %v; Total instructions: %v; Finished percentage: %v.", label, total_instrs, float32(finished_instrs)/float32(total_instrs))
-		status.UpdateReplayStatus(ctx, label, total_instrs, finished_instrs, deviceID)
+		log.D(ctx, "Replay status: Label: %v; Total instructions: %v; Finished percentage: %v.", label, totalInstrs, float32(finishedInstrs)/float32(totalInstrs))
+		r.Progress(ctx, label, totalInstrs, finishedInstrs)
 	}
 	return b.RegisterNotificationReader(ReplayProgressNotificationID, reader)
 }

--- a/gapis/replay/manager.go
+++ b/gapis/replay/manager.go
@@ -143,7 +143,7 @@ func (m *manager) createScheduler(ctx context.Context, device bind.Device) {
 	log.I(ctx, "New scheduler for device: %v", deviceID)
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
-	m.schedulers[deviceID] = scheduler.New(ctx, m.batch)
+	m.schedulers[deviceID] = scheduler.New(ctx, deviceID, m.batch)
 }
 
 func (m *manager) destroyScheduler(ctx context.Context, device bind.Device) {

--- a/gapis/replay/scheduler/BUILD.bazel
+++ b/gapis/replay/scheduler/BUILD.bazel
@@ -22,6 +22,7 @@ go_library(
     deps = [
         "//core/app/crash:go_default_library",
         "//core/app/status:go_default_library",
+        "//core/data/id:go_default_library",
         "//core/event/task:go_default_library",
     ],
 )
@@ -31,7 +32,9 @@ go_test(
     srcs = ["scheduler_test.go"],
     embed = [":go_default_library"],
     deps = [
+        "//core/app/status:go_default_library",
         "//core/assert:go_default_library",
+        "//core/data/id:go_default_library",
         "//core/event/task:go_default_library",
         "//core/log:go_default_library",
     ],

--- a/gapis/replay/scheduler/scheduler_test.go
+++ b/gapis/replay/scheduler/scheduler_test.go
@@ -21,7 +21,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/gapid/core/app/status"
 	"github.com/google/gapid/core/assert"
+	"github.com/google/gapid/core/data/id"
 	"github.com/google/gapid/core/event/task"
 	"github.com/google/gapid/core/log"
 )
@@ -40,7 +42,7 @@ type testExecutor struct {
 	err error
 }
 
-func (t *testExecutor) exec(ctx context.Context, l []Executable, b Batch) {
+func (t *testExecutor) exec(ctx context.Context, r *status.Replay, l []Executable, b Batch) {
 	tasks := make([]int, len(l))
 	for i, e := range l {
 		tasks[i] = e.Task.(int)
@@ -53,7 +55,7 @@ func (t *testExecutor) exec(ctx context.Context, l []Executable, b Batch) {
 func setup(t *testing.T) (context.Context, *testExecutor, *Scheduler, *sync.WaitGroup) {
 	ctx := log.Testing(t)
 	e := &testExecutor{val: 321}
-	s := New(ctx, e.exec)
+	s := New(ctx, id.ID{}, e.exec)
 	wg := &sync.WaitGroup{}
 	return ctx, e, s, wg
 }

--- a/gapis/server/grpc.go
+++ b/gapis/server/grpc.go
@@ -369,7 +369,7 @@ func (s *grpcServer) Status(req *service.ServerStatusRequest, stream service.Gap
 			cancel()
 		}
 	}
-	r := func(t *service.ReplayStatus) {
+	r := func(t *service.ReplayUpdate) {
 		if err := stream.Send(&service.ServerStatusResponse{
 			Res: &service.ServerStatusResponse_Replay{t},
 		}); err != nil {

--- a/gapis/server/server.go
+++ b/gapis/server/server.go
@@ -489,7 +489,7 @@ func (s *server) Profile(ctx context.Context, pprofW, traceW io.Writer, memorySn
 type statusListener struct {
 	f                  func(*service.TaskUpdate)
 	m                  func(*service.MemoryStatus)
-	r                  func(*service.ReplayStatus)
+	r                  func(*service.ReplayUpdate)
 	lastProgressUpdate map[*status.Task]time.Time // guarded by progressMutex
 	progressUpdateFreq time.Duration              // guarded by progressMutex
 	progressMutex      sync.Mutex
@@ -614,7 +614,7 @@ func (l *statusListener) OnReplayStatusUpdate(ctx context.Context, label uint64,
 	// defer l.progressMutex.Unlock()
 
 	device := path.NewDevice(deviceID)
-	l.r(&service.ReplayStatus{
+	l.r(&service.ReplayUpdate{
 		Label:          label,
 		TotalInstrs:    total_instrs,
 		FinishedInstrs: finished_instrs,
@@ -622,7 +622,7 @@ func (l *statusListener) OnReplayStatusUpdate(ctx context.Context, label uint64,
 	})
 }
 
-func (s *server) Status(ctx context.Context, snapshotInterval, statusInterval time.Duration, f func(*service.TaskUpdate), m func(*service.MemoryStatus), r func(*service.ReplayStatus)) error {
+func (s *server) Status(ctx context.Context, snapshotInterval, statusInterval time.Duration, f func(*service.TaskUpdate), m func(*service.MemoryStatus), r func(*service.ReplayUpdate)) error {
 	ctx = status.StartBackground(ctx, "RPC Status")
 	defer status.Finish(ctx)
 	ctx = log.Enter(ctx, "Status")

--- a/gapis/service/service.go
+++ b/gapis/service/service.go
@@ -144,7 +144,7 @@ type Service interface {
 		statusUpdateFrequency time.Duration,
 		f func(*TaskUpdate),
 		m func(*MemoryStatus),
-		r func(*ReplayStatus)) error
+		r func(*ReplayUpdate)) error
 
 	// GetPerformanceCounters returns the values of all global counters as
 	// a string.

--- a/gapis/service/service.proto
+++ b/gapis/service/service.proto
@@ -252,7 +252,7 @@ message MemoryStatus {
   uint64 totalHeap = 1;
 }
 
-message ReplayStatus {
+message ReplayUpdate {
   uint64 label = 1;
   uint32 total_instrs = 2;
   uint32 finished_instrs = 3;
@@ -268,7 +268,7 @@ message ServerStatusResponse {
   oneof res {
     TaskUpdate task = 1;
     MemoryStatus memory = 2;
-    ReplayStatus replay = 3;
+    ReplayUpdate replay = 3;
   }
 }
 

--- a/gapis/service/service.proto
+++ b/gapis/service/service.proto
@@ -252,11 +252,21 @@ message MemoryStatus {
   uint64 totalHeap = 1;
 }
 
+enum ReplayStatus {
+  REPLAY_QUEUED = 0;
+  REPLAY_STARTED = 1;
+  REPLAY_EXECUTING = 2;
+  REPLAY_FINISHED = 3;
+}
+
 message ReplayUpdate {
-  uint64 label = 1;
-  uint32 total_instrs = 2;
-  uint32 finished_instrs = 3;
-  path.Device device = 4;
+  uint32 replay_id = 1;
+  path.Device device = 2;
+  ReplayStatus status = 3;
+  // Progress information below, sent if status is EXECUTING.
+  uint64 label = 4;
+  uint32 total_instrs = 5;
+  uint32 finished_instrs = 6;
 }
 
 message ServerStatusRequest {

--- a/test/integration/replay/BUILD.bazel
+++ b/test/integration/replay/BUILD.bazel
@@ -37,6 +37,7 @@ go_test(
     ],
     deps = [
         "//core/app:go_default_library",
+        "//core/app/status:go_default_library",
         "//core/data/binary:go_default_library",
         "//core/event/task:go_default_library",
         "//core/log:go_default_library",

--- a/test/integration/replay/postback_test.go
+++ b/test/integration/replay/postback_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/google/gapid/core/app"
+	"github.com/google/gapid/core/app/status"
 	"github.com/google/gapid/core/data/binary"
 	"github.com/google/gapid/core/event/task"
 	"github.com/google/gapid/core/log"
@@ -75,7 +76,8 @@ func doReplay(t *testing.T, f func(*builder.Builder)) error {
 		return err
 	}
 
-	err = b.RegisterReplayStatusReader(ctx, device.Instance().ID.ID())
+	s := status.ReplayQueued(ctx, 0, device.Instance().ID.ID())
+	err = b.RegisterReplayStatusReader(ctx, s)
 	if err != nil {
 		t.Errorf("Failed to register replay status notification reader.", err)
 		return err


### PR DESCRIPTION
Notifies clients when a replay is first queued, when it is started (which is just before the building starts), while it is executing, and then when it has completed. This allows clients to better report the status of queued, under construction, and executing replays. Replays are also given a status identifiers, so clients can handle multiple concurrent replays correctly.