### PR TITLE
Add validation for Adreno GPU.

### DIFF
--- a/cmd/gapit/BUILD.bazel
+++ b/cmd/gapit/BUILD.bazel
@@ -47,6 +47,7 @@ go_library(
         "trace.go",
         "trim.go",
         "unpack.go",
+        "validate_gpu_profiling.go",
         "video.go",
     ],
     importpath = "github.com/google/gapid/cmd/gapit",

--- a/cmd/gapit/flags.go
+++ b/cmd/gapit/flags.go
@@ -399,4 +399,9 @@ type (
 
 	MakeDocFlags struct {
 	}
+
+	ValidateGpuProfilingFlags struct {
+		Gapis GapisFlags
+		OS    device.OSKind `help:"Only validate GPU profiling for devices of the given OS kind"`
+	}
 )

--- a/cmd/gapit/validate_gpu_profiling.go
+++ b/cmd/gapit/validate_gpu_profiling.go
@@ -1,0 +1,73 @@
+// Copyright (C) 2019 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/google/gapid/core/app"
+	"github.com/google/gapid/core/log"
+	"github.com/google/gapid/core/os/device"
+)
+
+type validateGpuProfilingVerb struct{ ValidateGpuProfilingFlags }
+
+func init() {
+	verb := &validateGpuProfilingVerb{}
+
+	app.AddVerb(&app.Verb{
+		Name:      "validate_gpu_profiling",
+		ShortHelp: "Validates the GPU profiling capability of a device",
+		Action:    verb,
+	})
+}
+
+func (verb *validateGpuProfilingVerb) Run(ctx context.Context, flags flag.FlagSet) error {
+	client, err := getGapis(ctx, verb.Gapis, GapirFlags{})
+	if err != nil {
+		return log.Err(ctx, err, "Failed to connect to the GAPIS server.")
+	}
+	defer client.Close()
+	devices, err := client.GetDevices(ctx)
+	if err != nil {
+		return log.Err(ctx, err, "Failed to get device list.")
+	}
+
+	stdout := os.Stdout
+
+	// TODO(lpy): Allow to specify an Android device.
+	for i, p := range devices {
+		fmt.Fprintf(stdout, "-- Device %v: %v --\n", i, p.ID.ID())
+		o, err := client.Get(ctx, p.Path(), nil)
+		if err != nil {
+			fmt.Fprintf(stdout, "%v\n", log.Err(ctx, err, "Couldn't resolve device"))
+			continue
+		}
+		d := o.(*device.Instance)
+		if verb.OS != device.UnknownOS && verb.OS != d.GetConfiguration().GetOS().GetKind() {
+			continue
+		}
+		err = client.ValidateDevice(ctx, p)
+		if err != nil {
+			fmt.Fprintf(stdout, "%v\n", log.Err(ctx, err, "Failed to validate device"))
+			continue
+		}
+		fmt.Fprintf(stdout, "Device is validated.\n")
+	}
+	return nil
+}

--- a/gapis/client/client.go
+++ b/gapis/client/client.go
@@ -565,3 +565,16 @@ func (c *client) PerfettoQuery(ctx context.Context, capture *path.Capture, query
 	}
 	return res.GetResult(), nil
 }
+
+func (c *client) ValidateDevice(ctx context.Context, device *path.Device) error {
+	res, err := c.client.ValidateDevice(ctx, &service.ValidateDeviceRequest{
+		Device: device,
+	})
+	if err != nil {
+		return err
+	}
+	if err := res.GetError(); err != nil {
+		return err.Get()
+	}
+	return nil
+}

--- a/gapis/server/grpc.go
+++ b/gapis/server/grpc.go
@@ -659,3 +659,11 @@ func (s *grpcServer) PerfettoQuery(ctx xctx.Context, req *service.PerfettoQueryR
 	}
 	return &service.PerfettoQueryResponse{Res: &service.PerfettoQueryResponse_Result{Result: data}}, nil
 }
