### PR TITLE
Allow to query perfetto capability on Q build.

### DIFF
--- a/core/os/android/adb/commands.go
+++ b/core/os/android/adb/commands.go
@@ -262,8 +262,8 @@ func (b *binding) SupportsPerfetto(ctx context.Context) bool {
 }
 
 func (b *binding) QueryPerfettoServiceState(ctx context.Context) (*device.PerfettoCapability, error) {
-	if b.Instance().GetConfiguration().GetOS().GetAPIVersion() <= 29 {
-		return &device.PerfettoCapability{}, log.Errf(ctx, nil, "Querying perfetto capability requires Android API > 29")
+	if b.Instance().GetConfiguration().GetOS().GetAPIVersion() < 29 {
+		return &device.PerfettoCapability{}, log.Errf(ctx, nil, "Querying perfetto capability requires Android API >= 29")
 	}
 	res, err := b.Shell("perfetto", "--query-raw", "|", "base64").Call(ctx)
 	if err != nil {


### PR DESCRIPTION
A requirement to make sure perfetto work properly for GPU profiling is to
cherry-pick certain patches to Q build such that the capabilities of perfetto
can be queried, hence loosing the requirement here. If a Q build device doesn't
support this functionality, that's fine as well becasue it will fail naturally
when attempting to decode the returned string.

BUG: #3086
Test: Tried on Q and R devices.