### PR TITLE
Add missing dependency to build instructions

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -186,7 +186,7 @@ tools/bin/sdkmanager platform-tools
 
 ```
 sudo apt-get update
-sudo apt-get install mesa-common-dev libncurses5-dev libgl1-mesa-dev
+sudo apt-get install mesa-common-dev libncurses5-dev libgl1-mesa-dev zlib1g-dev
 ```
 
 ### Configure the environment


### PR DESCRIPTION
Just tried to build on my reseted laptop, `zlib.h` was not
found. Adding the zlib development package fixes this.