### PR TITLE
Don't set up layer when driver apk is not found.

### DIFF
--- a/gapis/perfetto/android/trace.go
+++ b/gapis/perfetto/android/trace.go
@@ -73,9 +73,12 @@ func setupRenderStagesEnvironment(ctx context.Context, d adb.Device, packageName
 	if driverPackageName == "" {
 		return nil, nil
 	}
+	if res, err := d.Shell("pm", "path", driverPackageName).Call(ctx); err != nil || res == "" {
+		return nil, log.Err(ctx, err, "No driver package found.")
+	}
 	cleanup, err := android.SetupLayer(ctx, d, packageName, driverPackageName, renderStageVulkanLayerName, true)
 	if err != nil {
-		return nil, log.Err(ctx, err, "Failed to setup gpu.renderstages environment.")
+		return cleanup.Invoke(ctx), log.Err(ctx, err, "Failed to setup gpu.renderstages environment.")
 	}
 	return cleanup, nil
 }


### PR DESCRIPTION
Avoid setting up layer when driver apk is not found. Make sure to invoke
cleanup when an error happens.

BUG: b/142082436
Test: manual test with vulkan app