### PR TITLE
Use the ro.debuggable property, not ro.build.type.

### DIFF
--- a/core/os/android/adb/bind.go
+++ b/core/os/android/adb/bind.go
@@ -30,8 +30,8 @@ type Device interface {
 	// Root restarts adb as root. If the device is running a production build then
 	// Root will return ErrDeviceNotRooted.
 	Root(ctx context.Context) error
-	// IsUserdebugBuild returns true if the device runs an Android userdebug build
-	IsUserdebugBuild(ctx context.Context) (bool, error)
+	// IsDebuggableBuild returns true if the device runs a debuggable Android build.
+	IsDebuggableBuild(ctx context.Context) (bool, error)
 	// Forward will forward the specified device Port to the specified local Port.
 	Forward(ctx context.Context, local, device Port) error
 	// RemoveForward removes a port forward made by Forward.

--- a/core/os/android/adb/commands.go
+++ b/core/os/android/adb/commands.go
@@ -91,13 +91,13 @@ retry:
 	return log.Err(ctx, ErrRootFailed, buf.String())
 }
 
-// IsUserdebugBuild returns true if the device runs an Android userdebug build
-func (b *binding) IsUserdebugBuild(ctx context.Context) (bool, error) {
-	output, err := b.Command("shell", "getprop", "ro.build.type").Call(ctx)
+// IsDebuggableBuild returns true if the device runs a debuggable Android build.
+func (b *binding) IsDebuggableBuild(ctx context.Context) (bool, error) {
+	output, err := b.Command("shell", "getprop", "ro.debuggable").Call(ctx)
 	if err != nil {
 		return false, err
 	}
-	return (output == "userdebug"), nil
+	return output == "1", nil
 }
 
 // InstallAPK installs the specified APK to the device. If reinstall is true

--- a/gapidapk/packageinfo.go
+++ b/gapidapk/packageinfo.go
@@ -48,7 +48,7 @@ func PackageList(ctx context.Context, d adb.Device, includeIcons bool, iconDensi
 
 	// Can only capture debug application unless Android build is userdebug and adb root works
 	onlyDebug := true
-	isUserdebugBuild, err := d.IsUserdebugBuild(ctx)
+	isUserdebugBuild, err := d.IsDebuggableBuild(ctx)
 	if err != nil {
 		return nil, log.Err(ctx, err, "Failed to check Android build type")
 	}


### PR DESCRIPTION
ro.debuggable is the correct property to check if a build is debuggable, rather than trying to infer it from the build type. For example, "eng" is another build type that is debuggable.