### PR TITLE
Make replaying an archive that does not exist error out

### DIFF
--- a/cmd/gapir/cc/main.cpp
+++ b/cmd/gapir/cc/main.cpp
@@ -478,6 +478,8 @@ static int replayArchive(core::CrashHandler* crashHandler,
                          gapir::ReplayService* replayArchiveService) {
   std::shared_ptr<MemoryAllocator> allocator = createAllocator();
 
+  const std::string payloadName = "payload";
+
   // The directory consists an archive(resources.{index,data}) and payload.bin.
   MemoryManager memoryManager(allocator);
 
@@ -487,7 +489,11 @@ static int replayArchive(core::CrashHandler* crashHandler,
   std::unique_ptr<Context> context = Context::create(
       replayArchiveService, *crashHandler, resLoader.get(), &memoryManager);
 
-  if (context->initialize("payload")) {
+  if (replayArchiveService->getPayload(payloadName) == NULL) {
+    GAPID_ERROR("Replay payload could not be found.");
+  }
+
+  if (context->initialize(payloadName)) {
     GAPID_DEBUG("Replay context initialized successfully");
   } else {
     GAPID_ERROR("Replay context initialization failed");

--- a/gapir/cc/replay_service.h
+++ b/gapir/cc/replay_service.h
@@ -89,6 +89,8 @@ class ReplayService {
     Payload(std::unique_ptr<replay_service::Payload> protoPayload);
 
     ~Payload();
+
+    Payload() = delete;
     Payload(const Payload&) = delete;
     Payload(Payload&&) = delete;
     Payload& operator=(const Payload&) = delete;


### PR DESCRIPTION
At the moment, if you replay an archive that does not exist, you get the message "Replay Complete".

This is a lie. The code here prints an error and exists.