### PR TITLE
Revert "Add explicit memory read observation for commandbuffers in a submission"

### DIFF
--- a/gapis/api/vulkan/api/queue.api
+++ b/gapis/api/vulkan/api/queue.api
@@ -123,7 +123,6 @@ cmd VkResult vkQueueSubmit(
       }
     }
     read(info.pWaitDstStageMask[0:info.waitSemaphoreCount])
-    read(info.pCommandBuffers[0:info.commandBufferCount])
 
     command_buffers := info.pCommandBuffers[0:info.commandBufferCount]
     command_buffers_all_valid := MutableBool(true)


### PR DESCRIPTION
Reverts google/gapid#3239

Sorry for the noise. The observations are actually fine -- this was just disturbing something else broken enough that it worked with the change and not without.