### PR TITLE
Add surfaceflinger events to GPU track

### DIFF
--- a/core/os/android/adb/commands.go
+++ b/core/os/android/adb/commands.go
@@ -287,6 +287,10 @@ func (b *binding) QueryPerfettoServiceState(ctx context.Context) (*device.Perfet
 	perfettoCapability := &device.PerfettoCapability{
 		GpuProfiling: &device.GPUProfiling{},
 	}
+	if b.Instance().GetConfiguration().GetOS().GetName() == "R" {
+		// TODO(b/146384733): Change this to API version when it releases
+		perfettoCapability.GpuProfiling.HasFrameLifecycle = true
+	}
 	dataSources := tracingServiceState.GetDataSources()
 	for _, dataSource := range dataSources {
 		dataSourceDescriptor := dataSource.GetDsDescriptor()

--- a/core/os/device/device.proto
+++ b/core/os/device/device.proto
@@ -190,6 +190,7 @@ message GPUProfiling {
   bool hasRenderStage = 1;
   // The GPU performance counters.
   GpuCounterDescriptor gpu_counter_descriptor = 2;
+  bool hasFrameLifecycle = 3;
 }
 
 // Instance represents a physical device.

--- a/gapic/src/main/com/google/gapid/models/Settings.java
+++ b/gapic/src/main/com/google/gapid/models/Settings.java
@@ -113,6 +113,7 @@ public class Settings {
   public boolean perfettoVulkanCPUTimingPhysicalDevice = false;
   public boolean perfettoVulkanCPUTimingQueue = false;
   public boolean perfettoVulkanMemoryTracker = false;
+  public boolean perfettoSurfaceFlinger = true;
 
   public static Settings load() {
     Settings result = new Settings();
@@ -288,6 +289,7 @@ public class Settings {
     perfettoVulkanCPUTimingPhysicalDevice = getBoolean(properties, "perfetto.vulkan.cpu_timing.physical_device", perfettoVulkanCPUTimingPhysicalDevice);
     perfettoVulkanMemoryTracker =
         getBoolean(properties, "perfetto.vulkan.memory_tracker", perfettoVulkanMemoryTracker);
+    perfettoSurfaceFlinger = getBoolean(properties, "perfetto.surfaceflinger.frame", perfettoSurfaceFlinger);
   }
 
   private void updateTo(Properties properties) {
@@ -354,6 +356,7 @@ public class Settings {
 
     properties.setProperty(
         "perfetto.vulkan.memory_tracker", Boolean.toString(perfettoVulkanMemoryTracker));
+    properties.setProperty("perfetto.surfaceflinger.frame", Boolean.toString(perfettoSurfaceFlinger));
   }
 
   private static Point getPoint(Properties properties, String name) {

--- a/gapic/src/main/com/google/gapid/perfetto/canvas/RenderContext.java
+++ b/gapic/src/main/com/google/gapid/perfetto/canvas/RenderContext.java
@@ -168,6 +168,15 @@ public class RenderContext implements Fonts.TextMeasurer, AutoCloseable {
     gc.drawOval(scale(cx - r), scale(cy - r), d, d);
   }
 
+  public void fillPolygon(double[] xPoints, double[] yPoints, int n) {
+    int[] points = new int[2*n];
+    for (int i = 0, j = 0; i < n && j < 2*n; i++, j += 2) {
+      points[j] = scale(xPoints[i]);
+      points[j+1] = scale(yPoints[i]);
+    }
+    gc.fillPolygon(points);
+  }
+
   // x, y is top left corner of text.
   public void drawText(Fonts.Style style, String text, double x, double y) {
     if (style != lastFontStyle) {

--- a/gapic/src/main/com/google/gapid/perfetto/models/FrameEvents.java
+++ b/gapic/src/main/com/google/gapid/perfetto/models/FrameEvents.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2019 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.gapid.perfetto.models;
+
+import static com.google.gapid.util.MoreFutures.transform;
+
+import com.google.common.collect.Iterables;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.gapid.models.Perfetto;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Data about the tracks for the Frame Events.
+ */
+public class FrameEvents {
+  public static final FrameEvents NONE = new FrameEvents(Collections.emptyList());
+
+  private static final String MAX_DEPTH_QUERY =
+      "select t.id, max(depth) + 1, t.name " +
+      "from gpu_track t, gpu_slice s " +
+      "where t.id = s.track_id and t.scope = 'graphics_frame_event' " +
+      "group by t.id " +
+      "order by t.name";
+
+  private final List<Buffer> buffers;
+
+  private FrameEvents(List<Buffer> buffers) {
+    this.buffers = buffers;
+  }
+
+  public Iterable<Buffer> buffers() {
+    return Iterables.unmodifiableIterable(buffers);
+  }
+
+  public int bufferCount() {
+    return buffers.size();
+  }
+
+  public static ListenableFuture<Perfetto.Data.Builder> listFrameTracks(Perfetto.Data.Builder data) {
+    return transform(frameTracks(data.qe), buffers -> {
+      return data.setFrameEvents(new FrameEvents(buffers));
+    });
+  }
+
+  private static ListenableFuture<List<Buffer>> frameTracks(QueryEngine qe) {
+    return transform(qe.queries(MAX_DEPTH_QUERY), res -> res.list(Buffer::new));
+  }
+
+  public static class Buffer {
+    public final int id;
+    public final long trackId;
+    public final int maxDepth;
+    public final String name;
+
+    public Buffer(int id, long trackId, int maxDepth, String name) {
+      this.id = id;
+      this.trackId = trackId;
+      this.maxDepth = maxDepth;
+      this.name = name;
+    }
+
+    public Buffer(int id, QueryEngine.Row row) {
+      this(id, row.getLong(0), row.getInt(1), row.getString(2));
+    }
+
+    public String getDisplay() {
+      return name;
+    }
+  }
+}

--- a/gapic/src/main/com/google/gapid/perfetto/models/FrameEventsTrack.java
+++ b/gapic/src/main/com/google/gapid/perfetto/models/FrameEventsTrack.java
@@ -1,0 +1,376 @@
+/*
+ * Copyright (C) 2019 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.gapid.perfetto.models;
+
+import static com.google.gapid.perfetto.models.QueryEngine.createSpan;
+import static com.google.gapid.perfetto.models.QueryEngine.createView;
+import static com.google.gapid.perfetto.models.QueryEngine.createWindow;
+import static com.google.gapid.perfetto.models.QueryEngine.dropTable;
+import static com.google.gapid.perfetto.models.QueryEngine.dropView;
+import static com.google.gapid.perfetto.models.QueryEngine.expectOneRow;
+import static com.google.gapid.util.MoreFutures.transform;
+import static com.google.gapid.util.MoreFutures.transformAsync;
+import static java.lang.String.format;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.gapid.perfetto.TimeSpan;
+import com.google.gapid.perfetto.views.FrameEventsMultiSelectionView;
+import com.google.gapid.perfetto.views.FrameEventsSelectionView;
+import com.google.gapid.perfetto.views.State;
+
+import org.eclipse.swt.widgets.Composite;
+
+import java.util.List;
+import java.util.Set;
+import java.util.TreeMap;
+
+/**
+ * Data about a Surface Flinger Frame Events in the trace.
+ */
+public class FrameEventsTrack extends Track<FrameEventsTrack.Data>{
+  private static final String BASE_COLUMNS =
+      "slice_id, ts, dur, category, name, depth, stack_id, parent_stack_id, arg_set_id";
+  private static final String SLICES_VIEW =
+      "select " + BASE_COLUMNS + " from %s where track_id = %d";
+  private static final String SLICE_SQL =
+      "select " + BASE_COLUMNS + " from %s where slice_id = %d";
+  private static final String SLICES_SQL =
+       "select " + BASE_COLUMNS + " from %s " +
+           "where ts >= %d - dur and ts <= %d order by ts";
+  private static final String SUMMARY_SQL =
+      "select quantum_ts, count(*) " +
+      "from %s " +
+      "where name = 'PresentFenceSignaled' or name GLOB '*[0-9]*'" +
+      "group by quantum_ts";
+  private static final String RANGE_SQL =
+      "select " + BASE_COLUMNS + " from %s " +
+      "where ts < %d and ts + dur >= %d and depth >= %d and depth <= %d";
+
+  private final String table;
+  private final long trackId;
+
+  public FrameEventsTrack(String table, long trackId) {
+    super("sfevents_" + trackId);
+    this.table = table;
+    this.trackId = trackId;
+  }
+
+  public static FrameEventsTrack forSfEventsQueue(FrameEvents.Buffer queue) {
+    return new FrameEventsTrack("gpu_slice", queue.trackId);
+  }
+
+  @Override
+  protected ListenableFuture<?> initialize(QueryEngine qe) {
+    String slices = tableName("slices");
+    String window = tableName("window");
+    String span = tableName("span");
+    return qe.queries(
+        dropTable(span),
+        dropView(slices),
+        dropTable(window),
+        createWindow(window),
+        createView(slices, format(SLICES_VIEW, table, trackId)),
+        createSpan(span, window + ", " + slices + " PARTITIONED depth"));
+  }
+
+  @Override
+  public ListenableFuture<Data> computeData(QueryEngine qe, DataRequest req) {
+    Window window = Window.compute(req, 5);
+    return transformAsync(window.update(qe, tableName("window")),
+        $ -> window.quantized ? computeSummary(qe, req, window) : computeSlices(qe, req));
+  }
+
+  private ListenableFuture<Data> computeSlices(QueryEngine qe, DataRequest req) {
+    return transformAsync(qe.query(slicesSql(req)), res ->
+    transform(qe.getAllArgs(res.stream().mapToLong(r -> r.getLong(8))), args -> {
+      int rows = res.getNumRows();
+      Data data = new Data(req, new long[rows], new long[rows], new long[rows], new int[rows],
+          new String[rows], new String[rows], new ArgSet[rows]);
+      res.forEachRow((i, row) -> {
+        long start = row.getLong(1);
+        data.ids[i] = row.getLong(0);
+        data.starts[i] = start;
+        data.ends[i] = start + row.getLong(2);
+        data.categories[i] = row.getString(3);
+        data.titles[i] = row.getString(4);
+        data.depths[i] = row.getInt(5);
+        data.args[i] = args.getOrDefault(row.getLong(8), ArgSet.EMPTY);
+      });
+      return data;
+    }));
+  }
+
+  private String slicesSql(DataRequest req) {
+    return format(SLICES_SQL, tableName("slices"), req.range.start, req.range.end);
+  }
+
+  private ListenableFuture<Data> computeSummary(QueryEngine qe, DataRequest req, Window w) {
+    return transform(qe.query(summarySql()), result -> {
+      Data data = new Data(req, w.bucketSize, new long[w.getNumberOfBuckets()]);
+      result.forEachRow(($, r) -> data.numEvents[r.getInt(0)] = r.getLong(1));
+      return data;
+    });
+  }
+
+  private String summarySql() {
+    return format(SUMMARY_SQL, tableName("span"));
+  }
+
+  public ListenableFuture<Slice> getSlice(QueryEngine queryEngine, long id) {
+    return transformAsync(expectOneRow(queryEngine.query(sliceSql(id))), r ->
+        transform(queryEngine.getArgs(r.getLong(8)), args -> buildSlice(r, args, trackId)));
+  }
+
+  protected Slice buildSlice(QueryEngine.Row row, ArgSet args, long trackId) {
+    return new Slice(row, args, trackId);
+  }
+
+  private String sliceSql(long id) {
+    return format(SLICE_SQL, "gpu_slice", id);
+  }
+
+  public ListenableFuture<List<Slice>> getSlices(
+      QueryEngine qe, TimeSpan ts, int minDepth, int maxDepth) {
+    return transform(qe.query(sliceRangeSql(ts, minDepth, maxDepth)),
+        res -> res.list(($, row) -> buildSlice(row, ArgSet.EMPTY, trackId)));
+  }
+
+  private String sliceRangeSql(TimeSpan ts, int minDepth, int maxDepth) {
+    return format(RANGE_SQL, tableName("slices"), ts.end, ts.start, minDepth, maxDepth);
+  }
+
+  public static class Data extends Track.Data {
+    public final Kind kind;
+    // Summary.
+    public final long bucketSize;
+    public final long[] numEvents;
+    // slices
+    public final long[] ids;
+    public final long[] starts;
+    public final long[] ends;
+    public final int[] depths;
+    public final String[] titles;
+    public final String[] categories;
+    public final ArgSet[] args;
+
+    public static enum Kind {
+      slices,
+      summary,
+    }
+
+    public Data(DataRequest request, long bucketSize, long[] numEvents) {
+      super(request);
+      this.kind = Kind.summary;
+      this.bucketSize = bucketSize;
+      this.numEvents = numEvents;
+      this.ids = null;
+      this.starts = null;
+      this.ends = null;
+      this.depths = null;
+      this.titles = null;
+      this.categories = null;
+      this.args = null;
+    }
+
+    public Data(DataRequest request, long[] ids, long[] starts, long[] ends, int[] depths,
+        String[] titles, String[] categories, ArgSet[] args) {
+      super(request);
+      this.kind = Kind.slices;
+      this.bucketSize = 0;
+      this.numEvents = null;
+      this.ids = ids;
+      this.starts = starts;
+      this.ends = ends;
+      this.depths = depths;
+      this.titles = titles;
+      this.categories = categories;
+      this.args = args;
+    }
+  }
+
+  public static class Slice implements Selection<Slice.Key> {
+    public final long id;
+    public final long time;
+    public final long dur;
+    public final String name;
+    public final ArgSet args;
+    public final long trackId;
+
+    public Slice(
+        long id, long time, long dur, String name, long trackId) {
+      this.id = id;
+      this.time = time;
+      this.dur = dur;
+      this.name = name;
+      args = null;
+      this.trackId = trackId;
+    }
+
+    public Slice(long id, long time, long dur, String name, ArgSet args, long trackId) {
+      this.id = id;
+      this.time = time;
+      this.dur = dur;
+      this.name = name;
+      this.args = args;
+      this.trackId = trackId;
+    }
+
+    public Slice(QueryEngine.Row row, ArgSet args, long trackId) {
+      this(row.getLong(0), row.getLong(1), row.getLong(2), row.getString(4), args, trackId);
+    }
+
+    public Slice(QueryEngine.Row row, long trackId) {
+      this(row.getLong(0), row.getLong(1), row.getLong(2), row.getString(4), trackId);
+    }
+
+    @Override
+    public String getTitle() {
+      return "Frame Events";
+    }
+
+    @Override
+    public boolean contains(Slice.Key key) {
+      return key.matches(this);
+    }
+
+    @Override
+    public Composite buildUi(Composite parent, State state) {
+      return new FrameEventsSelectionView(parent, state, this);
+    }
+
+    @Override
+    public void markTime(State state) {
+      if (dur > 0) {
+        state.setHighlight(new TimeSpan(time, time + dur));
+      }
+    }
+
+    @Override
+    public void zoom(State state) {
+      if (dur > 0) {
+        state.setVisibleTime(new TimeSpan(time, time + dur));
+      }
+    }
+
+    public static class Key {
+      public final long time;
+      public final long dur;
+
+      public Key(long time, long dur) {
+        this.time = time;
+        this.dur = dur;
+      }
+
+      public Key(Slice slice) {
+        this(slice.time, slice.dur);
+      }
+
+      public boolean matches(Slice slice) {
+        return slice.time == time && slice.dur == dur;
+      }
+
+      @Override
+      public boolean equals(Object obj) {
+        if (obj == this) {
+          return true;
+        } else if (!(obj instanceof Key)) {
+          return false;
+        }
+        Key o = (Key)obj;
+        return time == o.time && dur == o.dur;
+      }
+
+      @Override
+      public int hashCode() {
+        return Long.hashCode(time ^ dur);
+      }
+    }
+  }
+
+  public static class Slices implements Selection.CombiningBuilder.Combinable<Slices> {
+    private final String title;
+    private final TreeMap<Long, Node> roots = Maps.newTreeMap();
+    private final Set<Slice.Key> sliceKeys = Sets.newHashSet();
+
+    public Slices(List<Slice> slices) {
+      String ti = "";
+      for (Slice slice : slices) {
+        ti = slice.getTitle();
+        roots.put(slice.id, new Node(slice.name, slice.dur, slice.dur, slice.trackId));
+        sliceKeys.add(new Slice.Key(slice));
+      }
+      this.title = ti;
+    }
+
+    @Override
+    public Slices combine(Slices other) {
+      roots.putAll(other.roots);
+      sliceKeys.addAll(other.sliceKeys);
+      return this;
+    }
+
+    @Override
+    public Selection build() {
+      return new Selection(title, ImmutableList.copyOf(roots.values()), ImmutableSet.copyOf(sliceKeys));
+    }
+
+    public static class Selection implements com.google.gapid.perfetto.models.Selection<Slice.Key> {
+      private final String title;
+      public final ImmutableList<Node> nodes;
+      public final ImmutableSet<Slice.Key> sliceKeys;
+
+      public Selection(String title, ImmutableList<Node> nodes, ImmutableSet<Slice.Key> sliceKeys) {
+        this.title = title;
+        this.nodes = nodes;
+        this.sliceKeys = sliceKeys;
+      }
+
+      @Override
+      public String getTitle() {
+        return title;
+      }
+
+      @Override
+      public boolean contains(Slice.Key key) {
+        return sliceKeys.contains(key);
+      }
+
+      @Override
+      public Composite buildUi(Composite parent, State state) {
+        return new FrameEventsMultiSelectionView(parent, this);
+      }
+    }
+
+    public static class Node {
+      public final String name;
+      public final long dur;
+      public final long self;
+      public final long trackId;
+
+      public Node(String name, long dur, long self, long id) {
+        this.name = name;
+        this.dur = dur;
+        this.self = self;
+        this.trackId = id;
+      }
+    }
+  }
+}

--- a/gapic/src/main/com/google/gapid/perfetto/models/Selection.java
+++ b/gapic/src/main/com/google/gapid/perfetto/models/Selection.java
@@ -152,6 +152,7 @@ public interface Selection<Key> {
     public static final Kind<Long> Cpu = new Kind<Long>(2);
     public static final Kind<Slice.Key> Gpu = new Kind<Slice.Key>(3);
     public static final Kind<Values.Key> Counter = new Kind<Values.Key>(4);
+    public static final Kind<FrameEventsTrack.Slice.Key> FrameEvents = new Kind<FrameEventsTrack.Slice.Key>(5);
 
     public int priority;
 

--- a/gapic/src/main/com/google/gapid/perfetto/models/Tracks.java
+++ b/gapic/src/main/com/google/gapid/perfetto/models/Tracks.java
@@ -30,6 +30,7 @@ import com.google.gapid.perfetto.views.CounterPanel;
 import com.google.gapid.perfetto.views.CpuFrequencyPanel;
 import com.google.gapid.perfetto.views.CpuPanel;
 import com.google.gapid.perfetto.views.CpuSummaryPanel;
+import com.google.gapid.perfetto.views.FrameEventsSummaryPanel;
 import com.google.gapid.perfetto.views.GpuQueuePanel;
 import com.google.gapid.perfetto.views.ProcessSummaryPanel;
 import com.google.gapid.perfetto.views.ThreadPanel;
@@ -55,6 +56,7 @@ public class Tracks {
     enumerateCpu(data);
     return transform(enumerateCounters(data), $2 -> {
       enumerateGpu(data);
+      enumerateFrameEvents(data);
       enumerateProcesses(data);
       return data;
     });
@@ -129,6 +131,19 @@ public class Tracks {
         data.tracks.addTrack("gpu_counters", track.getId(), counter.name,
             single(state -> new CounterPanel(state, track), true));
       }
+    }
+    return data;
+  }
+
+  public static Perfetto.Data.Builder enumerateFrameEvents(Perfetto.Data.Builder data) {
+    if (data.getFrameEvents().bufferCount() == 0)
+      return data;
+    data.tracks.addLabelGroup(null, "sf_events", "Surface Flinger Frame Events",
+        group(state -> new TitlePanel("Surface Flinger Frame Events"), true));
+    for (FrameEvents.Buffer queue : data.getFrameEvents().buffers()) {
+      FrameEventsTrack track = FrameEventsTrack.forSfEventsQueue(queue);
+      data.tracks.addTrack("sf_events", track.getId(), queue.getDisplay(),
+          single(state -> new FrameEventsSummaryPanel(state, queue, track), true));
     }
     return data;
   }

--- a/gapic/src/main/com/google/gapid/perfetto/views/FrameEventsMultiSelectionView.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/FrameEventsMultiSelectionView.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2019 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.gapid.perfetto.views;
+
+import static com.google.gapid.perfetto.TimeSpan.timeToString;
+import static com.google.gapid.widgets.Widgets.createTreeColumn;
+import static com.google.gapid.widgets.Widgets.createTreeViewer;
+import static com.google.gapid.widgets.Widgets.packColumns;
+
+import com.google.gapid.perfetto.models.FrameEventsTrack;
+
+import org.eclipse.jface.viewers.ITreeContentProvider;
+import org.eclipse.jface.viewers.LabelProvider;
+import org.eclipse.jface.viewers.TreeViewer;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.layout.FillLayout;
+import org.eclipse.swt.widgets.Composite;
+
+/**
+ * Displays information about a list of selected slices.
+ */
+public class FrameEventsMultiSelectionView extends Composite {
+  public FrameEventsMultiSelectionView(Composite parent, FrameEventsTrack.Slices.Selection sel) {
+    super(parent, SWT.NONE);
+    setLayout(new FillLayout());
+
+    TreeViewer viewer = createTreeViewer(this, SWT.NONE);
+    viewer.getTree().setHeaderVisible(true);
+    viewer.setContentProvider(new ITreeContentProvider() {
+      @Override
+      public Object[] getElements(Object inputElement) {
+        return sel.nodes.toArray();
+      }
+
+      @Override
+      public boolean hasChildren(Object element) {
+        return false;
+      }
+
+      @Override
+      public Object getParent(Object element) {
+        return null;
+      }
+
+      @Override
+      public Object[] getChildren(Object element) {
+        return null;
+      }
+    });
+    viewer.setLabelProvider(new LabelProvider());
+
+    createTreeColumn(viewer, "Name", e -> n(e).name);
+    createTreeColumn(viewer, "TrackId", e -> Long.toString(n(e).trackId));
+    createTreeColumn(viewer, "Self Time", e -> timeToString(n(e).self));
+    viewer.setInput(sel);
+    packColumns(viewer.getTree());
+  }
+
+  protected static FrameEventsTrack.Slices.Node n(Object o) {
+    return (FrameEventsTrack.Slices.Node)o;
+  }
+}

--- a/gapic/src/main/com/google/gapid/perfetto/views/FrameEventsSelectionView.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/FrameEventsSelectionView.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2019 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.gapid.perfetto.views;
+
+import static com.google.gapid.perfetto.TimeSpan.timeToString;
+import static com.google.gapid.widgets.Widgets.createBoldLabel;
+import static com.google.gapid.widgets.Widgets.createComposite;
+import static com.google.gapid.widgets.Widgets.createLabel;
+import static com.google.gapid.widgets.Widgets.withIndents;
+import static com.google.gapid.widgets.Widgets.withLayoutData;
+import static com.google.gapid.widgets.Widgets.withSpans;
+
+import com.google.common.collect.Iterables;
+import com.google.gapid.perfetto.models.FrameEventsTrack;
+
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.layout.GridLayout;
+import org.eclipse.swt.widgets.Composite;
+
+/**
+ * Displays information about a selected Frame event.
+ */
+public class FrameEventsSelectionView extends Composite {
+  private static final int PROPERTIES_PER_PANEL = 8;
+  private static final int PANEL_INDENT = 25;
+
+  public FrameEventsSelectionView(Composite parent, State state, FrameEventsTrack.Slice slice) {
+    super(parent, SWT.NONE);
+    setLayout(new GridLayout(2, false));
+
+    withLayoutData(createBoldLabel(this, "Slice:"), withSpans(new GridData(), 2, 1));
+
+    createLabel(this, "Time:");
+    createLabel(this, timeToString(slice.time - state.getTraceTime().start));
+
+    createLabel(this, "Duration:");
+    createLabel(this, timeToString(slice.dur));
+
+    if (!slice.args.isEmpty()) {
+      String[] keys = Iterables.toArray(slice.args.keys(), String.class);
+      int panels = (keys.length + PROPERTIES_PER_PANEL - 1) / PROPERTIES_PER_PANEL;
+      Composite props = withLayoutData(createComposite(this, new GridLayout(2 * panels, false)),
+          withIndents(new GridData(SWT.LEFT, SWT.TOP, false, false), PANEL_INDENT, 0));
+      withLayoutData(createBoldLabel(props, "Properties:"),
+          withSpans(new GridData(), 2 * panels, 1));
+
+      for (int i = 0; i < keys.length && i < PROPERTIES_PER_PANEL; i++) {
+        int cols = (keys.length - i + PROPERTIES_PER_PANEL - 1) / PROPERTIES_PER_PANEL;
+        for (int c = 0; c < cols; c++) {
+          withLayoutData(createLabel(props, keys[i + c * PROPERTIES_PER_PANEL] + ":"),
+              withIndents(new GridData(), (c == 0) ? 0 : PANEL_INDENT, 0));
+          createLabel(props, String.valueOf(slice.args.get(keys[i + c * PROPERTIES_PER_PANEL])));
+        }
+        if (cols != panels) {
+          withLayoutData(createLabel(props, ""), withSpans(new GridData(), 2 * (panels - cols), 1));
+        }
+      }
+    }
+  }
+}

--- a/gapic/src/main/com/google/gapid/perfetto/views/FrameEventsSummaryPanel.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/FrameEventsSummaryPanel.java
@@ -1,0 +1,363 @@
+/*
+ * Copyright (C) 2019 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.gapid.perfetto.views;
+
+import static com.google.gapid.perfetto.views.Loading.drawLoading;
+import static com.google.gapid.perfetto.views.StyleConstants.SELECTION_THRESHOLD;
+import static com.google.gapid.perfetto.views.StyleConstants.TRACK_MARGIN;
+import static com.google.gapid.perfetto.views.StyleConstants.colors;
+import static com.google.gapid.util.Colors.hsl;
+import static com.google.gapid.util.MoreFutures.transform;
+
+import com.google.gapid.perfetto.TimeSpan;
+import com.google.gapid.perfetto.canvas.Area;
+import com.google.gapid.perfetto.canvas.Fonts;
+import com.google.gapid.perfetto.canvas.RenderContext;
+import com.google.gapid.perfetto.canvas.Size;
+import com.google.gapid.perfetto.models.ArgSet;
+import com.google.gapid.perfetto.models.FrameEvents;
+import com.google.gapid.perfetto.models.FrameEventsTrack;
+import com.google.gapid.perfetto.models.Selection;
+import com.google.gapid.perfetto.models.Selection.CombiningBuilder;
+import com.google.gapid.perfetto.views.StyleConstants.Palette.BaseColor;
+
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.graphics.Cursor;
+import org.eclipse.swt.widgets.Display;
+
+/**
+ * Draws the instant events and the Displayed Frame track for the Surface Flinger Frame Events
+ */
+public class FrameEventsSummaryPanel extends TrackPanel<FrameEventsSummaryPanel> implements Selectable {
+  private static final double SLICE_HEIGHT = 30;
+  private static final double HOVER_MARGIN = 10;
+  private static final double HOVER_PADDING = 4;
+  private static final double CURSOR_SIZE = 5;
+
+  private final FrameEvents.Buffer queue;
+  protected final FrameEventsTrack track;
+
+  protected double mouseXpos, mouseYpos;
+  protected String hoveredTitle;
+  protected String hoveredCategory;
+  protected Size hoveredSize = Size.ZERO;
+  protected HoverCard hovered;
+
+  public FrameEventsSummaryPanel(State state, FrameEvents.Buffer queue, FrameEventsTrack track) {
+    super(state);
+    this.queue = queue;
+    this.track = track;
+  }
+
+
+  @Override
+  public String getTitle() {
+    return queue.getDisplay();
+  }
+
+  @Override
+  public double getHeight() {
+    return queue.maxDepth * SLICE_HEIGHT;
+  }
+
+  @Override
+  public void renderTrack(RenderContext ctx, Repainter repainter, double w, double h) {
+    ctx.trace("FrameEventsSummary", () -> {
+      FrameEventsTrack.Data data = track.getData(state, () -> {
+        repainter.repaint(new Area(0, 0, width, height));
+      });
+      drawLoading(ctx, data, state, h);
+
+      if (data == null) {
+        return;
+      }
+
+      switch(data.kind) {
+        case slices: renderSlices(ctx, data, repainter, w, h); break;
+        case summary: renderSummary(ctx, data, w, h); break;
+      }
+    });
+  }
+
+
+  private void renderSummary(
+      RenderContext ctx, FrameEventsTrack.Data data, double w, double h) {
+    long tStart = data.request.range.start;
+    int start = Math.max(0, (int)((state.getVisibleTime().start - tStart) / data.bucketSize));
+
+    ctx.setBackgroundColor(BaseColor.LIGHT_BLUE.rgb);
+    ctx.setForegroundColor(BaseColor.PACIFIC_BLUE.rgb);
+    ctx.path(path -> {
+      path.moveTo(0, h);
+      double y = h, x = 0;
+      for (int i = start; i < data.numEvents.length && x < w; i++) {
+        x = state.timeToPx(tStart + i * data.bucketSize);
+        double nextY = Math.round(Math.max(0,h - (h * (data.numEvents[i]))));
+        path.lineTo(x, y);
+        path.lineTo(x, nextY);
+        y = nextY;
+      }
+      path.lineTo(x, h);
+      path.close();
+      ctx.fillPath(path);
+      ctx.drawPath(path);
+    });
+
+    if (hovered != null && hovered.bucket >= start) {
+      double x = state.timeToPx(tStart + hovered.bucket * data.bucketSize + data.bucketSize / 2);
+      if (x < w) {
+        double dx = HOVER_PADDING + hovered.size.w + HOVER_PADDING;
+        double dy = HOVER_PADDING + hovered.size.h + HOVER_PADDING;
+        ctx.setBackgroundColor(colors().hoverBackground);
+        ctx.fillRect(x + HOVER_MARGIN, h - HOVER_PADDING - dy, dx, dy);
+        ctx.setForegroundColor(colors().textMain);
+        ctx.drawText(Fonts.Style.Normal, hovered.text, x + HOVER_MARGIN + HOVER_PADDING, h - dy);
+
+        ctx.setForegroundColor(colors().textMain);
+        ctx.drawCircle(x, Math.round(Math.max(0,h - (h * (hovered.numEvents)))), CURSOR_SIZE / 2);
+      }
+    }
+  }
+
+
+  public void renderSlices(RenderContext ctx, FrameEventsTrack.Data data, Repainter repainter, double w, double h) {
+      TimeSpan visible = state.getVisibleTime();
+      for (int i = 0; i < data.starts.length; i++) {
+        long tStart = data.starts[i];
+        long tEnd = data.ends[i];
+        int depth = data.depths[i];
+        String title = buildSliceTitle(data.titles[i], data.args[i]);
+
+        if (tEnd <= visible.start || tStart >= visible.end) {
+          continue;
+        }
+        double rectStart = state.timeToPx(tStart);
+
+        if (tEnd - tStart > 3 ) {
+          double rectWidth = Math.max(1, state.timeToPx(tEnd) - rectStart);
+          double y = depth * SLICE_HEIGHT;
+
+          float hue = (title.hashCode() & 0x7fffffff) % 360;
+          float saturation = Math.min(20 + depth * 10, 70) / 100f;
+          ctx.setBackgroundColor(hsl(hue, saturation, .65f));
+          ctx.fillRect(rectStart, y, rectWidth, SLICE_HEIGHT);
+
+          // Don't render text when we have less than 7px to play with.
+          if (rectWidth < 7) {
+            continue;
+          }
+
+          ctx.setForegroundColor(colors().textInvertedMain);
+          ctx.drawText(
+              Fonts.Style.Normal, title, rectStart + 2, y + 2, rectWidth - 4, SLICE_HEIGHT - 4);
+        } else {
+          double rectWidth = 20;
+          double y = depth * SLICE_HEIGHT;
+
+          float hue = (title.hashCode() & 0x7fffffff) % 360;
+          float saturation = Math.min(20 + depth * 10, 70) / 100f;
+          ctx.setBackgroundColor(hsl(hue, saturation, .65f));
+          ctx.setForegroundColor(title.substring(0,1).hashCode()%19);
+          double[] diamondX = new double[] {rectStart - (rectWidth)/2, rectStart, rectStart + (rectWidth)/2, rectStart};
+          double[] diamondY = new double[] { y+(SLICE_HEIGHT)/2,y, y+(SLICE_HEIGHT)/2, SLICE_HEIGHT};
+          ctx.fillPolygon(diamondX, diamondY, 4);
+          ctx.setForegroundColor(colors().textInvertedMain);
+          ctx.drawText(
+              Fonts.Style.Normal, title.substring(0,1), rectStart - rectWidth/2 + 1, y + 1, rectWidth - 1, SLICE_HEIGHT - 4);
+        }
+      }
+
+      if (hoveredTitle != null) {
+        ctx.setBackgroundColor(colors().hoverBackground);
+        ctx.fillRect(
+            mouseXpos + HOVER_MARGIN, mouseYpos, hoveredSize.w + 2 * HOVER_PADDING, hoveredSize.h);
+
+        ctx.setForegroundColor(colors().textMain);
+        ctx.drawText(Fonts.Style.Normal, hoveredTitle,
+            mouseXpos + HOVER_MARGIN + HOVER_PADDING, mouseYpos + HOVER_PADDING / 2);
+        if (!hoveredCategory.isEmpty()) {
+          ctx.setForegroundColor(colors().textAlt);
+          ctx.drawText(Fonts.Style.Normal, hoveredCategory,
+              mouseXpos + HOVER_MARGIN + HOVER_PADDING,
+              mouseYpos + hoveredSize.h / 2, hoveredSize.h / 2);
+        }
+      }
+    }
+
+  private static String buildSliceTitle(String title, ArgSet args) {
+    Object w = args.get("width"), h = args.get("height");
+    return (w == null || h == null) ? title : title + " (" + w + "x" + h + ")";
+  }
+
+  @Override
+  protected Hover onTrackMouseMove(Fonts.TextMeasurer m, double x, double y) {
+    FrameEventsTrack.Data data = track.getData(state, () -> { /* nothing */ });
+    if (data == null) {
+      return Hover.NONE;
+    }
+
+    switch (data.kind) {
+      case slices: return sliceHover(data, m, x, y);
+      case summary: return summaryHover(data, m, x);
+      default: return Hover.NONE;
+    }
+  }
+
+  private Hover summaryHover(FrameEventsTrack.Data data, Fonts.TextMeasurer m, double x) {
+    long time = state.pxToTime(x);
+    int bucket = (int)((time - data.request.range.start) / data.bucketSize);
+    if (bucket < 0 || bucket >= data.numEvents.length) {
+      return Hover.NONE;
+    }
+
+    long p = data.numEvents[bucket];
+    String text;
+    if (p == 0)
+      text = "Nothing presented";
+    else if (p == 1)
+      text = Long.toString(p) + " frame presented";
+    else
+      text = Long.toString(p) + " frames presented";
+    hovered = new HoverCard(bucket, p, text, m.measure(Fonts.Style.Normal, text));
+
+    double mouseX = state.timeToPx(
+        data.request.range.start + hovered.bucket * data.bucketSize + data.bucketSize / 2);
+    double dx = HOVER_PADDING + hovered.size.w + HOVER_PADDING;
+    double dy = height;
+    return new Hover() {
+      @Override
+      public Area getRedraw() {
+        return new Area(mouseX - CURSOR_SIZE, -TRACK_MARGIN, CURSOR_SIZE + HOVER_MARGIN + dx, dy);
+      }
+
+      @Override
+      public void stop() {
+        hovered = null;
+      }
+    };
+  }
+
+  private Hover sliceHover(FrameEventsTrack.Data data, Fonts.TextMeasurer m, double x, double y) {
+    int depth = (int)(y / SLICE_HEIGHT);
+    if (depth < 0 || depth > queue.maxDepth) {
+      return Hover.NONE;
+    }
+
+    mouseXpos = x;
+    mouseYpos = depth * SLICE_HEIGHT;
+    long t = state.pxToTime(x);
+    for (int i = 0; i < data.starts.length; i++) {
+      double ts = state.timeToPx(data.starts[i]);
+      double endts = state.timeToPx(data.ends[i]);
+      if (ts == endts) {
+        endts = ts + 12;
+        ts -= 12;
+      }
+      if (data.depths[i] == depth && x >= ts && x<= endts) {
+        hoveredTitle = data.titles[i];
+        hoveredCategory = data.categories[i];
+        if (hoveredTitle.isEmpty()) {
+          if (hoveredCategory.isEmpty()) {
+            return Hover.NONE;
+          }
+          hoveredTitle = hoveredCategory;
+          hoveredCategory = "";
+        }
+        hoveredTitle = buildSliceTitle(hoveredTitle, data.args[i]);
+
+        hoveredSize = Size.vertCombine(HOVER_PADDING, HOVER_PADDING / 2,
+            m.measure(Fonts.Style.Normal, hoveredTitle),
+            hoveredCategory.isEmpty() ? Size.ZERO : m.measure(Fonts.Style.Normal, hoveredCategory));
+        mouseYpos = Math.max(0, Math.min(mouseYpos - (hoveredSize.h - SLICE_HEIGHT) / 2,
+            (1 + queue.maxDepth) * SLICE_HEIGHT - hoveredSize.h));
+        long id = data.ids[i];
+        return new Hover() {
+          @Override
+          public Area getRedraw() {
+            return new Area(
+                x + HOVER_MARGIN, mouseYpos, hoveredSize.w + 2 * HOVER_PADDING, hoveredSize.h);
+          }
+
+          @Override
+          public void stop() {
+            hoveredTitle = hoveredCategory = null;
+          }
+
+          @Override
+          public Cursor getCursor(Display display) {
+            return (id < 0) ? null : display.getSystemCursor(SWT.CURSOR_HAND);
+          }
+
+          @Override
+          public boolean click() {
+            if (id >= 0) {
+              state.setSelection(Selection.Kind.FrameEvents, track.getSlice(state.getQueryEngine(), id));
+            }
+            return false;
+          }
+        };
+      }
+    }
+    return Hover.NONE;
+  }
+
+  @Override
+  public void computeSelection(CombiningBuilder builder, Area area, TimeSpan ts) {
+    int startDepth = (int)(area.y / SLICE_HEIGHT);
+    int endDepth = (int)((area.y + area.h) / SLICE_HEIGHT);
+    if (startDepth == endDepth && area.h / SLICE_HEIGHT < SELECTION_THRESHOLD) {
+      return;
+    }
+    if (((startDepth + 1) * SLICE_HEIGHT - area.y) / SLICE_HEIGHT < SELECTION_THRESHOLD) {
+      startDepth++;
+    }
+    if ((area.y + area.h - endDepth * SLICE_HEIGHT) / SLICE_HEIGHT < SELECTION_THRESHOLD) {
+      endDepth--;
+    }
+    if (startDepth > endDepth) {
+      return;
+    }
+
+    if (endDepth >= 0) {
+      if (endDepth >= queue.maxDepth) {
+        endDepth = Integer.MAX_VALUE;
+      }
+
+      builder.add(Selection.Kind.FrameEvents, transform(
+          track.getSlices(state.getQueryEngine(), ts, startDepth, endDepth),
+          FrameEventsTrack.Slices::new));
+    }
+  }
+
+  private static class HoverCard {
+    public final int bucket;
+    public final long numEvents;
+    public final String text;
+    public final Size size;
+
+    public HoverCard(int bucket, long numEvents, String text, Size size) {
+      this.bucket = bucket;
+      this.numEvents = numEvents;
+      this.text = text;
+      this.size = size;
+    }
+  }
+
+  @Override
+  public FrameEventsSummaryPanel copy() {
+    return new FrameEventsSummaryPanel(state, queue, track);
+  }
+}

--- a/gapic/src/main/com/google/gapid/perfetto/views/TraceConfigDialog.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/TraceConfigDialog.java
@@ -148,6 +148,14 @@ public class TraceConfigDialog extends DialogBase {
       }
       sb.append("Battery");
     }
+    if (gpuCaps.getHasFrameLifecycle()) {
+      if (settings.perfettoSurfaceFlinger) {
+         if (sb.length() > 0) {
+           sb.append(", ");
+         }
+         sb.append("Frame Lifecycle");
+      }
+    }
     if (settings.perfettoVulkanCPUTiming || settings.perfettoVulkanMemoryTracker) {
       if (sb.length() > 0) {
         sb.append(", ");
@@ -191,6 +199,13 @@ public class TraceConfigDialog extends DialogBase {
     }
 
     Device.GPUProfiling gpuCaps = caps.getGpuProfiling();
+    if (gpuCaps.getHasFrameLifecycle()) {
+      if (settings.perfettoSurfaceFlinger) {
+        config.addDataSourcesBuilder()
+            .getConfigBuilder()
+                .setName("android.surfaceflinger.frame");
+      }
+    }
     if (gpuCaps.getHasRenderStage() || gpuCaps.getGpuCounterDescriptor().getSpecsCount() > 0) {
       if (settings.perfettoGpu) {
         if (settings.perfettoGpuSlices) {
@@ -325,6 +340,8 @@ public class TraceConfigDialog extends DialogBase {
 
     private final Button vulkanMemoryTracking;
 
+    private final Button frame;
+
     public InputArea(
         Composite parent, Settings settings, Theme theme, Device.PerfettoCapability caps) {
       super(parent, SWT.NONE);
@@ -411,6 +428,14 @@ public class TraceConfigDialog extends DialogBase {
       batLabels[1] = createLabel(batGroup, "ms");
 
       addSeparator();
+
+      if (gpuCaps.getHasFrameLifecycle()) {
+        frame = createCheckbox(this, "Frame Lifecycle", settings.perfettoSurfaceFlinger, e -> {});
+        addSeparator();
+      } else {
+        frame = null;
+      }
+
       Composite vulkanGroup = withLayoutData(
         createComposite(this, new GridLayout(1, false)),
         withIndents(new GridData(), GROUP_INDENT, 0));
@@ -489,6 +514,9 @@ public class TraceConfigDialog extends DialogBase {
         settings.perfettoVulkanMemoryTracker = vulkanMemoryTracking.getSelection();
       } else {
         settings.perfettoVulkanMemoryTracker = false;
+      }
+      if (frame != null) {
+        settings.perfettoSurfaceFlinger = frame.getSelection();
       }
     }
 


### PR DESCRIPTION
Frame events emitted from the SurfaceFlinger process are shown on individual tracks based on the buffer id of the frames. The zoomed out summary panel shows small slices for only the present fences to help with identifying patterns on the screen.