### PR TITLE
Sampler desc set invalidation

### DIFF
--- a/gapis/api/vulkan/state_rebuilder.go
+++ b/gapis/api/vulkan/state_rebuilder.go
@@ -2504,6 +2504,10 @@ func (sb *stateBuilder) createDescriptorPoolAndAllocateDescriptorSets(dp Descrip
 		}
 	}
 
+	sb.allocateDescriptorSets(dp, descSetHandles, descSetLayoutHandles)
+}
+
+func (sb *stateBuilder) allocateDescriptorSets(dp DescriptorPoolObjectʳ, descSetHandles []VkDescriptorSet, descSetLayoutHandles []VkDescriptorSetLayout) {
 	if len(descSetHandles) != 0 && len(descSetLayoutHandles) != 0 {
 		sb.write(sb.cb.VkAllocateDescriptorSets(
 			dp.Device(),


### PR DESCRIPTION
When a Sampler is recreated it invalidates any Descriptor sets that were created before the loop start. Even though these DescriptorSets are not part of the loop, they must also be recreated.

This change makes that happen. It also renames a lot of variables to make it clearer how the recreation of one type of object can force the recreation of another.