### PR TITLE
Automatically setup variables for gpu.renderstages.

### DIFF
--- a/gapis/perfetto/android/BUILD.bazel
+++ b/gapis/perfetto/android/BUILD.bazel
@@ -23,6 +23,7 @@ go_library(
     importpath = "github.com/google/gapid/gapis/perfetto/android",
     visibility = ["//visibility:public"],
     deps = [
+        "//core/app:go_default_library",
         "//core/event/task:go_default_library",
         "//core/log:go_default_library",
         "//core/os/android:go_default_library",

--- a/gapis/trace/android/trace.go
+++ b/gapis/trace/android/trace.go
@@ -476,7 +476,9 @@ func (t *androidTracer) SetupTrace(ctx context.Context, o *service.TraceOptions)
 
 	var process tracer.Process
 	if o.Type == service.TraceType_Perfetto {
-		process, err = perfetto.Start(ctx, t.b, a, o)
+		var perfettoCleanup app.Cleanup
+		process, perfettoCleanup, err = perfetto.Start(ctx, t.b, a, o)
+		cleanup = cleanup.Then(perfettoCleanup)
 	} else {
 		log.I(ctx, "Starting with options %+v", tracer.GapiiOptions(o))
 		var gapiiCleanup app.Cleanup


### PR DESCRIPTION
Right before application activity is started, setup the variables for
gpu.renderstages so that the Vulkan layer is loaded properly.

BUG: b/142082436
Test: manual test with vulkan app