### PR TITLE
Add explicit memory read observation for commandbuffers in a submission

### DIFF
--- a/gapis/api/vulkan/api/queue.api
+++ b/gapis/api/vulkan/api/queue.api
@@ -123,6 +123,7 @@ cmd VkResult vkQueueSubmit(
       }
     }
     read(info.pWaitDstStageMask[0:info.waitSemaphoreCount])
+    read(info.pCommandBuffers[0:info.commandBufferCount])
 
     command_buffers := info.pCommandBuffers[0:info.commandBufferCount]
     command_buffers_all_valid := MutableBool(true)


### PR DESCRIPTION
Allows the tracer to successfully capture a vkQueueSubmit call where the
VkSubmitInfo::commandBufferCount > 1.

Google Bug: b/142511853