### PR TITLE
add new WAIT instruction and trigger replay pausing/continuation

### DIFF
--- a/gapir/README.md
+++ b/gapir/README.md
@@ -227,6 +227,12 @@ if the value on the top of the stack is not zero. Otherwise it is a Nop.
 Pops size and then a pointer from the top of the stack and streams back `size` bytes of
 data from the address to the server via the notification message.
 
+### `WAIT()` [no change]
+`<code:6> <fence-id:26>`
+
+Streams back the `fence-id` to the server. Replay pauses until
+the server streams back the same ID.
+
 ## Resources
 
 GAPIR is designed to be run on desktop and Android devices. When replaying on

--- a/gapir/api.go
+++ b/gapir/api.go
@@ -41,6 +41,10 @@ type (
 	Notification = replaysrv.Notification
 	// Severity represents the severity level of notification messages. It uses the same enum as gapis
 	Severity = severity.Severity
+	// FenceReadyRequest is sent when the device is waiting for the server perform a task
+	FenceReadyRequest = replaysrv.FenceReadyRequest
+	// FenceReady signals that the server finished a task and replay can continue
+	FenceReady = replaysrv.FenceReady
 )
 
 // ReplayResponseHandler handles all kinds of ReplayResponse messages received
@@ -58,6 +62,8 @@ type ReplayResponseHandler interface {
 	HandleNotification(context.Context, *Notification, Connection) error
 	// HandleFinished handles the replay complete
 	HandleFinished(context.Context, error, Connection) error
+	// HandleFenceReadyRequest handles the profiler ready message.
+	HandleFenceReadyRequest(context.Context, *FenceReadyRequest, Connection) error
 }
 
 // Connection represents a connection between GAPIS and GAPIR. It wraps the
