### PR TITLE
Skip updating expansion state if the state model is not available

### DIFF
--- a/gapic/src/main/com/google/gapid/views/StateView.java
+++ b/gapic/src/main/com/google/gapid/views/StateView.java
@@ -271,7 +271,11 @@ public class StateView extends Composite
 
       @Override
       protected void onUiThread(TreePath[] treePaths) {
-        setExpanded(treePaths, paths, retry);
+        // Only apply the UI update if nothing else has already pulled the state out from under us.
+        // TODO: cancel the futures when this happens to avoid some wasted work.
+        if (root == models.state.getData()) {
+          setExpanded(treePaths, paths, retry);
+        }
       }
     });
   }


### PR DESCRIPTION
It's possible to have a race here with multiple overlapping updates,
where the state model is not available. The crash here is not fatal, but
throws a dialog in the user's face which is fairly awful.