### PR TITLE
Enable to check pre-release updates

### DIFF
--- a/core/app/run.go
+++ b/core/app/run.go
@@ -97,6 +97,11 @@ func (v VersionSpec) GreaterThan(o VersionSpec) bool {
 	}
 }
 
+// Equal returns true if v is equal to o, ignoring the Build field.
+func (v VersionSpec) Equal(o VersionSpec) bool {
+	return (v.Major == o.Major) && (v.Minor == o.Minor) && (v.Point == o.Point)
+}
+
 func (v VersionSpec) String() string {
 	return fmt.Sprintf("%v", v)
 }

--- a/gapic/src/main/com/google/gapid/models/Settings.java
+++ b/gapic/src/main/com/google/gapid/models/Settings.java
@@ -86,6 +86,7 @@ public class Settings {
   public String[] recentFiles = new String[0];
   public String adb = "";
   public boolean autoCheckForUpdates = true;
+  public boolean includePrereleases = false;
   public boolean updateAvailable = false;
   public long lastCheckForUpdates = 0; // milliseconds since midnight, January 1, 1970 UTC.
   public String analyticsClientId = ""; // Empty means do not track.
@@ -250,6 +251,7 @@ public class Settings {
     recentFiles = getStringList(properties, "open.recent", recentFiles);
     adb = tryFindAdb(properties.getProperty("adb.path", ""));
     autoCheckForUpdates = getBoolean(properties, "updates.autoCheck", autoCheckForUpdates);
+    includePrereleases = getBoolean(properties, "updates.includePrereleases", includePrereleases);
     lastCheckForUpdates = getLong(properties, "updates.lastCheck", 0);
     updateAvailable = getBoolean(properties, "updates.available", updateAvailable);
     analyticsClientId = properties.getProperty("analytics.clientId", "");
@@ -306,6 +308,7 @@ public class Settings {
     setStringList(properties, "open.recent", recentFiles);
     properties.setProperty("adb.path", adb);
     properties.setProperty("updates.autoCheck", Boolean.toString(autoCheckForUpdates));
+    properties.setProperty("updates.includePrereleases", Boolean.toString(includePrereleases));
     properties.setProperty("updates.lastCheck", Long.toString(lastCheckForUpdates));
     properties.setProperty("updates.available", Boolean.toString(updateAvailable));
     properties.setProperty("analytics.clientId", analyticsClientId);

--- a/gapic/src/main/com/google/gapid/util/Messages.java
+++ b/gapic/src/main/com/google/gapid/util/Messages.java
@@ -63,7 +63,8 @@ public interface Messages {
       "Help improve GAPID by sending usage statistics to Google";
   public static final String CRASH_REPORTING_OPTION =
       "Help GAPID identify issues by sending crash reports to Google";
-  public static final String UPDATE_CHECK_OPTION = "Automatically check for GAPID updates";
+  public static final String UPDATE_CHECK_OPTION = "Automatically check for GAPID updates (please restart GAPID to force an update check)";
+  public static final String UPDATE_CHECK_PRERELEASE_OPTION = "Include developer preview releases";
   public static final String PRIVACY_POLICY =
       "Google's <a href=\"TOS\">APIs Terms of Service</a> and <a href=\"PP\">Privacy Policy</a>" +
       " govern your use of this application.";

--- a/gapic/src/main/com/google/gapid/util/UpdateWatcher.java
+++ b/gapic/src/main/com/google/gapid/util/UpdateWatcher.java
@@ -33,7 +33,6 @@ public class UpdateWatcher {
   private static final Logger LOG = Logger.getLogger(UpdateWatcher.class.getName());
 
   private static final long CHECK_INTERVAL_MS = TimeUnit.HOURS.toMillis(8);
-  private static final boolean INCLUDE_PRE_RELEASES = false;
 
   private final Settings settings;
   private final Client client;
@@ -65,7 +64,7 @@ public class UpdateWatcher {
 
   private void doCheck() {
     if (settings.autoCheckForUpdates) {
-      ListenableFuture<Release> future = client.checkForUpdates(INCLUDE_PRE_RELEASES);
+      ListenableFuture<Release> future = client.checkForUpdates(settings.includePrereleases);
       settings.updateAvailable = false;
       try {
         Release release = future.get();

--- a/gapic/src/main/com/google/gapid/views/SettingsDialog.java
+++ b/gapic/src/main/com/google/gapid/views/SettingsDialog.java
@@ -108,6 +108,7 @@ public class SettingsDialog extends DialogBase {
     private final Button allowAnalytics;
     private final Button allowCrashReports;
     private final Button allowUpdateChecks;
+    private final Button includePrerelease;
 
     public SettingsFormBase(Models models, Composite parent) {
       this(models, parent, 5, 5);
@@ -129,14 +130,17 @@ public class SettingsDialog extends DialogBase {
       beforeAnalytics();
 
       allowAnalytics = withLayoutData(
-          createCheckbox(this, Messages.ANALYTICS_OPTION, true),
+          createCheckbox(this, Messages.ANALYTICS_OPTION, models.settings.analyticsEnabled()),
           withSpans(new GridData(SWT.LEFT, SWT.TOP, false, false), 2, 1));
       allowCrashReports = withLayoutData(
-          createCheckbox(this, Messages.CRASH_REPORTING_OPTION, true),
+          createCheckbox(this, Messages.CRASH_REPORTING_OPTION, models.settings.reportCrashes),
           withSpans(new GridData(SWT.LEFT, SWT.TOP, false, false), 2, 1));
       allowUpdateChecks = withLayoutData(
-          createCheckbox(this, Messages.UPDATE_CHECK_OPTION, true),
+          createCheckbox(this, Messages.UPDATE_CHECK_OPTION, models.settings.autoCheckForUpdates),
           withSpans(new GridData(SWT.LEFT, SWT.TOP, false, false), 2, 1));
+      includePrerelease = withLayoutData(
+          createCheckbox(this, Messages.UPDATE_CHECK_PRERELEASE_OPTION, models.settings.includePrereleases),
+          withIndents(new GridData(SWT.LEFT, SWT.TOP, false, false), 20, 0));
       Label adbWarning = withLayoutData(createLabel(this, ""),
           withSpans(new GridData(SWT.FILL, SWT.FILL, true, false), 2, 1));
       adbWarning.setForeground(getDisplay().getSystemColor(SWT.COLOR_DARK_RED));
@@ -156,6 +160,13 @@ public class SettingsDialog extends DialogBase {
       };
       adbPath.addBoxListener(SWT.Modify, adbListener);
       adbListener.handleEvent(null);
+
+      allowUpdateChecks.addListener(SWT.Selection, e -> {
+        if (!allowUpdateChecks.getSelection()) {
+          includePrerelease.setSelection(false);
+        }
+        includePrerelease.setEnabled(allowUpdateChecks.getSelection());
+      });
     }
 
     protected void beforeAnalytics() {
@@ -167,6 +178,9 @@ public class SettingsDialog extends DialogBase {
       models.settings.setAnalyticsEnabled(allowAnalytics.getSelection());
       models.settings.reportCrashes = allowCrashReports.getSelection();
       models.settings.autoCheckForUpdates = allowUpdateChecks.getSelection();
+      models.settings.includePrereleases = includePrerelease.getSelection();
+      // When settings are saved, reset the update timer, to force update check on next start
+      models.settings.lastCheckForUpdates = 0;
       models.settings.save();
       models.analytics.updateSettings();
     }


### PR DESCRIPTION
Nightly is only checked if pre-releases are checked, which is
currently a hardcoded "false" in the UI. Next step is to enable
checking pre-releases from the UI.