@@ -79,6 +85,8 @@ type Connection interface {
 	SendResources(ctx context.Context, resources []byte) error
 	// SendPayload sends the given payload to the connected GAPIR device.
 	SendPayload(ctx context.Context, payload Payload) error
+	// SendFenceReady signals the device to continue a replay.
+	SendFenceReady(ctx context.Context, id uint32) error
 	// PrewarmReplay requests the GAPIR device to get itself into the given state
 	PrewarmReplay(ctx context.Context, payload string, cleanup string) error
 	// HandleReplayCommunication handles the communication with the GAPIR device on

--- a/gapir/cc/android/asset_replay_service.h
+++ b/gapir/cc/android/asset_replay_service.h
@@ -48,6 +48,10 @@ class AssetReplayService : public ReplayService {
     return nullptr;
   }
 
+  std::unique_ptr<FenceReady> getFenceReady(const uint32_t& id) override {
+    return nullptr;
+  }
+
   bool sendReplayFinished() override { return true; }
 
   bool sendCrashDump(const std::string& filepath, const void* crash_data,

--- a/gapir/cc/archive_replay_service.h
+++ b/gapir/cc/archive_replay_service.h
@@ -47,6 +47,10 @@ class ArchiveReplayService : public ReplayService {
     return nullptr;
   }
 
+  std::unique_ptr<FenceReady> getFenceReady(const uint32_t& id) override {
+    return nullptr;
+  }
+
   std::unique_ptr<replay_service::ReplayRequest> getReplayRequest() override {
     return std::unique_ptr<replay_service::ReplayRequest>(
         new replay_service::ReplayRequest());

--- a/gapir/cc/context.h
+++ b/gapir/cc/context.h
@@ -97,6 +97,9 @@ class Context : private Renderer::Listener {
   // second element of the stack (void*)
   bool loadResource(Stack* stack);
 
+  // Tell the server that we're waiting for it to respond
+  bool waitForFence(Stack* stack);
+
   // Starts the timer identified by u8 index.
   bool startTimer(Stack* stack);
 

--- a/gapir/cc/grpc_replay_service.cpp
+++ b/gapir/cc/grpc_replay_service.cpp
@@ -95,6 +95,26 @@ std::unique_ptr<ReplayService::Payload> GrpcReplayService::getPayload(
       std::unique_ptr<replay_service::Payload>(req->release_payload())));
 }
 
+std::unique_ptr<ReplayService::FenceReady> GrpcReplayService::getFenceReady(
+    const uint32_t& id) {
+  // Send a replay response with payload request
+  replay_service::ReplayResponse res;
+  auto frr = new replay_service::FenceReadyRequest();
+  frr->set_id(id);
+  res.set_allocated_fence_ready_request(frr);
+  mGrpcStream->Write(res);
+  std::unique_ptr<replay_service::ReplayRequest> req = getNonReplayRequest();
+  if (!req) {
+    return nullptr;
+  }
+  if (req->req_case() != replay_service::ReplayRequest::kFenceReady) {
+    return nullptr;
+  }
+  return std::unique_ptr<ReplayService::FenceReady>(
+      new ReplayService::FenceReady(std::unique_ptr<replay_service::FenceReady>(
+          req->release_fence_ready())));
+}
+
 std::unique_ptr<ReplayService::Resources> GrpcReplayService::getResources(
     const Resource* resources, size_t resCount) {
   if (!mGrpcStream) {

--- a/gapir/cc/grpc_replay_service.h
+++ b/gapir/cc/grpc_replay_service.h
@@ -76,6 +76,9 @@ class GrpcReplayService : public ReplayService {
   std::unique_ptr<ReplayService::Resources> getResources(
       const Resource* resource, size_t resCount) override;
 
+  std::unique_ptr<ReplayService::FenceReady> getFenceReady(
+      const uint32_t& id) override;
+
   // Sends ReplayFinished signal. Returns true if succeeded, otherwise returns
   // false.
   bool sendReplayFinished() override;

--- a/gapir/cc/interpreter.cpp
+++ b/gapir/cc/interpreter.cpp
@@ -313,6 +313,11 @@ Interpreter::Result Interpreter::notification() {
   return this->call(Interpreter::NOTIFICATION_FUNCTION_ID);
 }
 
+Interpreter::Result Interpreter::wait(uint32_t opcode) {
+  mStack.push<uint32_t>(extract26bitData(opcode));
+  return this->call(Interpreter::WAIT_FUNCTION_ID);
+}
+
 Interpreter::Result Interpreter::copy(uint32_t opcode) {
   uint32_t count = extract26bitData(opcode);
   void* target = mStack.pop<void*>();
@@ -573,6 +578,9 @@ Interpreter::Result Interpreter::interpret(uint32_t opcode) {
     case InstructionCode::NOTIFICATION:
       DEBUG_OPCODE("NOTIFICATION", opcode);
       return this->notification();
+    case InstructionCode::WAIT:
+      DEBUG_OPCODE("WAIT", opcode);
+      return this->wait(opcode);
     default:
       GAPID_WARNING("Unknown opcode! %#010x", opcode);
       return ERROR;

--- a/gapir/cc/interpreter.h
+++ b/gapir/cc/interpreter.h
@@ -64,6 +64,7 @@ class Interpreter {
     POST_FUNCTION_ID = 0xff00,
     RESOURCE_FUNCTION_ID = 0xff01,
     NOTIFICATION_FUNCTION_ID = 0xff02,
+    WAIT_FUNCTION_ID = 0xff03,
     // Debug function Ids
     PRINT_STACK_FUNCTION_ID = 0xff80,
     // 0xff81..0xffff reserved for synthetic functions
@@ -152,6 +153,7 @@ class Interpreter {
   Result jumpLabel(uint32_t opcode);
   Result jumpNZ(uint32_t opcode);
   Result notification();
+  Result wait(uint32_t opcode);
 
   // Returns true, if address..address+size(type) is "constant" memory.
   bool isConstantAddressForType(const void* address, BaseType type) const;

--- a/gapir/cc/replay_service.cpp
+++ b/gapir/cc/replay_service.cpp
@@ -64,6 +64,18 @@ uint64_t ReplayService::Posts::piece_id(int index) const {
 ReplayService::Posts::Posts()
     : mProtoPostData(new replay_service::PostData()) {}
 
+// FenceReady
+
+ReplayService::FenceReady::FenceReady(
+    std::unique_ptr<replay_service::FenceReady> protoFenceReady)
+    : mProtoFenceReady(std::move(protoFenceReady)) {}
+
+ReplayService::FenceReady::~FenceReady() = default;
+
+uint32_t ReplayService::FenceReady::id() const {
+  return mProtoFenceReady->id();
+}
+
 // Payload member methods
 
 ReplayService::Payload::Payload(

--- a/gapir/cc/replay_service.h
+++ b/gapir/cc/replay_service.h
@@ -30,6 +30,7 @@
 namespace replay_service {
 class Payload;
 class Resources;
+class FenceReady;
 class ReplayRequest;
 class PostData;
 class ReplayResponse;
@@ -41,7 +42,7 @@ namespace gapir {
 // communication methods needed for a replay.
 class ReplayService {
  public:
-  // Posts is a wraper class of replay_service::PostData, it hides the
+  // Posts is a wrapper class of replay_service::PostData, it hides the
   // new/delete operations of the proto object from the outer code.
   class Posts {
    public:
@@ -80,7 +81,7 @@ class ReplayService {
     std::unique_ptr<replay_service::PostData> mProtoPostData;
   };
 
-  // Payload is a wraper class of replay_service::Payload, it hides the
+  // Payload is a wrapper class of replay_service::Payload, it hides the
   // new/delete operations of the proto object from outer code.
   class Payload {
    public:
@@ -120,7 +121,24 @@ class ReplayService {
     // std::unique_ptr<replay_service::ReplayRequest> mProtoReplayRequest;
   };
 
-  // Resources is a wraper class of replay_service::Resources, it hides the
+  // FenceReady is a wrapper class of replay_service::FenceReady, it hides
+  // the new/delete operations of the proto object from outer code.
+  class FenceReady {
+   public:
+    FenceReady(std::unique_ptr<replay_service::FenceReady> protoFenceReady);
+
+    ~FenceReady();
+    FenceReady(const FenceReady&) = delete;
+    FenceReady(FenceReady&&) = delete;
+    FenceReady& operator=(const FenceReady&) = delete;
+    FenceReady& operator=(FenceReady&&) = delete;
+    uint32_t id() const;
+
+   private:
+    std::unique_ptr<replay_service::FenceReady> mProtoFenceReady;
+  };
+
+  // Resources is a wrapper class of replay_service::Resources, it hides the
   // new/delete operations of the proto object from outer code.
   class Resources {
    public:
@@ -158,6 +176,8 @@ class ReplayService {
   // Get Resources. Returns nullptr in case of error.
   virtual std::unique_ptr<Resources> getResources(const Resource* resources,
                                                   size_t resCount) = 0;
+
+  virtual std::unique_ptr<FenceReady> getFenceReady(const uint32_t& id) = 0;
 
   // Sends ReplayFinished signal. Returns true if succeeded, otherwise returns
   // false.

--- a/gapir/replay_service/service.proto
+++ b/gapir/replay_service/service.proto
@@ -52,12 +52,17 @@ message Replay {
   string dependent_id = 2;
 }
 
+message FenceReady {
+  uint32 id = 1;
+}
+
 message ReplayRequest {
   oneof req {
     Replay replay = 1;
     PrewarmRequest prewarm = 2;
     Payload payload = 3;
     Resources resources = 4;
+    FenceReady fence_ready = 5;
   }
 }
 
@@ -139,6 +144,10 @@ message Notification {
   }
 }
 
+message FenceReadyRequest {
+  uint32 id = 1;
+}
+
 message ReplayResponse {
   oneof res {
     Finished finished = 1;
@@ -147,6 +156,7 @@ message ReplayResponse {
     CrashDump crash_dump = 4;
     PostData post_data = 5;
     Notification notification = 6;
+    FenceReadyRequest fence_ready_request = 7;
   }
 }
 

--- a/gapir/replay_service/vm.h
+++ b/gapir/replay_service/vm.h
@@ -45,6 +45,7 @@ enum class Opcode {
   JUMP_LABEL = 17,
   JUMP_NZ = 18,
   NOTIFICATION = 19,
+  WAIT = 20,
 };
 
 // Unique ID for each supported data type. The ID have to fit into 6 bits (0-63)

--- a/gapis/replay/BUILD.bazel
+++ b/gapis/replay/BUILD.bazel
@@ -34,6 +34,7 @@ go_library(
         "replay.go",
         "replay_connection.go",
         "timestamps.go",
+        "wait_for_fence.go",
     ],
     embed = [":replay_go_proto"],
     importpath = "github.com/google/gapid/gapis/replay",

--- a/gapis/replay/asm/instructions.go
+++ b/gapis/replay/asm/instructions.go
@@ -390,3 +390,11 @@ func (a Notification) Encode(r value.PointerResolver, w binary.Writer) error {
 	}
 	return opcode.Notification{}.Encode(w)
 }
+
+type Wait struct {
+	ID uint32
+}
+
+func (a Wait) Encode(r value.PointerResolver, w binary.Writer) error {
+	return opcode.Wait{ID: a.ID}.Encode(w)
+}

--- a/gapis/replay/builder/builder.go
+++ b/gapis/replay/builder/builder.go
@@ -569,6 +569,12 @@ func (b *Builder) Notification(ID uint64, addr value.Pointer, size uint64) {
 	})
 }
 
+func (b *Builder) Wait(ID uint32) {
+	b.instructions = append(b.instructions, asm.Wait{
+		ID: ID,
+	})
+}
+
 // Pop removes the top count values from the top of the stack.
 func (b *Builder) Pop(count uint32) {
 	b.popStackMulti(int(count))

--- a/gapis/replay/opcode/opcodes.go
+++ b/gapis/replay/opcode/opcodes.go
@@ -344,6 +344,18 @@ func (c Notification) Encode(w binary.Writer) error {
 	return w.Error()
 }
 
+// Wait represents the Wait virtual machine opcode.
+type Wait struct {
+	ID uint32 // 26 bit fence ID.
+}
+
+func (c Wait) String() string { return fmt.Sprintf("Wait(ID: %v)", c.ID) }
+
+func (c Wait) Encode(w binary.Writer) error {
+	w.Uint32(packCX(protocol.OpWait, c.ID))
+	return w.Error()
+}
+
 // Decode returns the opcode decoded from decoder d.
 func Decode(r binary.Reader) (Opcode, error) {
 	i := r.Uint32()
@@ -392,6 +404,8 @@ func Decode(r binary.Reader) (Opcode, error) {
 		return Label{Value: unpackX(i)}, nil
 	case protocol.OpNotification:
 		return Notification{}, nil
+	case protocol.OpWait:
+		return Wait{ID: unpackX(i)}, nil
 	default:
 		return nil, fmt.Errorf("Unknown opcode with code %v", int(code))
 	}
@@ -415,3 +429,4 @@ func (Add) isOpcode()          {}
 func (Label) isOpcode()        {}
 func (SwitchThread) isOpcode() {}
 func (Notification) isOpcode() {}
+func (Wait) isOpcode()         {}

--- a/gapis/replay/protocol/opcode.go
+++ b/gapis/replay/protocol/opcode.go
@@ -40,6 +40,7 @@ const (
 	OpJumpLabel    = Opcode(17)
 	OpJumpNZ       = Opcode(18)
 	OpNotification = Opcode(19)
+	OpWait         = Opcode(20)
 )
 
 // String returns the human-readable name of the opcode.
@@ -85,6 +86,8 @@ func (t Opcode) String() string {
 		return "JumpNZ"
 	case OpNotification:
 		return "Notification"
+	case OpWait:
+		return "Wait"
 	default:
 		panic(fmt.Errorf("Unknown Opcode %d", uint32(t)))
 	}

--- a/gapis/replay/replay_connection.go
+++ b/gapis/replay/replay_connection.go
@@ -108,6 +108,15 @@ func (e *backgroundConnection) HandlePayloadRequest(ctx context.Context, payload
 	return log.Errf(ctx, err, "Payload type is unexpected: %T", boxed)
 }
 
+// HandleFenceReadyRequest implements gapir.ReplayResponseHandler interface.
+func (e *backgroundConnection) HandleFenceReadyRequest(ctx context.Context, req *gapir.FenceReadyRequest, conn gapir.Connection) error {
+	ctx = status.Start(ctx, "Fence Ready Request")
+	defer status.Finish(ctx)
+	// TODO(apbodnar) Tell the connection executor to start a perfetto trace here
+
+	return conn.SendFenceReady(ctx, req.GetId())
+}
+
 // HandleCrashDump implements gapir.ReplayResponseHandler interface.
 func (e *backgroundConnection) HandleCrashDump(ctx context.Context, dump *gapir.CrashDump, conn gapir.Connection) error {
 	if dump == nil {

--- a/gapis/replay/wait_for_fence.go
+++ b/gapis/replay/wait_for_fence.go
@@ -1,0 +1,43 @@
+// Copyright (C) 2019 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package replay
+
+import (
+	"context"
+
+	"github.com/google/gapid/gapis/api"
+	"github.com/google/gapid/gapis/api/transform"
+	"github.com/google/gapid/gapis/replay/builder"
+)
+
+type WaitForFence struct{}
+
+func (t *WaitForFence) Transform(ctx context.Context, id api.CmdID, cmd api.Cmd, out transform.Writer) {
+	if id == 0 {
+		t.AddWaitInstruction(ctx, id, out)
+	}
+	out.MutateAndWrite(ctx, id, cmd)
+}
+
+func (t *WaitForFence) Flush(ctx context.Context, out transform.Writer)    {}
+func (t *WaitForFence) PreLoop(ctx context.Context, out transform.Writer)  {}
+func (t *WaitForFence) PostLoop(ctx context.Context, out transform.Writer) {}
+
+func (t *WaitForFence) AddWaitInstruction(ctx context.Context, id api.CmdID, out transform.Writer) {
+	out.MutateAndWrite(ctx, id, Custom{T: 0, F: func(ctx context.Context, s *api.GlobalState, b *builder.Builder) error {
+		b.Wait(uint32(id))
+		return nil
+	}})
+}


### PR DESCRIPTION
An initial pass in preparation for replay profiling.  After a discussion with @pmuetschard we decided that adding a new `WAIT` instruction would be better than overloading the `NOTIFICATION` instruction.  Currently, executing the wait instruction is coupled with the logic to _eventually_ start a perfetto trace, but it should be extensible to allow waiting for other types of events from the server.

CC: @purvisa-at-google-com 