### PR TITLE
Add device flags to run GPU profiling validation on specific devices.

### DIFF
--- a/cmd/gapit/flags.go
+++ b/cmd/gapit/flags.go
@@ -401,7 +401,7 @@ type (
 	}
 
 	ValidateGpuProfilingFlags struct {
+		DeviceFlags
 		Gapis GapisFlags
-		OS    device.OSKind `help:"Only validate GPU profiling for devices of the given OS kind"`
 	}
 )


### PR DESCRIPTION
BUG: b/138717619
TesT: bazel run gapit -- validate_gpu_profiling --serial SERIAL_NUMBER