### PR TITLE
Direct Perfetto Consumer Client Implementation

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -25,7 +25,7 @@ load("//tools/build:rules.bzl", "copy_to", "copy_tree")
 
 # gazelle:prefix github.com/google/gapid
 # gazelle:resolve go    go    llvm/bindings/go/llvm                        @llvm//:go
-# gazelle:resolve go    go    perfetto/config                              @gapid//tools/build/third_party/perfetto:config_go_proto
+# gazelle:resolve go    go    protos/perfetto/config                       //tools/build/third_party/perfetto:config_go_proto
 # gazelle:resolve proto proto protos/perfetto/config/perfetto_config.proto @perfetto//:protos_perfetto_config_merged_config_protos
 # gazelle:resolve proto go    protos/perfetto/config/perfetto_config.proto @gapid//tools/build/third_party/perfetto:config_go_proto
 

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -25,7 +25,9 @@ load("//tools/build:rules.bzl", "copy_to", "copy_tree")
 
 # gazelle:prefix github.com/google/gapid
 # gazelle:resolve go    go    llvm/bindings/go/llvm                        @llvm//:go
+# gazelle:resolve go    go    protos/perfetto/common                       //tools/build/third_party/perfetto:common_go_proto
 # gazelle:resolve go    go    protos/perfetto/config                       //tools/build/third_party/perfetto:config_go_proto
+# gazelle:resolve go    go    protos/perfetto/ipc                          //tools/build/third_party/perfetto:ipc_go_proto
 # gazelle:resolve proto proto protos/perfetto/config/perfetto_config.proto @perfetto//:protos_perfetto_config_merged_config_protos
 # gazelle:resolve proto go    protos/perfetto/config/perfetto_config.proto @gapid//tools/build/third_party/perfetto:config_go_proto
 

--- a/cmd/gapit/trace.go
+++ b/cmd/gapit/trace.go
@@ -25,7 +25,7 @@ import (
 	"strings"
 	"time"
 
-	perfetto_pb "perfetto/config"
+	perfetto_pb "protos/perfetto/config"
 
 	"github.com/golang/protobuf/proto"
 	"github.com/google/gapid/core/app"

--- a/cmd/perfetto/BUILD.bazel
+++ b/cmd/perfetto/BUILD.bazel
@@ -1,0 +1,48 @@
+# Copyright (C) 2019 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("//tools/build:rules.bzl", "go_stripped_binary")
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "main.go",
+        "query.go",
+    ],
+    data = select({
+        "//tools/build:no-android": [],
+        "//conditions:default": [
+            "//gapidapk/android/apk:arm64-v8a.apk",
+            "//gapidapk/android/apk:armeabi-v7a.apk",
+            "//gapidapk/android/apk:x86.apk",
+        ],
+    }),
+    importpath = "github.com/google/gapid/cmd/perfetto",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//core/app:go_default_library",
+        "//core/log:go_default_library",
+        "//core/os/android/adb:go_default_library",
+        "//core/os/device/bind:go_default_library",
+        "//gapidapk:go_default_library",
+        "//tools/build/third_party/perfetto:common_go_proto",
+    ],
+)
+
+go_stripped_binary(
+    name = "perfetto",
+    embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
+)

--- a/cmd/perfetto/BUILD.bazel
+++ b/cmd/perfetto/BUILD.bazel
@@ -36,6 +36,7 @@ go_library(
         "//core/log:go_default_library",
         "//core/os/android/adb:go_default_library",
         "//core/os/device/bind:go_default_library",
+        "//core/os/device/remotessh:go_default_library",
         "//gapidapk:go_default_library",
         "//tools/build/third_party/perfetto:common_go_proto",
     ],

--- a/cmd/perfetto/main.go
+++ b/cmd/perfetto/main.go
@@ -1,0 +1,46 @@
+// Copyright (C) 2019 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+
+	"github.com/google/gapid/core/app"
+	"github.com/google/gapid/core/os/android/adb"
+	"github.com/google/gapid/core/os/device/bind"
+	_ "github.com/google/gapid/gapidapk"
+)
+
+func main() {
+	app.ShortHelp = "perfetto is a Perfetto command line utility"
+	app.Name = "perfetto"
+	app.Run(app.VerbMain)
+}
+
+func setupContext(ctx context.Context) context.Context {
+	r := bind.NewRegistry()
+	ctx = bind.PutRegistry(ctx, r)
+
+	host := bind.Host(ctx)
+	r.AddDevice(ctx, host)
+
+	if devs, err := adb.Devices(ctx); err == nil {
+		for _, d := range devs {
+			r.AddDevice(ctx, d)
+		}
+	}
+
+	return ctx
+}

