### PR TITLE
Change CPU slices' color at multi-selection.

### DIFF
--- a/gapic/src/main/com/google/gapid/perfetto/models/ThreadInfo.java
+++ b/gapic/src/main/com/google/gapid/perfetto/models/ThreadInfo.java
@@ -99,14 +99,12 @@ public class ThreadInfo {
   }
 
   public static RGBA getColor(State state, long utid) {
-    ThreadInfo selected = state.getSelectedThread();
     ThreadInfo queried = state.getThreadInfo(utid);
-
-    if (selected == null) {
+    if (!state.hasSelectedThreads()) {
       return colorForThread(queried, 0);
-    } else if (queried.utid == selected.utid) {
+    } else if (state.isUtidInSelection(queried.utid)) {
       return colorForThread(queried, 0);
-    } else if (queried.upid == selected.upid) {
+    } else if (state.isUpidInSelection(queried.upid)) {
       return colorForThread(queried, StyleConstants.isLight() ? 3 : -3);
     } else {
       return StyleConstants.getGrayColor().rgb();

--- a/gapic/src/main/com/google/gapid/perfetto/views/CpuPanel.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/CpuPanel.java
@@ -282,8 +282,10 @@ public class CpuPanel extends TrackPanel<CpuPanel> implements Selectable {
   public void computeSelection(CombiningBuilder builder, Area area, TimeSpan ts) {
     if (area.h / height >= SELECTION_THRESHOLD) {
       builder.add(Selection.Kind.Cpu, transform(
-          CpuTrack.getSlices(state.getQueryEngine(), track.getCpu(), ts),
-          r -> new CpuTrack.Slices(state, r)));
+          CpuTrack.getSlices(state.getQueryEngine(), track.getCpu(), ts), r -> {
+            r.stream().forEach(s -> state.addSelectedThread(state.getThreadInfo(s.utid)));
+            return new CpuTrack.Slices(state, r);
+          }));
     }
   }
 

--- a/gapic/src/main/com/google/gapid/perfetto/views/CpuSummaryPanel.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/CpuSummaryPanel.java
@@ -158,8 +158,11 @@ public class CpuSummaryPanel extends TrackPanel<CpuSummaryPanel> implements Sele
   @Override
   public void computeSelection(Selection.CombiningBuilder builder, Area area, TimeSpan ts) {
     if (area.h / height >= SELECTION_THRESHOLD) {
-      builder.add(Selection.Kind.Cpu, transform(CpuSummaryTrack.getSlices(state.getQueryEngine(), ts), r ->
-          new CpuTrack.Slices(state, r)));
+      builder.add(Selection.Kind.Cpu, transform(
+          CpuSummaryTrack.getSlices(state.getQueryEngine(), ts), r -> {
+            r.stream().forEach(s -> state.addSelectedThread(state.getThreadInfo(s.utid)));
+            return new CpuTrack.Slices(state, r);
+          }));
     }
   }
 

--- a/gapic/src/main/com/google/gapid/perfetto/views/RootPanel.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/RootPanel.java
@@ -323,6 +323,7 @@ public class RootPanel extends Panel.Base implements State.Listener {
     TimeSpan ts = new TimeSpan(
         state.pxToTime(onTrack.x), state.pxToTime(onTrack.x + onTrack.w));
 
+    state.clearSelectedThreads();
     Selection.CombiningBuilder builder = new Selection.CombiningBuilder();
     visit(Visitor.of(Selectable.class, (s, a) -> s.computeSelection(builder, a, ts)), selection);
     selection = Area.NONE;


### PR DESCRIPTION
 - Before this commit, we only change CPU slices' color at
 single-selection, support changing color at multi-selection on CPU
 slices as well, so that the UX behavior is more consistent.
 - Use HashMultimap to record state, so that both upid and utid lookup
 is fast.