### PR TITLE
Fix de-selection event in profiler.

### DIFF
--- a/gapic/src/main/com/google/gapid/perfetto/views/State.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/State.java
@@ -226,7 +226,6 @@ public class State {
   public boolean resetSelections() {
     boolean hasDeselection = selection != null || selectedThreads.size() > 0;
     setSelection((Selection.MultiSelection)null);
-    selectedThreads = HashMultimap.create();
     return hasDeselection;
   }
 
@@ -255,6 +254,10 @@ public class State {
   public void setSelection(Selection.MultiSelection selection) {
     lastSelectionUpdateId.incrementAndGet();
     this.selection = selection;
+    // If selection is cleared or set to a non-cpu one, don't do color grouping for cpu slices.
+    if (selection == null || selection.getSelection(Selection.Kind.Cpu) == Selection.EMPTY_SELECTION) {
+      clearSelectedThreads();
+    }
     listeners.fire().onSelectionChanged(selection);
   }
 

--- a/gapic/src/main/com/google/gapid/perfetto/views/TrackContainer.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/TrackContainer.java
@@ -326,7 +326,9 @@ public class TrackContainer {
 
     @Override
     public Hover onMouseMove(Fonts.TextMeasurer m, double x, double y) {
-      if (y < TITLE_HEIGHT && (expanded || x < LABEL_WIDTH)) {
+      if (y < TITLE_HEIGHT && x >= LABEL_WIDTH) {
+        return Hover.NONE;
+      } else if (y < TITLE_HEIGHT && (expanded || x < LABEL_WIDTH)) {
         hovered = true;
         double p = m.measure(Fonts.Style.Normal, summary.getTitle()).w + LABEL_OFFSET;
         if (expanded) {


### PR DESCRIPTION
 - Clear color grouping after selecting a non-cpu selection.
 - Allow de-selection by clicking empty area on panel group's title bar.
