### PR TITLE
Force report replays to replay without split-replay.

### DIFF
--- a/gapis/api/gles/read_texture.go
+++ b/gapis/api/gles/read_texture.go
@@ -148,7 +148,7 @@ func (r *ReadGPUTextureDataResolveable) Resolve(ctx context.Context) (interface{
 		Capture: r.Capture,
 	}
 	hints := &service.UsageHints{}
-	res, err := mgr.Replay(ctx, intent, c, textureRequest{r}, API{}, hints)
+	res, err := mgr.Replay(ctx, intent, c, textureRequest{r}, API{}, hints, true)
 	if err != nil {
 		return nil, err
 	}

--- a/gapis/api/gles/replay.go
+++ b/gapis/api/gles/replay.go
@@ -305,7 +305,7 @@ func (a API) QueryIssues(
 	hints *service.UsageHints) ([]replay.Issue, error) {
 
 	c, r := issuesConfig{}, issuesRequest{}
-	res, err := mgr.Replay(ctx, intent, c, r, a, hints)
+	res, err := mgr.Replay(ctx, intent, c, r, a, hints, true)
 	if err != nil {
 		return nil, err
 	}
@@ -345,7 +345,7 @@ func (a API) QueryFramebufferAttachment(
 		fb:         FramebufferId(framebufferIndex),
 		attachment: attachment,
 	}
-	res, err := mgr.Replay(ctx, intent, c, r, a, hints)
+	res, err := mgr.Replay(ctx, intent, c, r, a, hints, true)
 	if err != nil {
 		return nil, err
 	}
@@ -362,7 +362,7 @@ func (a API) Profile(
 	c := uniqueConfig()
 	r := profileRequest{overrides}
 
-	_, err := mgr.Replay(ctx, intent, c, r, a, hints)
+	_, err := mgr.Replay(ctx, intent, c, r, a, hints, true)
 	return err
 }
 

--- a/gapis/api/vulkan/replay.go
+++ b/gapis/api/vulkan/replay.go
@@ -1096,7 +1096,7 @@ func (a API) QueryFramebufferAttachment(
 	c := drawConfig{beginIndex, endIndex, subcommand, drawMode, disableReplayOptimization}
 	out := make(chan imgRes, 1)
 	r := framebufferRequest{after: after, width: width, height: height, framebufferIndex: framebufferIndex, attachment: attachment, out: out, displayToSurface: displayToSurface}
-	res, err := mgr.Replay(ctx, intent, c, r, a, hints)
+	res, err := mgr.Replay(ctx, intent, c, r, a, hints, false)
 	if err != nil {
 		return nil, err
 	}
@@ -1114,7 +1114,7 @@ func (a API) QueryIssues(
 	hints *service.UsageHints) ([]replay.Issue, error) {
 
 	c, r := issuesConfig{}, issuesRequest{displayToSurface: displayToSurface}
-	res, err := mgr.Replay(ctx, intent, c, r, a, hints)
+	res, err := mgr.Replay(ctx, intent, c, r, a, hints, true)
 	if err != nil {
 		return nil, err
 	}
@@ -1135,7 +1135,7 @@ func (a API) QueryTimestamps(
 	c, r := timestampsConfig{}, timestampsRequest{
 		handler:   handler,
 		loopCount: loopCount}
-	_, err := mgr.Replay(ctx, intent, c, r, a, hints)
+	_, err := mgr.Replay(ctx, intent, c, r, a, hints, false)
 	if err != nil {
 		return err
 	}
@@ -1155,6 +1155,6 @@ func (a API) Profile(
 	c := uniqueConfig()
 	r := profileRequest{overrides}
 
-	_, err := mgr.Replay(ctx, intent, c, r, a, hints)
+	_, err := mgr.Replay(ctx, intent, c, r, a, hints, false)
 	return err
 }

--- a/gapis/replay/export_replay.go
+++ b/gapis/replay/export_replay.go
@@ -132,13 +132,15 @@ func (m *exportManager) Replay(
 	cfg Config,
 	req Request,
 	generator Generator,
-	hints *service.UsageHints) (val interface{}, err error) {
+	hints *service.UsageHints,
+	forceNonSplitReplay bool) (val interface{}, err error) {
 
 	key := &batchKey{
-		capture:   intent.Capture.ID.ID(),
-		device:    intent.Device.ID.ID(),
-		config:    cfg,
-		generator: generator,
+		capture:             intent.Capture.ID.ID(),
+		device:              intent.Device.ID.ID(),
+		config:              cfg,
+		generator:           generator,
+		forceNonSplitReplay: forceNonSplitReplay,
 	}
 
 	if m.key == nil {


### PR DESCRIPTION
Since the instance creation happens during the split-replay
and we have to modify it for validation.