### PR TITLE
Add support for VK_KHR_device_group_creation

### DIFF
--- a/gapii/cc/vulkan_extras.cpp
+++ b/gapii/cc/vulkan_extras.cpp
@@ -749,6 +749,44 @@ uint32_t VulkanSpy::SpyOverride_vkEnumerateInstanceExtensionProperties(
   return VkResult::VK_SUCCESS;
 }
 
+uint32_t VulkanSpy::SpyOverride_vkEnumeratePhysicalDeviceGroups(
+    VkInstance instance, uint32_t* pPhysicalDeviceGroupCount,
+    VkPhysicalDeviceGroupProperties* pPhysicalDeviceGroupProperties) {
+  auto inst_func_iter = mImports.mVkInstanceFunctions.find(instance);
+  gapii::VulkanImports::PFNVKENUMERATEPHYSICALDEVICEGROUPS next =
+      inst_func_iter->second.vkEnumeratePhysicalDeviceGroups;
+
+  auto ret =
+      next(instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties);
+  if (!pPhysicalDeviceGroupProperties) {
+    return ret;
+  }
+  for (size_t i = 0; i < *pPhysicalDeviceGroupCount; ++i) {
+    pPhysicalDeviceGroupProperties[i].mphysicalDeviceCount = 1;
+    pPhysicalDeviceGroupProperties[i].msubsetAllocation = 0;
+  }
+  return ret;
+}
+
+uint32_t VulkanSpy::SpyOverride_vkEnumeratePhysicalDeviceGroupsKHR(
+    VkInstance instance, uint32_t* pPhysicalDeviceGroupCount,
+    VkPhysicalDeviceGroupProperties* pPhysicalDeviceGroupProperties) {
+  auto inst_func_iter = mImports.mVkInstanceFunctions.find(instance);
+  gapii::VulkanImports::PFNVKENUMERATEPHYSICALDEVICEGROUPSKHR next =
+      inst_func_iter->second.vkEnumeratePhysicalDeviceGroupsKHR;
+
+  auto ret =
+      next(instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties);
+  if (!pPhysicalDeviceGroupProperties) {
+    return ret;
+  }
+  for (size_t i = 0; i < *pPhysicalDeviceGroupCount; ++i) {
+    pPhysicalDeviceGroupProperties[i].mphysicalDeviceCount = 1;
+    pPhysicalDeviceGroupProperties[i].msubsetAllocation = 0;
+  }
+  return ret;
+}
+
 uint32_t VulkanSpy::SpyOverride_vkEnumerateDeviceExtensionProperties(
     VkPhysicalDevice physicalDevice, const char* pLayerName, uint32_t* pCount,
     VkExtensionProperties* pProperties) {

--- a/gapii/cc/vulkan_extras.inc
+++ b/gapii/cc/vulkan_extras.inc
@@ -46,6 +46,13 @@ uint32_t SpyOverride_vkEnumerateDeviceLayerProperties(
 uint32_t SpyOverride_vkEnumerateDeviceExtensionProperties(
     VkPhysicalDevice dev, const char* pLayerName, uint32_t* pCount,
     VkExtensionProperties* pProperties);
+uint32_t SpyOverride_vkEnumeratePhysicalDeviceGroups(
+    VkInstance instance, uint32_t* pPhysicalDeviceGroupCount,
+    VkPhysicalDeviceGroupProperties* pPhysicalDeviceGroupProperties);
+uint32_t SpyOverride_vkEnumeratePhysicalDeviceGroupsKHR(
+    VkInstance instance, uint32_t* pPhysicalDeviceGroupCount,
+    VkPhysicalDeviceGroupProperties* pPhysicalDeviceGroupProperties);
+
 void SpyOverride_vkGetDeviceQueue(VkDevice device, uint32_t queueFamilyIndex,
                                   uint32_t queueIndex, VkQueue* pQueue);
 uint32_t SpyOverride_vkAllocateCommandBuffers(

--- a/gapii/cc/vulkan_inlines.inc
+++ b/gapii/cc/vulkan_inlines.inc
@@ -27,6 +27,10 @@ inline void VulkanSpy::vkErrNullPointer(CallObserver*, std::string pointerType) 
     GAPID_WARNING("Error: Null pointer of %s", pointerType.c_str())
 }
 
+inline void VulkanSpy::vkErrUnsupported(CallObserver*, std::string val) {
+    GAPID_WARNING("Error: Unsupported: %s", val.c_str())
+}
+
 inline void VulkanSpy::vkErrNotNullPointer(CallObserver*, std::string pointerType) {
     GAPID_WARNING("Error: Not Null Pointer: %s", pointerType.c_str());
 }

--- a/gapis/api/vulkan/api/device.api
+++ b/gapis/api/vulkan/api/device.api
@@ -51,6 +51,7 @@
   @unused VkPhysicalDeviceFeatures   EnabledFeatures
   @unused VkDevice                   VulkanHandle
   @unused ref!VulkanDebugMarkerInfo  DebugInfo
+  @unused bool                       CreatedWithDeviceGroup
 
   // Vulkan 1.1
   @unused ref!VariablePointerFeatures VariablePointerFeatures
@@ -81,8 +82,11 @@ cmd VkResult vkCreateDevice(
   // NOTE: The logic for this function should be identical to the one of
   // replayCreateVkDevice() in synthetic.api. Change both together.
   device := createDeviceObject(pCreateInfo)
-  if !(physicalDevice in PhysicalDevices) { vkErrorInvalidPhysicalDevice(physicalDevice) }
-  device.PhysicalDevice = physicalDevice
+
+  if (device.PhysicalDevice != null) {
+    if !(physicalDevice in PhysicalDevices) { vkErrorInvalidPhysicalDevice(physicalDevice) }
+    device.PhysicalDevice = physicalDevice
+  }
 
   handle := ?
   if pDevice == null { vkErrorNullPointer("VkDevice*") }
@@ -165,6 +169,17 @@ sub ref!DeviceObject createDeviceObject(const VkDeviceCreateInfo* data) {
           ext := as!VkPhysicalDeviceScalarBlockLayoutFeaturesEXT*(next.Ptr)[0]
           object.PhysicalDeviceScalarBlockLayoutFeaturesEXT = new!PhysicalDeviceScalarBlockLayoutFeaturesEXT(
             ScalarBlockLayout: ext.scalarBlockLayout)
+        }
+        case VK_STRUCTURE_TYPE_DEVICE_GROUP_DEVICE_CREATE_INFO: {
+          ext := as!VkDeviceGroupDeviceCreateInfo*(next.Ptr)[0]
+          if (ext.physicalDeviceCount > 1) {
+            vkErrorUnsupported("More than one physical device in a devicegroup")
+          }
+          if (ext.physicalDeviceCount > 0) {
+            if !(ext.pPhysicalDevices[0] in PhysicalDevices) { vkErrorInvalidPhysicalDevice(ext.pPhysicalDevices[0]) }
+            object.PhysicalDevice = ext.pPhysicalDevices[0]
+            object.CreatedWithDeviceGroup = true
+          }
         }
         default: {
           // do nothing

--- a/gapis/api/vulkan/errors.api
+++ b/gapis/api/vulkan/errors.api
@@ -40,6 +40,7 @@
 // en-us.stb.md.
 extern void vkErrInvalidHandle(string handleType, u64 handle)
 extern void vkErrNullPointer(string pointerType)
+extern void vkErrUnsupported(string pointerType)
 extern void vkErrNotNullPointer(string pointerType)
 extern void vkErrUnrecognizedExtension(string name)
 extern void vkErrExpectNVDedicatedlyAllocatedHandle(string handleType, u64 handle)
@@ -227,6 +228,11 @@ sub void vkErrorInvalidHandle(string handleType, u64 handle) {
 
 sub void vkErrorNullPointer(string pointerType) {
   vkErrNullPointer(pointerType)
+  abort
+}
+
+sub void vkErrorUnsupported(string unsupported) {
+  vkErrUnsupported(unsupported)
   abort
 }
 

--- a/gapis/api/vulkan/extensions/khr_device_group_creation.api
+++ b/gapis/api/vulkan/extensions/khr_device_group_creation.api
@@ -1,0 +1,89 @@
+// Copyright (C) 2019 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Based off of the original vulkan.h header file which has the following
+// license.
+
+// Copyright (c) 2015 The Khronos Group Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and/or associated documentation files (the
+// "Materials"), to deal in the Materials without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Materials, and to
+// permit persons to whom the Materials are furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Materials.
+//
+// THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+// IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+// CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+// TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+// MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+
+///////////////
+// Constants //
+///////////////
+@extension("VK_KHR_device_group_creation") define VK_KHR_DEVICE_GROUP_CREATION_SPEC_VERSION 1
+@extension("VK_KHR_device_group_creation") define VK_KHR_DEVICE_GROUP_CREATION_EXTENSION_NAME "VK_KHR_device_group_creation"
+
+////////////////////////////////////////////////
+// Structs                                    //
+// The structs are already in vk11structs.api //
+////////////////////////////////////////////////
+
+//////////////
+// Commands //
+//////////////
+@override
+@indirect("VkInstance")
+cmd VkResult vkEnumeratePhysicalDeviceGroupsKHR(
+    VkInstance                                  instance,
+    u32*                                        pPhysicalDeviceGroupCount,
+    VkPhysicalDeviceGroupProperties*            pPhysicalDeviceGroupProperties) {
+    EnumerateDeviceGroups(instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties)
+    return ?
+}
+
+@override
+@indirect("VkInstance")
+cmd VkResult vkEnumeratePhysicalDeviceGroups(
+    VkInstance                                  instance,
+    u32*                                        pPhysicalDeviceGroupCount,
+    VkPhysicalDeviceGroupProperties*            pPhysicalDeviceGroupProperties) {
+    EnumerateDeviceGroups(instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties)
+    return ?
+}
+
+sub void EnumerateDeviceGroups(
+    VkInstance                                  instance,
+    u32*                                        pPhysicalDeviceGroupCount,
+    VkPhysicalDeviceGroupProperties*            pPhysicalDeviceGroupProperties) {
+  if !(instance in Instances) { vkErrorInvalidInstance(instance) }
+  if pPhysicalDeviceGroupCount == null { vkErrorNullPointer("uint32_t") }
+  _ = pPhysicalDeviceGroupCount[0]
+
+  fence
+  if pPhysicalDeviceGroupProperties == null {
+    pPhysicalDeviceGroupCount[0] = ?
+  } else {
+    count := as!u32(?)
+    pPhysicalDeviceGroupCount[0] = count
+    write(pPhysicalDeviceGroupProperties[0:count])
+  }
+}

--- a/gapis/api/vulkan/externs.go
+++ b/gapis/api/vulkan/externs.go
@@ -502,6 +502,14 @@ func (e externs) vkErrInvalidDescriptorCopy(srcSet VkDescriptorSet, srcBinding u
 	e.onVkError(issue)
 }
 
+func (e externs) vkErrUnsupported(str string) {
+	var issue replay.Issue
+	issue.Command = e.cmdID
+	issue.Severity = service.Severity_ErrorLevel
+	issue.Error = fmt.Errorf("Unsupported: %v", str)
+	e.onVkError(issue)
+}
+
 type fenceSignal uint64
 
 func (e externs) recordFenceSignal(fence VkFence) {

--- a/gapis/api/vulkan/vulkan.api
+++ b/gapis/api/vulkan/vulkan.api
@@ -95,6 +95,7 @@ import "extensions/khr_draw_indirect_count.api"
 import "extensions/khr_image_format_list.api"
 import "extensions/ext_scalar_block_layout.api"
 import "extensions/ext_hdr_metadata.api"
+import "extensions/khr_device_group_creation.api"
 
 import "android/vulkan_android.api"
 import "linux/vulkan_linux.api"
@@ -216,6 +217,7 @@ sub ref!ExtensionSet supportedInstanceExtensions() {
   supported.ExtensionNames["VK_KHR_external_fence_capabilities"] = true
   supported.ExtensionNames["VK_GGP_stream_descriptor_surface"] = true
   supported.ExtensionNames["VK_EXT_swapchain_colorspace"] = true
+  supported.ExtensionNames["VK_KHR_device_group_creation"] = true
   return supported
 }
 


### PR DESCRIPTION
This is preliminary support. We make all device groups contain a single device, we can expand on this later.