### PR TITLE
Empty tabs

### DIFF
--- a/cmd/gapit/dump_pipeline.go
+++ b/cmd/gapit/dump_pipeline.go
@@ -19,8 +19,6 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	"strconv"
-	"strings"
 	"text/tabwriter"
 
 	"github.com/google/gapid/core/app"
@@ -70,7 +68,7 @@ func (verb *pipeVerb) Run(ctx context.Context, flags flag.FlagSet) error {
 		return log.Err(ctx, err, "Failed to get bound pipeline resource data")
 	}
 
-	return verb.printPipelineData(ctx, client, pipelineData)
+	return verb.printPipelineData(ctx, client, pipelineData, "")
 }
 
 func (verb *pipeVerb) getBoundPipelineResource(ctx context.Context, c client.Client, cmd *path.Command) (*api.Pipeline, error) {
@@ -79,9 +77,9 @@ func (verb *pipeVerb) getBoundPipelineResource(ctx context.Context, c client.Cli
 		return nil, err
 	}
 
-	targetType := api.Pipeline_GRAPHICS
+	targetType := "Graphics Pipeline"
 	if verb.Compute {
-		targetType = api.Pipeline_COMPUTE
+		targetType = "Compute Pipeline"
 	}
 
 	resources := boxedResources.(*service.Resources)
@@ -97,7 +95,7 @@ func (verb *pipeVerb) getBoundPipelineResource(ctx context.Context, c client.Cli
 			}
 			resourceData := boxedResourceData.(*api.ResourceData)
 			pipelineData := protoutil.OneOf(protoutil.OneOf(resourceData)).(*api.Pipeline)
-			if pipelineData.Bound && pipelineData.Type == targetType {
+			if pipelineData.Bound && pipelineData.PipelineType == targetType {
 				return pipelineData, nil
 			}
 		}
@@ -105,82 +103,22 @@ func (verb *pipeVerb) getBoundPipelineResource(ctx context.Context, c client.Cli
 	return nil, fmt.Errorf("No bound %v pipeline found", targetType)
 }
 
-func (verb *pipeVerb) printPipelineData(ctx context.Context, c client.Client, data *api.Pipeline) error {
-	// Get the names for descriptor types and image layouts
-	typeNames, err := getConstantSetMap(ctx, c, data.API, data.BindingTypeConstantsIndex)
-	if err != nil {
-		return err
-	}
-	layoutNames, err := getConstantSetMap(ctx, c, data.API, data.ImageLayoutConstantsIndex)
-	if err != nil {
-		return err
-	}
+func (verb *pipeVerb) printPipelineData(ctx context.Context, c client.Client, data *api.Pipeline, prefix string) error {
 	w := tabwriter.NewWriter(os.Stdout, 4, 4, 0, ' ', 0)
 	defer w.Flush()
 
-	if verb.Print.Shaders {
-		fmt.Fprintf(w, "%v shader stages:\n", len(data.Stages))
-		for _, stage := range data.Stages {
-			fmt.Fprintf(w, "\t%v stage:\n", stage.Type)
-			fmt.Fprintf(w, "%v\n", stage.Shader.Source)
-		}
-	}
-	fmt.Fprintf(w, "%v bindings:\n", len(data.Bindings))
-	for _, binding := range data.Bindings {
-		fmt.Fprintf(w, "Binding #%v.%v:\n", binding.Set, binding.Binding)
-		typeName, ok := typeNames[binding.Type]
-		if !ok {
-			typeName = strconv.FormatUint(uint64(binding.Type), 10)
-		}
-		fmt.Fprintf(w, "\tType: \t%v\n", typeName)
-		stageTypes := make([]api.StageType, len(binding.StageIdxs))
-		for i, idx := range binding.StageIdxs {
-			stageTypes[i] = data.Stages[idx].Type
-		}
-		if len(stageTypes) > 0 {
-			fmt.Fprintf(w, "\tUsed by stages: \t%v\n", strings.Trim(fmt.Sprint(stageTypes), "[]"))
-		} else {
-			fmt.Fprintf(w, "\tUnused by pipeline\n")
-		}
-		if len(binding.Values) > 1 {
-			fmt.Fprintf(w, "\tBound values:\n")
-		}
-		for i, val := range binding.Values {
-			var valueType string
-			switch protoutil.OneOf(val).(type) {
-			case *api.BindingValue_Unbound:
-				valueType = "Unbound"
-			case *api.BindingValue_ImageInfo:
-				valueType = "Image"
-			case *api.BindingValue_BufferInfo:
-				valueType = "Buffer"
-			case *api.BindingValue_TexelBufferView:
-				valueType = "Texel Buffer View"
-			}
-			if len(binding.Values) > 1 {
-				fmt.Fprintf(w, "\t%v: %v\n", i, valueType)
-			} else {
-				fmt.Fprintf(w, "\tBound value: %v\n", valueType)
-			}
-			switch v := protoutil.OneOf(val).(type) {
-			case *api.BindingValue_ImageInfo:
-				fmt.Fprintf(w, "\t\tSampler: \t%v\n", v.ImageInfo.Sampler)
-				fmt.Fprintf(w, "\t\tImage View: \t%v\n", v.ImageInfo.ImageView)
-				layoutName, ok := layoutNames[v.ImageInfo.ImageLayout]
-				if !ok {
-					layoutName = strconv.FormatUint(uint64(v.ImageInfo.ImageLayout), 10)
-				}
-				fmt.Fprintf(w, "\t\tImage Layout: \t%v\n", layoutName)
-			case *api.BindingValue_BufferInfo:
-				fmt.Fprintf(w, "\t\tHandle: \t%v\n", v.BufferInfo.Buffer)
-				fmt.Fprintf(w, "\t\tOffset: \t%v\n", v.BufferInfo.Offset)
-				fmt.Fprintf(w, "\t\tRange: \t%v\n", v.BufferInfo.Range)
-			case *api.BindingValue_TexelBufferView:
-				fmt.Fprintf(w, "\t\tBuffer View: \t%v\n", v.TexelBufferView)
-			}
-		}
+	fmt.Fprintf(w, "%s├── %s: \n", prefix, data.PipelineType)
 
+	prefix = prefix + "│   "
+
+	for i, stage := range data.Stages {
+		if i == len(data.Stages)-1 {
+			fmt.Fprintf(w, "%s└── %s: \n", prefix, stage.StageName)
+		} else {
+			fmt.Fprintf(w, "%s├── %s: \n", prefix, stage.StageName)
+		}
 	}
+
 	return nil
 }
 

--- a/gapic/src/main/com/google/gapid/GraphicsTraceView.java
+++ b/gapic/src/main/com/google/gapid/GraphicsTraceView.java
@@ -27,6 +27,7 @@ import com.google.gapid.proto.service.path.Path;
 import com.google.gapid.views.CommandTree;
 import com.google.gapid.views.ContextSelector;
 import com.google.gapid.views.FramebufferView;
+import com.google.gapid.views.PipelineView;
 import com.google.gapid.views.GeometryView;
 import com.google.gapid.views.LogView;
 import com.google.gapid.views.MemoryView;
@@ -361,6 +362,7 @@ public class GraphicsTraceView extends Composite implements MainWindow.MainView 
       ApiCalls(View.Commands, "Commands", CommandTree::new),
 
       Framebuffer(View.Framebuffer, "Framebuffer", FramebufferView::new),
+      Pipeline(View.Pipeline, "Pipeline", PipelineView::new),
       Textures(View.Textures, "Textures", TextureView::new),
       Geometry(View.Geometry, "Geometry", GeometryView::new),
       Shaders(View.Shaders, "Shaders", ShaderView::new),

--- a/gapic/src/main/com/google/gapid/models/Analytics.java
+++ b/gapic/src/main/com/google/gapid/models/Analytics.java
@@ -34,7 +34,7 @@ public class Analytics implements ExceptionHandler {
     Main, FilmStrip, LeftTabs, RightTabs,
     About, GotoCommand, GotoMemory, Licenses, Settings, Trace, Welcome,
     // See MainWindow.MainTab.Type
-    Commands, Framebuffer, Textures, Geometry, Shaders, Report, Log, State, Memory,
+    Commands, Framebuffer, Pipeline, Textures, Geometry, Shaders, Report, Log, State, Memory,
     ContextSelector, ReplayDeviceSelector;
   }
 

--- a/gapic/src/main/com/google/gapid/models/Settings.java
+++ b/gapic/src/main/com/google/gapid/models/Settings.java
@@ -67,6 +67,7 @@ public class Settings {
   public int[] reportSplitterWeights = new int[] { 75, 25 };
   public int[] shaderTreeSplitterWeights = new int[] { 20, 80 };
   public int[] texturesSplitterWeights = new int[] { 20, 80 };
+  public int[] pipelineSplitterWeights = new int[] { 20, 80 };
   public String traceDevice = "";
   public String traceType = "Graphics";
   public String traceApi = "";

--- a/gapic/src/main/com/google/gapid/views/PipelineView.java
+++ b/gapic/src/main/com/google/gapid/views/PipelineView.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright (C) 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.gapid.views;
+
+import static com.google.gapid.proto.service.api.API.ResourceType.PipelineResource;
+import static com.google.gapid.util.Loadable.MessageType.Error;
+import static com.google.gapid.util.Loadable.MessageType.Info;
+import static com.google.gapid.widgets.Widgets.createComposite;
+import static com.google.gapid.widgets.Widgets.createTextarea;
+import static com.google.gapid.widgets.Widgets.createStandardTabFolder;
+import static com.google.gapid.widgets.Widgets.createStandardTabItem;
+import static com.google.gapid.widgets.Widgets.disposeAllChildren;
+import static java.util.logging.Level.FINE;
+
+import com.google.gapid.models.Models;
+import com.google.gapid.models.Resources;
+import com.google.gapid.models.Capture;
+import com.google.gapid.models.CommandStream;
+import com.google.gapid.models.CommandStream.CommandIndex;
+import com.google.gapid.proto.service.Service;
+import com.google.gapid.proto.service.api.API;
+import com.google.gapid.rpc.Rpc;
+import com.google.gapid.rpc.RpcException;
+import com.google.gapid.rpc.SingleInFlight;
+import com.google.gapid.rpc.UiCallback;
+import com.google.gapid.util.Loadable;
+import com.google.gapid.util.Messages;
+import com.google.gapid.widgets.LoadablePanel;
+import com.google.gapid.widgets.Widgets;
+
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.widgets.TabFolder;
+import org.eclipse.swt.widgets.TabItem;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Control;
+import org.eclipse.swt.widgets.Text;
+import org.eclipse.swt.layout.FillLayout;
+
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.logging.Logger;
+
+/**
+ * View the displays the information for each stage of the pipeline.
+ */
+public class PipelineView extends Composite
+    implements Tab, Capture.Listener, Resources.Listener, CommandStream.Listener {
+  protected static final Logger LOG = Logger.getLogger(ShaderView.class.getName());
+
+  private List<Data> pipelines;
+  private Models models;
+  private Widgets widgets;
+
+  private final LoadablePanel<Composite> loading;
+  private TabFolder folder;
+
+  public PipelineView(Composite parent, Models models, Widgets widgets) {
+    super(parent, SWT.NONE);
+    this.models = models;
+    this.widgets = widgets;
+
+    setLayout(new FillLayout());
+
+    loading = LoadablePanel.create(this, widgets,
+        panel -> createComposite(panel, new FillLayout(SWT.VERTICAL)));
+
+    models.resources.addListener(this);
+    models.commands.addListener(this);
+    addListener(SWT.Dispose, e -> {
+      models.resources.removeListener(this);
+      models.commands.removeListener(this);
+    });
+  }
+
+  @Override
+  public void reinitialize() {
+    updatePipelines();
+  }
+
+  @Override
+  public void onCaptureLoadingStart(boolean maintainState) {
+    loading.showMessage(Info, Messages.LOADING_CAPTURE);
+  }
+
+  @Override
+  public void onCaptureLoaded(Loadable.Message error) {
+    if (error != null) {
+      loading.showMessage(Error, Messages.CAPTURE_LOAD_FAILURE);
+    }
+  }
+
+  @Override
+  public void onResourcesLoaded() {
+ 
+  }
+
+  @Override
+  public void onCommandsLoaded() {
+    if (!models.commands.isLoaded()) {
+      loading.showMessage(Info, Messages.CAPTURE_LOAD_FAILURE);
+    } else {
+      loading.stopLoading();
+    }
+  }
+
+  @Override
+  public void onCommandsSelected(CommandIndex path) {
+    updatePipelines();
+  }
+
+
+  public void updatePipelines() {
+    disposeAllChildren(loading.getContents());
+    folder = createStandardTabFolder(loading.getContents());
+
+    Resources.ResourceList resources = models.resources.getResources(API.ResourceType.PipelineResource);
+
+    if (!resources.isEmpty()) {
+      resources.stream()
+        .map(r -> new Data(r.resource))
+        .forEach(data -> {
+          getPipeline(data, folder);
+        });
+    }
+    
+    loading.getContents().requestLayout();
+  }
+
+  public void getPipeline(Data data, TabFolder folder) {
+    Rpc.listen(models.resources.loadResource(data.info),
+        new UiCallback<API.ResourceData, API.Pipeline>(this, LOG) {
+      @Override
+      protected API.Pipeline onRpcThread(Rpc.Result<API.ResourceData> result)
+          throws RpcException, ExecutionException {
+        API.Pipeline pipeline = result.get().getPipeline();
+        data.resource = pipeline;
+        return pipeline;
+      }
+
+      @Override
+      protected void onUiThread(API.Pipeline result) {
+        if (result.getBound()) {
+          List<API.Stage> stages = result.getStagesList();
+
+          for (API.Stage stage : stages) {
+            createStandardTabItem(folder, stage.getDebugName());
+          }
+        }
+      }
+    });
+  }
+
+  @Override
+  public Control getControl() {
+    return this;
+  }
+
+  private static class Data {
+    public final Service.Resource info;
+    public Object resource;
+
+    public Data(Service.Resource info) {
+      this.info = info;
+    }
+
+    public String getId() {
+      return info.getHandle();
+    }
+
+    public long getSortId() {
+      return info.getOrder();
+    }
+
+    public String getLabel() {
+      return info.getLabel();
+    }
+  }
+}

--- a/gapis/api/service.go
+++ b/gapis/api/service.go
@@ -16,7 +16,6 @@ package api
 
 import (
 	"fmt"
-	"strings"
 )
 
 // IsColor returns true if a is a color attachment.
@@ -53,14 +52,6 @@ func (a AspectType) Format(f fmt.State, c rune) {
 	default:
 		fmt.Fprintf(f, "Unknown AspectType %d", int(a))
 	}
-}
-
-func (t Pipeline_Type) Format(f fmt.State, c rune) {
-	fmt.Fprint(f, strings.Title(strings.ToLower(t.String())))
-}
-
-func (t StageType) Format(f fmt.State, c rune) {
-	fmt.Fprint(f, strings.Title(strings.ToLower(t.String())))
 }
 
 func (x ShaderType) Extension() string {

--- a/gapis/api/service.proto
+++ b/gapis/api/service.proto
@@ -237,44 +237,19 @@ message CubemapArray {
 message Pipeline {
   // The API ID used for this pipeline belongs to.
   path.API API = 1;
-  // PipelineType is the possible types for a pipeline.
-  enum Type {
-    GRAPHICS = 0;
-    COMPUTE = 1;
-  }
   // Whether this pipeline is a graphics or compute pipeline
-  Type type = 2;
+  string pipeline_type = 2;
+  string debug_name = 3;
   // The bound programmable stages of the pipeline.
-  repeated Stage stages = 3;
-  // The descriptor bindings used by the shaders in this pipeline.
-  repeated DescriptorBinding bindings = 4;
+  repeated Stage stages = 4;
   // Whether this pipeline is currently bound
   bool bound = 5;
-  // The index to get the constants names for `DescriptorBinding.type`, to be
-  // fetched with the path.ConstantSet endpoint.  A value of -1 indicates no
-  // type names should be fetched.
-  int32 binding_type_constants_index = 6;
-  // The index to get the constants names for `ImageInfo.layout`, to be
-  // fetched with the path.ConstantSet endpoint.  A value of -1 indicates no
-  // layout names should be fetched.
-  int32 image_layout_constants_index = 7;
-}
-
-// StageType is all bindable pipeline stage points.
-enum StageType {
-  UNKNOWN = 0;
-  VERTEX = 1;
-  TESSELLATION_CONTROL = 2;
-  TESSELLATION_EVALUATION = 3;
-  GEOMETRY = 4;
-  FRAGMENT = 5;
-  COMPUTE = 6;
 }
 
 // Stage represents a single stage in a pipeline.
 message Stage {
-  StageType type = 1;
-  Shader shader = 2;
+  string stage_name = 1;
+  string debug_name = 2;
 }
 
 // DescriptorBinding represents one descriptor binding in a pipeline.

--- a/gapis/api/vulkan/BUILD.bazel
+++ b/gapis/api/vulkan/BUILD.bazel
@@ -109,7 +109,6 @@ go_library(
         "//core/data/id:go_default_library",
         #TODO: remove protoconv when it's supplied by deps
         "//core/data/protoconv:go_default_library",  # keep
-        "//core/data/protoutil:go_default_library",
         "//core/event/task:go_default_library",  # keep
         "//core/image:go_default_library",
         "//core/image/astc:go_default_library",

--- a/gapis/api/vulkan/resources.go
+++ b/gapis/api/vulkan/resources.go
@@ -18,10 +18,8 @@ import (
 	"context"
 	"encoding/binary"
 	"fmt"
-	"sort"
 
 	"github.com/google/gapid/core/data/id"
-	"github.com/google/gapid/core/data/protoutil"
 	"github.com/google/gapid/core/image"
 	"github.com/google/gapid/core/image/astc"
 	"github.com/google/gapid/core/log"
@@ -1002,7 +1000,6 @@ func (p GraphicsPipelineObjectʳ) ResourceType(ctx context.Context) api.Resource
 func (p GraphicsPipelineObjectʳ) ResourceData(ctx context.Context, s *api.GlobalState) (*api.ResourceData, error) {
 	vkState := GetState(s)
 	isBound := false
-	var boundDsets map[uint32]DescriptorSetObjectʳ
 	// Use LastDrawInfos to get bound descriptor set data.
 	// TODO: Ideally we could look at just a specific pipeline/descriptor
 	// set pair.  Maybe we could modify mutate to track which what
@@ -1012,15 +1009,63 @@ func (p GraphicsPipelineObjectʳ) ResourceData(ctx context.Context, s *api.Globa
 		if ok {
 			if ldi.GraphicsPipeline() == p {
 				isBound = true
-				// It doesn't make sense to get the descriptor
-				// sets if the pipeline isn't currently bound.
-				boundDsets = ldi.DescriptorSets().All()
 			}
 		}
 	}
 
-	return pipelineResourceData(ctx, s, p.Stages().All(), p.Layout(),
-		boundDsets, isBound, api.Pipeline_GRAPHICS)
+	stages := []*api.Stage{
+		&api.Stage{
+			StageName: "Input Assembly",
+			DebugName: "IA",
+		},
+
+		&api.Stage{
+			StageName: "Vertex Shader",
+			DebugName: "VS",
+		},
+
+		&api.Stage{
+			StageName: "Tessellation Control Shader",
+			DebugName: "TCS",
+		},
+
+		&api.Stage{
+			StageName: "Tessellation Evaluation Shader",
+			DebugName: "TES",
+		},
+
+		&api.Stage{
+			StageName: "Geometry Shader",
+			DebugName: "GS",
+		},
+
+		&api.Stage{
+			StageName: "Rasterizer",
+			DebugName: "RAST",
+		},
+
+		&api.Stage{
+			StageName: "Fragment Shader",
+			DebugName: "FS",
+		},
+
+		&api.Stage{
+			StageName: "Color Blending",
+			DebugName: "BLEND",
+		},
+	}
+
+	return &api.ResourceData{
+		Data: &api.ResourceData_Pipeline{
+			Pipeline: &api.Pipeline{
+				API:          path.NewAPI(id.ID(ID)),
+				PipelineType: "Graphics Pipeline",
+				DebugName:    "Graph",
+				Stages:       stages,
+				Bound:        isBound,
+			},
+		},
+	}, nil
 }
 
 // SetResourceData sets resource data in a new capture.
@@ -1071,7 +1116,6 @@ func (p ComputePipelineObjectʳ) ResourceType(ctx context.Context) api.ResourceT
 func (p ComputePipelineObjectʳ) ResourceData(ctx context.Context, s *api.GlobalState) (*api.ResourceData, error) {
 	vkState := GetState(s)
 	isBound := false
-	var boundDsets map[uint32]DescriptorSetObjectʳ
 	// Use LastComputeInfos to get bound descriptor set data.
 	// TODO: Ideally we could look at just a specific pipeline/descriptor
 	// set pair.  Maybe we could modify mutate to track which what
@@ -1081,16 +1125,28 @@ func (p ComputePipelineObjectʳ) ResourceData(ctx context.Context, s *api.Global
 		if ok {
 			if lci.ComputePipeline() == p {
 				isBound = true
-				// It doesn't make sense to get the descriptor
-				// sets if the pipeline isn't currently bound.
-				boundDsets = lci.DescriptorSets().All()
 			}
 		}
 	}
 
-	return pipelineResourceData(ctx, s, map[uint32]StageData{
-		0: p.Stage(),
-	}, p.PipelineLayout(), boundDsets, isBound, api.Pipeline_COMPUTE)
+	stages := []*api.Stage{
+		&api.Stage{
+			StageName: "Compute Shader",
+			DebugName: "CS",
+		},
+	}
+
+	return &api.ResourceData{
+		Data: &api.ResourceData_Pipeline{
+			Pipeline: &api.Pipeline{
+				API:          path.NewAPI(id.ID(ID)),
+				PipelineType: "Compute Pipeline",
+				DebugName:    "COMP",
+				Stages:       stages,
+				Bound:        isBound,
+			},
+		},
+	}, nil
 }
 
 // SetResourceData sets resource data in a new capture.
@@ -1105,22 +1161,22 @@ func (p ComputePipelineObjectʳ) SetResourceData(
 	return fmt.Errorf("SetResourceData is not supported on ComputePipeline")
 }
 
-func stageType(vkStage VkShaderStageFlagBits) (api.StageType, error) {
+func stageType(vkStage VkShaderStageFlagBits) (string, error) {
 	switch vkStage {
 	case VkShaderStageFlagBits_VK_SHADER_STAGE_VERTEX_BIT:
-		return api.StageType_VERTEX, nil
+		return "Vertex", nil
 	case VkShaderStageFlagBits_VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT:
-		return api.StageType_TESSELLATION_CONTROL, nil
+		return "Tessellation Control", nil
 	case VkShaderStageFlagBits_VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT:
-		return api.StageType_TESSELLATION_EVALUATION, nil
+		return "Tessellation Evaluation", nil
 	case VkShaderStageFlagBits_VK_SHADER_STAGE_GEOMETRY_BIT:
-		return api.StageType_GEOMETRY, nil
+		return "Geometry", nil
 	case VkShaderStageFlagBits_VK_SHADER_STAGE_FRAGMENT_BIT:
-		return api.StageType_FRAGMENT, nil
+		return "Fragment", nil
 	case VkShaderStageFlagBits_VK_SHADER_STAGE_COMPUTE_BIT:
-		return api.StageType_COMPUTE, nil
+		return "Compute", nil
 	default:
-		return 0, fmt.Errorf("Invalid Vulkan stage: %v", vkStage)
+		return "", fmt.Errorf("Invalid Vulkan stage: %v", vkStage)
 	}
 }
 
@@ -1169,162 +1225,29 @@ func pipelineResourceData(ctx context.Context,
 	layout PipelineLayoutObjectʳ,
 	boundDsets map[uint32]DescriptorSetObjectʳ,
 	bound bool,
-	pipeType api.Pipeline_Type,
+	pipeType string,
+	debugName string,
 ) (*api.ResourceData, error) {
-	bindings := map[bindIdx]*api.DescriptorBinding{}
-	// Enumerate the bindings from the pipeline layout
-	for set, setData := range layout.SetLayouts().All() {
-		for binding, bindingData := range setData.Bindings().All() {
-			values := make([]*api.BindingValue, bindingData.Count())
-			for i := range values {
-				values[i] = &api.BindingValue{
-					Val: &api.BindingValue_Unbound{
-						Unbound: &api.Unbound{},
-					},
-				}
-			}
-			bindings[bindIdx{set, binding}] = &api.DescriptorBinding{
-				Set:       set,
-				Binding:   binding,
-				Type:      uint32(bindingData.Type()),
-				Values:    values,
-				StageIdxs: []uint32{},
-			}
-		}
-	}
-	moduleShaders := map[VkShaderModule]*api.Shader{}
 	stages := make([]*api.Stage, len(stageMap))
 	for i := 0; i < len(stageMap); i++ {
 		v := stageMap[uint32(i)]
-		moduleHandle := v.Module().VulkanHandle()
-		if _, ok := moduleShaders[moduleHandle]; !ok {
-			res, err := v.Module().ResourceData(ctx, s)
-			if err != nil {
-				return nil, err
-			}
-			moduleShaders[moduleHandle] = protoutil.OneOf(protoutil.OneOf(res)).(*api.Shader)
-		}
-		moduleShader := moduleShaders[moduleHandle]
 		typ, err := stageType(v.Stage())
 		if err != nil {
 			return nil, err
 		}
 		stages[i] = &api.Stage{
-			Type:   typ,
-			Shader: moduleShader,
-		}
-
-		shaderWords := v.Module().Words().MustRead(ctx, nil, s, nil)
-		stageBindings, err := shadertools.ParseDescriptorSets(shaderWords, v.EntryPoint())
-		if err != nil {
-			return nil, err
-		}
-		for set, setBindings := range stageBindings {
-			for _, bindingData := range setBindings {
-				idx := bindIdx{set, bindingData.Binding}
-				binding, ok := bindings[idx]
-				if !ok {
-					// Shader uses binding that isn't included in the pipeline layout.
-					// This is invalid, so don't bother handling it here.
-					return nil, fmt.Errorf(
-						"Shader stage %v uses uniform at %v.%v that isn't defined in the pipeline layout.",
-						v.Stage(), set, bindingData.Binding)
-				}
-				if !typeMatch(bindingData.DescriptorType, binding.Type) {
-					return nil, fmt.Errorf(
-						"Shader stage %v has uniform at %v.%v with descriptor type %v which is incompatible with the pipeline layout type of %v",
-						v.Stage(), set, bindingData.Binding,
-						bindingData.DescriptorType, binding.Type)
-				}
-				if uint32(len(binding.Values)) < bindingData.DescriptorCount {
-					// NOTE(scppurcell): I was unable to find language in the spec disallowing this case,
-					// but it's a validation error.
-					return nil, fmt.Errorf(
-						"Shader stage %v has uniform at %v.%v that expects a descriptorCount of at least %v but the pipeline specifies %v",
-						v.Stage(), set, bindingData.Binding,
-						bindingData.DescriptorCount, len(binding.Values))
-				}
-				binding.StageIdxs = append(binding.StageIdxs, uint32(i))
-			}
+			StageName: typ,
 		}
 	}
-	for set, setInfo := range boundDsets {
-		for bindingIdx, bindingInfo := range setInfo.Bindings().All() {
-			idx := bindIdx{set, bindingIdx}
-			binding, ok := bindings[idx]
-			if !ok {
-				continue
-			}
-
-			if binding.Type != uint32(bindingInfo.BindingType()) {
-				return nil, fmt.Errorf(
-					"Pipeline binding type of %v does not match descriptor set binding type of %v",
-					binding.Type,
-					bindingInfo.BindingType())
-			}
-
-			// Only one of these should be populated
-			for i, iInfo := range bindingInfo.ImageBinding().All() {
-				if iInfo.Sampler() == 0 && iInfo.ImageView() == 0 {
-					continue
-				}
-				binding.Values[i] = &api.BindingValue{
-					Val: &api.BindingValue_ImageInfo{
-						ImageInfo: &api.ImageInfo{
-							Sampler:     uint64(iInfo.Sampler()),
-							ImageView:   uint64(iInfo.ImageView()),
-							ImageLayout: uint32(iInfo.ImageLayout()),
-						},
-					},
-				}
-			}
-			for i, bInfo := range bindingInfo.BufferBinding().All() {
-				if bInfo.Buffer() == 0 {
-					continue
-				}
-				binding.Values[i] = &api.BindingValue{
-					Val: &api.BindingValue_BufferInfo{
-						BufferInfo: &api.BufferInfo{
-							Buffer: uint64(bInfo.Buffer()),
-							Offset: uint64(bInfo.Offset()),
-							Range:  uint64(bInfo.Range()),
-						},
-					},
-				}
-			}
-			for i, bufferView := range bindingInfo.BufferViewBindings().All() {
-				if bufferView == 0 {
-					continue
-				}
-				binding.Values[i] = &api.BindingValue{
-					Val: &api.BindingValue_TexelBufferView{
-						uint64(bufferView),
-					},
-				}
-			}
-		}
-	}
-
-	bindingSlice := make([]*api.DescriptorBinding, 0, len(bindings))
-	for _, binding := range bindings {
-		bindingSlice = append(bindingSlice, binding)
-	}
-	sort.Slice(bindingSlice, func(i, j int) bool {
-		a := bindIdx{bindingSlice[i].Set, bindingSlice[i].Binding}
-		b := bindIdx{bindingSlice[j].Set, bindingSlice[j].Binding}
-		return a.Less(&b)
-	})
 
 	return &api.ResourceData{
 		Data: &api.ResourceData_Pipeline{
 			Pipeline: &api.Pipeline{
-				API:                       path.NewAPI(id.ID(ID)),
-				Type:                      pipeType,
-				Stages:                    stages,
-				Bindings:                  bindingSlice,
-				Bound:                     bound,
-				BindingTypeConstantsIndex: int32(VkDescriptorTypeConstants()),
-				ImageLayoutConstantsIndex: int32(VkImageLayoutConstants()),
+				API:          path.NewAPI(id.ID(ID)),
+				PipelineType: pipeType,
+				DebugName:    debugName,
+				Stages:       stages,
+				Bound:        bound,
 			},
 		},
 	}, nil

--- a/gapis/api/vulkan/resources.go
+++ b/gapis/api/vulkan/resources.go
@@ -1060,7 +1060,7 @@ func (p GraphicsPipelineObjectʳ) ResourceData(ctx context.Context, s *api.Globa
 			Pipeline: &api.Pipeline{
 				API:          path.NewAPI(id.ID(ID)),
 				PipelineType: "Graphics Pipeline",
-				DebugName:    "Graph",
+				DebugName:    "GRAPH",
 				Stages:       stages,
 				Bound:        isBound,
 			},


### PR DESCRIPTION
This creates empty tabs for each stage of the bound pipeline(s). As of now, compute and graphics are combined. This is just preliminary. Expect an additional commit or PR that separates the two.

Bug: 141624419