### PR TITLE
Minor fixes in Vulkan memory tracker in GAPID profiler

### DIFF
--- a/core/vulkan/vk_memory_tracker_layer/cc/memory_tracker_layer_impl.h
+++ b/core/vulkan/vk_memory_tracker_layer/cc/memory_tracker_layer_impl.h
@@ -497,8 +497,6 @@ class MemoryTracker {
   rwlock rwl_device_memory_type_map;
   std::unordered_map<VkDeviceMemory, uint32_t> device_memory_type_map;
 
-  std::deque<uint32_t> memory_type_index_to_heap_index;
-
   // Add the event to the current state of the memory usage.
   void StoreCreateDeviceEvent(VkPhysicalDevice physical_device,
                               VkDeviceCreateInfo const* create_info,


### PR DESCRIPTION
This change contains minor fixes in Vulkan memory tracker code in GAPID
profiler:
 - Delegates sending the state of the memory to a separate thread.
 - Minor fixes toward multi-gpu support.