### PR TITLE
Fix copyright header

### DIFF
--- a/core/memory/arena/cc/arena.h
+++ b/core/memory/arena/cc/arena.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2017 The Android Open Source Project
+// Copyright (C) 2017 Google Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
AOSP was used when GAPID was part of Android Studio, the code is
copyright Google since GAPID became stand-alone.