### PR TITLE
Fix the image layout validation errors for image primer

### DIFF
--- a/gapis/api/vulkan/frame_loop.go
+++ b/gapis/api/vulkan/frame_loop.go
@@ -1471,7 +1471,7 @@ func (f *frameLoop) backupChangedImages(ctx context.Context, stateBuilder *state
 
 		// Create staging Image which is used to backup the changed images
 		imgObj := apiState.Images().Get(img).Clone(apiState.Arena(), api.CloneContext{})
-		usage := VkImageUsageFlags(uint32(imgObj.Info().Usage()) | uint32(VkImageUsageFlagBits_VK_IMAGE_USAGE_TRANSFER_DST_BIT|VkImageUsageFlagBits_VK_IMAGE_USAGE_TRANSFER_SRC_BIT))
+		usage := VkImageUsageFlags(uint32(imgObj.Info().Usage()) | uint32(VkImageUsageFlagBits_VK_IMAGE_USAGE_TRANSFER_DST_BIT|VkImageUsageFlagBits_VK_IMAGE_USAGE_TRANSFER_SRC_BIT|VkImageUsageFlagBits_VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT))
 		imgObj.Info().SetUsage(usage)
 
 		stagingImage, _, err := imgPrimer.CreateSameStagingImage(imgObj)

--- a/gapis/api/vulkan/image_primer_render.go
+++ b/gapis/api/vulkan/image_primer_render.go
@@ -154,14 +154,6 @@ func (kb *ipRenderKitBuilder) BuildRenderKits(sb *stateBuilder, recipes ...ipRen
 	for i := range kits {
 		kits[i].dependentPieces = append(kits[i].dependentPieces, descSetReservation)
 		des := descSets[i]
-		inputImage := GetState(sb.newState).Images().Get(recipes[i].inputAttachmentImage)
-		queue := getQueueForPriming(sb, inputImage, VkQueueFlagBits_VK_QUEUE_GRAPHICS_BIT)
-		queueHandler := sb.scratchRes.GetQueueCommandHandler(sb, queue.VulkanHandle())
-		inputAttachmentBarriers := ipImageLayoutTransitionBarriers(sb, inputImage, sameLayoutsOfImage(inputImage), useSpecifiedLayout(ipRenderInputAttachmentLayout))
-		if err = ipRecordImageMemoryBarriers(sb, queueHandler, inputAttachmentBarriers...); err != nil {
-			return nil, log.Err(sb.ctx, err, "Failed to record image layout transition for input attachment")
-		}
-
 		inputView := kb.imageViewPool.getOrCreateImageView(sb, kb.nm, ipImageViewInfo{
 			image:  recipes[i].inputAttachmentImage,
 			aspect: recipes[i].inputAttachmentAspect,


### PR DESCRIPTION
Previous PR #3410 transit the layout during the buildrenderkits, which
was done(partially, this PR is to make it done fully) in the prime in
ipPrimeableHostCopy.