### PR TITLE
Fix vkUpdateDescriptorSet copy operation crash 

### DIFF
--- a/gapii/cc/vulkan_inlines.inc
+++ b/gapii/cc/vulkan_inlines.inc
@@ -84,6 +84,10 @@ inline void VulkanSpy::vkErrSemaphoreNotSubmitted(CallObserver*, VkImage img) {
     GAPID_DEBUG("Error: Semaphore %" PRIu64 " has not submitted for signal", img);
 }
 
+inline void VulkanSpy::vkErrInvalidDescriptorCopy(CallObserver*, VkDescriptorSet srcSet, uint32_t srcBinding, VkDescriptorSet dstSet, uint32_t dstBinding) {
+    GAPID_WARNING("Error: Copy descriptor set from %" PRIu64 " to %" PRIu64 " for the binding %" PRIu64 " to %" PRIu64 " is invalid", srcSet, dstSet, srcBinding, dstBinding);
+}
+
 inline void VulkanSpy::vkErrInvalidDescriptorBindingType(CallObserver*, VkDescriptorSet set, uint32_t binding, uint32_t layout_type, uint32_t update_type) {
     GAPID_DEBUG("Error: Updating descriptor binding at: %" PRIu64 ": %" PRIu32 " with type: %" PRIu32 ", but the type defined in descriptor set layout is: %" PRIu32 "", set, binding, layout_type, update_type);
 }

