### PR TITLE
Redraw overlays if they are overdrawn.

### DIFF
--- a/gapic/src/main/com/google/gapid/perfetto/canvas/Area.java
+++ b/gapic/src/main/com/google/gapid/perfetto/canvas/Area.java
@@ -40,6 +40,11 @@ public class Area {
     }
 
     @Override
+    public boolean intersects(Area o) {
+      return false;
+    }
+
+    @Override
     public int hashCode() {
       return 0;
     }
@@ -74,6 +79,11 @@ public class Area {
     @Override
     public Area intersect(double ox, double oy, double ow, double oh) {
       return (ow <= 0 || oh <= 0) ? NONE : new Area(ox, oy, ow, oh);
+    }
+
+    @Override
+    public boolean intersects(Area o) {
+      return !o.isEmpty();
     }
 
     @Override
@@ -133,6 +143,15 @@ public class Area {
     double nx = Math.max(x, ox), nw = Math.min(x + w, ox + ow) - nx;
     double ny = Math.max(y, oy), nh = Math.min(y + h, oy + oh) - ny;
     return (nw <= 0 || nh <= 0) ? Area.NONE : new Area(nx, ny, nw, nh);
+  }
+
+  public boolean intersects(Area o) {
+    if (o == FULL) {
+      return true;
+    } else if (o.isEmpty()) {
+      return false;
+    }
+    return (x + w > o.x) && (x < o.x + o.w) && (y + h > o.y) && (y < o.y + o.h);
   }
 
   public boolean isEmpty() {

--- a/gapic/src/main/com/google/gapid/perfetto/canvas/Panel.java
+++ b/gapic/src/main/com/google/gapid/perfetto/canvas/Panel.java
@@ -110,6 +110,7 @@ public interface Panel {
     public default Area getRedraw() { return Area.NONE; }
     public default Cursor getCursor(@SuppressWarnings("unused") Display display) { return null; }
     public default void stop() { /* empty */ }
+    public default boolean isOverlay() { return false; }
 
     /** Returns whether the screen should be redrawn. */
     public default boolean click() { return false; }
@@ -138,6 +139,11 @@ public interface Panel {
         @Override
         public void stop() {
           Hover.this.stop();
+        }
+
+        @Override
+        public boolean isOverlay() {
+          return Hover.this.isOverlay();
         }
 
         @Override

--- a/gapic/src/main/com/google/gapid/perfetto/canvas/PanelCanvas.java
+++ b/gapic/src/main/com/google/gapid/perfetto/canvas/PanelCanvas.java
@@ -149,6 +149,13 @@ public class PanelCanvas extends Canvas {
         updateMousePosition(lastMouse.x, lastMouse.y, 0, true, false);
       }
 
+      if (hover.isOverlay()) {
+        Area hoverArea = hover.getRedraw();
+        if (area.intersects(hoverArea)) {
+          area = area.combine(hoverArea);
+        }
+      }
+
       Rectangle size = getClientArea();
       if (area != Area.FULL) {
         size.x = Math.max(0, Math.min(size.width - 1, (int)Math.floor(area.x)));

--- a/gapic/src/main/com/google/gapid/perfetto/views/TrackPanel.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/TrackPanel.java
@@ -118,6 +118,11 @@ public abstract class TrackPanel extends Panel.Base implements TitledPanel {
         }
 
         @Override
+        public boolean isOverlay() {
+          return true;
+        }
+
+        @Override
         public void stop() {
           tooltip = null;
         }


### PR DESCRIPTION
Currently, if an overlay from track A fully or partially covers track B, a redraw of track B (e.g. when the data for it is loaded) will overdraw the overlay, which will not be drawn, since track A is not redrawn. This change fixes this by redrawing the whole area of the overlay if we are redrawing any portion of the area covered by an overlay.