### PR TITLE
Cleanup traces after they're pulled from the device

### DIFF
--- a/gapis/perfetto/android/trace.go
+++ b/gapis/perfetto/android/trace.go
@@ -97,6 +97,10 @@ func (p *Process) Capture(ctx context.Context, start task.Signal, stop task.Sign
 		return 0, err
 	}
 
+	if err := p.device.RemoveFile(ctx, perfettoTraceFile); err != nil {
+		log.E(ctx, "Failed to delete perfetto trace file %v", err)
+	}
+
 	size := tmp.Info().Size()
 	atomic.StoreInt64(written, size)
 	fh, err := os.Open(tmp.System())


### PR DESCRIPTION
Fix for b/140064402 
Perfetto fails to overwrite a trace when running as a different user than the creator of the trace.  This is the case for the `shell` user accessing a trace owned by `root` and vice versa. 

This is fixed mostly by deleting the trace immediately after pulling it from the device.

For the edge cases where the trace somehow still exists, we will attempt to delete the file before starting a new trace.  This now works when running as `root`, and will still fail when running as `shell` (b/141704436), but now we present the failure that Perfetto logged to the UI instead of `exited with status 1`