--- a/gapis/api/vulkan/api/descriptor.api
+++ b/gapis/api/vulkan/api/descriptor.api
@@ -492,7 +492,7 @@ sub map!(u32, DescriptorSetCopy) RewriteWriteDescriptorCopies
       for k in (dstRecord.Binding .. dstSet.Layout.MaximumBinding + 1) {
         if !dstFound.b {
           if k in dstSet.Layout.Bindings {
-            if dstRecord.ArrayIndex < srcSet.Layout.Bindings[k].Count {
+            if dstRecord.ArrayIndex < dstSet.Layout.Bindings[k].Count {
               dstRecord.Binding = k
               dstFound.b = true
             } else {
@@ -562,9 +562,7 @@ cmd void vkUpdateDescriptorSets(
         next.Ptr = as!VulkanStructHeader*(next.Ptr)[0:1][0].PNext
       }
     }
-
   }
-
 
   writes := RewriteWriteDescriptorSets(
     descriptorWriteCount,
@@ -643,28 +641,18 @@ cmd void vkUpdateDescriptorSets(
   for _ , _ , c in copies {
     srcSet := DescriptorSets[c.SrcSet]
     dstSet := DescriptorSets[c.DstSet]
-    srcBinding := switch srcSet.Bindings[c.SrcBinding] == null {
-      case false:
-        srcSet.Bindings[c.SrcBinding]
-      case true:
-        new!DescriptorBinding(BindingType: srcSet.Layout.Bindings[c.SrcBinding].Type)
-    }
-    dstBinding := switch dstSet.Bindings[c.DstBinding] == null {
-      case false:
-        dstSet.Bindings[c.DstBinding]
-      case true:
-        new!DescriptorBinding(BindingType: dstSet.Layout.Bindings[c.DstBinding].Type)
-    }
-    switch (srcBinding.BindingType) {
-      case VK_DESCRIPTOR_TYPE_SAMPLER,
-          VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
-          VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE,
-          VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
-          VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT: {
+    srcBinding := srcSet.Bindings[c.SrcBinding]
+    dstBinding := dstSet.Bindings[c.DstBinding]
 
-        if srcBinding.ImageBinding[c.SrcArrayIndex] == null {
-           vkErrInvalidDescriptorArrayElement(as!u64(c.SrcSet), c.SrcBinding, c.SrcArrayIndex)
-        } else {
+    if ((srcBinding == null) || (dstBinding == null)) {
+      vkErrorInvalidDescriptorCopy(c.SrcSet, c.SrcBinding, c.DstSet, c.DstBinding)
+    } else {
+      switch (srcBinding.BindingType) {
+        case VK_DESCRIPTOR_TYPE_SAMPLER,
+            VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
+            VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE,
+            VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
+            VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT: {
           imageBinding := dstBinding.ImageBinding
           imageBinding[c.DstArrayIndex] = srcBinding.ImageBinding[c.SrcArrayIndex]
           dstBinding.ImageBinding = imageBinding
@@ -685,40 +673,40 @@ cmd void vkUpdateDescriptorSets(
             }
           }
         }
-      }
 
-      case VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER,
-          VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER: {
-        bufferViews := dstBinding.BufferViewBindings
-        bufferViews[c.DstArrayIndex] =
-        srcBinding.BufferViewBindings[c.SrcArrayIndex]
-        dstBinding.BufferViewBindings = bufferViews
+        case VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER,
+            VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER: {
+          bufferViews := dstBinding.BufferViewBindings
+          bufferViews[c.DstArrayIndex] =
+          srcBinding.BufferViewBindings[c.SrcArrayIndex]
+          dstBinding.BufferViewBindings = bufferViews
 
-        vkView := srcBinding.BufferViewBindings[c.SrcArrayIndex]
-        if vkView in BufferViews {
-          viewObj := BufferViews[vkView]
-          if viewObj != null {
-            registerDescriptorUser!BufferViewObject(viewObj, c.DstSet, c.DstBinding, c.DstArrayIndex)
+          vkView := srcBinding.BufferViewBindings[c.SrcArrayIndex]
+          if vkView in BufferViews {
+            viewObj := BufferViews[vkView]
+            if viewObj != null {
+              registerDescriptorUser!BufferViewObject(viewObj, c.DstSet, c.DstBinding, c.DstArrayIndex)
+            }
+          }
+        }
+
+        case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
+            VK_DESCRIPTOR_TYPE_STORAGE_BUFFER,
+            VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC,
+            VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC: {
+          bufferBinding := dstBinding.BufferBinding
+          bufferBinding[c.DstArrayIndex] =
+          srcBinding.BufferBinding[c.SrcArrayIndex]
+          dstBinding.BufferBinding = bufferBinding
+          for _, _, b in dstBinding.BufferBinding {
+            if !b.Buffer in Buffers {
+              vkErrorInvalidBuffer(b.Buffer)
+            }
           }
         }
       }
-
-      case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
-          VK_DESCRIPTOR_TYPE_STORAGE_BUFFER,
-          VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC,
-          VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC: {
-        bufferBinding := dstBinding.BufferBinding
-        bufferBinding[c.DstArrayIndex] =
-        srcBinding.BufferBinding[c.SrcArrayIndex]
-        dstBinding.BufferBinding = bufferBinding
-        for _, _, b in dstBinding.BufferBinding {
-          if !b.Buffer in Buffers {
-            vkErrorInvalidBuffer(b.Buffer)
-          }
-        }
-      }
+      dstSet.Bindings[c.DstBinding] = dstBinding
     }
-    dstSet.Bindings[c.DstBinding] = dstBinding
   }
 }
 

--- a/gapis/api/vulkan/errors.api
+++ b/gapis/api/vulkan/errors.api
@@ -55,6 +55,7 @@ extern void vkErrInvalidImageLayout(VkImage img, u32 aspect, u32 layer, u32 leve
 extern void vkErrInvalidImageSubresource(VkImage img, string subresourceType, u32 value)
 extern void vkErrImageMemoryNotBound(VkImage img)
 extern void vkErrSemaphoreNotSubmitted(VkSemaphore semaphore)
+extern void vkErrInvalidDescriptorCopy(VkDescriptorSet srcSet, u32 srcBinding, VkDescriptorSet dstSet, u32 dstBinding)
 
 sub void vkErrorInvalidInstance(VkInstance inst) {
   vkErrorInvalidHandle("VkInstance", as!u64(inst))
@@ -156,12 +157,12 @@ sub void vkErrorInvalidPipelineLayout(VkPipelineLayout layout) {
   vkErrorInvalidHandle("VkPipelineLayout", as!u64(layout))
 }
 
-sub void vkErrorInvalidSampler(VkSampler sampler) {
-  vkErrorInvalidHandle("VkSampler", as!u64(sampler))
-}
-
 sub void vkErrorInvalidDescriptorSet(VkDescriptorSet set) {
   vkErrorInvalidHandle("VkDescriptorSet", as!u64(set))
+}
+
+sub void vkErrorInvalidDescriptorCopy(VkDescriptorSet srcSet, u32 srcBinding, VkDescriptorSet dstSet, u32 dstBinding) {
+  vkErrInvalidDescriptorCopy(srcSet, srcBinding, dstSet, dstBinding)
 }
 
 sub void vkErrorInvalidDescriptorSetLayout(VkDescriptorSetLayout layout) {

--- a/gapis/api/vulkan/externs.go
+++ b/gapis/api/vulkan/externs.go
@@ -494,6 +494,14 @@ func (e externs) vkErrSemaphoreNotSubmitted(semaphore VkSemaphore) {
 	e.onVkError(issue)
 }
 
+func (e externs) vkErrInvalidDescriptorCopy(srcSet VkDescriptorSet, srcBinding uint32, dstSet VkDescriptorSet, dstBinding uint32) {
+	var issue replay.Issue
+	issue.Command = e.cmdID
+	issue.Severity = service.Severity_ErrorLevel
+	issue.Error = fmt.Errorf("Copy descriptor set from %v to %v for the binding %v to %v is invalid", srcSet, dstSet, srcBinding, dstBinding)
+	e.onVkError(issue)
+}
+
 type fenceSignal uint64
 
 func (e externs) recordFenceSignal(fence VkFence) {


### PR DESCRIPTION
Fix the crash due to copying non existent srcBinding during vkUpdateDescriptorSet.