### PR TITLE
Add a missing #include in virtual_swapchain.h

### DIFF
--- a/core/vulkan/vk_virtual_swapchain/cc/virtual_swapchain.h
+++ b/core/vulkan/vk_virtual_swapchain/cc/virtual_swapchain.h
@@ -23,6 +23,7 @@
 #include <functional>
 #include <memory>
 #include <mutex>
+#include <string>
 #include "base_swapchain.h"
 #include "layer.h"
 


### PR DESCRIPTION
This caused build failures on clang.