### PR TITLE
Add Vulkan validation layers to GAPID APK

### DIFF
--- a/gapidapk/android/apk/rules.bzl
+++ b/gapidapk/android/apk/rules.bzl
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//tools/build:rules.bzl", "android_native_vulkan_validation_layers", "extract", "filehash")
+load("//tools/build:rules.bzl", "extract", "filehash")
 load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
 
 def _strip_impl(ctx):
@@ -100,10 +100,11 @@ def gapid_apk(name = "", abi = "", pkg = "", libs = {}, bins = {}):
         name = name + "_native",
         linkstatic = 1,
         srcs = select({
-            "//tools/build:android-" + name: [
-                name + "_libs",
-                "@android_native_vulkan_validation_layers//:vulkan_validation_layer_" + abi,
-            ],
+            "//tools/build:android-" + name: [name + "_libs"],
+            "//conditions:default": [],
+        }),
+        deps = select({
+            "//tools/build:android-" + name: ["@ndk_vk_validation_layer//:" + abi],
             "//conditions:default": [],
         }),
     )

--- a/gapidapk/android/apk/rules.bzl
+++ b/gapidapk/android/apk/rules.bzl
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//tools/build:rules.bzl", "extract", "filehash")
+load("//tools/build:rules.bzl", "android_native_vulkan_validation_layers", "extract", "filehash")
 load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
 
 def _strip_impl(ctx):
