### PR TITLE
Fix a problem that image primer didn't release the resource it allocated

### DIFF
--- a/gapis/api/vulkan/state_rebuilder.go
+++ b/gapis/api/vulkan/state_rebuilder.go
@@ -180,15 +180,11 @@ func (API) RebuildState(ctx context.Context, oldState *api.GlobalState) ([]api.C
 	for _, buf := range s.Buffers().Keys() {
 		sb.createBuffer(s.Buffers().Get(buf))
 	}
-
-	{
-		imgPrimer := newImagePrimer(sb)
-		defer imgPrimer.Free()
-		for _, img := range s.Images().Keys() {
-			subRange, err := sb.createImage(s.Images().Get(img), sb.oldState, img)
-			if len(subRange) != 0 && err == nil {
-				sb.primeImage(s.Images().Get(img), imgPrimer, subRange)
-			}
+	imgPrimer := newImagePrimer(sb)
+	for _, img := range s.Images().Keys() {
+		subRange, err := sb.createImage(s.Images().Get(img), sb.oldState, img)
+		if len(subRange) != 0 && err == nil {
+			sb.primeImage(s.Images().Get(img), imgPrimer, subRange)
 		}
 	}
 
@@ -279,7 +275,7 @@ func (API) RebuildState(ctx context.Context, oldState *api.GlobalState) ([]api.C
 	}
 
 	sb.scratchRes.Free(sb)
-
+	imgPrimer.Free()
 	return out.cmds, sb.memoryIntervals
 }
 


### PR DESCRIPTION
The original code put the Free() function into defer will not affect
the returned cmds list, thus the cmds to release the resource in
image primer is not included in the initial state for MEC.

This also fix issue #3361, as we recreate image views that should
already be destroyed in the initial state.