### PR TITLE
Expose Perfetto capability from gapis.

### DIFF
--- a/gapis/service/service.proto
+++ b/gapis/service/service.proto
@@ -1270,6 +1270,7 @@ message TraceTypeCapabilities {
   bool can_enable_unsupported_extensions = 4;
   // Does this trace require starting an application.
   bool requires_application = 6;
+  device.PerfettoCapability perfetto_capability = 7;
 }
 
 // GetTimestampsRequest is the request send to server to get the timestamps for

--- a/gapis/trace/android/trace.go
+++ b/gapis/trace/android/trace.go
@@ -105,7 +105,7 @@ func (t *androidTracer) TraceConfiguration(ctx context.Context) (*service.Device
 		apis = append(apis, tracer.VulkanTraceOptions())
 	}
 	if t.b.SupportsPerfetto(ctx) {
-		apis = append(apis, tracer.PerfettoTraceOptions())
+		apis = append(apis, tracer.PerfettoTraceOptions(t.b.Instance().GetConfiguration().GetPerfettoCapability()))
 	}
 
 	return &service.DeviceTraceConfiguration{

--- a/gapis/trace/desktop/ggp_trace.go
+++ b/gapis/trace/desktop/ggp_trace.go
@@ -74,7 +74,7 @@ func (t *GGPTracer) TraceConfiguration(ctx context.Context) (*service.DeviceTrac
 	}
 
 	if t.b.SupportsPerfetto(ctx) {
-		apis = append(apis, tracer.PerfettoTraceOptions())
+		apis = append(apis, tracer.PerfettoTraceOptions(t.b.Instance().GetConfiguration().GetPerfettoCapability()))
 	}
 
 	return &service.DeviceTraceConfiguration{

--- a/gapis/trace/desktop/trace.go
+++ b/gapis/trace/desktop/trace.go
@@ -65,7 +65,7 @@ func (t *DesktopTracer) TraceConfiguration(ctx context.Context) (*service.Device
 	}
 
 	if t.b.SupportsPerfetto(ctx) {
-		apis = append(apis, tracer.PerfettoTraceOptions())
+		apis = append(apis, tracer.PerfettoTraceOptions(t.b.Instance().GetConfiguration().GetPerfettoCapability()))
 	}
 
 	return &service.DeviceTraceConfiguration{

--- a/gapis/trace/tracer/BUILD.bazel
+++ b/gapis/trace/tracer/BUILD.bazel
@@ -25,6 +25,7 @@ go_library(
     deps = [
         "//core/app:go_default_library",
         "//core/event/task:go_default_library",
+        "//core/os/device:go_default_library",
         "//core/os/device/bind:go_default_library",
         "//gapii/client:go_default_library",
         "//gapis/service:go_default_library",

--- a/gapis/trace/tracer/default_api_trace_options.go
+++ b/gapis/trace/tracer/default_api_trace_options.go
@@ -15,6 +15,7 @@
 package tracer
 
 import (
+	"github.com/google/gapid/core/os/device"
 	"github.com/google/gapid/gapis/service"
 )
 
@@ -43,12 +44,13 @@ func GLESTraceOptions() *service.TraceTypeCapabilities {
 }
 
 // PerfettoTraceOptions returns the default trace options for Perfetto.
-func PerfettoTraceOptions() *service.TraceTypeCapabilities {
+func PerfettoTraceOptions(perfettoCapability *device.PerfettoCapability) *service.TraceTypeCapabilities {
 	return &service.TraceTypeCapabilities{
 		Type:                           service.TraceType_Perfetto,
 		CanDisablePcs:                  false,
 		MidExecutionCaptureSupport:     service.FeatureStatus_Supported,
 		CanEnableUnsupportedExtensions: false,
 		RequiresApplication:            false,
+		PerfettoCapability:             perfettoCapability,
 	}
 }


### PR DESCRIPTION
To build up proper selection UI, we need to expose Perfetto capability from
gapis. Currently we only advertize render stages and GPU counters capability.

BUG: #3086
Test: manually verified with counter producer