### PR TITLE
Launch perfetto producer only if property ro.gfx.driver.1 is set

### DIFF
--- a/gapidapk/deviceinfo.go
+++ b/gapidapk/deviceinfo.go
@@ -111,7 +111,12 @@ func fetchDeviceInfo(ctx context.Context, d adb.Device) error {
 		return nil
 	}
 
-	if d.Instance().GetConfiguration().GetOS().GetAPIVersion() >= 29 {
+	driverProperty, err := d.SystemProperty(ctx, "ro.gfx.driver.1")
+	if err != nil {
+		return err
+	}
+
+	if d.Instance().GetConfiguration().GetOS().GetAPIVersion() >= 29 && driverProperty != "" {
 		startSignal, startFunc := task.NewSignal()
 		startFunc = task.Once(startFunc)
 		crash.Go(func() {


### PR DESCRIPTION
If property ro.gfx.driver.1 is not set, the perfetto launcher will
abort. Not all Android10 devices have it set, hence we strenghten the
condition to launch the perfetto producer.

Google bug: b/143507358