### PR TITLE
Make sure the VirtualSwapchain layer is loaded only once in a replay

### DIFF
--- a/gapis/api/templates/vulkan_gfx_api_extras.tmpl
+++ b/gapis/api/templates/vulkan_gfx_api_extras.tmpl
@@ -106,12 +106,15 @@ bool Vulkan::replayCreateVkInstanceImpl(Stack* stack,
                                       pCreateInfo->ppEnabledExtensionNames +
                                           pCreateInfo->enabledExtensionCount);
   extensions.reserve(pCreateInfo->enabledExtensionCount + 1);
-  // Drop the GraphicsSpy layer and validation layers if requested.
+  // Drop the GraphicsSpy and VirtualSwapchain layers, plus validation layers if requested.
   layers.erase(
       std::remove_if(
           layers.begin(), layers.end(),
           [dropValidationLayersAndDebugReport](const char* layer) -> bool {
             if (strcmp(kGraphicsSpyLayerName, layer) == 0) {
+              return true;
+            }
+            if (strcmp(kVirtualSwapchainLayerName, layer) == 0) {
               return true;
             }
             if (dropValidationLayersAndDebugReport) {


### PR DESCRIPTION
Gapir systematically loads the VirtualSwapchain layer as the last
layer. A trace may list the VirtualSwapchain layer as a required
layer (e.g., the trace of a replay would.) To avoid loading the
VirtualSwapchain layer twice, we remove it from the list of layers
requested by the trace.