+
+func (s *grpcServer) ValidateDevice(ctx xctx.Context, req *service.ValidateDeviceRequest) (*service.ValidateDeviceResponse, error) {
+	err := s.handler.ValidateDevice(s.bindCtx(ctx), req.Device)
+	if err := service.NewError(err); err != nil {
+		return &service.ValidateDeviceResponse{Error: err}, nil
+	}
+	return &service.ValidateDeviceResponse{}, nil
+}

--- a/gapis/server/server.go
+++ b/gapis/server/server.go
@@ -929,3 +929,10 @@ func (s *server) PerfettoQuery(ctx context.Context, c *path.Capture, query strin
 	}
 	return res, nil
 }
+
+func (s *server) ValidateDevice(ctx context.Context, d *path.Device) error {
+	ctx = status.Start(ctx, "RPC ValidateDevice")
+	defer status.Finish(ctx)
+	ctx = log.Enter(ctx, "ValidateDevice")
+	return trace.Validate(ctx, d)
+}

--- a/gapis/service/service.go
+++ b/gapis/service/service.go
@@ -186,6 +186,10 @@ type Service interface {
 
 	// Run a perfetto query
 	PerfettoQuery(ctx context.Context, c *path.Capture, query string) (*perfetto.QueryResult, error)
+
+	// ValidateDevice validates the GPU profiling capabilities of the given device and returns
+	// an error if validation failed or the GPU profiling data is invalid.
+	ValidateDevice(ctx context.Context, d *path.Device) error
 }
 
 type TraceHandler interface {

--- a/gapis/service/service.proto
+++ b/gapis/service/service.proto
@@ -759,6 +759,17 @@ service Gapid {
   rpc GetTimestamps(GetTimestampsRequest)
       returns (stream GetTimestampsResponse) {
   }
+
+  rpc ValidateDevice(ValidateDeviceRequest) returns (ValidateDeviceResponse) {
+  }
+}
+
+message ValidateDeviceRequest {
+  path.Device device = 1;
+}
+
+message ValidateDeviceResponse {
+  Error error = 1;
 }
 
 message Error {

--- a/gapis/trace/android/BUILD.bazel
+++ b/gapis/trace/android/BUILD.bazel
@@ -21,6 +21,9 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//core/app:go_default_library",
+        "//core/app/crash:go_default_library",
+        "//core/app/status:go_default_library",
+        "//core/event/task:go_default_library",
         "//core/log:go_default_library",
         "//core/os/android:go_default_library",
         "//core/os/android/adb:go_default_library",
@@ -30,8 +33,13 @@ go_library(
         "//gapidapk:go_default_library",
         "//gapidapk/pkginfo:go_default_library",
         "//gapii/client:go_default_library",
+        "//gapis/perfetto:go_default_library",
         "//gapis/perfetto/android:go_default_library",
         "//gapis/service:go_default_library",
+        "//gapis/trace/android/adreno:go_default_library",
+        "//gapis/trace/android/validate:go_default_library",
         "//gapis/trace/tracer:go_default_library",
+        "//tools/build/third_party/perfetto:config_go_proto",
+        "@com_github_golang_protobuf//proto:go_default_library",
     ],
 )

--- a/gapis/trace/android/adreno/BUILD.bazel
+++ b/gapis/trace/android/adreno/BUILD.bazel
@@ -1,0 +1,12 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["validate.go"],
+    importpath = "github.com/google/gapid/gapis/trace/android/adreno",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//gapis/perfetto:go_default_library",
+        "//gapis/trace/android/validate:go_default_library",
+    ],
+)

