### PR TITLE
Use aapt with --android_aapt.

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -52,3 +52,6 @@ build:nodroid --define NO_ANDROID=1
 
 # Tests requiring a GPU fail in the sandbox.
 test --strategy TestRunner=standalone --test_env DISPLAY
+
+# Use AAPT before we switch to AAPT2
+build --android_aapt=aapt


### PR DESCRIPTION
Bazel 1.0.0 upgrade now forces to use aapt2 by default, before we upgrade to
use newer SDK, keep using aapt to build.

BUG: #3235
Test: build