### PR TITLE
Make vkbuffer can be copied

### DIFF
--- a/gapis/api/vulkan/state_rebuilder.go
+++ b/gapis/api/vulkan/state_rebuilder.go
@@ -2880,7 +2880,7 @@ func (sb *stateBuilder) createSameBuffer(src BufferObjectʳ, buffer VkBuffer) er
 				pNext,                    // pNext
 				src.Info().CreateFlags(), // flags
 				src.Info().Size(),        // size
-				VkBufferUsageFlags(uint32(src.Info().Usage())|uint32(VkBufferUsageFlagBits_VK_BUFFER_USAGE_TRANSFER_DST_BIT)), // usage
+				VkBufferUsageFlags(uint32(src.Info().Usage())|uint32(VkBufferUsageFlagBits_VK_BUFFER_USAGE_TRANSFER_DST_BIT)|uint32(VkBufferUsageFlagBits_VK_BUFFER_USAGE_TRANSFER_SRC_BIT)), // usage
 				src.Info().SharingMode(),                                                    // sharingMode
 				uint32(src.Info().QueueFamilyIndices().Len()),                               // queueFamilyIndexCount
 				NewU32ᶜᵖ(sb.MustUnpackReadMap(src.Info().QueueFamilyIndices().All()).Ptr()), // pQueueFamilyIndices


### PR DESCRIPTION
Add VK_BUFFER_USAGE_TRANSFER_SRC_BIT to buffer usage when create
the buffer, this will make the buffer can be copied to be backed up.