### PR TITLE
Make selection event in thread panel consistent.

### DIFF
--- a/gapic/src/main/com/google/gapid/perfetto/views/ThreadPanel.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/ThreadPanel.java
@@ -293,6 +293,7 @@ public class ThreadPanel extends TrackPanel implements Selectable {
               if (data.schedIds[index] != 0) {
                 state.setSelection(Selection.Kind.Cpu,
                     CpuTrack.getSlice(state.getQueryEngine(), data.schedIds[index]));
+                state.setSelectedThread(state.getThreadInfo(track.getThread().utid));
               } else {
                 state.setSelection(Selection.Kind.ThreadState,
                     new ThreadTrack.StateSlice(data.schedStarts[index],
@@ -378,6 +379,9 @@ public class ThreadPanel extends TrackPanel implements Selectable {
     if (startDepth == 0) {
       builder.add(Selection.Kind.ThreadState,
           transform(track.getStates(state.getQueryEngine(), ts), ThreadTrack.StateSlices::new));
+      builder.add(Selection.Kind.Cpu, transform(
+          CpuTrack.getSlicesForThread(state.getQueryEngine(), track.getThread().utid, ts),
+          r -> new CpuTrack.Slices(state, r)));
     }
 
     startDepth = Math.max(0, startDepth - 1);


### PR DESCRIPTION
 - When single-select a thread slice, also change slice color in CPU
 panel.
 - When area-select several thread slices, select the corresponding
 slices in CPU panel as well.