### PR TITLE
Remove duplicated image layout transition barriers.

### DIFF
--- a/gapis/api/vulkan/frame_loop.go
+++ b/gapis/api/vulkan/frame_loop.go
@@ -2101,7 +2101,7 @@ func (f *frameLoop) copyImage(ctx context.Context, srcImg, dstImg ImageObjectʳ,
 	}
 
 	dstPostCopyBarriers := ipImageLayoutTransitionBarriers(stateBuilder, dstImg, useSpecifiedLayout(ipHostCopyImageLayout), sameLayoutsOfImage(dstImg))
-	srcPostCopyBarriers := ipImageLayoutTransitionBarriers(stateBuilder, srcImg, useSpecifiedLayout(VkImageLayout_VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL), sameLayoutsOfImage(dstImg))
+	srcPostCopyBarriers := ipImageLayoutTransitionBarriers(stateBuilder, srcImg, useSpecifiedLayout(VkImageLayout_VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL), sameLayoutsOfImage(srcImg))
 	postCopyBarriers := append(dstPostCopyBarriers, srcPostCopyBarriers...)
 	if err = ipRecordImageMemoryBarriers(stateBuilder, queueHandler, postCopyBarriers...); err != nil {
 		return log.Err(ctx, err, "Failed at post device copy image layout transition")

--- a/gapis/api/vulkan/image_primer.go
+++ b/gapis/api/vulkan/image_primer.go
@@ -322,7 +322,7 @@ func ipImageLayoutTransitionBarriers(sb *stateBuilder, imgObj ImageObjectʳ, old
 			if newLayout == VkImageLayout_VK_IMAGE_LAYOUT_UNDEFINED || newLayout == VkImageLayout_VK_IMAGE_LAYOUT_PREINITIALIZED || oldLayout == newLayout {
 				return
 			}
-			barriers = append(barriers, ipImageSubresourceLayoutTransitionBarrier(
+			imageBarrier := ipImageSubresourceLayoutTransitionBarrier(
 				sb,
 				imgObj,
 				aspect,
@@ -330,7 +330,13 @@ func ipImageLayoutTransitionBarriers(sb *stateBuilder, imgObj ImageObjectʳ, old
 				level,
 				oldLayout,
 				newLayout,
-			))
+			)
+			for _, barrier := range barriers {
+				if barrier.Equals(imageBarrier) {
+					return
+				}
+			}
+			barriers = append(barriers, imageBarrier)
 		})
 	return barriers
 }


### PR DESCRIPTION
Currently, if the image has both depth and stencil aspect, when
transition its layout, it will generate a duplicated image barrier.