--- a/cmd/perfetto/query.go
+++ b/cmd/perfetto/query.go
@@ -1,0 +1,76 @@
+// Copyright (C) 2019 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"time"
+
+	"github.com/google/gapid/core/app"
+	"github.com/google/gapid/core/log"
+	"github.com/google/gapid/core/os/device/bind"
+
+	common "protos/perfetto/common"
+)
+
+type queryVerb struct {
+}
+
+func init() {
+	verb := &queryVerb{}
+	app.AddVerb(&app.Verb{
+		Name:      "query",
+		ShortHelp: "Queries the Perfetto service state",
+		Action:    verb,
+	})
+}
+
+func (verb *queryVerb) Run(ctx context.Context, flags flag.FlagSet) error {
+	ctx = setupContext(ctx)
+	time.Sleep(2 * time.Second) // Give the producers some time to register.
+
+	for _, d := range bind.GetRegistry(ctx).Devices() {
+		if !d.SupportsPerfetto(ctx) {
+			log.I(ctx, "Device %s doesn't support Perfetto", d)
+			continue
+		}
+
+		log.I(ctx, "Connecting to Perfetto...")
+		c, err := d.ConnectPerfetto(ctx)
+		if err != nil {
+			log.E(ctx, "Failed to connect to perfetto: %s", err)
+			return err
+		}
+		defer c.Close(ctx)
+		log.I(ctx, "Connected.")
+
+		if err := c.Query(ctx, func(r *common.TracingServiceState) error {
+			jsonBytes, err := json.MarshalIndent(r, "", "  ")
+			if err != nil {
+				fmt.Printf("%v\n", log.Err(ctx, err, "Couldn't marshal response to JSON"))
+				return err
+			}
+			fmt.Println(string(jsonBytes))
+			return nil
+		}); err != nil {
+			log.E(ctx, "Failed to query Perfetto: %s", err)
+			return err
+		}
+	}
+	return nil
+}

--- a/core/os/android/adb/BUILD.bazel
+++ b/core/os/android/adb/BUILD.bazel
@@ -45,6 +45,7 @@ go_library(
         "//core/os/device/bind:go_default_library",
         "//core/os/file:go_default_library",
         "//core/os/shell:go_default_library",
+        "//tools/build/third_party/perfetto:common_go_proto",
         "//tools/build/third_party/perfetto:config_go_proto",
         "@com_github_golang_protobuf//proto:go_default_library",
     ],

