### PR TITLE
Fix termination of observations of concurrent capture

### DIFF
--- a/gapii/cc/call_observer.cpp
+++ b/gapii/cc/call_observer.cpp
@@ -132,7 +132,7 @@ void CallObserver::encode(const ::google::protobuf::Message* cmd) {
   encoder()->object(cmd);
 }
 
-void CallObserver::reenter() {
+void CallObserver::resume() {
   if (!mShouldTrace) {
     // This observer was disabled from the start of the command, nothing to do.
     return;

--- a/gapii/cc/call_observer.cpp
+++ b/gapii/cc/call_observer.cpp
@@ -132,6 +132,21 @@ void CallObserver::encode(const ::google::protobuf::Message* cmd) {
   encoder()->object(cmd);
 }
 
+void CallObserver::reenter() {
+  if (!mShouldTrace) {
+    // This observer was disabled from the start of the command, nothing to do.
+    return;
+  }
+  mShouldTrace = mSpy->should_trace(mApi);
+  if (!mShouldTrace) {
+    // This branch is taken when this observer was enabled for pre-fence
+    // observations, but a concurrent command terminated the trace while this
+    // command was passed on to the driver. Pop the encoder which was pushed at
+    // creation.
+    mEncoderStack.pop();
+  }
+}
+
 void CallObserver::exit() {
   if (!mShouldTrace) {
     return;

--- a/gapii/cc/call_observer.h
+++ b/gapii/cc/call_observer.h
@@ -171,6 +171,11 @@ class CallObserver : public context_t {
   template <typename T, typename = enable_if_encodable<T> >
   inline void encode(const T& obj);
 
+  // reenter updates whether the observer should keep on tracing or not. It is
+  // meant to be called when a threadsafe command is re-entered after the actual
+  // driver call, and after re-acquiring the Spy lock.
+  void reenter();
+
   // exit returns encoding to the group bound before calling enter().
   void exit();
 

--- a/gapii/cc/call_observer.h
+++ b/gapii/cc/call_observer.h
@@ -171,10 +171,10 @@ class CallObserver : public context_t {
   template <typename T, typename = enable_if_encodable<T> >
   inline void encode(const T& obj);
 
-  // reenter updates whether the observer should keep on tracing or not. It is
-  // meant to be called when a threadsafe command is re-entered after the actual
-  // driver call, and after re-acquiring the Spy lock.
-  void reenter();
+  // resume updates whether the observer should keep on tracing or not. It is
+  // meant to be called when observation of a threadsafe command is resumed
+  // after the actual driver call, and after re-acquiring the Spy lock.
+  void resume();
 
   // exit returns encoding to the group bound before calling enter().
   void exit();

--- a/gapii/cc/spy_base.cpp
+++ b/gapii/cc/spy_base.cpp
@@ -52,7 +52,7 @@ void SpyBase::init(CallObserver* observer) {
   mIsSuspended = false;
 }
 
-void SpyBase::lock(CallObserver* observer) { mSpinLock.Lock(); }
+void SpyBase::lock() { mSpinLock.Lock(); }
 
 void SpyBase::unlock() { mSpinLock.Unlock(); }
 

--- a/gapii/cc/spy_base.h
+++ b/gapii/cc/spy_base.h
@@ -116,7 +116,7 @@ class SpyBase {
   // lock begins the interception of a single command. It must be called
   // before invoking any command on the spy. Blocks if any other thread
   // is has called lock and not yet called unlock.
-  void lock(CallObserver* observer);
+  void lock();
 
   // unlock must be called after invoking any command.
   // resets the buffers reused between commands.

--- a/gapis/api/templates/api_spy.cpp.tmpl
+++ b/gapis/api/templates/api_spy.cpp.tmpl
@@ -245,7 +245,7 @@
         {{end}}
         {{if (GetAnnotation $ "threadsafe")}}
         lock();
-        observer->reenter();
+        observer->resume();
         {{end}}
 ¶
         {{if IsVoid $.Return.Type}}

--- a/gapis/api/templates/api_spy.cpp.tmpl
+++ b/gapis/api/templates/api_spy.cpp.tmpl
@@ -244,7 +244,8 @@
           {{end}}
         {{end}}
         {{if (GetAnnotation $ "threadsafe")}}
-        lock(observer);
+        lock();
+        observer->reenter();
         {{end}}
 ¶
         {{if IsVoid $.Return.Type}}


### PR DESCRIPTION
This is a fixed version of 0b0ceed9900d9f6231de6b4162f0abecdcedf235,
which was reverted in 5effe3537faaa83492f1728098ff937914fd85a4.

This change adds the necessary checks for CallObserver of
"@threadsafe" commands to know if they have to keep on observing after
the actual driver call.

When capturing multithreaded applications, a thread may emit a command
which ends the capture, while other threads have threadsafe commands
in-flight. We add a CallObsever::reenter() function to check whether
observations should keep on happening when an observer re-enters after
a driver call.

A CallObserver caches whether it should trace or not in its
mShouldTrace field. This field must be set/updated when the
CallObserver enters/reenters. Any modification that impact whether a
call observer should trace or not should be guarded by the Spy
lock. Because of this:

 - the SpyBase::lock() argument of type CallObserver is removed as we
   do need to acquire this lock *before* the creation of the call
   observer, where mShouldTrace is set.

 - in Spy::onPostFrameBoundary(), set_suspended() is called *before*
   the spy lock is released in exit().

Google bug: b/141847511