### PR TITLE
Reset command buffers that are changed during loop

### DIFF
--- a/gapis/api/vulkan/frame_loop.go
+++ b/gapis/api/vulkan/frame_loop.go
@@ -150,6 +150,12 @@ type frameLoop struct {
 	renderPassToDestroy map[VkRenderPass]bool
 	renderPassToCreate  map[VkRenderPass]bool
 
+	commandBufferAllocated   map[VkCommandBuffer]bool
+	commandBufferFreed       map[VkCommandBuffer]bool
+	commandBufferChanged     map[VkCommandBuffer]bool
+	commandBufferRecorded    map[VkCommandBuffer]bool // Command buffers recorded during loop.
+	commandBufferNotRecorded map[VkCommandBuffer]bool // Command buffers submitted but not recorded during loop.
+
 	loopCountPtr value.Pointer
 
 	frameNum uint32
@@ -242,6 +248,12 @@ func newFrameLoop(ctx context.Context, graphicsCapture *capture.GraphicsCapture,
 
 		renderPassToDestroy: make(map[VkRenderPass]bool),
 		renderPassToCreate:  make(map[VkRenderPass]bool),
+
+		commandBufferAllocated:   make(map[VkCommandBuffer]bool),
+		commandBufferFreed:       make(map[VkCommandBuffer]bool),
+		commandBufferChanged:     make(map[VkCommandBuffer]bool),
+		commandBufferRecorded:    make(map[VkCommandBuffer]bool),
+		commandBufferNotRecorded: make(map[VkCommandBuffer]bool),
 
 		loopTerminated:      false,
 		lastObservedCommand: api.CmdNoID,
@@ -756,14 +768,82 @@ func (f *frameLoop) buildStartEndStates(ctx context.Context, startState *api.Glo
 				f.renderPassToCreate[renderPass] = true
 			}
 
-			// TODO:  Recreate destroyed resources.
+		// Command Buffers
+		case *VkAllocateCommandBuffers:
+			vkCmd := cmd.(*VkAllocateCommandBuffers)
+			cmdBuffers := vkCmd.PCommandBuffers().MustRead(ctx, vkCmd, currentState, nil)
+			f.commandBufferAllocated[cmdBuffers] = true
+			log.D(ctx, "Command buffer %v allcoated.", cmdBuffers)
+		case *VkFreeCommandBuffers:
+			vkCmd := cmd.(*VkFreeCommandBuffers)
+			cmdBufCount := vkCmd.CommandBufferCount()
+			if cmdBufCount == 0 {
+				break
+			}
+			cmdBufs := vkCmd.PCommandBuffers().Slice(0, uint64(cmdBufCount), currentState.MemoryLayout).MustRead(ctx, cmd, currentState, nil)
+			for _, cmdBuf := range cmdBufs {
+				// The command buffer deleted in this call was created during loop, no action needed.
+				log.D(ctx, "Command buffer %v freed", cmdBufs)
+				if _, ok := f.commandBufferAllocated[cmdBuf]; ok {
+					delete(f.commandBufferAllocated, cmdBuf)
+				} else { // The command buffer deleted in this call was not created during loop, need to back up it
+					f.commandBufferFreed[cmdBuf] = true
+				}
+			}
+		case *VkBeginCommandBuffer:
+			vkCmd := cmd.(*VkBeginCommandBuffer)
+			cmdBuf := vkCmd.CommandBuffer()
+			f.commandBufferRecorded[cmdBuf] = true
+			log.D(ctx, "Command buffer %v beginned", cmdBuf)
+
+			// If this command buffer is allocated during loop then it is reset by the re-allocation step.
+			if _, ok := f.commandBufferAllocated[cmdBuf]; ok {
+				break
+			}
+			// If this command buffer has not been submitted before no action needed.
+			if _, ok := f.commandBufferNotRecorded[cmdBuf]; !ok {
+				break
+			}
+			// Only backup the fist time it changes
+			if _, ok := f.commandBufferChanged[cmdBuf]; !ok {
+				f.commandBufferChanged[cmdBuf] = true
+			}
+
+		case *VkResetCommandBuffer:
+			vkCmd := cmd.(*VkResetCommandBuffer)
+			cmdBuf := vkCmd.CommandBuffer()
+			log.D(ctx, "Command buffer %v resetted", cmdBuf)
+			// If this command buffer is allocated during loop then it is reset by the re-allocation step.
+			if _, ok := f.commandBufferAllocated[cmdBuf]; ok {
+				break
+			}
+			// If this command buffer has not been submitted before no action needed.
+			if _, ok := f.commandBufferNotRecorded[cmdBuf]; !ok {
+				break
+			}
+			// Only backup the fist time it changes
+			if _, ok := f.commandBufferChanged[cmdBuf]; !ok {
+				f.commandBufferChanged[cmdBuf] = true
+			}
+		case *VkQueueSubmit:
+			vkCmd := cmd.(*VkQueueSubmit)
+			vkCmd.Extras().Observations().ApplyReads(currentState.Memory.ApplicationPool())
+			submitCount := vkCmd.SubmitCount()
+			submitInfos := vkCmd.pSubmits.Slice(0, uint64(submitCount), currentState.MemoryLayout).MustRead(ctx, cmd, currentState, nil)
+			for i := uint32(0); i < submitCount; i++ {
+				si := submitInfos[i]
+				cmdBuffers := si.PCommandBuffers().Slice(0, uint64(si.CommandBufferCount()), currentState.MemoryLayout).MustRead(ctx, cmd, currentState, nil)
+				cmdCount := si.CommandBufferCount()
+				for j := uint32(0); j < cmdCount; j++ {
+					cmdBuf := cmdBuffers[j]
+					if _, ok := f.commandBufferRecorded[cmdBuf]; !ok {
+						f.commandBufferNotRecorded[cmdBuf] = true
+					}
+				}
+			}
 		}
 
-		if err := cmd.Mutate(ctx, cmdId, currentState, nil, f.watcher); err != nil {
-			return fmt.Errorf("%v: %v: %v", cmdId, cmd, err)
-		}
-
-		return nil
+		return cmd.Mutate(ctx, cmdId, currentState, nil, f.watcher)
 	})
 
 	if err != nil {
@@ -837,6 +917,10 @@ func (f *frameLoop) detectChangedImages(ctx context.Context) {
 
 		// We exempt the frame buffer (swap chain) images from capture.
 		if image.IsSwapchainImage() {
+			continue
+		}
+		// Skip multi-sampled images.
+		if image.Info().Samples() != VkSampleCountFlagBits_VK_SAMPLE_COUNT_1_BIT {
 			continue
 		}
 
@@ -1098,6 +1182,10 @@ func (f *frameLoop) resetResources(ctx context.Context, stateBuilder *stateBuild
 	}
 
 	if err := f.resetRenderPasses(ctx, stateBuilder); err != nil {
+		return err
+	}
+
+	if err := f.resetCommandBuffers(ctx, stateBuilder); err != nil {
 		return err
 	}
 
@@ -1614,6 +1702,112 @@ func (f *frameLoop) resetRenderPasses(ctx context.Context, stateBuilder *stateBu
 		renderPass := GetState(f.loopStartState).renderPasses.Get(toCreate)
 		stateBuilder.createRenderPass(renderPass)
 	}
+
+	return nil
+}
+
+func (f *frameLoop) resetCommandBuffers(ctx context.Context, stateBuilder *stateBuilder) error {
+
+	for cmdBuf := range f.commandBufferAllocated {
+		log.D(ctx, "Command buffer %v allocated during loop, free it.", cmdBuf)
+		cmdBufObj := GetState(f.loopEndState).CommandBuffers().Get(cmdBuf)
+		if cmdBufObj != NilCommandBufferObjectʳ {
+			stateBuilder.write(stateBuilder.cb.VkFreeCommandBuffers(
+				cmdBufObj.Device(),
+				cmdBufObj.Pool(),
+				1,
+				stateBuilder.MustAllocReadData(cmdBufObj.VulkanHandle()).Ptr(),
+			))
+		} else {
+			log.E(ctx, "Command buffer %v cannot be found in loop ending state", cmdBuf)
+		}
+	}
+
+	for cmdBuf := range f.commandBufferFreed {
+		cmdBufObj := GetState(f.loopStartState).CommandBuffers().Get(cmdBuf)
+		if cmdBufObj == NilCommandBufferObjectʳ {
+			log.E(ctx, "Command buffer %v can not be found in loop starting state", cmdBuf)
+			continue
+		}
+		log.D(ctx, "Command buffer %v freed during loop, recreate it.", cmdBuf)
+		// sb.createCommandBuffer(cmdBufObj, cmdBufObj.Level())
+		stateBuilder.write(stateBuilder.cb.VkAllocateCommandBuffers(
+			cmdBufObj.Device(),
+			stateBuilder.MustAllocReadData(NewVkCommandBufferAllocateInfo(stateBuilder.ta,
+				VkStructureType_VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO, // sType
+				0,                 // pNext
+				cmdBufObj.Pool(),  // commandPool
+				cmdBufObj.Level(), // level
+				1,                 // commandBufferCount
+			)).Ptr(),
+			stateBuilder.MustAllocWriteData(cmdBufObj.VulkanHandle()).Ptr(),
+			VkResult_VK_SUCCESS,
+		))
+
+		f.reRecordCommandBuffer(ctx, stateBuilder, cmdBufObj, cmdBuf)
+	}
+
+	for cmdBuf := range f.commandBufferChanged {
+		cmdBufObj := GetState(f.loopStartState).CommandBuffers().Get(cmdBuf)
+		if cmdBufObj == NilCommandBufferObjectʳ {
+			log.E(ctx, "Command buffer %v can not be found in loop starting state", cmdBuf)
+		}
+		log.D(ctx, "Command buffer %v changed during loop, re-record it.", cmdBuf)
+		if err := f.reRecordCommandBuffer(ctx, stateBuilder, cmdBufObj, cmdBuf); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (f *frameLoop) reRecordCommandBuffer(ctx context.Context, stateBuilder *stateBuilder, refCmdBuf CommandBufferObjectʳ, commandBufferID VkCommandBuffer) error {
+	beginInfo := NewVkCommandBufferBeginInfo(stateBuilder.ta,
+		VkStructureType_VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO, // sType
+		0, // pNext
+		VkCommandBufferUsageFlags(refCmdBuf.BeginInfo().Flags()), // flags
+		0, // pInheritanceInfo
+	)
+
+	if refCmdBuf.BeginInfo().Inherited() {
+		if refCmdBuf.BeginInfo().InheritedFramebuffer() != VkFramebuffer(0) &&
+			!GetState(f.loopStartState).Framebuffers().Contains(refCmdBuf.BeginInfo().InheritedFramebuffer()) {
+			return fmt.Errorf("Command Buffer %v is invalid, it will not be recorded: - Inherited framebuffer does not exist", refCmdBuf.VulkanHandle())
+		}
+
+		inheritanceInfo := stateBuilder.MustAllocReadData(NewVkCommandBufferInheritanceInfo(stateBuilder.ta,
+			VkStructureType_VK_STRUCTURE_TYPE_COMMAND_BUFFER_INHERITANCE_INFO, // sType
+			0, // pNext
+			refCmdBuf.BeginInfo().InheritedRenderPass(),         // renderPass
+			refCmdBuf.BeginInfo().InheritedSubpass(),            // subpass
+			refCmdBuf.BeginInfo().InheritedFramebuffer(),        // framebuffer
+			refCmdBuf.BeginInfo().InheritedOcclusionQuery(),     // occlusionQueryEnable
+			refCmdBuf.BeginInfo().InheritedQueryFlags(),         // queryFlags
+			refCmdBuf.BeginInfo().InheritedPipelineStatsFlags(), // pipelineStatistics
+		))
+		beginInfo.SetPInheritanceInfo(NewVkCommandBufferInheritanceInfoᶜᵖ(inheritanceInfo.Ptr()))
+	}
+
+	stateBuilder.write(stateBuilder.cb.VkBeginCommandBuffer(
+		refCmdBuf.VulkanHandle(),
+		stateBuilder.MustAllocReadData(beginInfo).Ptr(),
+		VkResult_VK_SUCCESS,
+	))
+
+	for i, c := uint32(0), uint32(refCmdBuf.CommandReferences().Len()); i < c; i++ {
+		arg := GetCommandArgs(stateBuilder.ctx, refCmdBuf.CommandReferences().Get(i), GetState(f.loopStartState))
+		cleanup, cmd, err := AddCommand(stateBuilder.ctx, stateBuilder.cb, refCmdBuf.VulkanHandle(), stateBuilder.newState, f.loopStartState, arg)
+		if err != nil {
+			return log.Errf(ctx, err, "Command Buffer %v is invalid, it will not be recorded", refCmdBuf.VulkanHandle())
+		}
+		stateBuilder.write(cmd)
+		cleanup()
+	}
+
+	stateBuilder.write(stateBuilder.cb.VkEndCommandBuffer(
+		refCmdBuf.VulkanHandle(),
+		VkResult_VK_SUCCESS,
+	))
 
 	return nil
 }

--- a/gapis/api/vulkan/state_rebuilder.go
+++ b/gapis/api/vulkan/state_rebuilder.go
@@ -267,10 +267,12 @@ func (API) RebuildState(ctx context.Context, oldState *api.GlobalState) ([]api.C
 
 	for _, qp := range s.CommandBuffers().Keys() {
 		sb.createCommandBuffer(s.CommandBuffers().Get(qp), VkCommandBufferLevel_VK_COMMAND_BUFFER_LEVEL_SECONDARY)
+		sb.recordCommandBuffer(s.CommandBuffers().Get(qp), VkCommandBufferLevel_VK_COMMAND_BUFFER_LEVEL_SECONDARY, sb.oldState)
 	}
 
 	for _, qp := range s.CommandBuffers().Keys() {
 		sb.createCommandBuffer(s.CommandBuffers().Get(qp), VkCommandBufferLevel_VK_COMMAND_BUFFER_LEVEL_PRIMARY)
+		sb.recordCommandBuffer(s.CommandBuffers().Get(qp), VkCommandBufferLevel_VK_COMMAND_BUFFER_LEVEL_SECONDARY, sb.oldState)
 	}
 
 	sb.scratchRes.Free(sb)
@@ -2768,6 +2770,13 @@ func (sb *stateBuilder) createCommandBuffer(cb CommandBufferObjectʳ, level VkCo
 		VkResult_VK_SUCCESS,
 	))
 
+}
+
+func (sb *stateBuilder) recordCommandBuffer(cb CommandBufferObjectʳ, level VkCommandBufferLevel, srcState *api.GlobalState) {
+	if cb.Level() != level {
+		return
+	}
+
 	if cb.Recording() == RecordingState_NOT_STARTED || cb.Recording() == RecordingState_TO_BE_RESET {
 		return
 	}
@@ -2807,8 +2816,8 @@ func (sb *stateBuilder) createCommandBuffer(cb CommandBufferObjectʳ, level VkCo
 	hasError := false
 	// fill command buffer
 	for i, c := uint32(0), uint32(cb.CommandReferences().Len()); i < c; i++ {
-		arg := GetCommandArgs(sb.ctx, cb.CommandReferences().Get(i), GetState(sb.oldState))
-		cleanup, cmd, err := AddCommand(sb.ctx, sb.cb, cb.VulkanHandle(), sb.oldState, sb.newState, arg)
+		arg := GetCommandArgs(sb.ctx, cb.CommandReferences().Get(i), GetState(srcState))
+		cleanup, cmd, err := AddCommand(sb.ctx, sb.cb, cb.VulkanHandle(), srcState, sb.newState, arg)
 		if err != nil {
 			log.W(sb.ctx, "Command Buffer %v is invalid, it will not be recorded: - %v", cb.VulkanHandle(), err)
 			hasError = true
@@ -2827,7 +2836,6 @@ func (sb *stateBuilder) createCommandBuffer(cb CommandBufferObjectʳ, level VkCo
 		))
 	}
 }
-
 func queueFamilyIndicesToU32Slice(m U32ːu32ᵐ) []uint32 {
 	r := make([]uint32, 0, m.Len())
 	for _, k := range m.Keys() {


### PR DESCRIPTION
Reset command buffers that are changed during loop:
1. Re-allocate if freed during loop;
2. Free if allocated during loop;
3. Re-record it if it was submitted and then being re-recorded during
loop.