--- a/core/os/android/adb/BUILD.bazel
+++ b/core/os/android/adb/BUILD.bazel
@@ -45,6 +45,7 @@ go_library(
         "//core/os/device/bind:go_default_library",
         "//core/os/file:go_default_library",
         "//core/os/shell:go_default_library",
+        "//gapis/perfetto:go_default_library",
         "//tools/build/third_party/perfetto:common_go_proto",
         "//tools/build/third_party/perfetto:config_go_proto",
         "@com_github_golang_protobuf//proto:go_default_library",

--- a/core/os/android/adb/commands.go
+++ b/core/os/android/adb/commands.go
@@ -23,14 +23,14 @@ import (
 	"strings"
 	"time"
 
-	perfetto_pb "protos/perfetto/config"
-
 	"github.com/golang/protobuf/proto"
 	"github.com/google/gapid/core/fault"
 	"github.com/google/gapid/core/log"
 	"github.com/google/gapid/core/os/android"
 	"github.com/google/gapid/core/os/device"
 	"github.com/google/gapid/core/os/shell"
+
+	common_pb "protos/perfetto/common"
 )
 
 const (
@@ -281,7 +281,7 @@ func (b *binding) QueryPerfettoServiceState(ctx context.Context) (*device.Perfet
 		return result, log.Errf(ctx, err, "adb shell perfetto returned error: %s", res)
 	}
 	decoded, _ := base64.StdEncoding.DecodeString(res)
-	tracingServiceState := &perfetto_pb.TracingServiceState{}
+	tracingServiceState := &common_pb.TracingServiceState{}
 	if err = proto.Unmarshal(decoded, tracingServiceState); err != nil {
 		return result, log.Errf(ctx, err, "Unmarshal returned error")
 	}

--- a/core/os/android/adb/commands.go
+++ b/core/os/android/adb/commands.go
@@ -23,7 +23,7 @@ import (
 	"strings"
 	"time"
 
-	perfetto_pb "perfetto/config"
+	perfetto_pb "protos/perfetto/config"
 
 	"github.com/golang/protobuf/proto"
 	"github.com/google/gapid/core/fault"

--- a/core/os/android/adb/perfetto.go
+++ b/core/os/android/adb/perfetto.go
@@ -24,7 +24,7 @@ import (
 	"regexp"
 	"strings"
 
-	perfetto_pb "perfetto/config"
+	perfetto_pb "protos/perfetto/config"
 
 	"github.com/golang/protobuf/proto"
 	"github.com/google/gapid/core/app/crash"

--- a/core/os/android/device.go
+++ b/core/os/android/device.go
@@ -19,7 +19,7 @@ import (
 	"fmt"
 	"time"
 
-	perfetto_pb "perfetto/config"
+	perfetto_pb "protos/perfetto/config"
 
 	"github.com/google/gapid/core/event/task"
 	"github.com/google/gapid/core/log"

--- a/core/os/device/bind/BUILD.bazel
+++ b/core/os/device/bind/BUILD.bazel
@@ -38,6 +38,7 @@ go_library(
         "//core/os/device:go_default_library",
         "//core/os/device/host:go_default_library",
         "//core/os/shell:go_default_library",
+        "//gapis/perfetto:go_default_library",
     ],
 )
 

--- a/core/os/device/bind/device.go
+++ b/core/os/device/bind/device.go
@@ -22,6 +22,7 @@ import (
 	"github.com/google/gapid/core/app"
 	"github.com/google/gapid/core/os/device"
 	"github.com/google/gapid/core/os/shell"
+	"github.com/google/gapid/gapis/perfetto"
 )
 
 // Device represents a connection to an attached device.
@@ -65,6 +66,9 @@ type Device interface {
 	CanTrace() bool
 	// SupportsPerfetto returns true if this device will work with perfetto
 	SupportsPerfetto(ctx context.Context) bool
+	// ConnectPerfetto connects to a Perfetto service running on this device
+	// and returns an open socket connection to the service.
+	ConnectPerfetto(ctx context.Context) (*perfetto.Client, error)
 	// PushFile will transfer the local file at sourcePath to the remote
 	// machine at destPath
 	PushFile(ctx context.Context, sourcePath, destPath string) error

--- a/core/os/device/bind/simple_windows.go
+++ b/core/os/device/bind/simple_windows.go
@@ -24,6 +24,8 @@ import (
 	"strings"
 	"syscall"
 	"unsafe"
+
+	"github.com/google/gapid/gapis/perfetto"
 )
 
 // ListExecutables returns the executables in a particular directory as given by path
@@ -119,4 +121,10 @@ func (b *Simple) ListDirectories(ctx context.Context, path string) ([]string, er
 // Perfetto trace.
 func (b *Simple) SupportsPerfetto(ctx context.Context) bool {
 	return false
+}
+
+// ConnectPerfetto connects to a Perfetto service running on this device
+// and returns an open socket connection to the service.
+func (b *Simple) ConnectPerfetto(ctx context.Context) (*perfetto.Client, error) {
+	return nil, fmt.Errorf("Perfetto is not supported on this device")
 }

--- a/core/os/device/remotessh/BUILD.bazel
+++ b/core/os/device/remotessh/BUILD.bazel
@@ -34,6 +34,7 @@ go_library(
         "//core/os/device/bind:go_default_library",
         "//core/os/shell:go_default_library",
         "//core/text:go_default_library",
+        "//gapis/perfetto:go_default_library",
         "@com_github_golang_protobuf//jsonpb:go_default_library_gen",
         "@org_golang_x_crypto//ssh:go_default_library",
         "@org_golang_x_crypto//ssh/agent:go_default_library",

--- a/core/os/device/remotessh/BUILD.bazel
+++ b/core/os/device/remotessh/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
         "commands.go",
         "configuration.go",
         "device.go",
+        "forward.go",
     ],
     importpath = "github.com/google/gapid/core/os/device/remotessh",
     visibility = ["//visibility:public"],

--- a/core/os/device/remotessh/commands.go
+++ b/core/os/device/remotessh/commands.go
@@ -33,6 +33,7 @@ import (
 	"github.com/google/gapid/core/os/device/bind"
 	"github.com/google/gapid/core/os/shell"
 	"github.com/google/gapid/core/text"
+	"github.com/google/gapid/gapis/perfetto"
 )
 
 // remoteProcess is the interface to a running process, as started by a Target.
@@ -362,4 +363,18 @@ func (b binding) SupportsPerfetto(ctx context.Context) bool {
 		return support
 	}
 	return false
+}
+
+// ConnectPerfetto connects to a Perfetto service running on this device
+// and returns an open socket connection to the service.
+func (b *binding) ConnectPerfetto(ctx context.Context) (*perfetto.Client, error) {
+	if !b.SupportsPerfetto(ctx) {
+		return nil, fmt.Errorf("Perfetto is not supported on this device")
+	}
+
+	conn, err := UnixPort("/tmp/perfetto-consumer").dial(b.connection)
+	if err != nil {
+		return nil, err
+	}
+	return perfetto.NewClient(ctx, conn, nil)
 }

--- a/core/os/device/remotessh/device.go
+++ b/core/os/device/remotessh/device.go
@@ -234,6 +234,8 @@ func scanDevices(ctx context.Context, configurations []Configuration) error {
 			if device, err := GetConnectedDevice(ctx, cfg); err == nil {
 				registry.AddDevice(ctx, device)
 				cache[cfg.Name] = device.(*binding)
+			} else {
+				log.E(ctx, "Failed to connect to remote device %s: %v", cfg.Name, err)
 			}
 		}
 	}

--- a/core/os/device/remotessh/forward.go
+++ b/core/os/device/remotessh/forward.go
@@ -1,0 +1,108 @@
+// Copyright (C) 2019 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package remotessh
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"sync"
+
+	"github.com/google/gapid/core/app/crash"
+	"github.com/google/gapid/core/event/task"
+	"github.com/google/gapid/core/log"
+)
+
+// doTunnel tunnels a single connection through the SSH connection.
+func (b binding) doTunnel(ctx context.Context, local net.Conn, remotePort int) error {
+	remote, err := b.connection.Dial("tcp", fmt.Sprintf("localhost:%d", remotePort))
+	if err != nil {
+		local.Close()
+		return err
+	}
+
+	wg := sync.WaitGroup{}
+
+	copy := func(writer net.Conn, reader net.Conn) {
+		// Use the same buffer size used in io.Copy
+		buf := make([]byte, 32*1024)
+		var err error
+		for {
+			nr, er := reader.Read(buf)
+			if nr > 0 {
+				nw, ew := writer.Write(buf[0:nr])
+				if ew != nil {
+					err = ew
+					break
+				}
+				if nr != nw {
+					err = fmt.Errorf("short write")
+					break
+				}
+			}
+			if er != nil {
+				if er != io.EOF {
+					err = er
+				}
+				break
+			}
+		}
+		writer.Close()
+		if err != nil {
+			log.E(ctx, "Copy Error %s", err)
+		}
+		wg.Done()
+	}
+
+	wg.Add(2)
+	crash.Go(func() { copy(local, remote) })
+	crash.Go(func() { copy(remote, local) })
+
+	crash.Go(func() {
+		defer local.Close()
+		defer remote.Close()
+		wg.Wait()
+	})
+	return nil
+}
+
+// SetupLocalPort forwards a local TCP port to the remote machine on the remote port.
+// The local port that was opened is returned.
+func (b binding) SetupLocalPort(ctx context.Context, remotePort int) (int, error) {
+	listener, err := net.Listen("tcp", ":0")
+
+	if err != nil {
+		return 0, err
+	}
+	crash.Go(func() {
+		<-task.ShouldStop(ctx)
+		listener.Close()
+	})
+	crash.Go(func() {
+		defer listener.Close()
+		for {
+			local, err := listener.Accept()
+			if err != nil {
+				return
+			}
+			if err = b.doTunnel(ctx, local, remotePort); err != nil {
+				return
+			}
+		}
+	})
+
+	return listener.Addr().(*net.TCPAddr).Port, nil
+}

--- a/gapis/perfetto/BUILD.bazel
+++ b/gapis/perfetto/BUILD.bazel
@@ -30,6 +30,8 @@ go_library(
         "//core/log:go_default_library",
         "//gapis/perfetto/client:go_default_library",
         "//gapis/perfetto/service:go_default_library",
+        "//tools/build/third_party/perfetto:common_go_proto",
+        "//tools/build/third_party/perfetto:ipc_go_proto",
         "@com_github_golang_protobuf//proto:go_default_library",
     ],
 )

--- a/gapis/perfetto/android/trace.go
+++ b/gapis/perfetto/android/trace.go
@@ -21,7 +21,7 @@ import (
 	"os"
 	"sync/atomic"
 
-	perfetto_pb "perfetto/config"
+	perfetto_pb "protos/perfetto/config"
 
 	"github.com/google/gapid/core/app"
 	"github.com/google/gapid/core/event/task"

--- a/gapis/perfetto/client.go
+++ b/gapis/perfetto/client.go
@@ -1,0 +1,67 @@
+// Copyright (C) 2019 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package perfetto
+
+import (
+	"context"
+	"net"
+
+	"github.com/google/gapid/core/app"
+	"github.com/google/gapid/gapis/perfetto/client"
+)
+
+const (
+	consumerService = "ConsumerPort"
+)
+
+// Client is a client ("consumer") of a Perfetto service.
+type Client struct {
+	conn    *client.Connection
+	methods map[string]*client.Method
+}
+
+// NewClient returns a new client using the provided socket connection. The
+// client takes ownership of the connection and invokes the provided cleanup
+// on shutdown.
+func NewClient(ctx context.Context, conn net.Conn, cleanup app.Cleanup) (*Client, error) {
+	c, err := client.Connect(ctx, conn, cleanup)
+	if err != nil {
+		conn.Close()
+		cleanup.Invoke(ctx)
+		return nil, err
+	}
+
+	bind := client.NewBindSync(ctx)
+	if err := c.Bind(ctx, consumerService, bind.Handler); err != nil {
+		c.Close(ctx)
+		return nil, err
+	}
+	methods, err := bind.Wait(ctx)
+	if err != nil {
+		c.Close(ctx)
+		return nil, err
+	}
+
+	return &Client{
+		conn:    c,
+		methods: methods,
+	}, nil
+}
+
+// Close closes the underlying connection to the Perfetto service of this client.
+func (c *Client) Close(ctx context.Context) {
+	c.conn.Close(ctx)
+	c.conn = nil
+}

--- a/gapis/perfetto/client/BUILD.bazel
+++ b/gapis/perfetto/client/BUILD.bazel
@@ -19,6 +19,7 @@ go_library(
     srcs = [
         "connection.go",
         "doc.go",
+        "proto.go",
         "sync.go",
     ],
     importpath = "github.com/google/gapid/gapis/perfetto/client",
@@ -31,6 +32,8 @@ go_library(
         "//core/event/task:go_default_library",
         "//core/log:go_default_library",
         "//core/os/device:go_default_library",
+        "//tools/build/third_party/perfetto:common_go_proto",
+        "//tools/build/third_party/perfetto:ipc_go_proto",
         "//tools/build/third_party/perfetto:wire_go_proto",
         "@com_github_golang_protobuf//proto:go_default_library",
     ],

--- a/gapis/perfetto/client/BUILD.bazel
+++ b/gapis/perfetto/client/BUILD.bazel
@@ -17,19 +17,21 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = [
-        "client.go",
+        "connection.go",
         "doc.go",
-        "processor.go",
+        "sync.go",
     ],
-    cdeps = ["//gapis/perfetto/cc:cc"],
-    cgo = True,
-    importpath = "github.com/google/gapid/gapis/perfetto",
+    importpath = "github.com/google/gapid/gapis/perfetto/client",
     visibility = ["//visibility:public"],
     deps = [
         "//core/app:go_default_library",
+        "//core/app/crash:go_default_library",
+        "//core/data/binary:go_default_library",
+        "//core/data/endian:go_default_library",
+        "//core/event/task:go_default_library",
         "//core/log:go_default_library",
-        "//gapis/perfetto/client:go_default_library",
-        "//gapis/perfetto/service:go_default_library",
+        "//core/os/device:go_default_library",
+        "//tools/build/third_party/perfetto:wire_go_proto",
         "@com_github_golang_protobuf//proto:go_default_library",
     ],
 )

--- a/gapis/perfetto/client/connection.go
+++ b/gapis/perfetto/client/connection.go
@@ -1,0 +1,228 @@
+// Copyright (C) 2019 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"sync"
+
+	"github.com/golang/protobuf/proto"
+	"github.com/google/gapid/core/app"
+	"github.com/google/gapid/core/app/crash"
+	"github.com/google/gapid/core/data/binary"
+	"github.com/google/gapid/core/data/endian"
+	"github.com/google/gapid/core/log"
+	"github.com/google/gapid/core/os/device"
+
+	wire "protos/perfetto/wire"
+)
+
+// Connection is a connection to the Perfetto service.
+type Connection struct {
+	conn    net.Conn
+	out     binary.Writer
+	in      binary.Reader
+	reqID   uint64
+	cleanup app.Cleanup
+
+	closed   chan struct{}
+	packets  chan packet
+	lock     sync.Mutex
+	handlers map[uint64]handler
+}
+
+// Method represents an RPC method that can be called on the Perfetto service.
+type Method struct {
+	Name      string
+	serviceID uint32
+	methodID  uint32
+}
+
+type packet struct {
+	Frame *wire.IPCFrame
+	Err   error
+}
+
+type handler func(frame *wire.IPCFrame, err error) bool
+
+// Connect creates a new connection that uses the established socket to
+// communicate with the Perfetto service.
+func Connect(ctx context.Context, conn net.Conn, cleanup app.Cleanup) (*Connection, error) {
+	c := &Connection{
+		conn:    conn,
+		out:     endian.Writer(conn, device.LittleEndian),
+		in:      endian.Reader(conn, device.LittleEndian),
+		cleanup: cleanup,
+
+		closed:   make(chan struct{}),
+		packets:  make(chan packet, 1),
+		handlers: map[uint64]handler{},
+	}
+
+	// Reads frames from the wire and pushes them into the channel. Will exit on
+	// error (including if the connection is closed).
+	crash.Go(func() {
+		for {
+			frame, err := c.readFrame(ctx)
+			select {
+			case c.packets <- packet{frame, err}:
+				if err != nil {
+					close(c.packets)
+					return
+				}
+			case <-c.closed:
+				close(c.packets)
+				return
+			}
+		}
+	})
+
+	// Collects frames from the channel and passes them onto the registered
+	// handlers. Drops unknown frames on the floor.
+	crash.Go(func() {
+		for {
+			select {
+			case pkt := <-c.packets:
+				if pkt.Err != nil {
+					// Broadcast the error to all the registered handlers.
+					c.lock.Lock()
+					handlers := c.handlers
+					c.handlers = nil
+					c.lock.Unlock()
+
+					for _, h := range handlers {
+						h(nil, pkt.Err)
+					}
+					return
+				}
+
+				c.lock.Lock()
+				h, ok := c.handlers[pkt.Frame.GetRequestId()]
+				c.lock.Unlock()
+
+				if ok {
+					if !h(pkt.Frame, nil) {
+						c.unregisterHandler(pkt.Frame.GetRequestId())
+					}
+				} else {
+					log.W(ctx, "Got a Perfetto packet with an unkown request ID: %v", pkt.Frame)
+				}
+			case <-c.closed:
+				return
+			}
+		}
+	})
+
+	return c, nil
+}
+
+// BindHandler is the callback invoked when the Bind completes.
+type BindHandler func(methods map[string]*Method, err error)
+
+// Bind binds to the given proto service.
+func (c *Connection) Bind(ctx context.Context, service string, handler BindHandler) error {
+	f := c.newFrame()
+	f.Msg = &wire.IPCFrame_MsgBindService{
+		MsgBindService: &wire.IPCFrame_BindService{
+			ServiceName: proto.String(service),
+		},
+	}
+	return c.writeFrame(ctx, f, func(frame *wire.IPCFrame, err error) bool {
+		if err != nil {
+			handler(nil, err)
+			return false
+		}
+
+		if !frame.GetMsgBindServiceReply().GetSuccess() {
+			handler(nil, fmt.Errorf("Failed to bind to the %s service", service))
+			return false
+		}
+
+		serviceID := frame.GetMsgBindServiceReply().GetServiceId()
+		methods := map[string]*Method{}
+		for _, m := range frame.GetMsgBindServiceReply().GetMethods() {
+			methods[m.GetName()] = &Method{m.GetName(), serviceID, m.GetId()}
+		}
+		handler(methods, nil)
+		return false
+	})
+}
+
+// Close closes this connection and the underlying socket.
+func (c *Connection) Close(ctx context.Context) {
+	if c != nil {
+		close(c.closed)
+		c.conn.Close()
+		c.cleanup.Invoke(ctx)
+	}
+}
+
+func (c *Connection) registerHandler(reqID uint64, handler handler) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	c.handlers[reqID] = handler
+}
+
+func (c *Connection) unregisterHandler(reqID uint64) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	delete(c.handlers, reqID)
+}
+
+func (c *Connection) newFrame() *wire.IPCFrame {
+	c.reqID++
+	return &wire.IPCFrame{
+		RequestId: proto.Uint64(c.reqID - 1),
+	}
+}
+
+func (c *Connection) writeFrame(ctx context.Context, frame *wire.IPCFrame, handler handler) error {
+	buf, err := proto.Marshal(frame)
+	if err != nil {
+		return err
+	}
+
+	c.registerHandler(frame.GetRequestId(), handler)
+	c.out.Uint32(uint32(len(buf)))
+	c.out.Data(buf)
+
+	if err := c.out.Error(); err != nil {
+		c.unregisterHandler(frame.GetRequestId())
+		return err
+	}
+	return nil
+}
+
+func (c *Connection) readFrame(ctx context.Context) (*wire.IPCFrame, error) {
+	size := c.in.Uint32()
+	buf := make([]byte, size)
+	c.in.Data(buf)
+	if err := c.in.Error(); err != nil {
+		return nil, err
+	}
+
+	frame := &wire.IPCFrame{}
+	if err := proto.Unmarshal(buf, frame); err != nil {
+		return nil, err
+	}
+
+	switch m := frame.Msg.(type) {
+	case *wire.IPCFrame_MsgRequestError:
+		return nil, fmt.Errorf("Request Error: %s", m.MsgRequestError.GetError())
+	}
+	return frame, nil
+}

