### PR TITLE
Clean capture termination of concurrent app with in-flight commands

### DIFF
--- a/gapii/cc/call_observer.cpp
+++ b/gapii/cc/call_observer.cpp
@@ -132,6 +132,21 @@ void CallObserver::encode(const ::google::protobuf::Message* cmd) {
   encoder()->object(cmd);
 }
 
+void CallObserver::reenter() {
+  if (!mShouldTrace) {
+    // This observer was disabled from the start of the command, nothing to do.
+    return;
+  }
+  mShouldTrace = mSpy->should_trace(mApi);
+  if (!mShouldTrace) {
+    // This branch is taken when this observer was enabled for pre-fence
+    // observations, but a concurrent command terminated the trace while this
+    // command was passed on to the driver. Pop the encoder which was pushed at
+    // creation.
+    mEncoderStack.pop();
+  }
+}
+
 void CallObserver::exit() {
   if (!mShouldTrace) {
     return;

--- a/gapii/cc/call_observer.h
+++ b/gapii/cc/call_observer.h
@@ -171,6 +171,11 @@ class CallObserver : public context_t {
   template <typename T, typename = enable_if_encodable<T> >
   inline void encode(const T& obj);
 
+  // reenter updates whether the observer should keep on tracing or not. It is
+  // meant to be called when a threadsafe command is re-entered after the actual
+  // driver call, and after re-acquiring the Spy lock.
+  void reenter();
+
   // exit returns encoding to the group bound before calling enter().
   void exit();
 

--- a/gapii/cc/spy.cpp
+++ b/gapii/cc/spy.cpp
@@ -252,8 +252,8 @@ Spy::Spy()
 void Spy::resolveImports() { GlesSpy::mImports.resolve(); }
 
 CallObserver* Spy::enter(const char* name, uint32_t api) {
+  lock();
   auto ctx = new CallObserver(this, gContext, api);
-  lock(ctx);
   ctx->setCurrentCommandName(name);
   gContext = ctx;
   return ctx;

--- a/gapii/cc/spy_base.cpp
+++ b/gapii/cc/spy_base.cpp
@@ -52,7 +52,7 @@ void SpyBase::init(CallObserver* observer) {
   mIsSuspended = false;
 }
 
-void SpyBase::lock(CallObserver* observer) { mSpinLock.Lock(); }
+void SpyBase::lock() { mSpinLock.Lock(); }
 
 void SpyBase::unlock() { mSpinLock.Unlock(); }
 

--- a/gapii/cc/spy_base.h
+++ b/gapii/cc/spy_base.h
@@ -116,7 +116,7 @@ class SpyBase {
   // lock begins the interception of a single command. It must be called
   // before invoking any command on the spy. Blocks if any other thread
   // is has called lock and not yet called unlock.
-  void lock(CallObserver* observer);
+  void lock();
 
   // unlock must be called after invoking any command.
   // resets the buffers reused between commands.

--- a/gapis/api/templates/api_spy.cpp.tmpl
+++ b/gapis/api/templates/api_spy.cpp.tmpl
@@ -244,7 +244,8 @@
           {{end}}
         {{end}}
         {{if (GetAnnotation $ "threadsafe")}}
-        lock(observer);
+        lock();
+        observer->reenter();
         {{end}}
 ¶
         {{if IsVoid $.Return.Type}}
@@ -273,10 +274,16 @@
       {{if GetAnnotation $ "draw_call"}}onPostDrawCall(observer, {{Global "ApiIndex"}});{{end}}
 
       observer->observePending();
-      observer->exit();
+
+      // onPostStartOfFrame() and onPostEndOfFrame() may stop the capture, this
+      // impacts observers of concurrently running commands, so they must be
+      // called before the observer exits its critical section.
 
       {{if GetAnnotation $ "frame_start"}}onPostStartOfFrame();{{end}}
       {{if GetAnnotation $ "frame_end"}}onPostEndOfFrame();{{end}}
+
+      observer->exit();
+
       {{if not (IsVoid $.Return.Type)}}¶
         return result;
       {{end}}


### PR DESCRIPTION
When capturing multithreaded applications, thread A may emit an
command which ends the capture, such that should_trace(api) returns
false, while thread B emits a command which eventually leads to
sendResource(). In this case, it is valid to reach sendResource() with
should_trace(api) returning false.

It looks OK to keep on trying sending resource even if the
capture has ended, as getEncoder(api)->object(&resource) will
eventually call ChunkWriterImpl::write() which will not try to write
to the closed stream.

Google bug: b/141847511