### PR TITLE
Revert "Cleanup termination of concurrent capture (#3282)"

### DIFF
--- a/gapii/cc/call_observer.cpp
+++ b/gapii/cc/call_observer.cpp
@@ -132,21 +132,6 @@ void CallObserver::encode(const ::google::protobuf::Message* cmd) {
   encoder()->object(cmd);
 }
 
-void CallObserver::reenter() {
-  if (!mShouldTrace) {
-    // This observer was disabled from the start of the command, nothing to do.
-    return;
-  }
-  mShouldTrace = mSpy->should_trace(mApi);
-  if (!mShouldTrace) {
-    // This branch is taken when this observer was enabled for pre-fence
-    // observations, but a concurrent command terminated the trace while this
-    // command was passed on to the driver. Pop the encoder which was pushed at
-    // creation.
-    mEncoderStack.pop();
-  }
-}
-
 void CallObserver::exit() {
   if (!mShouldTrace) {
     return;

--- a/gapii/cc/call_observer.h
+++ b/gapii/cc/call_observer.h
@@ -171,11 +171,6 @@ class CallObserver : public context_t {
   template <typename T, typename = enable_if_encodable<T> >
   inline void encode(const T& obj);
 
-  // reenter updates whether the observer should keep on tracing or not. It is
-  // meant to be called when a threadsafe command is re-entered after the actual
-  // driver call, and after re-acquiring the Spy lock.
-  void reenter();
-
   // exit returns encoding to the group bound before calling enter().
   void exit();
 

--- a/gapii/cc/spy.cpp
+++ b/gapii/cc/spy.cpp
@@ -252,8 +252,8 @@ Spy::Spy()
 void Spy::resolveImports() { GlesSpy::mImports.resolve(); }
 
 CallObserver* Spy::enter(const char* name, uint32_t api) {
-  lock();
   auto ctx = new CallObserver(this, gContext, api);
+  lock(ctx);
   ctx->setCurrentCommandName(name);
   gContext = ctx;
   return ctx;

--- a/gapii/cc/spy_base.cpp
+++ b/gapii/cc/spy_base.cpp
@@ -52,7 +52,7 @@ void SpyBase::init(CallObserver* observer) {
   mIsSuspended = false;
 }
 
-void SpyBase::lock() { mSpinLock.Lock(); }
+void SpyBase::lock(CallObserver* observer) { mSpinLock.Lock(); }
 
 void SpyBase::unlock() { mSpinLock.Unlock(); }
 

--- a/gapii/cc/spy_base.h
+++ b/gapii/cc/spy_base.h
@@ -116,7 +116,7 @@ class SpyBase {
   // lock begins the interception of a single command. It must be called
   // before invoking any command on the spy. Blocks if any other thread
   // is has called lock and not yet called unlock.
-  void lock();
+  void lock(CallObserver* observer);
 
   // unlock must be called after invoking any command.
   // resets the buffers reused between commands.

--- a/gapis/api/templates/api_spy.cpp.tmpl
+++ b/gapis/api/templates/api_spy.cpp.tmpl
@@ -244,8 +244,7 @@
           {{end}}
         {{end}}
         {{if (GetAnnotation $ "threadsafe")}}
-        lock();
-        observer->reenter();
+        lock(observer);
         {{end}}
 ¶
         {{if IsVoid $.Return.Type}}
@@ -274,16 +273,10 @@
       {{if GetAnnotation $ "draw_call"}}onPostDrawCall(observer, {{Global "ApiIndex"}});{{end}}
 
       observer->observePending();
-
-      // onPostStartOfFrame() and onPostEndOfFrame() may stop the capture, this
-      // impacts observers of concurrently running commands, so they must be
-      // called before the observer exits its critical section.
+      observer->exit();
 
       {{if GetAnnotation $ "frame_start"}}onPostStartOfFrame();{{end}}
       {{if GetAnnotation $ "frame_end"}}onPostEndOfFrame();{{end}}
-
-      observer->exit();
-
       {{if not (IsVoid $.Return.Type)}}¶
         return result;
       {{end}}


### PR DESCRIPTION
This reverts commit 0b0ceed9900d9f6231de6b4162f0abecdcedf235.

This change seems to trigger a regression, see b/143507358