### PR TITLE
Filter out GPU counter tracks with no values.

### DIFF
--- a/gapic/src/main/com/google/gapid/perfetto/models/CounterInfo.java
+++ b/gapic/src/main/com/google/gapid/perfetto/models/CounterInfo.java
@@ -23,7 +23,7 @@ import com.google.gapid.models.Perfetto;
 
 public class CounterInfo {
   private static final String LIST_SQL =
-      "select counter_id, name, ref, ref_type, description, count(1)," +
+      "select counter_id, name, ref, ref_type, description, count(value)," +
       " min(value), max(value), avg(value) " +
       "from counter_definitions left join counter_values using (counter_id) " +
       "group by counter_id";

--- a/gapic/src/main/com/google/gapid/perfetto/models/Tracks.java
+++ b/gapic/src/main/com/google/gapid/perfetto/models/Tracks.java
@@ -98,7 +98,7 @@ public class Tracks {
     }
 
     for (CounterInfo counter : data.getCounters().values()) {
-      if ("gpu".equals(counter.refType)) {
+      if ("gpu".equals(counter.refType) && counter.count > 0) {
         if (!found) {
           addGpuGroup(data);
           found = true;


### PR DESCRIPTION
The counter definition records are created, even if a counter was not selected.