--- a/gapis/perfetto/client/doc.go
+++ b/gapis/perfetto/client/doc.go
@@ -1,0 +1,18 @@
+// Copyright (C) 2019 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package client implements a client for the Perfetto consumer API. This is
+// an internal package only to be used from within the gapis/perfetto package
+// and provides implementation details for the perfetto.Client class.
+package client

--- a/gapis/perfetto/client/proto.go
+++ b/gapis/perfetto/client/proto.go
@@ -1,0 +1,36 @@
+// Copyright (C) 2019 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+import (
+	"context"
+
+	"github.com/golang/protobuf/proto"
+
+	common "protos/perfetto/common"
+	ipc "protos/perfetto/ipc"
+)
+
+// NewQuerySync returns an InvokeSync that handles unmarshalling the proto bytes
+// and invokes the given callback.
+func NewQuerySync(ctx context.Context, cb func(*common.TracingServiceState) error) *InvokeSync {
+	return NewInvokeSync(ctx, func(data []byte) error {
+		resp := &ipc.QueryServiceStateResponse{}
+		if err := proto.Unmarshal(data, resp); err != nil {
+			return err
+		}
+		return cb(resp.GetServiceState())
+	})
+}

--- a/gapis/perfetto/client/sync.go
+++ b/gapis/perfetto/client/sync.go
@@ -1,0 +1,50 @@
+// Copyright (C) 2019 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+import (
+	"context"
+
+	"github.com/google/gapid/core/event/task"
+)
+
+// BindSync is a sync helper to turn async Bind calls into sync ones. Use the
+// Handler struct member in calling Bind() and then call Wait.
+type BindSync struct {
+	Handler BindHandler
+	methods map[string]*Method
+	err     error
+	wait    task.Signal
+}
+
+// NewBindSync returns a new BindSync.
+func NewBindSync(ctx context.Context) *BindSync {
+	wait, fire := task.NewSignal()
+	s := &BindSync{wait: wait}
+	s.Handler = func(methods map[string]*Method, err error) {
+		s.methods = methods
+		s.err = err
+		fire(ctx)
+	}
+	return s
+}
+
+// Wait waits on the sync and returns the result of the Bind call.
+func (s *BindSync) Wait(ctx context.Context) (map[string]*Method, error) {
+	if !s.wait.Wait(ctx) {
+		return nil, task.StopReason(ctx)
+	}
+	return s.methods, s.err
+}

