### PR TITLE
Revert "Reset command buffers that are changed during loop (#3169)"

### DIFF
--- a/gapis/api/vulkan/frame_loop.go
+++ b/gapis/api/vulkan/frame_loop.go
@@ -153,12 +153,6 @@ type frameLoop struct {
 	renderPassToDestroy map[VkRenderPass]bool
 	renderPassToCreate  map[VkRenderPass]bool
 
-	commandBufferToFree      map[VkCommandBuffer]bool
-	commandBufferToAllocate  map[VkCommandBuffer]bool
-	commandBufferChanged     map[VkCommandBuffer]bool
-	commandBufferRecorded    map[VkCommandBuffer]bool // Command buffers recorded during loop.
-	commandBufferNotRecorded map[VkCommandBuffer]bool // Command buffers submitted but not recorded during loop.
-
 	loopCountPtr value.Pointer
 
 	frameNum uint32
@@ -254,12 +248,6 @@ func newFrameLoop(ctx context.Context, graphicsCapture *capture.GraphicsCapture,
 
 		renderPassToDestroy: make(map[VkRenderPass]bool),
 		renderPassToCreate:  make(map[VkRenderPass]bool),
-
-		commandBufferToFree:      make(map[VkCommandBuffer]bool),
-		commandBufferToAllocate:  make(map[VkCommandBuffer]bool),
-		commandBufferChanged:     make(map[VkCommandBuffer]bool),
-		commandBufferRecorded:    make(map[VkCommandBuffer]bool),
-		commandBufferNotRecorded: make(map[VkCommandBuffer]bool),
 
 		loopTerminated:      false,
 		lastObservedCommand: api.CmdNoID,
@@ -791,75 +779,14 @@ func (f *frameLoop) buildStartEndStates(ctx context.Context, startState *api.Glo
 				f.renderPassToCreate[renderPass] = true
 			}
 
-		// Command Buffers
-		case *VkAllocateCommandBuffers:
-			vkCmd := cmd.(*VkAllocateCommandBuffers)
-			cmdBuffers := vkCmd.PCommandBuffers().MustRead(ctx, vkCmd, currentState, nil)
-			f.commandBufferToFree[cmdBuffers] = true
-			log.D(ctx, "Command buffer %v allcoated.", cmdBuffers)
-		case *VkFreeCommandBuffers:
-			vkCmd := cmd.(*VkFreeCommandBuffers)
-			cmdBufCount := vkCmd.CommandBufferCount()
-			cmdBufs := vkCmd.PCommandBuffers().Slice(0, uint64(cmdBufCount), currentState.MemoryLayout).MustRead(ctx, cmd, currentState, nil)
-			for _, cmdBuf := range cmdBufs {
-				// The command buffer deleted in this call was created during loop, no action needed.
-				log.D(ctx, "Command buffer %v freed", cmdBufs)
-				if _, ok := f.commandBufferToFree[cmdBuf]; ok {
-					delete(f.commandBufferToFree, cmdBuf)
-				} else { // The command buffer deleted in this call was not created during loop, need to back up it
-					f.commandBufferToAllocate[cmdBuf] = true
-				}
-			}
-		case *VkBeginCommandBuffer:
-			vkCmd := cmd.(*VkBeginCommandBuffer)
-			cmdBuf := vkCmd.CommandBuffer()
-			f.commandBufferRecorded[cmdBuf] = true
-			log.D(ctx, "Command buffer %v began", cmdBuf)
-
-			// If this command buffer is allocated during loop then it is reset by the re-allocation step.
-			if _, ok := f.commandBufferToFree[cmdBuf]; ok {
-				break
-			}
-			// If this command buffer has not been submitted before no action needed.
-			if _, ok := f.commandBufferNotRecorded[cmdBuf]; !ok {
-				break
-			}
-			// Only backup the fist time it changes
-			if _, ok := f.commandBufferChanged[cmdBuf]; !ok {
-				f.commandBufferChanged[cmdBuf] = true
-			}
-
-		case *VkResetCommandBuffer:
-			vkCmd := cmd.(*VkResetCommandBuffer)
-			cmdBuf := vkCmd.CommandBuffer()
-			log.D(ctx, "Command buffer %v reset", cmdBuf)
-			// If this command buffer is allocated during loop then it is reset by the re-allocation step.
-			if _, ok := f.commandBufferToFree[cmdBuf]; ok {
-				break
-			}
-			// If this command buffer has not been submitted before no action needed.
-			if _, ok := f.commandBufferNotRecorded[cmdBuf]; !ok {
-				break
-			}
-			// Only backup the fist time it changes
-			if _, ok := f.commandBufferChanged[cmdBuf]; !ok {
-				f.commandBufferChanged[cmdBuf] = true
-			}
-		case *VkQueueSubmit:
-			vkCmd := cmd.(*VkQueueSubmit)
-			submitCount := vkCmd.SubmitCount()
-			submitInfos := vkCmd.pSubmits.Slice(0, uint64(submitCount), currentState.MemoryLayout).MustRead(ctx, cmd, currentState, nil)
-			for _, si := range submitInfos {
-				cmdBuffers := si.PCommandBuffers().Slice(0, uint64(si.CommandBufferCount()), currentState.MemoryLayout).MustRead(ctx, cmd, currentState, nil)
-				for _, cmdBuf := range cmdBuffers {
-					if _, ok := f.commandBufferRecorded[cmdBuf]; !ok {
-						f.commandBufferNotRecorded[cmdBuf] = true
-					}
-				}
-			}
+			// TODO:  Recreate destroyed resources.
 		}
 
-		return cmd.Mutate(ctx, cmdId, currentState, nil, f.watcher)
+		if err := cmd.Mutate(ctx, cmdId, currentState, nil, f.watcher); err != nil {
+			return fmt.Errorf("%v: %v: %v", cmdId, cmd, err)
+		}
+
+		return nil
 	})
 
 	if err != nil {
@@ -1208,10 +1135,6 @@ func (f *frameLoop) resetResources(ctx context.Context, stateBuilder *stateBuild
 	}
 
 	if err := f.resetRenderPasses(ctx, stateBuilder); err != nil {
-		return err
-	}
-
-	if err := f.resetCommandBuffers(ctx, stateBuilder); err != nil {
 		return err
 	}
 
@@ -1865,46 +1788,6 @@ func (f *frameLoop) resetRenderPasses(ctx context.Context, stateBuilder *stateBu
 		// Write the commands needed to recreate the destroyed object
 		renderPass := GetState(f.loopStartState).renderPasses.Get(toCreate)
 		stateBuilder.createRenderPass(renderPass)
-	}
-
-	return nil
-}
-
-func (f *frameLoop) resetCommandBuffers(ctx context.Context, stateBuilder *stateBuilder) error {
-
-	for cmdBuf := range f.commandBufferToFree {
-		log.D(ctx, "Command buffer %v allocated during loop, free it.", cmdBuf)
-		cmdBufObj := GetState(f.loopEndState).CommandBuffers().Get(cmdBuf)
-		if cmdBufObj != NilCommandBufferObjectʳ {
-			stateBuilder.write(stateBuilder.cb.VkFreeCommandBuffers(
-				cmdBufObj.Device(),
-				cmdBufObj.Pool(),
-				1,
-				stateBuilder.MustAllocReadData(cmdBufObj.VulkanHandle()).Ptr(),
-			))
-		} else {
-			log.F(ctx, true, "Command buffer %v cannot be found in loop ending state", cmdBuf)
-		}
-	}
-
-	for cmdBuf := range f.commandBufferToAllocate {
-		cmdBufObj := GetState(f.loopStartState).CommandBuffers().Get(cmdBuf)
-		if cmdBufObj == NilCommandBufferObjectʳ {
-			log.F(ctx, true, "Command buffer %v can not be found in loop starting state", cmdBuf)
-			continue
-		}
-		log.D(ctx, "Command buffer %v freed during loop, recreate it.", cmdBuf)
-		stateBuilder.createCommandBuffer(cmdBufObj, cmdBufObj.Level())
-		stateBuilder.recordCommandBuffer(cmdBufObj, cmdBufObj.Level(), f.loopStartState)
-	}
-
-	for cmdBuf := range f.commandBufferChanged {
-		cmdBufObj := GetState(f.loopStartState).CommandBuffers().Get(cmdBuf)
-		if cmdBufObj == NilCommandBufferObjectʳ {
-			log.F(ctx, true, "Command buffer %v can not be found in loop starting state", cmdBuf)
-		}
-		log.D(ctx, "Command buffer %v changed during loop, re-record it.", cmdBuf)
-		stateBuilder.recordCommandBuffer(cmdBufObj, cmdBufObj.Level(), f.loopStartState)
 	}
 
 	return nil

--- a/gapis/api/vulkan/state_rebuilder.go
+++ b/gapis/api/vulkan/state_rebuilder.go
@@ -267,12 +267,10 @@ func (API) RebuildState(ctx context.Context, oldState *api.GlobalState) ([]api.C
 
 	for _, qp := range s.CommandBuffers().Keys() {
 		sb.createCommandBuffer(s.CommandBuffers().Get(qp), VkCommandBufferLevel_VK_COMMAND_BUFFER_LEVEL_SECONDARY)
-		sb.recordCommandBuffer(s.CommandBuffers().Get(qp), VkCommandBufferLevel_VK_COMMAND_BUFFER_LEVEL_SECONDARY, sb.oldState)
 	}
 
 	for _, qp := range s.CommandBuffers().Keys() {
 		sb.createCommandBuffer(s.CommandBuffers().Get(qp), VkCommandBufferLevel_VK_COMMAND_BUFFER_LEVEL_PRIMARY)
-		sb.recordCommandBuffer(s.CommandBuffers().Get(qp), VkCommandBufferLevel_VK_COMMAND_BUFFER_LEVEL_SECONDARY, sb.oldState)
 	}
 
 	sb.scratchRes.Free(sb)
@@ -2770,13 +2768,6 @@ func (sb *stateBuilder) createCommandBuffer(cb CommandBufferObjectʳ, level VkCo
 		VkResult_VK_SUCCESS,
 	))
 
-}
-
-func (sb *stateBuilder) recordCommandBuffer(cb CommandBufferObjectʳ, level VkCommandBufferLevel, srcState *api.GlobalState) {
-	if cb.Level() != level {
-		return
-	}
-
 	if cb.Recording() == RecordingState_NOT_STARTED || cb.Recording() == RecordingState_TO_BE_RESET {
 		return
 	}
@@ -2816,8 +2807,8 @@ func (sb *stateBuilder) recordCommandBuffer(cb CommandBufferObjectʳ, level VkCo
 	hasError := false
 	// fill command buffer
 	for i, c := uint32(0), uint32(cb.CommandReferences().Len()); i < c; i++ {
-		arg := GetCommandArgs(sb.ctx, cb.CommandReferences().Get(i), GetState(srcState))
-		cleanup, cmd, err := AddCommand(sb.ctx, sb.cb, cb.VulkanHandle(), srcState, sb.newState, arg)
+		arg := GetCommandArgs(sb.ctx, cb.CommandReferences().Get(i), GetState(sb.oldState))
+		cleanup, cmd, err := AddCommand(sb.ctx, sb.cb, cb.VulkanHandle(), sb.oldState, sb.newState, arg)
 		if err != nil {
 			log.W(sb.ctx, "Command Buffer %v is invalid, it will not be recorded: - %v", cb.VulkanHandle(), err)
 			hasError = true
@@ -2836,6 +2827,7 @@ func (sb *stateBuilder) recordCommandBuffer(cb CommandBufferObjectʳ, level VkCo
 		))
 	}
 }
+
 func queueFamilyIndicesToU32Slice(m U32ːu32ᵐ) []uint32 {
 	r := make([]uint32, 0, m.Len())
 	for _, k := range m.Keys() {


### PR DESCRIPTION
This reverts commit 4a6575c4139d7ddae5e9a4255404d687c18b64bd.

This change has introduced crashes in QueueSubmit in various MEC scenarios. @RenfengLiu  has the bug for finding a proper fix and relanding.