### PR TITLE
Initial Perfetto config dialog

### DIFF
--- a/gapic/src/main/com/google/gapid/models/Settings.java
+++ b/gapic/src/main/com/google/gapid/models/Settings.java
@@ -93,6 +93,12 @@ public class Settings {
   public boolean reportCrashes = false;
   public int[] perfettoSplitterWeights = new int[] { 85, 15 };
   public boolean perfettoDarkMode = false;
+  public boolean perfettoCpu = true;
+  public boolean perfettoCpuFreq = false;
+  public boolean perfettoCpuChain = true;
+  public boolean perfettoCpuSlices = true;
+  public boolean perfettoMem = true;
+  public int perfettoMemRate = 10;
 
   public static Settings load() {
     Settings result = new Settings();
@@ -248,6 +254,12 @@ public class Settings {
     perfettoSplitterWeights =
         getIntList(properties, "perfetto.splitter.weights", perfettoSplitterWeights);
     perfettoDarkMode = getBoolean(properties, "perfetto.dark", perfettoDarkMode);
+    perfettoCpu = getBoolean(properties, "perfetto.cpu", perfettoCpu);
+    perfettoCpuFreq = getBoolean(properties, "perfetto.cpu.freq", perfettoCpuFreq);
+    perfettoCpuChain = getBoolean(properties, "perfetto.cpu.chain", perfettoCpuChain);
+    perfettoCpuSlices = getBoolean(properties, "perfetto.cpu.slices", perfettoCpuSlices);
+    perfettoMem = getBoolean(properties, "perfetto.mem", perfettoMem);
+    perfettoMemRate = getInt(properties, "perfetto.mem.rate", perfettoMemRate);
   }
 
   private void updateTo(Properties properties) {
@@ -292,6 +304,12 @@ public class Settings {
     properties.setProperty("crash.reporting", Boolean.toString(reportCrashes));
     setIntList(properties, "perfetto.splitter.weights", perfettoSplitterWeights);
     properties.setProperty("perfetto.dark", Boolean.toString(perfettoDarkMode));
+    properties.setProperty("perfetto.cpu", Boolean.toString(perfettoCpu));
+    properties.setProperty("perfetto.cpu.freq", Boolean.toString(perfettoCpuFreq));
+    properties.setProperty("perfetto.cpu.chain", Boolean.toString(perfettoCpuChain));
+    properties.setProperty("perfetto.cpu.slices", Boolean.toString(perfettoCpuSlices));
+    properties.setProperty("perfetto.mem", Boolean.toString(perfettoMem));
+    properties.setProperty("perfetto.mem.rate", Integer.toString(perfettoMemRate));
   }
 
   private static Point getPoint(Properties properties, String name) {

--- a/gapic/src/main/com/google/gapid/models/Settings.java
+++ b/gapic/src/main/com/google/gapid/models/Settings.java
@@ -74,10 +74,8 @@ public class Settings {
   public String traceArguments = "";
   public String traceCwd = "";
   public String traceEnv = "";
-  public int traceInitialFrameCount = 0;
-  public int traceFrameCount = 7;
-  public boolean traceInteractiveStart = true;
-  public boolean traceMidExecution = true;
+  public int traceStartAt = -1; // -1: manual (mec), 0: beginning, 1+ frame x
+  public int traceDuration = 7; // 0: manual, 1+ frames/seconds
   public boolean traceWithoutBuffering = false;
   public boolean traceHideUnknownExtensions = false;
   public boolean traceClearCache = false;
@@ -229,9 +227,8 @@ public class Settings {
     traceArguments = properties.getProperty("trace.arguments", traceArguments);
     traceCwd = properties.getProperty("trace.cwd", traceCwd);
     traceEnv = properties.getProperty("trace.env", traceEnv);
-    traceFrameCount = getInt(properties, "trace.frameCount", traceFrameCount);
-    traceInteractiveStart = getBoolean(properties, "trace.interactiveStart", traceInteractiveStart);
-    traceMidExecution = getBoolean(properties, "trace.midExecution", traceMidExecution);
+    traceStartAt = getInt(properties, "trace.startAt", traceStartAt);
+    traceDuration = getInt(properties, "trace.duration", traceDuration);
     traceWithoutBuffering = getBoolean(properties, "trace.withoutBuffering", traceWithoutBuffering);
     traceHideUnknownExtensions = getBoolean(properties, "trace.hideUnknownExtensions", traceHideUnknownExtensions);
     traceClearCache = getBoolean(properties, "trace.clearCache", traceClearCache);
@@ -275,8 +272,8 @@ public class Settings {
     properties.setProperty("trace.arguments", traceArguments);
     properties.setProperty("trace.cwd", traceCwd);
     properties.setProperty("trace.env", traceEnv);
-    properties.setProperty("trace.frameCount", Integer.toString(traceFrameCount));
-    properties.setProperty("trace.midExecution", Boolean.toString(traceMidExecution));
+    properties.setProperty("trace.startAt", Integer.toString(traceStartAt));
+    properties.setProperty("trace.duration", Integer.toString(traceDuration));
     properties.setProperty("trace.withoutBuffering", Boolean.toString(traceWithoutBuffering));
     properties.setProperty("trace.hideUnknownExtensions", Boolean.toString(traceHideUnknownExtensions));
     properties.setProperty("trace.clearCache", Boolean.toString(traceClearCache));

--- a/gapic/src/main/com/google/gapid/perfetto/views/TraceConfigDialog.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/TraceConfigDialog.java
@@ -1,0 +1,234 @@
+/*
+ * Copyright (C) 2019 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.gapid.perfetto.views;
+
+import static com.google.gapid.widgets.Widgets.createCheckbox;
+import static com.google.gapid.widgets.Widgets.createComposite;
+import static com.google.gapid.widgets.Widgets.createLabel;
+import static com.google.gapid.widgets.Widgets.createSpinner;
+import static com.google.gapid.widgets.Widgets.withIndents;
+import static com.google.gapid.widgets.Widgets.withLayoutData;
+
+import com.google.gapid.models.Models;
+import com.google.gapid.models.Settings;
+import com.google.gapid.util.Messages;
+import com.google.gapid.widgets.DialogBase;
+import com.google.gapid.widgets.Theme;
+import com.google.gapid.widgets.Widgets;
+
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.layout.GridLayout;
+import org.eclipse.swt.widgets.Button;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Control;
+import org.eclipse.swt.widgets.Label;
+import org.eclipse.swt.widgets.Shell;
+import org.eclipse.swt.widgets.Spinner;
+
+import java.util.Arrays;
+
+import perfetto.protos.PerfettoConfig;
+
+public class TraceConfigDialog extends DialogBase {
+  private static final int BUFFER_SIZE = 131072;
+  private static final int FTRACE_BUFFER_SIZE = 8192;
+  private static final String[] CPU_BASE_FTRACE = {
+      "sched/sched_switch",
+      "sched/sched_process_exit",
+      "sched/sched_process_free",
+      "task/task_newtask",
+      "task/task_rename",
+      "power/suspend_resume",
+  };
+  private static final String[] CPU_FREQ_FTRACE = {
+      "power/cpu_frequency",
+      "power/cpu_idle"
+  };
+  private static final String[] CPU_CHAIN_FTRACE = {
+      "sched/sched_wakeup",
+      "sched/sched_wakeup_new",
+      "sched/sched_waking",
+  };
+  private static final String[] CPU_SLICES_ATRACE = {
+      // TODO: this should come from the device.
+      "adb", "aidl", "am", "audio", "binder_driver", "binder_lock", "bionic", "camera",
+      "core_services", "dalvik", "database", "disk", "freq", "gfx", "hal", "i2c", "idle", "input",
+      "ion", "irq", "memory", "memreclaim", "network", "nnapi", "pagecache", "pdx", "pm", "power",
+      "regulators", "res", "rro", "rs", "sched", "sm", "ss", "sync", "vibrator", "video", "view",
+      "webview", "wm", "workq"
+  };
+  private static final PerfettoConfig.MeminfoCounters[] MEM_COUNTERS = {
+      PerfettoConfig.MeminfoCounters.MEMINFO_MEM_TOTAL,
+      PerfettoConfig.MeminfoCounters.MEMINFO_MEM_FREE,
+      PerfettoConfig.MeminfoCounters.MEMINFO_BUFFERS,
+      PerfettoConfig.MeminfoCounters.MEMINFO_CACHED,
+      PerfettoConfig.MeminfoCounters.MEMINFO_SWAP_CACHED,
+  };
+
+  private final Settings settings;
+  private InputArea input;
+
+  public TraceConfigDialog(Shell shell, Settings settings, Theme theme) {
+    super(shell, theme);
+    this.settings = settings;
+  }
+
+  public static void showPerfettoConfigDialog(Shell shell, Models models, Widgets widgets) {
+    new TraceConfigDialog(shell, models.settings, widgets.theme).open();
+  }
+
+  public static String getConfigSummary(Settings settings) {
+    StringBuilder sb = new StringBuilder();
+    if (settings.perfettoCpu) {
+      sb.append("CPU");
+    }
+    if (settings.perfettoMem) {
+      if (sb.length() > 0) {
+        sb.append(", ");
+      }
+      sb.append("Memory");
+    }
+    return sb.toString();
+  }
+
+  public static PerfettoConfig.TraceConfig.Builder getConfig(Settings settings) {
+    PerfettoConfig.TraceConfig.Builder config = PerfettoConfig.TraceConfig.newBuilder()
+        .addBuffers(PerfettoConfig.TraceConfig.BufferConfig.newBuilder()
+            .setSizeKb(BUFFER_SIZE));
+
+    if (settings.perfettoCpu) {
+      // Record process names.
+      config.addDataSourcesBuilder()
+          .getConfigBuilder()
+              .setName("linux.process_stats")
+              .getProcessStatsConfigBuilder()
+                  .setScanAllProcessesOnStart(true);
+
+      PerfettoConfig.FtraceConfig.Builder ftrace = config.addDataSourcesBuilder()
+          .getConfigBuilder()
+              .setName("linux.ftrace")
+              .getFtraceConfigBuilder()
+                  .setBufferSizeKb(FTRACE_BUFFER_SIZE)
+                  .addAllFtraceEvents(Arrays.asList(CPU_BASE_FTRACE));
+      if (settings.perfettoCpuFreq) {
+        ftrace.addAllFtraceEvents(Arrays.asList(CPU_FREQ_FTRACE));
+      }
+      if (settings.perfettoCpuChain) {
+        ftrace.addAllFtraceEvents(Arrays.asList(CPU_CHAIN_FTRACE));
+      }
+      if (settings.perfettoCpuSlices) {
+        ftrace.addAllAtraceCategories(Arrays.asList(CPU_SLICES_ATRACE));
+      }
+    }
+
+    if (settings.perfettoMem) {
+      config.addDataSourcesBuilder()
+          .getConfigBuilder()
+              .setName("linux.sys_stats")
+              .getSysStatsConfigBuilder()
+                  .setMeminfoPeriodMs(settings.perfettoMemRate)
+                  .addAllMeminfoCounters(Arrays.asList(MEM_COUNTERS));
+    }
+
+    return config;
+  }
+
+  @Override
+  public String getTitle() {
+    return Messages.CAPTURE_TRACE_PERFETTO;
+  }
+
+  @Override
+  protected Control createDialogArea(Composite parent) {
+    Composite area = (Composite)super.createDialogArea(parent);
+    input = withLayoutData(new InputArea(area, settings), new GridData(GridData.FILL_BOTH));
+    return area;
+  }
+
+  @Override
+  protected void okPressed() {
+    input.update(settings);
+    super.okPressed();
+  }
+
+  private static class InputArea extends Composite {
+    private static final int GROUP_INDENT = 20;
+
+    private final Button cpu;
+    private final Button cpuFreq;
+    private final Button cpuChain;
+    private final Button cpuSlices;
+
+    private final Button mem;
+    private final Label[] memLabels;
+    private final Spinner memRate;
+
+    public InputArea(Composite parent, Settings settings) {
+      super(parent, SWT.NONE);
+      setLayout(new GridLayout(1, false));
+
+      cpu = createCheckbox(this, "CPU", settings.perfettoCpu, e -> updateCpu());
+      Composite cpuGroup = withLayoutData(createComposite(this, new GridLayout(1, false)),
+          withIndents(new GridData(), GROUP_INDENT, 0));
+      cpuFreq = createCheckbox(cpuGroup, "Frequency and idle states", settings.perfettoCpuFreq);
+      cpuChain = createCheckbox(cpuGroup, "Scheduling chains / latency", settings.perfettoCpuChain);
+      cpuSlices = createCheckbox(cpuGroup, "Thread slices", settings.perfettoCpuSlices);
+      addSeparator();
+
+      mem = createCheckbox(this, "Memory", settings.perfettoMem, e -> updateMem());
+      memLabels = new Label[2];
+      Composite memGroup = withLayoutData(createComposite(this, new GridLayout(3, false)),
+          withIndents(new GridData(), GROUP_INDENT, 0));
+      memLabels[0] = createLabel(memGroup, "Poll Rate:");
+      memRate = createSpinner(memGroup, settings.perfettoMemRate, 1, 1000);
+      memLabels[1] = createLabel(memGroup, "ms");
+
+      updateCpu();
+      updateMem();
+    }
+
+    public void update(Settings settings) {
+      settings.perfettoCpu = cpu.getSelection();
+      settings.perfettoCpuChain = cpuChain.getSelection();
+      settings.perfettoCpuFreq = cpuFreq.getSelection();
+      settings.perfettoCpuSlices = cpuSlices.getSelection();
+
+      settings.perfettoMem = mem.getSelection();
+      settings.perfettoMemRate = memRate.getSelection();
+    }
+
+    private void addSeparator() {
+      withLayoutData(new Label(this, SWT.SEPARATOR | SWT.HORIZONTAL),
+          new GridData(GridData.FILL_HORIZONTAL));
+    }
+
+    private void updateCpu() {
+      boolean enabled = cpu.getSelection();
+      cpuFreq.setEnabled(enabled);
+      cpuChain.setEnabled(enabled);
+      cpuSlices.setEnabled(enabled);
+    }
+
+    private void updateMem() {
+      boolean enabled = mem.getSelection();
+      memRate.setEnabled(enabled);
+      for (Label label : memLabels) {
+        label.setEnabled(enabled);
+      }
+    }
+  }
+}

--- a/gapic/src/main/com/google/gapid/util/Messages.java
+++ b/gapic/src/main/com/google/gapid/util/Messages.java
@@ -42,7 +42,8 @@ public interface Messages {
   public static final String COMMAND_ID = "API Call Number";
   public static final String MEMORY_ADDRESS = "Memory Address";
   public static final String MEMORY_POOL = "Memory Pool";
-  public static final String CAPTURE_TRACE = "Capture Graphics Trace";
+  public static final String CAPTURE_TRACE_GRAPHICS = "Capture Graphics Trace";
+  public static final String CAPTURE_TRACE_PERFETTO = "Capture System Profile";
   public static final String CAPTURING_TRACE = "Capturing Graphics Trace...";
   public static final String CAPTURE_DIRECTORY = "Capture output directory...";
   public static final String CAPTURE_EXECUTABLE = "Executable to trace...";

--- a/gapic/src/main/com/google/gapid/views/TracerDialog.java
+++ b/gapic/src/main/com/google/gapid/views/TracerDialog.java
@@ -20,13 +20,13 @@ import static com.google.gapid.widgets.Widgets.createBoldLabel;
 import static com.google.gapid.widgets.Widgets.createCheckbox;
 import static com.google.gapid.widgets.Widgets.createComposite;
 import static com.google.gapid.widgets.Widgets.createDropDownViewer;
+import static com.google.gapid.widgets.Widgets.createGroup;
 import static com.google.gapid.widgets.Widgets.createLabel;
 import static com.google.gapid.widgets.Widgets.createLink;
 import static com.google.gapid.widgets.Widgets.createSpinner;
 import static com.google.gapid.widgets.Widgets.createTextbox;
 import static com.google.gapid.widgets.Widgets.withIndents;
 import static com.google.gapid.widgets.Widgets.withLayoutData;
-import static com.google.gapid.widgets.Widgets.withMargin;
 import static com.google.gapid.widgets.Widgets.withSpans;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.stream.Collectors.toList;
@@ -71,11 +71,13 @@ import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Button;
+import org.eclipse.swt.widgets.Combo;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.DirectoryDialog;
 import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.FileDialog;
+import org.eclipse.swt.widgets.Group;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Link;
 import org.eclipse.swt.widgets.Listener;
@@ -242,12 +244,13 @@ public class TracerDialog {
       private static final String TRACE_EXTENSION = ".gfxtrace";
       private static final String PERFETTO_EXTENSION = ".perfetto";
       private static final DateFormat TRACE_DATE_FORMAT = new SimpleDateFormat("_yyyyMMdd_HHmm");
-      private static final String INITIAL_FRAMES_LABEL = "Start Frame:";
       private static final String FRAMES_LABEL = "Stop After:";
       private static final String DURATION_LABEL = "Duration:";
-      private static final String FRAMES_UNIT = "Frames (0 for unlimited)";
-      private static final String DURATION_UNIT = "Seconds (0 for unlimited)";
-      private static final String MEC_LABEL_WARNING = "\tNOTE: Mid-Execution capture for %s is experimental";
+      private static final String FRAMES_UNIT = "Frames (0 for manual)";
+      private static final String DURATION_UNIT = "Seconds (0 for manual)";
+      private static final String MEC_LABEL_WARNING =
+          "NOTE: Mid-Execution capture for %s is experimental";
+      private static final int DEFAULT_START_FRAME = 100;
 
       private final String date = TRACE_DATE_FORMAT.format(new Date());
 
@@ -263,12 +266,12 @@ public class TracerDialog {
       private final Text arguments;
       private final Text cwd;
       private final Text envVars;
-      private final Spinner frameInitial;
-      private final Label frameCountLabel;
-      private final Spinner frameCount;
-      private final Label frameCountUnit;
+      private final Combo startType;
+      private final Spinner startFrame;
+      private final Label durationLabel;
+      private final Spinner duration;
+      private final Label durationUnit;
       private Label mecWarningLabel;
-      private final Button automaticTracing;
       private final Button withoutBuffering;
       private final Button hideUnknownExtensions;
       private final Button clearCache;
@@ -280,7 +283,6 @@ public class TracerDialog {
       private final Label pcsWarning;
       private final Label requiredFieldMessage;
 
-
       protected String friendlyName = "";
       protected boolean userHasChangedOutputFile = false;
       protected boolean userHasChangedTarget = false;
@@ -289,14 +291,14 @@ public class TracerDialog {
         super(parent, SWT.NONE);
         this.friendlyName = models.settings.traceFriendlyName;
 
-        setLayout(new GridLayout(2, false));
+        setLayout(new GridLayout(1, false));
 
-        deviceLabel = createLabel(this, "Device*:");
-        deviceLabel.setForeground(getDisplay().getSystemColor(SWT.COLOR_RED));
-        Composite deviceComposite =
-            createComposite(this, withMargin(new GridLayout(2, false), 0, 0));
-        device = createDeviceDropDown(deviceComposite);
-        deviceLoader = widgets.loading.createWidgetWithRefresh(deviceComposite);
+        Group mainGroup = withLayoutData(
+            createGroup(this, "Device and Type", new GridLayout(3, false)),
+            new GridData(GridData.FILL_HORIZONTAL));
+        deviceLabel = createLabel(mainGroup, "Device*:");
+        device = createDeviceDropDown(mainGroup);
+        deviceLoader = widgets.loading.createWidgetWithRefresh(mainGroup);
         device.getCombo().setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false));
         deviceLoader.setLayoutData(
             withIndents(new GridData(SWT.RIGHT, SWT.CENTER, false, false), 5, 0));
@@ -308,16 +310,15 @@ public class TracerDialog {
           logFailure(LOG, Scheduler.EXECUTOR.schedule(refreshDevices, 300, TimeUnit.MILLISECONDS));
         });
 
-        deviceComposite.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false));
-
-        apiLabel = createLabel(this, "Type*:");
-        apiLabel.setForeground(getDisplay().getSystemColor(SWT.COLOR_RED));
-        api = createApiDropDown(this);
+        apiLabel = createLabel(mainGroup, "Type*:");
+        api = createApiDropDown(mainGroup);
         api.getCombo().setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false));
 
-        targetLabel = createLabel(this, "Application*:");
-        targetLabel.setForeground(getDisplay().getSystemColor(SWT.COLOR_RED));
-        traceTarget = withLayoutData(new ActionTextbox(this, models.settings.traceUri) {
+        Group appGroup  = withLayoutData(
+            createGroup(this, "Application", new GridLayout(2, false)),
+            new GridData(GridData.FILL_HORIZONTAL));
+        targetLabel = createLabel(appGroup, "Application*:");
+        traceTarget = withLayoutData(new ActionTextbox(appGroup, models.settings.traceUri) {
           @Override
           protected String createAndShowDialog(String current) {
             DeviceCaptureInfo dev = getSelectedDevice();
@@ -340,84 +341,88 @@ public class TracerDialog {
           }
         }, new GridData(SWT.FILL, SWT.FILL, true, false));
 
-        createLabel(this, "Additional Arguments:");
-        arguments = withLayoutData(createTextbox(this, models.settings.traceArguments),
+        createLabel(appGroup, "Additional Arguments:");
+        arguments = withLayoutData(createTextbox(appGroup, models.settings.traceArguments),
             new GridData(SWT.FILL, SWT.FILL, true, false));
 
-        createLabel(this, "Working Directory:");
-        cwd = withLayoutData(createTextbox(this, models.settings.traceCwd),
+        createLabel(appGroup, "Working Directory:");
+        cwd = withLayoutData(createTextbox(appGroup, models.settings.traceCwd),
             new GridData(SWT.FILL, SWT.FILL, true, false));
         cwd.setEnabled(false);
 
-        createLabel(this, "Environment Variables:");
-        envVars = withLayoutData(createTextbox(this, models.settings.traceEnv),
+        createLabel(appGroup, "Environment Variables:");
+        envVars = withLayoutData(createTextbox(appGroup, models.settings.traceEnv),
             new GridData(SWT.FILL, SWT.FILL, true, false));
         envVars.setEnabled(false);
 
-        createLabel(this, INITIAL_FRAMES_LABEL);
-        Composite frameInitialComposite =
-            createComposite(this, withMargin(new GridLayout(3, false), 0, 0));
-        automaticTracing = withLayoutData(
-          createCheckbox(frameInitialComposite, "", !models.settings.traceInteractiveStart),
-          new GridData(SWT.FILL, SWT.CENTER, true, false));
-        frameInitial = withLayoutData(
-            createSpinner(frameInitialComposite, models.settings.traceInitialFrameCount, 0, 999999),
-            new GridData(SWT.LEFT, SWT.FILL, false, false));
-        frameInitial.setEnabled(!models.settings.traceInteractiveStart);
-        mecWarningLabel = createLabel(frameInitialComposite, "");
+        Group durGroup = withLayoutData(
+            createGroup(this, "Start and Duration", new GridLayout(4, false)),
+            new GridData(GridData.FILL_HORIZONTAL));
+        createLabel(durGroup, "Start at:");
+        startType = Widgets.createDropDown(durGroup);
+        startType.setItems("Beginning", "Manual", "Frame");
+        startFrame = withLayoutData(
+            createSpinner(durGroup, Math.max(1, models.settings.traceStartAt), 1, 999999),
+            new GridData(SWT.FILL, SWT.TOP, false, false));
+        mecWarningLabel = createLabel(durGroup, "");
 
-        frameCountLabel = createLabel(this, FRAMES_LABEL);
-        Composite frameCountComposite =
-            createComposite(this, withMargin(new GridLayout(3, false), 0, 0));
-        frameCount = withLayoutData(
-            createSpinner(frameCountComposite, models.settings.traceFrameCount, 0, 999999),
-            new GridData(SWT.LEFT, SWT.FILL, false, false));
-        frameCountUnit = createLabel(frameCountComposite, FRAMES_UNIT);
+        if (models.settings.traceStartAt < 0) {
+          startType.select(1);
+          startFrame.setSelection(DEFAULT_START_FRAME);
+        } else if (models.settings.traceStartAt > 0) {
+          startType.select(2);
+        } else {
+          startType.select(0);
+          startFrame.setSelection(DEFAULT_START_FRAME);
+        }
 
-        createLabel(this, "");
-        withoutBuffering = withLayoutData(
-            createCheckbox(this, "Disable Buffering", models.settings.traceWithoutBuffering),
-            new GridData(SWT.FILL, SWT.FILL, true, false));
+        durationLabel = createLabel(durGroup, FRAMES_LABEL);
+        duration = withLayoutData(
+            createSpinner(durGroup, models.settings.traceDuration, 0, 999999),
+            new GridData(SWT.FILL, SWT.TOP, false, false));
+        durationUnit = createLabel(durGroup, FRAMES_UNIT);
 
-        createLabel(this, "");
-        clearCache = withLayoutData(
-            createCheckbox(this, "Clear package cache", models.settings.traceClearCache),
-            new GridData(SWT.FILL, SWT.FILL, true, false));
+        Group optGroup  = withLayoutData(
+            createGroup(this, "Trace Options", new GridLayout(2, false)),
+            new GridData(GridData.FILL_HORIZONTAL));
+        withoutBuffering = createCheckbox(
+            optGroup, "Disable Buffering", models.settings.traceWithoutBuffering);
+        disablePcs = createCheckbox(
+            optGroup, "Disable pre-compiled shaders", models.settings.traceDisablePcs);
+        clearCache = createCheckbox(
+            optGroup, "Clear package cache", models.settings.traceClearCache);
+        hideUnknownExtensions = createCheckbox(
+            optGroup, "Hide Unknown Extensions", models.settings.traceHideUnknownExtensions);
         clearCache.setEnabled(false);
-
-        createLabel(this, "");
-        hideUnknownExtensions = withLayoutData(
-            createCheckbox(this, "Hide Unknown Extensions", models.settings.traceHideUnknownExtensions),
-            new GridData(SWT.FILL, SWT.FILL, true, false));
-
-        createLabel(this, "");
-        disablePcs = withLayoutData(
-            createCheckbox(this, "Disable pre-compiled shaders", models.settings.traceDisablePcs),
-            new GridData(SWT.FILL, SWT.FILL, true, false));
         disablePcs.setEnabled(false);
 
-        directoryLabel = createLabel(this, "Output Directory*:");
-        directoryLabel.setForeground(getDisplay().getSystemColor(SWT.COLOR_RED));
-        directory = withLayoutData(new FileTextbox.Directory(this, models.settings.traceOutDir) {
+        Group outGroup = withLayoutData(
+            createGroup(this, "Output", new GridLayout(2, false)),
+            new GridData(GridData.FILL_HORIZONTAL));
+        directoryLabel = createLabel(outGroup, "Output Directory*:");
+        directory = withLayoutData(new FileTextbox.Directory(outGroup, models.settings.traceOutDir) {
           @Override
           protected void configureDialog(DirectoryDialog dialog) {
             dialog.setText(Messages.CAPTURE_DIRECTORY);
           }
         }, new GridData(SWT.FILL, SWT.FILL, true, false));
 
-        fileLabel = createLabel(this, "File Name*:");
-        fileLabel.setForeground(getDisplay().getSystemColor(SWT.COLOR_RED));
-        file = withLayoutData(createTextbox(this, formatTraceName(friendlyName)),
+        fileLabel = createLabel(outGroup, "File Name*:");
+        file = withLayoutData(createTextbox(outGroup, formatTraceName(friendlyName)),
             new GridData(SWT.FILL, SWT.FILL, true, false));
 
-        createLabel(this, "");
         pcsWarning = withLayoutData(
             createLabel(this, "Warning: Pre-compiled shaders are not supported in the replay."),
             new GridData(SWT.FILL, SWT.FILL, true, false));
         pcsWarning.setForeground(getDisplay().getSystemColor(SWT.COLOR_DARK_YELLOW));
         pcsWarning.setVisible(!models.settings.traceDisablePcs);
 
-        createLabel(this, "");
+        requiredFieldMessage = withLayoutData(
+            createLabel(this, "Please fill out required information (labeled with *)."),
+            new GridData(SWT.FILL, SWT.FILL, true, false));
+        requiredFieldMessage.setForeground(getDisplay().getSystemColor(SWT.COLOR_RED));
+        requiredFieldMessage.setVisible(!this.isReady());
+
         Link adbWarning = withLayoutData(
             createLink(this, "Path to adb invalid/missing. " +
                 "To trace on Android, please fix it in the <a>preferences</a>.",
@@ -426,40 +431,29 @@ public class TracerDialog {
         adbWarning.setForeground(getDisplay().getSystemColor(SWT.COLOR_DARK_RED));
         adbWarning.setVisible(!models.settings.isAdbValid());
 
-        createLabel(this, "");
-        requiredFieldMessage = withLayoutData(
-            createLabel(this, "Please fill out required information (labeled with *)."),
-            new GridData(SWT.FILL, SWT.FILL, true, false));
-        requiredFieldMessage.setForeground(getDisplay().getSystemColor(SWT.COLOR_RED));
-        requiredFieldMessage.setVisible(!this.isReady());
-
         device.getCombo().addListener(
             SWT.Selection, e -> update(models.settings, getSelectedDevice()));
         api.getCombo().addListener(SWT.Selection, e -> update(models.settings, getSelectedApi()));
 
         Listener mecListener = e -> {
           TraceTypeCapabilities config = getSelectedApi();
-
-          if((!automaticTracing.getSelection() || frameInitial.getSelection() > 0) && config != null &&
-              config.getMidExecutionCaptureSupport() == Service.FeatureStatus.Experimental){
-                mecWarningLabel.setText(String.format(MEC_LABEL_WARNING, config.getApi()));
-                mecWarningLabel.requestLayout();
-          }
-          else{
+          boolean beginning = startType.getSelectionIndex() == 0;
+          if (!beginning && config != null &&
+              config.getMidExecutionCaptureSupport() == Service.FeatureStatus.Experimental) {
+            mecWarningLabel.setText(String.format(MEC_LABEL_WARNING, config.getApi()));
+          } else {
             mecWarningLabel.setText("");
-            mecWarningLabel.requestLayout();
           }
+          mecWarningLabel.requestLayout();
+
+          boolean startAtFrame = startType.getSelectionIndex() == 2;
+          startFrame.setVisible(startAtFrame);
         };
         api.getCombo().addListener(SWT.Selection, mecListener);
-        automaticTracing.addListener(SWT.Selection, mecListener);
-        frameInitial.addListener(SWT.Selection, mecListener);
+        startType.addListener(SWT.Selection, mecListener);
 
         disablePcs.addListener(
             SWT.Selection, e -> pcsWarning.setVisible(!disablePcs.getSelection()));
-
-        automaticTracing.addListener(SWT.Selection, e -> {
-          frameInitial.setEnabled(automaticTracing.getSelection());
-        });
 
         traceTarget.addBoxListener(SWT.Modify, e -> {
           userHasChangedTarget = true;
@@ -473,9 +467,7 @@ public class TracerDialog {
           }
         });
 
-        Listener filledListener = e -> colorFilledInput(widgets.theme);
-
-        this.addModifyListener(filledListener);
+        addModifyListener(e -> colorFilledInput(widgets.theme));
 
         updateDevicesDropDown(models.settings);
         colorFilledInput(widgets.theme);
@@ -542,16 +534,6 @@ public class TracerDialog {
         disablePcs.setEnabled(pcs);
         disablePcs.setSelection(pcs && settings.traceDisablePcs);
 
-        boolean mec = config != null &&
-            config.getMidExecutionCaptureSupport() != Service.FeatureStatus.NotSupported;
-
-        frameInitial.setEnabled(mec && !settings.traceInteractiveStart);
-        automaticTracing.setEnabled(mec);
-        automaticTracing.setSelection(mec && !settings.traceInteractiveStart);
-        if(!mec){
-          frameInitial.setSelection(0);
-        }
-
         boolean ext = config != null && config.getCanEnableUnsupportedExtensions();
         hideUnknownExtensions.setEnabled(ext);
         hideUnknownExtensions.setSelection(!ext || settings.traceHideUnknownExtensions);
@@ -559,9 +541,18 @@ public class TracerDialog {
         boolean isPerfetto = isPerfetto(config);
         withoutBuffering.setEnabled(!isPerfetto);
         withoutBuffering.setSelection(!isPerfetto && settings.traceWithoutBuffering);
-        frameCountLabel.setText(isPerfetto ? DURATION_LABEL : FRAMES_LABEL);
-        frameCountUnit.setText(isPerfetto ? DURATION_UNIT : FRAMES_UNIT);
-        frameCountUnit.requestLayout();
+        if (isPerfetto && startType.getItemCount() == 3) {
+          if (startType.getSelectionIndex() == 2) {
+            // Switch to manual if it was "start at frame x".
+            startType.select(1);
+          }
+          startType.remove(2);
+        } else if (!isPerfetto && startType.getItemCount() == 2) {
+          startType.add("Frame");
+        }
+        durationLabel.setText(isPerfetto ? DURATION_LABEL : FRAMES_LABEL);
+        durationUnit.setText(isPerfetto ? DURATION_UNIT : FRAMES_UNIT);
+        durationUnit.requestLayout();
 
         if (!userHasChangedOutputFile) {
           file.setText(formatTraceName(friendlyName));
@@ -689,7 +680,17 @@ public class TracerDialog {
         settings.traceApi = config.getApi();
         settings.traceUri = traceTarget.getText();
         settings.traceArguments = arguments.getText();
-        settings.traceFrameCount = frameCount.getSelection();
+        switch (startType.getSelectionIndex()) {
+          case 0: // Beginning
+            settings.traceStartAt = 0;
+            break;
+          case 1: // Manaul
+            settings.traceStartAt = -1;
+            break;
+          default: // Frame
+            settings.traceStartAt = startFrame.getSelection();
+        }
+        settings.traceDuration = duration.getSelection();
         settings.traceWithoutBuffering = withoutBuffering.getSelection();
         settings.traceHideUnknownExtensions = hideUnknownExtensions.getSelection();
         settings.traceOutDir = directory.getText();
@@ -701,7 +702,7 @@ public class TracerDialog {
             .addApis(config.getApi())
             .setUri(traceTarget.getText())
             .setAdditionalCommandLineArgs(arguments.getText())
-            .setFramesToCapture(frameCount.getSelection())
+            .setFramesToCapture(duration.getSelection())
             .setNoBuffer(withoutBuffering.getSelection())
             .setHideUnknownExtensions(hideUnknownExtensions.getSelection())
             .setServerLocalSavePath(output.getAbsolutePath());
@@ -715,12 +716,9 @@ public class TracerDialog {
           options.addAllEnvironment(splitEnv(envVars.getText()));
         }
         if (config.getMidExecutionCaptureSupport() != Service.FeatureStatus.NotSupported) {
-          settings.traceInteractiveStart = !automaticTracing.getSelection();
-          settings.traceMidExecution = (frameInitial.isEnabled() && frameInitial.getSelection() > 0) || !automaticTracing.getSelection();
-          options.setDeferStart(settings.traceInteractiveStart);
-          if(!settings.traceInteractiveStart){
-            settings.traceInitialFrameCount = frameInitial.getSelection();
-            options.setStartFrame(settings.traceInitialFrameCount);
+          options.setDeferStart(settings.traceStartAt != 0);
+          if (settings.traceStartAt > 0) {
+            options.setStartFrame(settings.traceStartAt);
           }
         }
         if (dev.config.getHasCache()) {
@@ -733,11 +731,11 @@ public class TracerDialog {
         }
 
         if (isPerfetto(config)) {
-          int duration = frameCount.getSelection() * 1000;
+          int durationMs = duration.getSelection() * 1000;
           // TODO: this isn't really unlimitted.
-          duration = (duration == 0) ? (int)MINUTES.toMillis(10) : duration;
+          durationMs = (durationMs == 0) ? (int)MINUTES.toMillis(10) : durationMs;
           options.setPerfettoConfig(PerfettoConfig.get().getConfig().toBuilder()
-              .setDurationMs(duration));
+              .setDurationMs(durationMs));
         }
 
         return new TraceRequest(output, options.build());

--- a/gapic/src/main/com/google/gapid/views/TracerDialog.java
+++ b/gapic/src/main/com/google/gapid/views/TracerDialog.java
@@ -246,6 +246,7 @@ public class TracerDialog {
       private static final String TRACE_EXTENSION = ".gfxtrace";
       private static final String PERFETTO_EXTENSION = ".perfetto";
       private static final DateFormat TRACE_DATE_FORMAT = new SimpleDateFormat("_yyyyMMdd_HHmm");
+      private static final String TARGET_LABEL = "Application";
       private static final String FRAMES_LABEL = "Stop After:";
       private static final String DURATION_LABEL = "Duration:";
       private static final String FRAMES_UNIT = "Frames (0 for manual)";
@@ -322,7 +323,7 @@ public class TracerDialog {
         Group appGroup  = withLayoutData(
             createGroup(this, "Application", new GridLayout(2, false)),
             new GridData(GridData.FILL_HORIZONTAL));
-        targetLabel = createLabel(appGroup, "Application*:");
+        targetLabel = createLabel(appGroup, TARGET_LABEL + ":");
         traceTarget = withLayoutData(new ActionTextbox(appGroup, models.settings.traceUri) {
           @Override
           protected String createAndShowDialog(String current) {
@@ -561,6 +562,10 @@ public class TracerDialog {
         boolean ext = config != null && config.getCanEnableUnsupportedExtensions();
         hideUnknownExtensions.setEnabled(ext);
         hideUnknownExtensions.setSelection(!ext || settings.traceHideUnknownExtensions);
+
+        boolean appRequired = config != null && config.getRequiresApplication();
+        targetLabel.setText(TARGET_LABEL + (appRequired ? "*:" : ":"));
+        targetLabel.requestLayout();
 
         boolean isPerfetto = isPerfetto(config);
         getShell().setText(

--- a/gapic/src/main/com/google/gapid/views/TracerDialog.java
+++ b/gapic/src/main/com/google/gapid/views/TracerDialog.java
@@ -203,7 +203,7 @@ public class TracerDialog {
 
     @Override
     public String getTitle() {
-      return Messages.CAPTURE_TRACE;
+      return Messages.CAPTURE_TRACE_GRAPHICS;
     }
 
     @Override
@@ -539,6 +539,8 @@ public class TracerDialog {
         hideUnknownExtensions.setSelection(!ext || settings.traceHideUnknownExtensions);
 
         boolean isPerfetto = isPerfetto(config);
+        getShell().setText(
+            isPerfetto ? Messages.CAPTURE_TRACE_PERFETTO : Messages.CAPTURE_TRACE_GRAPHICS);
         withoutBuffering.setEnabled(!isPerfetto);
         withoutBuffering.setSelection(!isPerfetto && settings.traceWithoutBuffering);
         if (isPerfetto && startType.getItemCount() == 3) {

--- a/gapic/src/main/com/google/gapid/views/TracerDialog.java
+++ b/gapic/src/main/com/google/gapid/views/TracerDialog.java
@@ -263,7 +263,6 @@ public class TracerDialog {
       private final Text arguments;
       private final Text cwd;
       private final Text envVars;
-      private final Label frameInitialLabel;
       private final Spinner frameInitial;
       private final Label frameCountLabel;
       private final Spinner frameCount;
@@ -355,7 +354,7 @@ public class TracerDialog {
             new GridData(SWT.FILL, SWT.FILL, true, false));
         envVars.setEnabled(false);
 
-        frameInitialLabel = createLabel(this, INITIAL_FRAMES_LABEL);
+        createLabel(this, INITIAL_FRAMES_LABEL);
         Composite frameInitialComposite =
             createComposite(this, withMargin(new GridLayout(3, false), 0, 0));
         automaticTracing = withLayoutData(

--- a/gapic/src/main/com/google/gapid/views/TracerDialog.java
+++ b/gapic/src/main/com/google/gapid/views/TracerDialog.java
@@ -393,12 +393,16 @@ public class TracerDialog {
             new GridData(GridData.FILL_HORIZONTAL));
         withoutBuffering = createCheckbox(
             optGroup, "Disable Buffering", models.settings.traceWithoutBuffering);
+        withoutBuffering.setEnabled(true);
         disablePcs = createCheckbox(
             optGroup, "Disable pre-compiled shaders", models.settings.traceDisablePcs);
+        disablePcs.setEnabled(false);
         clearCache = createCheckbox(
             optGroup, "Clear package cache", models.settings.traceClearCache);
+        clearCache.setEnabled(false);
         hideUnknownExtensions = createCheckbox(
             optGroup, "Hide Unknown Extensions", models.settings.traceHideUnknownExtensions);
+        hideUnknownExtensions.setEnabled(false);
 
         perfettoConfig = withLayoutData(
             createComposite(optGroup, withMargin(new GridLayout(2, false), 5, 0)),
@@ -411,10 +415,6 @@ public class TracerDialog {
           perfettoConfigLabel.requestLayout();
         });
         perfettoConfig.setVisible(false);
-
-
-        clearCache.setEnabled(false);
-        disablePcs.setEnabled(false);
 
         Group outGroup = withLayoutData(
             createGroup(this, "Output", new GridLayout(2, false)),

--- a/gapic/src/main/com/google/gapid/views/TracerDialog.java
+++ b/gapic/src/main/com/google/gapid/views/TracerDialog.java
@@ -440,7 +440,7 @@ public class TracerDialog {
             createLabel(this, "Please fill out required information (labeled with *)."),
             new GridData(SWT.FILL, SWT.FILL, true, false));
         requiredFieldMessage.setForeground(getDisplay().getSystemColor(SWT.COLOR_RED));
-        requiredFieldMessage.setVisible(!this.isReady());
+        requiredFieldMessage.setVisible(false);
 
         Link adbWarning = withLayoutData(
             createLink(this, "Path to adb invalid/missing. " +
@@ -493,6 +493,11 @@ public class TracerDialog {
       }
 
       private void colorFilledInput(Theme theme) {
+        if (devices == null) {
+          // Don't mark anything red, until the devices are loaded.
+          return;
+        }
+
         requiredFieldMessage.setVisible(!this.isReady());
         deviceLabel.setForeground(getSelectedDevice() == null ? theme.missingInput() : theme.filledInput());
         directoryLabel.setForeground(directory.getText().isEmpty() ? theme.missingInput() : theme.filledInput());

--- a/gapic/src/main/com/google/gapid/views/TracerDialog.java
+++ b/gapic/src/main/com/google/gapid/views/TracerDialog.java
@@ -558,6 +558,7 @@ public class TracerDialog {
         boolean pcs = config != null && config.getCanDisablePcs();
         disablePcs.setEnabled(pcs);
         disablePcs.setSelection(pcs && settings.traceDisablePcs);
+        pcsWarning.setVisible(pcs && !settings.traceDisablePcs);
 
         boolean ext = config != null && config.getCanEnableUnsupportedExtensions();
         hideUnknownExtensions.setEnabled(ext);

--- a/gapic/src/main/com/google/gapid/widgets/Widgets.java
+++ b/gapic/src/main/com/google/gapid/widgets/Widgets.java
@@ -527,8 +527,12 @@ public class Widgets {
   }
 
   public static Group createGroup(Composite parent, String text) {
+    return createGroup(parent, text, new FillLayout(SWT.VERTICAL));
+  }
+
+  public static Group createGroup(Composite parent, String text, Layout layout) {
     Group group = new Group(parent, SWT.NONE);
-    group.setLayout(new FillLayout(SWT.VERTICAL));
+    group.setLayout(layout);
     group.setText(text);
     group.setFont(JFaceResources.getFontRegistry().getBold(JFaceResources.DEFAULT_FONT));
     return group;


### PR DESCRIPTION
- reworks the tracing dialog to group things a bit more neatly
- reworks the duration selection to be more explicit
- adds a new (very basic) dialog to select various supported Perfetto features and generate the config based on the selection
- few small other trace dialog improvements

(NOTE: this means the `--perfetto` command line option is now ignored)