### PR TITLE
Fix the MEC crash related to unopened forward dependency

### DIFF
--- a/gapis/resolve/dependencygraph2/dependency_graph_builder.go
+++ b/gapis/resolve/dependencygraph2/dependency_graph_builder.go
@@ -123,9 +123,9 @@ func (b *dependencyGraphBuilder) OnEndCmd(ctx context.Context, cmdID api.CmdID, 
 
 	fragAcc := b.fragWatcher.OnEndCmd(ctx, cmdCtx)
 	memAcc := b.memWatcher.OnEndCmd(ctx, cmdCtx)
-	forwardAcc := b.forwardWatcher.OnEndCmd(ctx, cmdCtx)
+	accesses := b.forwardWatcher.OnEndCmd(ctx, cmdCtx)
 
-	b.graphBuilder.AddDependencies(ctx, fragAcc, memAcc, forwardAcc)
+	b.graphBuilder.AddDependencies(ctx, fragAcc, memAcc, accesses.nodeAccesses, accesses.isUnopened)
 
 	b.subCmdStack = b.subCmdStack[:0]
 }

--- a/gapis/resolve/dependencygraph2/forward.go
+++ b/gapis/resolve/dependencygraph2/forward.go
@@ -40,12 +40,17 @@ type ForwardAccess struct {
 	Mode         ForwardAccessMode
 }
 
+type Accesses struct {
+	nodeAccesses map[NodeID][]ForwardAccess
+	isUnopened   bool
+}
+
 type ForwardWatcher interface {
 	OpenForwardDependency(ctx context.Context, cmdCtx CmdContext, dependencyID interface{})
 	CloseForwardDependency(ctx context.Context, cmdCtx CmdContext, dependencyID interface{})
 	DropForwardDependency(ctx context.Context, cmdCtx CmdContext, dependencyID interface{})
 	OnBeginCmd(ctx context.Context, cmdCtx CmdContext)
-	OnEndCmd(ctx context.Context, cmdCtx CmdContext) map[NodeID][]ForwardAccess
+	OnEndCmd(ctx context.Context, cmdCtx CmdContext) Accesses
 	OnBeginSubCmd(ctx context.Context, cmdCtx CmdContext, subCmdCtx CmdContext)
 	OnEndSubCmd(ctx context.Context, cmdCtx CmdContext)
 }
@@ -54,6 +59,7 @@ type forwardWatcher struct {
 	openForwardDependencies map[interface{}]*ForwardNodes
 	forwardAccesses         []ForwardAccess
 	nodeAccesses            map[NodeID][]ForwardAccess
+	isUnopened              bool
 }
 
 func NewForwardWatcher() *forwardWatcher {
@@ -105,9 +111,9 @@ func (b *forwardWatcher) CloseForwardDependency(ctx context.Context, cmdCtx CmdC
 			Mode:         FORWARD_CLOSE,
 		})
 	} else {
+		b.isUnopened = true
 		log.D(ctx, "CloseForwardDependency: Forward dependency closed before being opened. DependencyID: %v, close node: %v", dependencyID, cmdCtx.nodeID)
 	}
-
 }
 
 func (b *forwardWatcher) DropForwardDependency(ctx context.Context, cmdCtx CmdContext, dependencyID interface{}) {
@@ -129,11 +135,15 @@ func (b *forwardWatcher) Flush(ctx context.Context, cmdCtx CmdContext) {
 	b.forwardAccesses = []ForwardAccess{}
 }
 func (b *forwardWatcher) OnBeginCmd(ctx context.Context, cmdCtx CmdContext) {}
-func (b *forwardWatcher) OnEndCmd(ctx context.Context, cmdCtx CmdContext) map[NodeID][]ForwardAccess {
+func (b *forwardWatcher) OnEndCmd(ctx context.Context, cmdCtx CmdContext) Accesses {
 	b.Flush(ctx, cmdCtx)
-	acc := b.nodeAccesses
+	acc := Accesses{
+		nodeAccesses: b.nodeAccesses,
+		isUnopened:   b.isUnopened,
+	}
 	b.nodeAccesses = make(map[NodeID][]ForwardAccess)
 	b.forwardAccesses = []ForwardAccess{}
+	b.isUnopened = false
 	return acc
 }
 func (b *forwardWatcher) OnBeginSubCmd(ctx context.Context, cmdCtx CmdContext, subCmdCtx CmdContext) {


### PR DESCRIPTION
During MEC we capture commands that are dependent on other commands(e.g VkUnmapMemory)
Normally they are discarded during DCE. But this may cause crash on the next command that
operates on the same resource. As the original command run during state reconstruction
the corresponding dependent command should also be kept alive and run