### PR TITLE
Allow tracks to render into their margins and fix some hovers.

### DIFF
--- a/gapic/src/main/com/google/gapid/perfetto/views/CounterPanel.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/CounterPanel.java
@@ -16,6 +16,7 @@
 package com.google.gapid.perfetto.views;
 
 import static com.google.gapid.perfetto.views.Loading.drawLoading;
+import static com.google.gapid.perfetto.views.StyleConstants.TRACK_MARGIN;
 import static com.google.gapid.perfetto.views.StyleConstants.colors;
 import static com.google.gapid.util.MoreFutures.transform;
 
@@ -115,8 +116,9 @@ public class CounterPanel extends TrackPanel implements Selectable {
     return new Hover() {
       @Override
       public Area getRedraw() {
-        return new Area(mouseXpos - CURSOR_SIZE, 0,
-            CURSOR_SIZE + HOVER_MARGIN + HOVER_PADDING + hovered.size.w + HOVER_PADDING, HEIGHT);
+        return new Area(mouseXpos - CURSOR_SIZE, -TRACK_MARGIN,
+            CURSOR_SIZE + HOVER_MARGIN + HOVER_PADDING + hovered.size.w + HOVER_PADDING,
+            HEIGHT + 2 * TRACK_MARGIN);
       }
 
       @Override

--- a/gapic/src/main/com/google/gapid/perfetto/views/CpuPanel.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/CpuPanel.java
@@ -239,11 +239,11 @@ public class CpuPanel extends TrackPanel implements Selectable {
     double mouseX = state.timeToPx(
         data.request.range.start + hovered.bucket * data.bucketSize + data.bucketSize / 2);
     double dx = HOVER_PADDING + hovered.size.w + HOVER_PADDING;
-    double dy = height - 2 * TRACK_MARGIN;
+    double dy = height;
     return new Hover() {
       @Override
       public Area getRedraw() {
-        return new Area(mouseX - CURSOR_SIZE, TRACK_MARGIN, CURSOR_SIZE + HOVER_MARGIN + dx, dy);
+        return new Area(mouseX - CURSOR_SIZE, -TRACK_MARGIN, CURSOR_SIZE + HOVER_MARGIN + dx, dy);
       }
 
       @Override

--- a/gapic/src/main/com/google/gapid/perfetto/views/CpuSummaryPanel.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/CpuSummaryPanel.java
@@ -134,11 +134,11 @@ public class CpuSummaryPanel extends TrackPanel implements Selectable {
     double mouseX = state.timeToPx(
         data.request.range.start + hovered.bucket * data.bucketSize + data.bucketSize / 2);
     double dx = HOVER_PADDING + hovered.size.w + HOVER_PADDING;
-    double dy = height - 2 * TRACK_MARGIN;
+    double dy = height;
     return new Hover() {
       @Override
       public Area getRedraw() {
-        return new Area(mouseX - CURSOR_SIZE, TRACK_MARGIN, CURSOR_SIZE + HOVER_MARGIN + dx, dy);
+        return new Area(mouseX - CURSOR_SIZE, -TRACK_MARGIN, CURSOR_SIZE + HOVER_MARGIN + dx, dy);
       }
 
       @Override

--- a/gapic/src/main/com/google/gapid/perfetto/views/MemorySummaryPanel.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/MemorySummaryPanel.java
@@ -160,9 +160,9 @@ public class MemorySummaryPanel extends TrackPanel {
     return new Hover() {
       @Override
       public Area getRedraw() {
-        return new Area(mouseXpos - CURSOR_SIZE, mouseYpos,
+        return new Area(mouseXpos - CURSOR_SIZE, -TRACK_MARGIN,
             CURSOR_SIZE + HOVER_MARGIN + hovered.allSize.w + 3 * HOVER_PADDING + LEGEND_SIZE,
-            hovered.allSize.h);
+            HEIGHT + 2 * TRACK_MARGIN);
       }
 
       @Override

--- a/gapic/src/main/com/google/gapid/perfetto/views/ProcessSummaryPanel.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/ProcessSummaryPanel.java
@@ -238,11 +238,11 @@ public class ProcessSummaryPanel extends TrackPanel {
     double mouseX = state.timeToPx(
         data.request.range.start + hovered.bucket * data.bucketSize + data.bucketSize / 2);
     double dx = HOVER_PADDING + hovered.size.w + HOVER_PADDING;
-    double dy = height - 2 * TRACK_MARGIN;
+    double dy = height;
     return new Hover() {
       @Override
       public Area getRedraw() {
-        return new Area(mouseX - CURSOR_SIZE, TRACK_MARGIN, CURSOR_SIZE + HOVER_MARGIN + dx, dy);
+        return new Area(mouseX - CURSOR_SIZE, -TRACK_MARGIN, CURSOR_SIZE + HOVER_MARGIN + dx, dy);
       }
 
       @Override

--- a/gapic/src/main/com/google/gapid/perfetto/views/TrackPanel.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/TrackPanel.java
@@ -50,7 +50,7 @@ public abstract class TrackPanel extends Panel.Base implements TitledPanel {
     double w = width - LABEL_WIDTH, h = height - 2 * TRACK_MARGIN;
     drawGridLines(ctx, state, LABEL_WIDTH, 0, w, height);
     ctx.withTranslation(LABEL_WIDTH, TRACK_MARGIN, () ->
-      ctx.withClip(0, 0, w, h, () ->
+      ctx.withClip(0, -TRACK_MARGIN, w, h + 2 * TRACK_MARGIN, () ->
         renderTrack(ctx, repainter, w, h)));
   }
 


### PR DESCRIPTION
Still translates so the (0,0) point is inside the track margin, but doesn't clip, so tracks can draw into the margin. This allows the hover markers do go into the margins and not be clipped.

This change also fixes some of the hover redraw areas to properly render the hover circles in the margins.