### PR TITLE
WIP plumb perfetto into WAIT callback

### DIFF
--- a/core/event/task/task.go
+++ b/core/event/task/task.go
@@ -37,6 +37,12 @@ func Once(task Task) Task {
 	}
 }
 
+func Noop() Task {
+	return func(context.Context) error {
+		return nil
+	}
+}
+
 // Retry repeatedly calls f until f returns a true, the number of attempts
 // reaches maxAttempts or the context is cancelled. Retry will sleep for
 // retryDelay between retry attempts.

--- a/core/os/android/device.go
+++ b/core/os/android/device.go
@@ -89,7 +89,7 @@ type Device interface {
 	// namespaced key.
 	DeleteSystemSetting(ctx context.Context, namespace, key string) error
 	// StartPerfettoTrace starts a perfetto trace.
-	StartPerfettoTrace(ctx context.Context, config *perfetto_pb.TraceConfig, out string, stop task.Signal) error
+	StartPerfettoTrace(ctx context.Context, config *perfetto_pb.TraceConfig, out string, stop task.Signal, ready task.Task) error
 }
 
 // LogcatMessage represents a single logcat message.

--- a/gapii/client/capture.go
+++ b/gapii/client/capture.go
@@ -153,7 +153,7 @@ func (p *Process) connect(ctx context.Context, gvrHandle uint64, interceptorPath
 // until start is fired.
 // Capturing will stop when the stop signal is fired (clean stop) or the
 // context is cancelled (abort).
-func (p *Process) Capture(ctx context.Context, start task.Signal, stop task.Signal, w io.Writer, written *int64) (size int64, err error) {
+func (p *Process) Capture(ctx context.Context, start task.Signal, stop task.Signal, ready task.Task, w io.Writer, written *int64) (size int64, err error) {
 	stopTiming := analytics.SendTiming("trace", "duration")
 	defer func() {
 		stopTiming(analytics.Size(size))

--- a/gapis/api/gles/replay.go
+++ b/gapis/api/gles/replay.go
@@ -362,6 +362,8 @@ func (a API) Profile(
 	intent replay.Intent,
 	mgr replay.Manager,
 	hints *service.UsageHints,
+	traceOptions *service.TraceOptions,
+	handler *replay.SignalHandler,
 	overrides *path.OverrideConfig) error {
 
 	c := uniqueConfig()

--- a/gapis/api/test/mutate_test.go
+++ b/gapis/api/test/mutate_test.go
@@ -66,7 +66,7 @@ func (test test) check(ctx context.Context, ca, ra *device.MemoryLayout) {
 		return nil
 	})
 
-	payload, _, _, err := b.Build(ctx)
+	payload, _, _, _, err := b.Build(ctx)
 	assert.For(ctx, "Build opcodes").ThatError(err).Succeeded()
 
 	ops := bytes.NewBuffer(payload.Opcodes)

--- a/gapis/api/vulkan/replay.go
+++ b/gapis/api/vulkan/replay.go
@@ -734,7 +734,9 @@ func uniqueConfig() replay.Config {
 }
 
 type profileRequest struct {
-	overrides *path.OverrideConfig
+	overrides    *path.OverrideConfig
+	traceOptions *service.TraceOptions
+	handler      *replay.SignalHandler
 }
 
 func (a API) GetInitialPayload(ctx context.Context,
@@ -956,6 +958,7 @@ func (a API) Replay(
 			profile.AddResult(rr.Result)
 			makeReadable.imagesOnly = true
 			optimize = false
+			transforms.Add(replay.WaitForPerfetto(req.traceOptions, req.handler))
 			if req.overrides.GetViewportSize() {
 				transforms.Add(minimizeViewport(ctx))
 			}
@@ -1164,10 +1167,12 @@ func (a API) Profile(
 	intent replay.Intent,
 	mgr replay.Manager,
 	hints *service.UsageHints,
+	traceOptions *service.TraceOptions,
+	handler *replay.SignalHandler,
 	overrides *path.OverrideConfig) error {
 
 	c := uniqueConfig()
-	r := profileRequest{overrides}
+	r := profileRequest{overrides, traceOptions, handler}
 
 	_, err := mgr.Replay(ctx, intent, c, r, a, hints, false)
 	return err

--- a/gapis/perfetto/android/trace.go
+++ b/gapis/perfetto/android/trace.go
@@ -151,7 +151,7 @@ func Start(ctx context.Context, d adb.Device, a *android.ActivityAction, opts *s
 }
 
 // Capture starts the perfetto capture.
-func (p *Process) Capture(ctx context.Context, start task.Signal, stop task.Signal, w io.Writer, written *int64) (int64, error) {
+func (p *Process) Capture(ctx context.Context, start task.Signal, stop task.Signal, ready task.Task, w io.Writer, written *int64) (int64, error) {
 	tmp, err := file.Temp()
 	if err != nil {
 		return 0, log.Err(ctx, err, "Failed to create a temp file")
@@ -164,7 +164,7 @@ func (p *Process) Capture(ctx context.Context, start task.Signal, stop task.Sign
 		return 0, log.Err(ctx, nil, "Cancelled")
 	}
 
-	if err := p.device.StartPerfettoTrace(ctx, p.config, perfettoTraceFile, stop); err != nil {
+	if err := p.device.StartPerfettoTrace(ctx, p.config, perfettoTraceFile, stop, ready); err != nil {
 		return 0, err
 	}
 

--- a/gapis/perfetto/desktop/trace.go
+++ b/gapis/perfetto/desktop/trace.go
@@ -142,9 +142,10 @@ func (l *remoteSetup) pullTrace(ctx context.Context, source string, dest string)
 	return dest, nil
 }
 
-func startPerfettoTrace(ctx context.Context, perfettocmd string, b bind.Device, opts *perfetto_pb.TraceConfig, fileLoc string) (shell.Process, chan error, error) {
+func startPerfettoTrace(ctx context.Context, perfettocmd string, b bind.Device, ready task.Task, opts *perfetto_pb.TraceConfig, fileLoc string) (shell.Process, chan error, error) {
 	reader, stdout := io.Pipe()
 	data, err := proto.Marshal(opts)
+	readyOnce := task.Once(ready)
 
 	if err != nil {
 		return nil, nil, err
@@ -155,6 +156,7 @@ func startPerfettoTrace(ctx context.Context, perfettocmd string, b bind.Device, 
 		buf := bufio.NewReader(reader)
 		for {
 			line, e := buf.ReadString('\n')
+			readyOnce(ctx)
 			switch e {
 			default:
 				log.E(ctx, "[perfetto] Read error %v", e)
@@ -199,6 +201,7 @@ func Start(ctx context.Context, d bind.Device, abi *device.ABI, opts *service.Tr
 	}
 
 	perfettoTraceFile := tempdir + "/gapis-trace"
+	readyFunc := task.Noop()
 
 	var fail chan error
 	var cmd shell.Process
@@ -208,7 +211,7 @@ func Start(ctx context.Context, d bind.Device, abi *device.ABI, opts *service.Tr
 	}
 
 	if !opts.DeferStart {
-		cmd, fail, err = startPerfettoTrace(ctx, c, d, opts.PerfettoConfig, perfettoTraceFile)
+		cmd, fail, err = startPerfettoTrace(ctx, c, d, readyFunc, opts.PerfettoConfig, perfettoTraceFile)
 		if err != nil {
 			return nil, err
 		}
@@ -228,7 +231,7 @@ func Start(ctx context.Context, d bind.Device, abi *device.ABI, opts *service.Tr
 }
 
 // Capture starts the perfetto capture.
-func (p *Process) Capture(ctx context.Context, start task.Signal, stop task.Signal, w io.Writer, written *int64) (int64, error) {
+func (p *Process) Capture(ctx context.Context, start task.Signal, stop task.Signal, ready task.Task, w io.Writer, written *int64) (int64, error) {
 	tmp, err := file.Temp()
 	if err != nil {
 		return 0, log.Err(ctx, err, "Failed to create a temp file")
@@ -241,7 +244,7 @@ func (p *Process) Capture(ctx context.Context, start task.Signal, stop task.Sign
 		if !start.Wait(ctx) {
 			return 0, log.Err(ctx, nil, "Cancelled")
 		}
-		cmd, fail, err := startPerfettoTrace(ctx, p.perfettoCmd, p.device, p.config, p.tracefile)
+		cmd, fail, err := startPerfettoTrace(ctx, p.perfettoCmd, p.device, ready, p.config, p.tracefile)
 		if err != nil {
 			return 0, err
 		}

--- a/gapis/replay/BUILD.bazel
+++ b/gapis/replay/BUILD.bazel
@@ -35,6 +35,7 @@ go_library(
         "replay_connection.go",
         "timestamps.go",
         "wait_for_fence.go",
+        "wait_for_perfetto.go",
     ],
     embed = [":replay_go_proto"],
     importpath = "github.com/google/gapid/gapis/replay",
@@ -49,6 +50,7 @@ go_library(
         "//core/context/keys:go_default_library",
         "//core/data/binary:go_default_library",
         "//core/data/id:go_default_library",
+        "//core/event/task:go_default_library",
         "//core/image:go_default_library",
         "//core/log:go_default_library",
         "//core/memory/arena:go_default_library",
@@ -69,6 +71,7 @@ go_library(
         "//gapis/resolve/initialcmds:go_default_library",
         "//gapis/service:go_default_library",
         "//gapis/service/path:go_default_library",
+        "//gapis/trace:go_default_library",
     ],
 )
 

--- a/gapis/replay/batch.go
+++ b/gapis/replay/batch.go
@@ -167,7 +167,7 @@ func (r *InitialPayloadResolvable) Resolve(
 	var payload gapir.Payload
 	builderBuildTimer.Time(func() {
 		log.D(ctx, "Initial Payload:")
-		payload, _, _, err = b.Build(ctx)
+		payload, _, _, _, err = b.Build(ctx)
 	})
 	if err != nil {
 		return nil, log.Err(ctx, err, "Failed to build initial payload")
@@ -204,7 +204,7 @@ func (r *InitialPayloadResolvable) Resolve(
 	var cleanupPayload gapir.Payload
 	builderBuildTimer.Time(func() {
 		log.D(ctx, "Cleanup Payload:")
-		cleanupPayload, _, _, err = b.Build(ctx)
+		cleanupPayload, _, _, _, err = b.Build(ctx)
 	})
 
 	id, err := database.Store(ctx, &payload)
@@ -351,9 +351,10 @@ func (m *manager) execute(
 	var payload gapir.Payload
 	var handlePost builder.PostDataHandler
 	var handleNotification builder.NotificationHandler
+	var fenceReadyCallback builder.FenceReadyRequestCallback
 	builderBuildTimer.Time(func() {
 		log.D(ctx, "Main Payload:")
-		payload, handlePost, handleNotification, err = b.Build(ctx)
+		payload, handlePost, handleNotification, fenceReadyCallback, err = b.Build(ctx)
 	})
 	if err != nil {
 		return log.Err(ctx, err, "Failed to build replay payload")
@@ -374,6 +375,7 @@ func (m *manager) execute(
 			payload,
 			handlePost,
 			handleNotification,
+			fenceReadyCallback,
 			connection,
 			replayABI.MemoryLayout,
 			d.Instance().GetConfiguration().GetOS(),

--- a/gapis/replay/builder/builder.go
+++ b/gapis/replay/builder/builder.go
@@ -60,6 +60,8 @@ type NotificationReader func(p gapir.Notification)
 // replay virtual machine.
 type NotificationHandler func(p *gapir.Notification)
 
+type FenceReadyRequestCallback func(p *gapir.FenceReadyRequest)
+
 // PostDataHandler handles the original PostData messages, which may contains
 // multiple pieces of post back data issued by multiple POST instructions, from
 // the replay virual machine.
@@ -108,6 +110,7 @@ type Builder struct {
 	decoders            []postBackDecoder
 	nextNotificationID  uint64
 	notificationReaders map[uint64]NotificationReader
+	fenceReadyCallbacks map[uint32]FenceReadyRequestCallback
 	stack               []stackItem
 	memoryLayout        *device.MemoryLayout
 	inCmd               bool   // true if between BeginCommand and CommitCommand/RevertCommand
@@ -158,6 +161,7 @@ func New(memoryLayout *device.MemoryLayout, dependent *Builder) *Builder {
 		instructions:        []asm.Instruction{},
 		nextNotificationID:  InitialNextNotificationID,
 		notificationReaders: map[uint64]NotificationReader{},
+		fenceReadyCallbacks: map[uint32]FenceReadyRequestCallback{},
 		memoryLayout:        memoryLayout,
 		lastLabel:           ^uint64(0),
 		volatileSpace:       volatileSpace,
@@ -710,6 +714,14 @@ func (b *Builder) RegisterReplayStatusReader(ctx context.Context, r *status.Repl
 	return b.RegisterNotificationReader(ReplayProgressNotificationID, reader)
 }
 
+func (b *Builder) RegisterFenceReadyRequestCallback(fenceID uint32, callback FenceReadyRequestCallback) error {
+	if _, ok := b.fenceReadyCallbacks[fenceID]; ok {
+		return fmt.Errorf("fenceID callback %d already registered", fenceID)
+	}
+	b.fenceReadyCallbacks[fenceID] = callback
+	return nil
+}
+
 // Export compiles the replay instructions, returning a Payload that can be
 // sent to the replay virtual-machine.
 func (b *Builder) Export(ctx context.Context) (gapir.Payload, error) {
@@ -717,7 +729,7 @@ func (b *Builder) Export(ctx context.Context) (gapir.Payload, error) {
 	defer status.Finish(ctx)
 	ctx = log.Enter(ctx, "Export")
 
-	payload, _, _, err := b.Build(ctx)
+	payload, _, _, _, err := b.Build(ctx)
 	if err != nil {
 		return payload, err
 	}
@@ -733,7 +745,7 @@ func (b *Builder) Export(ctx context.Context) (gapir.Payload, error) {
 // Build compiles the replay instructions, returning a Payload that can be
 // sent to the replay virtual-machine and a PostDataHandler for interpreting
 // the responses.
-func (b *Builder) Build(ctx context.Context) (gapir.Payload, PostDataHandler, NotificationHandler, error) {
+func (b *Builder) Build(ctx context.Context) (gapir.Payload, PostDataHandler, NotificationHandler, FenceReadyRequestCallback, error) {
 	ctx = status.Start(ctx, "Build")
 	defer status.Finish(ctx)
 	ctx = log.Enter(ctx, "Build")
@@ -760,7 +772,7 @@ func (b *Builder) Build(ctx context.Context) (gapir.Payload, PostDataHandler, No
 		}
 		if err := i.Encode(vml, w); err != nil {
 			err = fmt.Errorf("Encode %T failed for command with id %v: %v", i, id, err)
-			return gapir.Payload{}, nil, nil, err
+			return gapir.Payload{}, nil, nil, nil, err
 		}
 	}
 
@@ -832,7 +844,21 @@ func (b *Builder) Build(ctx context.Context) (gapir.Payload, PostDataHandler, No
 		})
 	}
 
-	return payload, handlePost, handleNotification, nil
+	callbacks := b.fenceReadyCallbacks
+	fenceReadyCallback := func(n *gapir.FenceReadyRequest) {
+		if n == nil {
+			log.E(ctx, "Cannot handle nil FenceReadyRequest")
+			return
+		}
+		id := n.GetId()
+		if r, ok := callbacks[id]; ok {
+			r(n)
+		} else {
+			log.W(ctx, "Unknown fence ready received, ID is %d: %v", id, n)
+		}
+	}
+
+	return payload, handlePost, handleNotification, fenceReadyCallback, nil
 }
 
 const ErrInvalidResource = fault.Const("Invaid resource")

--- a/gapis/replay/interfaces.go
+++ b/gapis/replay/interfaces.go
@@ -89,6 +89,8 @@ type Profiler interface {
 		intent Intent,
 		mgr Manager,
 		hints *service.UsageHints,
+		traceOptions *service.TraceOptions,
+		handler *SignalHandler,
 		overrides *path.OverrideConfig) error
 }
 

--- a/gapis/replay/replay.go
+++ b/gapis/replay/replay.go
@@ -17,6 +17,7 @@ package replay
 import (
 	"context"
 
+	"github.com/google/gapid/core/event/task"
 	"github.com/google/gapid/core/os/device"
 	"github.com/google/gapid/gapis/api/transform"
 	"github.com/google/gapid/gapis/capture"
@@ -113,4 +114,18 @@ func (r Result) Transform(f func(in interface{}) (out interface{}, err error)) R
 type RequestAndResult struct {
 	Request Request
 	Result  Result
+}
+
+//TODO(apbodnar) move this into whatever eventually calls Profile()
+type SignalHandler struct {
+	StartSignal task.Signal
+	StartFunc   task.Task
+	ReadySignal task.Signal
+	ReadyFunc   task.Task
+	StopSignal  task.Signal
+	StopFunc    task.Task
+	DoneSignal  task.Signal
+	DoneFunc    task.Task
+	Written     int64
+	Err         error
 }

--- a/gapis/replay/wait_for_fence.go
+++ b/gapis/replay/wait_for_fence.go
@@ -17,27 +17,52 @@ package replay
 import (
 	"context"
 
+	"github.com/google/gapid/gapir"
 	"github.com/google/gapid/gapis/api"
 	"github.com/google/gapid/gapis/api/transform"
 	"github.com/google/gapid/gapis/replay/builder"
 )
 
-type WaitForFence struct{}
+type WaitForFence struct {
+	transformCallback func(ctx context.Context, p *gapir.FenceReadyRequest)
+	flushCallback     func(ctx context.Context, p *gapir.FenceReadyRequest)
+	shouldWait        func(ctx context.Context, id api.CmdID, cmd api.Cmd) bool
+}
 
 func (t *WaitForFence) Transform(ctx context.Context, id api.CmdID, cmd api.Cmd, out transform.Writer) {
-	if id == 0 {
-		t.AddWaitInstruction(ctx, id, out)
+	if t.transformCallback != nil && t.shouldWait != nil && t.shouldWait(ctx, id, cmd) {
+		t.AddTransformWait(ctx, id, out)
 	}
 	out.MutateAndWrite(ctx, id, cmd)
 }
 
-func (t *WaitForFence) Flush(ctx context.Context, out transform.Writer)    {}
+func (t *WaitForFence) Flush(ctx context.Context, out transform.Writer) {
+	if t.flushCallback != nil {
+		t.AddFlushWait(ctx, out)
+	}
+}
+
 func (t *WaitForFence) PreLoop(ctx context.Context, out transform.Writer)  {}
 func (t *WaitForFence) PostLoop(ctx context.Context, out transform.Writer) {}
 
-func (t *WaitForFence) AddWaitInstruction(ctx context.Context, id api.CmdID, out transform.Writer) {
+func (t *WaitForFence) AddTransformWait(ctx context.Context, id api.CmdID, out transform.Writer) {
 	out.MutateAndWrite(ctx, id, Custom{T: 0, F: func(ctx context.Context, s *api.GlobalState, b *builder.Builder) error {
-		b.Wait(uint32(id))
-		return nil
+		fenceID := uint32(id)
+		b.Wait(fenceID)
+		tcb := func(p *gapir.FenceReadyRequest) {
+			t.transformCallback(ctx, p)
+		}
+		return b.RegisterFenceReadyRequestCallback(fenceID, tcb)
+	}})
+}
+
+func (t *WaitForFence) AddFlushWait(ctx context.Context, out transform.Writer) {
+	out.MutateAndWrite(ctx, api.CmdNoID, Custom{T: 0, F: func(ctx context.Context, s *api.GlobalState, b *builder.Builder) error {
+		fenceID := uint32(0x3ffffff)
+		b.Wait(fenceID)
+		fcb := func(p *gapir.FenceReadyRequest) {
+			t.flushCallback(ctx, p)
+		}
+		return b.RegisterFenceReadyRequestCallback(fenceID, fcb)
 	}})
 }

--- a/gapis/replay/wait_for_perfetto.go
+++ b/gapis/replay/wait_for_perfetto.go
@@ -1,0 +1,37 @@
+package replay
+
+import (
+	"context"
+
+	"github.com/google/gapid/gapir"
+	"github.com/google/gapid/gapis/api"
+	"github.com/google/gapid/gapis/service"
+	"github.com/google/gapid/gapis/trace"
+)
+
+func WaitForPerfetto(traceOptions *service.TraceOptions, h *SignalHandler) *WaitForFence {
+	tcb := func(ctx context.Context, p *gapir.FenceReadyRequest) {
+		go func() {
+			trace.Trace(ctx, traceOptions.Device, h.StartSignal, h.StopSignal, h.ReadyFunc, traceOptions, &h.Written)
+			if !h.DoneSignal.Fired() {
+				h.DoneFunc(ctx)
+			}
+		}()
+		h.ReadySignal.Wait(ctx)
+	}
+
+	fcb := func(ctx context.Context, p *gapir.FenceReadyRequest) {
+		if !h.StopSignal.Fired() {
+			h.StopFunc(ctx)
+		}
+	}
+
+	waitTest := func(ctx context.Context, id api.CmdID, cmd api.Cmd) bool {
+		if id == 0 {
+			return true
+		}
+		return false
+	}
+
+	return &WaitForFence{tcb, fcb, waitTest}
+}

--- a/gapis/server/server.go
+++ b/gapis/server/server.go
@@ -790,9 +790,10 @@ func (r *traceHandler) Initialize(ctx context.Context, opts *service.TraceOption
 	}
 	r.initialized = true
 	stopSignal, stopFunc := task.NewSignal()
+	readyFunc := task.Noop()
 	r.stopFunc = stopFunc
 	go func() {
-		r.err = trace.Trace(ctx, opts.Device, r.startSignal, stopSignal, opts, &r.bytesWritten)
+		r.err = trace.Trace(ctx, opts.Device, r.startSignal, stopSignal, readyFunc, opts, &r.bytesWritten)
 		r.done = true
 		r.doneSignalFunc(ctx)
 	}()

--- a/gapis/trace/android/trace.go
+++ b/gapis/trace/android/trace.go
@@ -166,11 +166,12 @@ func (t *androidTracer) Validate(ctx context.Context) error {
 	// Start to capture.
 	status.Do(ctx, "Tracing", func(ctx context.Context) {
 		startSignal, startFunc := task.NewSignal()
+		readyFunc := task.Noop()
 		stopSignal, _ := task.NewSignal()
 		doneSignal, doneFunc := task.NewSignal()
 
 		crash.Go(func() {
-			_, err = process.Capture(ctx, startSignal, stopSignal, &buf, &written)
+			_, err = process.Capture(ctx, startSignal, stopSignal, readyFunc, &buf, &written)
 			doneFunc(ctx)
 		})
 

--- a/gapis/trace/trace.go
+++ b/gapis/trace/trace.go
@@ -29,7 +29,7 @@ import (
 	"github.com/google/gapid/gapis/trace/tracer"
 )
 
-func Trace(ctx context.Context, device *path.Device, start task.Signal, stop task.Signal, options *service.TraceOptions, written *int64) error {
+func Trace(ctx context.Context, device *path.Device, start task.Signal, stop task.Signal, ready task.Task, options *service.TraceOptions, written *int64) error {
 	gapiiOpts := tracer.GapiiOptions(options)
 	var process tracer.Process
 	var cleanup app.Cleanup
@@ -76,7 +76,7 @@ func Trace(ctx context.Context, device *path.Device, start task.Signal, stop tas
 		ctx, _ = task.WithTimeout(ctx, time.Duration(options.Duration)*time.Second)
 	}
 
-	_, err = process.Capture(ctx, start, stop, file, written)
+	_, err = process.Capture(ctx, start, stop, ready, file, written)
 	return err
 }
 

--- a/gapis/trace/tracer/tracer.go
+++ b/gapis/trace/tracer/tracer.go
@@ -47,7 +47,7 @@ type Process interface {
 	// until start is fired.
 	// Capturing will stop when the stop signal is fired (clean stop) or the
 	// context is cancelled (abort).
-	Capture(ctx context.Context, start task.Signal, stop task.Signal, w io.Writer, written *int64) (size int64, err error)
+	Capture(ctx context.Context, start task.Signal, stop task.Signal, ready task.Task, w io.Writer, written *int64) (size int64, err error)
 }
 
 // Tracer is an option interface that a bind.Device can implement.

--- a/test/integration/replay/postback_test.go
+++ b/test/integration/replay/postback_test.go
@@ -70,7 +70,7 @@ func doReplay(t *testing.T, f func(*builder.Builder)) error {
 
 	f(b)
 
-	payload, decoder, notification, err := b.Build(ctx)
+	payload, decoder, notification, fenceReady, err := b.Build(ctx)
 	if err != nil {
 		t.Errorf("Build failed with error: %v", err)
 		return err
@@ -83,7 +83,7 @@ func doReplay(t *testing.T, f func(*builder.Builder)) error {
 		return err
 	}
 
-	err = replay.Execute(ctx, "", payload, decoder, notification, bgc, abi.MemoryLayout, os)
+	err = replay.Execute(ctx, "", payload, decoder, notification, fenceReady, bgc, abi.MemoryLayout, os)
 	if err != nil {
 		t.Errorf("Executor failed with error: %v", err)
 		return err


### PR DESCRIPTION
This adds the WaitForFence transform that injects a WAIT instruction at the beginning and end of the command list.  With hopefully minimal plumbing, this can be integrated with @pmuetschard 's WIP replay profiling commits (https://github.com/pmuetschard/gapid/commit/d38d72f393bd9965db753baea698bdbdad764e44 https://github.com/pmuetschard/gapid/commit/38251c4bff428703c99186ab7c6cc1bfe32d2925)  Since nothing in master is calling `replay.Profile()` yet, this should be safe to merge.