### PR TITLE
Upgrade to use bazel 1.0.0.

### DIFF
--- a/tools/build/rules/grpc.bzl
+++ b/tools/build/rules/grpc.bzl
@@ -15,8 +15,8 @@
 def _gen_java_source_impl(ctx):
   # Use .jar since .srcjar makes protoc think output will be a directory
   srcdotjar = ctx.actions.declare_file(ctx.label.name + "-src.jar")
-  protos = [f for dep in ctx.attr.srcs for f in dep.proto.direct_sources]
-  includes = [f for dep in ctx.attr.srcs for f in dep.proto.transitive_imports.to_list()]
+  protos = [f for dep in ctx.attr.srcs for f in dep[ProtoInfo].direct_sources]
+  includes = [f for dep in ctx.attr.srcs for f in dep[ProtoInfo].transitive_imports.to_list()]
 
   arguments = [
     "--plugin=protoc-gen-grpc-java=" + ctx.executable._plugin.path,
@@ -53,7 +53,7 @@ _gen_java_source = rule(
     "srcs": attr.label_list(
       mandatory = True,
       allow_empty = False,
-      providers = ["proto"],
+      providers = [ProtoInfo],
     ),
     "_protoc": attr.label(
       default = Label("@com_google_protobuf//:protoc"),
@@ -73,8 +73,8 @@ _gen_java_source = rule(
 )
 
 def _gen_cc_source_impl(ctx):
-  protos = [f for dep in ctx.attr.srcs for f in dep.proto.direct_sources]
-  includes = [f for dep in ctx.attr.srcs for f in dep.proto.transitive_imports.to_list()]
+  protos = [f for dep in ctx.attr.srcs for f in dep[ProtoInfo].direct_sources]
+  includes = [f for dep in ctx.attr.srcs for f in dep[ProtoInfo].transitive_imports.to_list()]
 
   proto_root = ""
   if ctx.label.workspace_root:
@@ -133,7 +133,7 @@ _gen_cc_source = rule(
     "srcs": attr.label_list(
       mandatory = True,
       allow_empty = False,
-      providers = ["proto"],
+      providers = [ProtoInfo],
     ),
     "_protoc": attr.label(
       default = Label("@com_google_protobuf//:protoc"),


### PR DESCRIPTION
Bazel 1.0.0 deprecates the proto provider, upgrade our rule files to use the
new ProtoInfo provider.

BUG: #3235
Test: build