@@ -100,9 +100,12 @@ def gapid_apk(name = "", abi = "", pkg = "", libs = {}, bins = {}):
         name = name + "_native",
         linkstatic = 1,
         srcs = select({
-            "//tools/build:android-" + name: [name + "_libs"],
+            "//tools/build:android-" + name: [
+                name + "_libs",
+                "@android_native_vulkan_validation_layers//:vulkan_validation_layer_" + abi,
+            ],
             "//conditions:default": [],
-        })
+        }),
     )
     native.android_binary(
         name = name,

--- a/tools/build/rules.bzl
+++ b/tools/build/rules.bzl
@@ -16,6 +16,7 @@ load("//tools/build/rules:android.bzl",
     _android_native_app_glue = "android_native_app_glue",
     _android_native = "android_native",
     _android_native_binary = "android_native_binary",
+    _android_native_vulkan_validation_layers = "android_native_vulkan_validation_layers",
 )
 load("//tools/build/rules:apic.bzl",
     _apic_compile = "apic_compile",
@@ -76,6 +77,7 @@ load("//tools/build/rules:zip.bzl",
 android_native_app_glue = _android_native_app_glue
 android_native = _android_native
 android_native_binary = _android_native_binary
+android_native_vulkan_validation_layers = _android_native_vulkan_validation_layers
 apic_compile = _apic_compile
 apic_template = _apic_template
 cc_copts = _cc_copts

--- a/tools/build/rules.bzl
+++ b/tools/build/rules.bzl
@@ -13,10 +13,8 @@
 # limitations under the License.
 
 load("//tools/build/rules:android.bzl",
-    _android_native_app_glue = "android_native_app_glue",
     _android_native = "android_native",
     _android_native_binary = "android_native_binary",
-    _android_native_vulkan_validation_layers = "android_native_vulkan_validation_layers",
 )
 load("//tools/build/rules:apic.bzl",
     _apic_compile = "apic_compile",
@@ -74,10 +72,8 @@ load("//tools/build/rules:zip.bzl",
     _extract = "extract",
 )
 
-android_native_app_glue = _android_native_app_glue
 android_native = _android_native
 android_native_binary = _android_native_binary
-android_native_vulkan_validation_layers = _android_native_vulkan_validation_layers
 apic_compile = _apic_compile
 apic_template = _apic_template
 cc_copts = _cc_copts

--- a/tools/build/rules/android.bzl
+++ b/tools/build/rules/android.bzl
@@ -108,7 +108,7 @@ android_native_app_glue = repository_rule(
 
 # Retrieve Vulkan validation layers from the Android NDK
 
-def _android_native_vulkan_validation_layers(ctx):
+def _ndk_vk_validation_layer(ctx):
     build = ""
     for abi in ["armeabi-v7a", "arm64-v8a", "x86", "x86_64"]:
 
@@ -121,8 +121,8 @@ def _android_native_vulkan_validation_layers(ctx):
             )
 
         build += "\n".join([
-            "filegroup(",
-            "    name = \"vulkan_validation_layer_" + abi + "\",",
+            "cc_library(",
+            "    name = \"" + abi + "\",",
             "    srcs = glob([\"" + abi + "/libVkLayer*.so\"]),",
             "    visibility = [\"//visibility:public\"],",
             ")",
@@ -130,8 +130,8 @@ def _android_native_vulkan_validation_layers(ctx):
 
     ctx.file("BUILD", build)
 
-android_native_vulkan_validation_layers = repository_rule(
-    implementation = _android_native_vulkan_validation_layers,
+ndk_vk_validation_layer = repository_rule(
+    implementation = _ndk_vk_validation_layer,
     local = True,
     environ = [
         "ANDROID_NDK_HOME",

--- a/tools/build/rules/android.bzl
+++ b/tools/build/rules/android.bzl
@@ -105,3 +105,35 @@ android_native_app_glue = repository_rule(
         "ANDROID_NDK_HOME",
     ]
 )
+
+# Retrieve Vulkan validation layers from the Android NDK
+
+def _android_native_vulkan_validation_layers(ctx):
+    build = ""
+    for abi in ["armeabi-v7a", "arm64-v8a", "x86", "x86_64"]:
+
+        for layer in ["core_validation", "object_tracker", "parameter_validation", "threading", "unique_objects"]:
+            layerpath = abi + "/libVkLayer_" + layer + ".so"
+            ctx.symlink(
+                ctx.path(ctx.os.environ["ANDROID_NDK_HOME"] +
+                         "/sources/third_party/vulkan/src/build-android/jniLibs/" + layerpath),
+                ctx.path(layerpath),
+            )
+
+        build += "\n".join([
+            "filegroup(",
+            "    name = \"vulkan_validation_layer_" + abi + "\",",
+            "    srcs = glob([\"" + abi + "/libVkLayer*.so\"]),",
+            "    visibility = [\"//visibility:public\"],",
+            ")",
+        ]) + "\n"
+
+    ctx.file("BUILD", build)
+
+android_native_vulkan_validation_layers = repository_rule(
+    implementation = _android_native_vulkan_validation_layers,
+    local = True,
+    environ = [
+        "ANDROID_NDK_HOME",
+    ],
+)

--- a/tools/build/workspace.bzl
+++ b/tools/build/workspace.bzl
@@ -16,7 +16,7 @@
 # dependencies and toolchains.
 
 load("@gapid//tools/build:cc_toolchain.bzl", "cc_configure")
-load("@gapid//tools/build/rules:android.bzl", "android_native_app_glue", "android_native_vulkan_validation_layers")
+load("@gapid//tools/build/rules:android.bzl", "android_native_app_glue", "ndk_vk_validation_layer")
 load("@gapid//tools/build/rules:repository.bzl", "github_repository", "maybe_repository")
 load("@gapid//tools/build/third_party:breakpad.bzl", "breakpad")
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository", "new_git_repository")
@@ -279,8 +279,8 @@ def gapid_dependencies(android = True, mingw = True, locals = {}):
         )
 
         maybe_repository(
-            android_native_vulkan_validation_layers,
-            name = "android_native_vulkan_validation_layers",
+            ndk_vk_validation_layer,
+            name = "ndk_vk_validation_layer",
             locals = locals,
         )
 

--- a/tools/build/workspace.bzl
+++ b/tools/build/workspace.bzl
@@ -16,7 +16,7 @@
 # dependencies and toolchains.
 
 load("@gapid//tools/build:cc_toolchain.bzl", "cc_configure")
-load("@gapid//tools/build/rules:android.bzl", "android_native_app_glue")
+load("@gapid//tools/build/rules:android.bzl", "android_native_app_glue", "android_native_vulkan_validation_layers")
 load("@gapid//tools/build/rules:repository.bzl", "github_repository", "maybe_repository")
 load("@gapid//tools/build/third_party:breakpad.bzl", "breakpad")
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository", "new_git_repository")
@@ -275,6 +275,12 @@ def gapid_dependencies(android = True, mingw = True, locals = {}):
         maybe_repository(
             android_native_app_glue,
             name = "android_native_app_glue",
+            locals = locals,
+        )
+
+        maybe_repository(
+            android_native_vulkan_validation_layers,
+            name = "android_native_vulkan_validation_layers",
             locals = locals,
         )
 


### PR DESCRIPTION
We need to have access to the ANDROID_NDK_HOME environment variable,
hence the new repository_rule.

Google bug: b/141360600