### PR TITLE
Add a flag to enable pprof profiling.

### DIFF
--- a/core/app/flags.go
+++ b/core/app/flags.go
@@ -38,5 +38,6 @@ type (
 		CPU   string `help:"_write cpu profile to file"`
 		Mem   string `help:"_write mem profile to file"`
 		Trace string `help:"_write a trace to file"`
+		Pprof bool   `help:"_enable pprof profiling"`
 	}
 )

--- a/core/app/profile.go
+++ b/core/app/profile.go
@@ -17,6 +17,8 @@ package app
 import (
 	"bufio"
 	"context"
+	"net/http"
+	_ "net/http/pprof"
 	"os"
 	"runtime"
 	"runtime/pprof"
@@ -69,6 +71,12 @@ func applyProfiler(ctx context.Context, flags *ProfileFlags) func() {
 			f.Close()
 			log.I(ctx, "Trace profile written")
 		})
+	}
+	if flags.Pprof {
+		log.I(ctx, "Enabling pprof on :6060")
+		go func() {
+			http.ListenAndServe("localhost:6060", nil)
+		}()
 	}
 	return func() {
 		for _, closer := range closers {


### PR DESCRIPTION
This will let you attach with go tool pprof to port :6060
in order to collect data.