--- a/gapis/trace/android/adreno/validate.go
+++ b/gapis/trace/android/adreno/validate.go
@@ -1,0 +1,44 @@
+// Copyright (C) 2019 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package adreno
+
+import (
+	"context"
+
+	"github.com/google/gapid/gapis/perfetto"
+	"github.com/google/gapid/gapis/trace/android/validate"
+)
+
+var (
+	counters = []validate.GpuCounter{
+		{1, "Clocks / Second", validate.And(validate.IsNumber, validate.CheckLargerThanZero)},
+		{4, "GPU % Bus Busy", validate.And(validate.IsNumber, validate.CheckLargerThanZero)},
+		{20, "% Shaders Busy", validate.And(validate.IsNumber, validate.CheckLargerThanZero)},
+	}
+)
+
+type AdrenoValidator struct {
+}
+
+func (v *AdrenoValidator) Validate(ctx context.Context, processor *perfetto.Processor) error {
+	if err := validate.ValidateGpuCounters(ctx, processor, v.GetCounters()); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (v *AdrenoValidator) GetCounters() []validate.GpuCounter {
+	return counters
+}

--- a/gapis/trace/android/validate/BUILD.bazel
+++ b/gapis/trace/android/validate/BUILD.bazel
@@ -1,0 +1,13 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["validate.go"],
+    importpath = "github.com/google/gapid/gapis/trace/android/validate",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//core/log:go_default_library",
+        "//gapis/perfetto:go_default_library",
+        "//gapis/perfetto/service:go_default_library",
+    ],
+)

