### PR TITLE
Change Frame Looping logic to not rewind state on last iteration

### DIFF
--- a/gapir/cc/interpreter.h
+++ b/gapir/cc/interpreter.h
@@ -95,6 +95,9 @@ class Interpreter {
   // from this point.
   void resetInstructions();
 
+  // Scan the instructions building the jump destination table.
+  bool updateJumpTable(uint32_t jumpLabel);
+
   // Registers an API instance if it has not already been done.
   bool registerApi(uint8_t api);
 
@@ -152,6 +155,7 @@ class Interpreter {
   Result switchThread(uint32_t opcode);
   Result jumpLabel(uint32_t opcode);
   Result jumpNZ(uint32_t opcode);
+  Result jumpZ(uint32_t opcode);
   Result notification();
   Result wait(uint32_t opcode);
 
@@ -214,7 +218,7 @@ class Interpreter {
   ThreadPool mThreadPool;
 
   // Jump ID to instruction ID
-  std::unordered_map<uint32_t, uint32_t> mJumpLables;
+  std::map<uint32_t, uint32_t> mJumpLabels;
 };
 
 inline bool Interpreter::isConstantAddressForType(const void* address,

--- a/gapir/replay_service/vm.h
+++ b/gapir/replay_service/vm.h
@@ -44,8 +44,9 @@ enum class Opcode {
   SWITCH_THREAD = 16,
   JUMP_LABEL = 17,
   JUMP_NZ = 18,
-  NOTIFICATION = 19,
-  WAIT = 20,
+  JUMP_Z = 19,
+  NOTIFICATION = 20,
+  WAIT = 21,
 };
 
 // Unique ID for each supported data type. The ID have to fit into 6 bits (0-63)

--- a/gapis/replay/asm/instructions.go
+++ b/gapis/replay/asm/instructions.go
@@ -368,6 +368,14 @@ func (a JumpNZ) Encode(r value.PointerResolver, w binary.Writer) error {
 	return opcode.JumpNZ{Label: a.Label}.Encode(w)
 }
 
+type JumpZ struct {
+	Label uint32
+}
+
+func (a JumpZ) Encode(r value.PointerResolver, w binary.Writer) error {
+	return opcode.JumpZ{Label: a.Label}.Encode(w)
+}
+
 // Notification is an Instruction that sends Size bytes from Source to the server, with the ID returned as well.
 type Notification struct {
 	ID     uint64

--- a/gapis/replay/builder/builder.go
+++ b/gapis/replay/builder/builder.go
@@ -555,6 +555,15 @@ func (b *Builder) JumpNZ(label uint32) {
 	})
 }
 
+// JumpZ jumps to the instruction specified label if the value
+// on top of the stack is zero. Otherwise it will be be a Nop.
+func (b *Builder) JumpZ(label uint32) {
+	b.popStack()
+	b.instructions = append(b.instructions, asm.JumpZ{
+		Label: label,
+	})
+}
+
 // Notification asks the GAPIR to stream back the size bytes from addr. The |ID| will
 // be sent back as well to help identify which reader will process the notification.
 // A Notification reader must be registered to read the data the from the stream.

--- a/gapis/replay/opcode/opcodes.go
+++ b/gapis/replay/opcode/opcodes.go
@@ -334,6 +334,18 @@ func (c JumpNZ) Encode(w binary.Writer) error {
 	return w.Error()
 }
 
+// JumpZ represents the JumpZ virtual machine opcode.
+type JumpZ struct {
+	Label uint32 // 26 bit jump label.
+}
+
+func (c JumpZ) String() string { return fmt.Sprintf("JumpZ(Label: 0x%x)", c.Label) }
+
+func (c JumpZ) Encode(w binary.Writer) error {
+	w.Uint32(packCX(protocol.OpJumpZ, c.Label))
+	return w.Error()
+}
+
 // Notification represents the NOTIFICATION virtual machine opcode.
 type Notification struct{}
 
@@ -401,6 +413,8 @@ func Decode(r binary.Reader) (Opcode, error) {
 	case protocol.OpJumpLabel:
 		return Label{Value: unpackX(i)}, nil
 	case protocol.OpJumpNZ:
+		return Label{Value: unpackX(i)}, nil
+	case protocol.OpJumpZ:
 		return Label{Value: unpackX(i)}, nil
 	case protocol.OpNotification:
 		return Notification{}, nil

--- a/gapis/replay/protocol/opcode.go
+++ b/gapis/replay/protocol/opcode.go
@@ -39,8 +39,9 @@ const (
 	OpSwitchThread = Opcode(16)
 	OpJumpLabel    = Opcode(17)
 	OpJumpNZ       = Opcode(18)
-	OpNotification = Opcode(19)
-	OpWait         = Opcode(20)
+	OpJumpZ        = Opcode(19)
+	OpNotification = Opcode(20)
+	OpWait         = Opcode(21)
 )
 
 // String returns the human-readable name of the opcode.
@@ -84,6 +85,8 @@ func (t Opcode) String() string {
 		return "JumpLabel"
 	case OpJumpNZ:
 		return "JumpNZ"
+	case OpJumpZ:
+		return "JumpZ"
 	case OpNotification:
 		return "Notification"
 	case OpWait:


### PR DESCRIPTION
Changes the loop in frame looping so that we do not rewind the state on the last iteration.

This required some changes to the bytecode interpreter, since forward branching did not work in the old code.