### PR TITLE
Update the list of GPU counters for validation.

### DIFF
--- a/gapis/trace/android/adreno/validate.go
+++ b/gapis/trace/android/adreno/validate.go
@@ -25,14 +25,16 @@ var (
 	// All counters must be inside this array.
 	counters = []validate.GpuCounter{
 		{1, "Clocks / Second", validate.And(validate.IsNumber, validate.CheckLargerThanZero)},
+		{3, "GPU % Utilization", validate.And(validate.IsNumber, validate.CheckLargerThanZero)},
 		{21, "% Shaders Busy", validate.And(validate.IsNumber, validate.CheckLargerThanZero)},
 		{26, "Fragment ALU Instructions / Sec (Full)", validate.And(validate.IsNumber, validate.CheckLargerThanZero)},
-		{29, "Fragment EFU Instructions / Second", validate.And(validate.IsNumber, validate.CheckLargerThanZero)},
+		{29, "Fragment EFU Instructions / Second", validate.And(validate.IsNumber, validate.CheckEqualTo(0.0))},
 		{30, "Textures / Vertex", validate.And(validate.IsNumber, validate.CheckEqualTo(0.0))},
 		{31, "Textures / Fragment", validate.And(validate.IsNumber, validate.CheckApproximateTo(1.0, 0.01))},
 		{37, "% Time Shading Fragments", validate.And(validate.IsNumber, validate.CheckLargerThanZero)},
 		{38, "% Time Shading Vertices", validate.And(validate.IsNumber, validate.CheckLargerThanZero)},
 		{39, "% Time Compute", validate.And(validate.IsNumber, validate.CheckEqualTo(0.0))},
+		{58, "Avg Memory Latency Cycles", validate.And(validate.IsNumber, validate.CheckLargerThanZero)},
 	}
 )
 


### PR DESCRIPTION
Based on the new Vulkan sample cube app, update the list of GPU counters for
device validation.

BUG: b/138717619
Test: bazel run gapit -- validate_gpu_profiling --os android