### PR TITLE
Fixes to the default device selection in the trace dialog.

### DIFF
--- a/gapic/src/main/com/google/gapid/models/Devices.java
+++ b/gapic/src/main/com/google/gapid/models/Devices.java
@@ -286,5 +286,9 @@ public class Devices {
       this.config = config;
       this.targets = targets;
     }
+
+    public boolean isAndroid() {
+      return device.getConfiguration().getOS().getKind() == Device.OSKind.Android;
+    }
   }
 }


### PR DESCRIPTION
The priorities are now:
1) The selected device from the most recent trace
2) If there's only one device, pick it
3) If there's only two devices, where one is Android and the other is not, select the Android device.