--- a/gapis/perfetto/desktop/trace.go
+++ b/gapis/perfetto/desktop/trace.go
@@ -26,7 +26,7 @@ import (
 
 	"sync/atomic"
 
-	perfetto_pb "perfetto/config"
+	perfetto_pb "protos/perfetto/config"
 
 	"github.com/golang/protobuf/proto"
 	"github.com/google/gapid/core/app"

--- a/gapis/trace/android/trace.go
+++ b/gapis/trace/android/trace.go
@@ -28,7 +28,7 @@ import (
 	"strings"
 	"time"
 
-	perfetto_pb "perfetto/config"
+	perfetto_pb "protos/perfetto/config"
 
 	"github.com/golang/protobuf/proto"
 	"github.com/google/gapid/core/app"

--- a/tools/build/third_party/perfetto/BUILD.bazel
+++ b/tools/build/third_party/perfetto/BUILD.bazel
@@ -27,10 +27,28 @@ cc_library(
 ######## Perfetto Proto libraries ########
 
 go_proto_library(
+    name = "common_go_proto",
+    importpath = "protos/perfetto/common",
+    proto = "@perfetto//:protos_perfetto_common_protos",
+    visibility = ["//visibility:public"],
+)
+
+go_proto_library(
     name = "config_go_proto",
     importpath = "protos/perfetto/config",
-    proto = "@perfetto//:protos_perfetto_config_merged_config_protos",
+    protos = [
+        "@perfetto//:protos_perfetto_config_android_protos",
+        "@perfetto//:protos_perfetto_config_ftrace_protos",
+        "@perfetto//:protos_perfetto_config_gpu_protos",
+        "@perfetto//:protos_perfetto_config_inode_file_protos",
+        "@perfetto//:protos_perfetto_config_power_protos",
+        "@perfetto//:protos_perfetto_config_process_stats_protos",
+        "@perfetto//:protos_perfetto_config_profiling_protos",
+        "@perfetto//:protos_perfetto_config_protos",
+        "@perfetto//:protos_perfetto_config_sys_stats_protos",
+    ],
     visibility = ["//visibility:public"],
+    deps = [":common_go_proto"],
 )
 
 java_proto_library(

--- a/tools/build/third_party/perfetto/BUILD.bazel
+++ b/tools/build/third_party/perfetto/BUILD.bazel
@@ -51,6 +51,24 @@ go_proto_library(
     deps = [":common_go_proto"],
 )
 
+go_proto_library(
+    name = "ipc_go_proto",
+    importpath = "protos/perfetto/ipc",
+    proto = "@perfetto//:protos_perfetto_ipc_protos",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":common_go_proto",
+        ":config_go_proto",
+    ],
+)
+
+go_proto_library(
+    name = "wire_go_proto",
+    importpath = "protos/perfetto/wire",
+    proto = "@perfetto//:protos_perfetto_ipc_wire_protocol_protos",
+    visibility = ["//visibility:public"],
+)
+
 java_proto_library(
     name = "config_java_proto",
     visibility = ["//visibility:public"],

--- a/tools/build/third_party/perfetto/BUILD.bazel
+++ b/tools/build/third_party/perfetto/BUILD.bazel
@@ -28,7 +28,7 @@ cc_library(
 
 go_proto_library(
     name = "config_go_proto",
-    importpath = "perfetto/config",
+    importpath = "protos/perfetto/config",
     proto = "@perfetto//:protos_perfetto_config_merged_config_protos",
     visibility = ["//visibility:public"],
 )

--- a/tools/build/third_party/perfetto/perfetto_cfg.bzl
+++ b/tools/build/third_party/perfetto/perfetto_cfg.bzl
@@ -52,7 +52,7 @@ PERFETTO_CONFIG = struct(
     sqlite_ext_percentile = ["@sqlite_src//:percentile_ext"],
     zlib = ["@net_zlib//:zlib"],
   ),
-  proto_library_visibility = "//visibility:private",
+  proto_library_visibility = "//visibility:public",
   deps_copts = struct(
     zlib = [],
     jsoncpp = [],
@@ -62,5 +62,5 @@ PERFETTO_CONFIG = struct(
   rule_overrides = struct(
     cc_library =_always_optimize_cc_library,
     cc_binary = _always_optimize_cc_binary,
-  )
+  ),
 )


### PR DESCRIPTION
Adds a new client, and lower level protocol implementation, for the Perfetto consumer API. The consumer API allows us to directly query and trace via the Perfetto service, rather than using the 'perfetto' CLI.

Uses this new implementation to query the Perfetto producers.

Also adds a new command line utility in `cmd/perfetto` to exercise the client.