### PR TITLE
Preserve error when framebuffer attachments can't be fetched

### DIFF
--- a/gapis/api/vulkan/vulkan.go
+++ b/gapis/api/vulkan/vulkan.go
@@ -106,6 +106,10 @@ func (API) GetFramebufferAttachmentInfo(
 	attachment api.FramebufferAttachment) (info api.FramebufferAttachmentInfo, err error) {
 
 	w, h, form, i, r, err := GetState(state).getFramebufferAttachmentInfo(attachment)
+	if err != nil {
+		return api.FramebufferAttachmentInfo{}, err
+	}
+
 	switch attachment {
 	case api.FramebufferAttachment_Stencil:
 		return api.FramebufferAttachmentInfo{}, fmt.Errorf("Unsupported Stencil")


### PR DESCRIPTION
The next layer down produces a variety of meaningful error messages for
why a framebuffer attachment is not available. Unfortunately, we were
ignoring them, and instead failing to convert VK_FORMAT_UNDEFINED to our
internal format representation and complaining about that instead.

Google bug: b/142860636