### PR TITLE
Fix dev release update: let a dev release know its own dev version

### DIFF
--- a/core/app/run.go
+++ b/core/app/run.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"os"
 	"runtime/debug"
+	"strconv"
 	"sync"
 	"syscall"
 	"time"
@@ -118,6 +119,19 @@ func (v VersionSpec) Format(f fmt.State, c rune) {
 	if v.Build != "" {
 		fmt.Fprint(f, ":", v.Build)
 	}
+}
+
+// GetDevVersion returns the dev version, or -1 if no dev version is found.
+func (v VersionSpec) GetDevVersion() int {
+	// A dev release has a Build string prefixed by "dev-YYYYMMDD-",
+	// where YYYYMMDD is the dev version.
+	const prefix = "dev-"
+	if len(v.Build) >= len(prefix) && v.Build[0:len(prefix)] == prefix {
+		if devVersion, err := strconv.Atoi(v.Build[4:12]); err == nil {
+			return devVersion
+		}
+	}
+	return -1
 }
 
 func init() {

--- a/core/app/run.go
+++ b/core/app/run.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"runtime/debug"
 	"strconv"
+	"strings"
 	"sync"
 	"syscall"
 	"time"
@@ -125,8 +126,7 @@ func (v VersionSpec) Format(f fmt.State, c rune) {
 func (v VersionSpec) GetDevVersion() int {
 	// A dev release has a Build string prefixed by "dev-YYYYMMDD-",
 	// where YYYYMMDD is the dev version.
-	const prefix = "dev-"
-	if len(v.Build) >= len(prefix) && v.Build[0:len(prefix)] == prefix {
+	if strings.HasPrefix(v.Build, "dev-") && len(v.Build) >= 12 {
 		if devVersion, err := strconv.Atoi(v.Build[4:12]); err == nil {
 			return devVersion
 		}

--- a/gapis/server/server.go
+++ b/gapis/server/server.go
@@ -129,7 +129,7 @@ func (s *server) CheckForUpdates(ctx context.Context, includePrereleases bool) (
 	}
 	var mostRecent *service.Release
 	mostRecentVersion := app.Version
-	mostRecentDevVersion := -1
+	mostRecentDevVersion := app.Version.GetDevVersion()
 
 	for _, release := range releases {
 		if !includePrereleases && release.GetPrerelease() {

--- a/kokoro/linux/build-dev.sh
+++ b/kokoro/linux/build-dev.sh
@@ -15,6 +15,8 @@
 
 # Linux dev Build Script.
 
-export DEV_PREFIX="dev-"
+devdate=`date '+%Y%m%d'`
+
+export DEV_PREFIX="dev-${devdate}-"
 
 . $PWD/github/gapid/kokoro/linux/build.sh

--- a/kokoro/macos/build-dev.sh
+++ b/kokoro/macos/build-dev.sh
@@ -15,6 +15,8 @@
 
 # MacOS dev Build Script.
 
-export DEV_PREFIX="dev-"
+devdate=`date '+%Y%m%d'`
+
+export DEV_PREFIX="dev-${devdate}-"
 
 . $PWD/github/gapid/kokoro/macos/build.sh

--- a/kokoro/windows/build-dev.bat
+++ b/kokoro/windows/build-dev.bat
@@ -16,6 +16,10 @@ limitations under the License.
 Windows Build Script.
 
 :start
-set DEV_PREFIX=dev-
+
+REM Get date in YYYYMMDD format
+for /f "tokens=1,2,3 delims=/ " %%a in ('date /t') do set devdate=%%c%%b%%a
+
+set DEV_PREFIX=dev-%devdate%-
 
 call %cd%\github\gapid\kokoro\windows\build.bat


### PR DESCRIPTION
A dev release build needs to know its own dev version to be able to
check whether other pre-release on GitHub are newer or not.