### PR TITLE
Use pid file to avoid launching multiple producers.

### DIFF
--- a/gapidapk/BUILD.bazel
+++ b/gapidapk/BUILD.bazel
@@ -25,7 +25,6 @@ go_library(
     importpath = "github.com/google/gapid/gapidapk",
     visibility = ["//visibility:public"],
     deps = [
-        "//core/app:go_default_library",
         "//core/app/crash:go_default_library",
         "//core/app/layout:go_default_library",
         "//core/event/task:go_default_library",


### PR DESCRIPTION
Previously we couldn't run multiple instances of gapid for system profiler
because of launch_producer launches multiple profiling producers. This patch
makes launch_producer writes its pid file and have the tool always kill the
existing one and run a new one.

Minor: Removed the unused path of profiling producer, we no longer want them to
exist in /assets folder.

BUG: b/143532393
Test: launch multiple instances of gapid