### PR TITLE
Change the way counters are turned into slices.

### DIFF
--- a/gapic/src/main/com/google/gapid/perfetto/models/CounterTrack.java
+++ b/gapic/src/main/com/google/gapid/perfetto/models/CounterTrack.java
@@ -35,8 +35,8 @@ import java.util.Arrays;
 
 public class CounterTrack extends Track<CounterTrack.Data> {
   private static final String VIEW_SQL =
-      "select ts, lead(ts) over (order by ts) - ts dur, value " +
-      "from counter_values where counter_id = %d";
+      "select ts + 1 ts, lead(ts) over win - ts dur, lead(value) over win value " +
+      "from counter_values where counter_id = %d window win as (order by ts)";
   private static final String SUMMARY_SQL =
       "select min(ts), max(ts + dur), avg(value) from %s group by quantum_ts";
   private static final String COUNTER_SQL = "select ts, ts + dur, value from %s";


### PR DESCRIPTION
Given a counter with value v0 and v1 at time t0 and t1, respectively: the current implementation turns this into a slice [t0, t1) with v0.

With this change it'll be (t0, t1] v1, which more closely matches what the counters represent (esp. GPU counters). A counter value at some time t, represents what the counter *was* up to time t, not what it will be right after time t.

For example, a "triangles processed" counter shows the triangles that were processed in the previous time period, not the following, when sampled.