### PR TITLE
Fix push constant state tracking

### DIFF
--- a/gapis/api/vulkan/api/descriptor.api
+++ b/gapis/api/vulkan/api/descriptor.api
@@ -871,7 +871,7 @@ sub void dovkCmdPushConstants(ref!vkCmdPushConstantsArgs args) {
   _ = PipelineLayouts[args.Layout]
   pushConstants := lastPushConstants()
   if pushConstants != null {
-    write(pushConstants.Data[args.Offset:args.Offset+args.Size])
+    copy(pushConstants.Data[args.Offset:args.Offset+args.Size], args.Data[0:args.Size])
   }
 }
 


### PR DESCRIPTION
Tracing of vkCmdPushConstants missed capturing the actual data; there
was a write observation created for the push constant state, but the
data in the command was not observed.

This led to two issues:
- LastPushConstants state would never show the actual push constants
- rebuildVkCmdPushConstants would sporadically explode

Bug: #3234