### PR TITLE
Chore: Remove ANSI color codes from perfetto logs

### DIFF
--- a/core/os/android/adb/perfetto.go
+++ b/core/os/android/adb/perfetto.go
@@ -33,7 +33,7 @@ import (
 )
 
 var (
-	ansiRegex = regexp.MustCompile("\u001b\\[\\d+m")
+	AnsiRegex = regexp.MustCompile("\u001b\\[\\d+m")
 )
 
 // StartPerfettoTrace starts a perfetto trace on this device.
@@ -56,6 +56,8 @@ func (b *binding) StartPerfettoTrace(ctx context.Context, config *perfetto_pb.Tr
 		buf := bufio.NewReader(reader)
 		for {
 			line, e := buf.ReadString('\n')
+			// Remove ANSI color codes from perfetto output
+			line = AnsiRegex.ReplaceAllString(line, "")
 			readyOnce(ctx)
 			logRing.Value = line
 			logRing = logRing.Next()
@@ -99,8 +101,6 @@ func (b *binding) StartPerfettoTrace(ctx context.Context, config *perfetto_pb.Tr
 					msg += "\n" + s
 				}
 			})
-			// Remove ANSI color codes from perfetto output
-			msg = ansiRegex.ReplaceAllString(msg, "")
 
 			if msg != "" {
 				err = errors.New(err.Error() + "\nPerfetto Output:" + msg)

--- a/gapidapk/deviceinfo.go
+++ b/gapidapk/deviceinfo.go
@@ -205,7 +205,7 @@ func launchPerfettoProducerFromApk(ctx context.Context, d adb.Device, startFunc 
 				fail <- nil
 				return
 			case nil:
-				log.E(ctx, "[launch producer] %s", strings.TrimSuffix(line, "\n"))
+				log.E(ctx, "[launch producer] %s", strings.TrimSuffix(adb.AnsiRegex.ReplaceAllString(line, ""), "\n"))
 			}
 		}
 	})


### PR DESCRIPTION
Improves log readability by removing incorrectly rendered ANSI color codes from perfetto stdout/stderr