--- a/gapis/trace/android/validate/validate.go
+++ b/gapis/trace/android/validate/validate.go
@@ -1,0 +1,118 @@
+// Copyright (C) 2018 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validate
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/gapid/core/log"
+	"github.com/google/gapid/gapis/perfetto"
+	perfetto_service "github.com/google/gapid/gapis/perfetto/service"
+)
+
+const (
+	counterIdQuery = "" +
+		"select counter_id from counter_definitions " +
+		"where name = '%v'"
+	counterValuesQuery = "" +
+		"select value from counter_values " +
+		"where counter_id = %v order by ts " +
+		"limit %v offset 10"
+	sampleCounter = 100
+)
+
+type Checker func(column *perfetto_service.QueryResult_ColumnValues, columnType perfetto_service.QueryResult_ColumnDesc_Type) bool
+
+type GpuCounter struct {
+	Id    uint32
+	Name  string
+	Check Checker
+}
+
+type Validator interface {
+	Validate(ctx context.Context, processor *perfetto.Processor) error
+	GetCounters() []GpuCounter
+}
+
+func And(c1, c2 Checker) Checker {
+	return func(column *perfetto_service.QueryResult_ColumnValues, columnType perfetto_service.QueryResult_ColumnDesc_Type) bool {
+		return c1(column, columnType) && c2(column, columnType)
+	}
+}
+
+func IsNumber(column *perfetto_service.QueryResult_ColumnValues, columnType perfetto_service.QueryResult_ColumnDesc_Type) bool {
+	if columnType != perfetto_service.QueryResult_ColumnDesc_LONG && columnType != perfetto_service.QueryResult_ColumnDesc_DOUBLE {
+		return false
+	}
+	return true
+}
+
+func CheckLargerThanZero(column *perfetto_service.QueryResult_ColumnValues, columnType perfetto_service.QueryResult_ColumnDesc_Type) bool {
+	longValues := column.GetLongValues()
+	doubleValues := column.GetDoubleValues()
+	for i := 0; i < sampleCounter; i++ {
+		if columnType == perfetto_service.QueryResult_ColumnDesc_LONG {
+			if longValues[i] <= 0 {
+				return false
+			}
+		} else if columnType == perfetto_service.QueryResult_ColumnDesc_DOUBLE {
+			if doubleValues[i] <= 0.0 {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// GPU counters validation will fail in the below cases:
+// 1. Fail to query
+// 2. Missing GPU counter samples
+// 3. Fail to check
+func ValidateGpuCounters(ctx context.Context, processor *perfetto.Processor, counters []GpuCounter) error {
+	for _, counter := range counters {
+		queryResult, err := processor.Query(fmt.Sprintf(counterIdQuery, counter.Name))
+		if err != nil {
+			return log.Errf(ctx, err, "Failed to query with %v", fmt.Sprintf(counterIdQuery, counter.Name))
+		}
+		if len(queryResult.GetColumns()) != 1 {
+			return log.Errf(ctx, err, "Expect one result with query: %v", fmt.Sprintf(counterIdQuery, counter.Name))
+		}
+		var counterId int64
+		for _, column := range queryResult.GetColumns() {
+			longValues := column.GetLongValues()
+			if len(longValues) != 1 {
+				// This should never happen, but sill have a check.
+				return log.Err(ctx, nil, "Query result is not 1.")
+			}
+			counterId = longValues[0]
+			break
+		}
+		queryResult, err = processor.Query(fmt.Sprintf(counterValuesQuery, counterId, sampleCounter))
+		if err != nil {
+			return log.Errf(ctx, err, "Failed to query with %v for counter %v", fmt.Sprintf(counterValuesQuery, counterId), counter)
+		}
+
+		// Query exactly #sampleCounter samples, fail if not enough samples
+		if queryResult.GetNumRecords() != sampleCounter {
+			return log.Errf(ctx, nil, "Number of samples is incorrect for counter: %v %v", counter, queryResult.GetNumRecords())
+		}
+
+		if !counter.Check(queryResult.GetColumns()[0], queryResult.GetColumnDescriptors()[0].GetType()) {
+			return log.Errf(ctx, nil, "Check failed for counter: %v", counter)
+		}
+	}
+	return nil
+}

--- a/gapis/trace/desktop/trace.go
+++ b/gapis/trace/desktop/trace.go
@@ -47,6 +47,10 @@ func (t *DesktopTracer) GetDevice() bind.Device {
 	return t.b
 }
 
+func (t *DesktopTracer) Validate(ctx context.Context) error {
+	return nil
+}
+
 // TraceConfiguration returns the device's supported trace configuration.
 func (t *DesktopTracer) TraceConfiguration(ctx context.Context) (*service.DeviceTraceConfiguration, error) {
 	apis := make([]*service.TraceTypeCapabilities, 0, 1)

--- a/gapis/trace/trace.go
+++ b/gapis/trace/trace.go
@@ -90,6 +90,18 @@ func TraceConfiguration(ctx context.Context, device *path.Device) (*service.Devi
 	return tracer.TraceConfiguration(ctx)
 }
 
+func Validate(ctx context.Context, p *path.Device) error {
+	if p == nil {
+		return log.Err(ctx, nil, "Invalid device path")
+	}
+	mgr := GetManager(ctx)
+	tracer, ok := mgr.tracers[p.ID.ID()]
+	if !ok || tracer == nil {
+		return log.Errf(ctx, nil, "Could not find tracer for device %d", p.ID.ID())
+	}
+	return tracer.Validate(ctx)
+}
+
 func isSupported(config *service.DeviceTraceConfiguration, options *service.TraceOptions) bool {
 	numApis := len(options.Apis)
 

--- a/gapis/trace/tracer/tracer.go
+++ b/gapis/trace/tracer/tracer.go
@@ -69,6 +69,10 @@ type Tracer interface {
 
 	// GetDevice returns the device associated with this tracer
 	GetDevice() bind.Device
+
+	// Validate validates the GPU profiling capabilities of the given device and returns
+	// an error if validation failed or the GPU profiling data is invalid.
+	Validate(ctx context.Context) error
 }
 
 // LayersFromOptions Parses the perfetto options, and returns the required layers


### PR DESCRIPTION
Create the basic framework of GPU profiling validation as well as a gapit
command to run validation. When an Android device is connected, register a
validator if the GPU is supported and the device has basic GPU profiling
capabilities discovered.

BUG: b/138717619
Test: bazel run gapit validate