### PR TITLE
Update vulkan memory tracking layer to allow selecting categories

### DIFF
--- a/core/vulkan/perfetto_producer/perfetto_threadlocal_emitter.h
+++ b/core/vulkan/perfetto_producer/perfetto_threadlocal_emitter.h
@@ -51,6 +51,10 @@ class ThreadlocalEmitter : ThreadlocalEmitterBase {
       const typename perfetto::DataSourceBase::SetupArgs&) override;
   void StopTracing() override { enabled_ = false; }
   bool Enabled() { return enabled_; }
+  bool CategoryEnabled(const char* category) {
+    return enabled_categories_.empty() ||
+           enabled_categories_.contains(category);
+  }
   void StartEvent(const char* catagory, const char* name);
   void EndEvent(const char* category);
   void EmitVulkanMemoryUsageEvent(const VulkanMemoryEvent* vulkan_memory_event);
@@ -92,7 +96,7 @@ class ThreadlocalEmitter : ThreadlocalEmitterBase {
   gapil::Map<std::string, uint64_t, false> interned_categories_;
   gapil::Map<std::string, uint64_t, false> interned_function_names_;
   gapil::Map<std::string, uint64_t, false> interned_vulkan_annotation_keys_;
-  gapil::Map<std::string, uint64_t, false> enabled_categories;
+  gapil::Map<std::string, uint64_t, false> enabled_categories_;
   bool emitted_thread_data_ = false;
   bool emitted_process_data_ = false;
   uint64_t last_reset_timestamp_;

--- a/core/vulkan/perfetto_producer/perfetto_threadlocal_emitter.inc
+++ b/core/vulkan/perfetto_producer/perfetto_threadlocal_emitter.inc
@@ -48,7 +48,7 @@ ThreadlocalEmitter<T>::ThreadlocalEmitter()
       interned_categories_(&arena_),
       interned_function_names_(&arena_),
       interned_vulkan_annotation_keys_(&arena_),
-      enabled_categories(&arena_),
+      enabled_categories_(&arena_),
       last_reset_timestamp_(0),
       reset_period_ms_(SEQUENCE_RESET_PERIOD_MS),
       reset_(false) {
@@ -239,16 +239,16 @@ void ThreadlocalEmitter<T>::SetupTracing(
     const typename perfetto::DataSourceBase::SetupArgs& a) {
   auto config = a.config;
   if (config) {
-    enabled_categories.clear();
+    enabled_categories_.clear();
     std::istringstream f(config->legacy_config());
     std::string s;
-    enabled_categories[""] = 1;
+    enabled_categories_[""] = 1;
     while (std::getline(f, s, ':')) {
-      enabled_categories[s] = 1;
+      enabled_categories_[s] = 1;
     }
   } else {
-    enabled_categories.clear();
-    enabled_categories[""] = 1;
+    enabled_categories_.clear();
+    enabled_categories_[""] = 1;
   }
 }
 
@@ -257,7 +257,7 @@ void ThreadlocalEmitter<T>::StartEvent(const char* category, const char* name) {
   if (!enabled_) {
     return;
   }
-  if (category && !enabled_categories.contains(category)) {
+  if (category && !enabled_categories_.contains(category)) {
     return;
   }
   ResetIfNecessary();
@@ -291,7 +291,7 @@ void ThreadlocalEmitter<T>::EndEvent(const char* category) {
   if (!enabled_) {
     return;
   }
-  if (category && !enabled_categories.contains(category)) {
+  if (category && !enabled_categories_.contains(category)) {
     return;
   }
   uint64_t time = perfetto::base::GetBootTimeNs().count();

--- a/core/vulkan/vk_memory_tracker_layer/cc/memory_tracker_layer_impl.cpp
+++ b/core/vulkan/vk_memory_tracker_layer/cc/memory_tracker_layer_impl.cpp
@@ -979,13 +979,11 @@ VulkanMemoryEventPtr HostAllocation::GetVulkanMemoryEvent() {
 }
 
 // --------------------------- Memory events tracker ---------------------------
-
-MemoryTracker::MemoryTracker()
-    : track_host_memory_(true), initial_state_is_sent_(false) {}
+MemoryTracker::MemoryTracker() : initial_state_is_sent_(false) {}
 
 const VkAllocationCallbacks* MemoryTracker::GetTrackedAllocator(
     const VkAllocationCallbacks* pUserAllocator, const std::string& caller) {
-  if (!track_host_memory_) return pUserAllocator;
+  if (!Emit().CategoryEnabled("Driver")) return pUserAllocator;
 
   auto cb_handle = AllocationCallbacksTracker::GetAllocationCallbacksHandle(
       pUserAllocator, caller);
@@ -1157,7 +1155,7 @@ void MemoryTracker::EmitAndClearAllStoredEvents() {
   rwl_devices.wunlock();
 
   // Emit and clear host memory events
-  if (track_host_memory_) {
+  if (Emit().CategoryEnabled("Driver")) {
     rwl_host_allocations.wlock();
     for (auto it = host_allocations.begin(); it != host_allocations.end();
          it++) {
@@ -1442,12 +1440,14 @@ void MemoryTracker::EmitHostMemoryFreeEvent(uintptr_t ptr) {
 void MemoryTracker::ProcessCreateDeviceEvent(
     VkPhysicalDevice physical_device, VkDeviceCreateInfo const* create_info,
     VkDevice device) {
+  if (!Emit().CategoryEnabled("Device")) return;
   if (Emit().Enabled())
     return EmitCreateDeviceEvent(physical_device, create_info, device);
   return StoreCreateDeviceEvent(physical_device, create_info, device);
 }
 
 void MemoryTracker::ProcessDestoryDeviceEvent(VkDevice vk_device) {
+  if (!Emit().CategoryEnabled("Device")) return;
   if (Emit().Enabled()) return EmitDestoryDeviceEvent(vk_device);
   return StoreDestoryDeviceEvent(vk_device);
 }
@@ -1455,6 +1455,7 @@ void MemoryTracker::ProcessDestoryDeviceEvent(VkDevice vk_device) {
 void MemoryTracker::ProcessAllocateMemoryEvent(
     VkDevice device, VkDeviceMemory memory,
     VkMemoryAllocateInfo const* allocate_info) {
+  if (!Emit().CategoryEnabled("Device")) return;
   if (Emit().Enabled())
     return EmitAllocateMemoryEvent(device, memory, allocate_info);
   return StoreAllocateMemoryEvent(device, memory, allocate_info);
@@ -1462,12 +1463,14 @@ void MemoryTracker::ProcessAllocateMemoryEvent(
 
 void MemoryTracker::ProcessFreeMemoryEvent(VkDevice vk_device,
                                            VkDeviceMemory vk_device_memory) {
+  if (!Emit().CategoryEnabled("Device")) return;
   if (Emit().Enabled()) return EmitFreeMemoryEvent(vk_device, vk_device_memory);
   return StoreFreeMemoryEvent(vk_device, vk_device_memory);
 }
 
 void MemoryTracker::ProcessCreateBufferEvent(
     VkDevice device, VkBuffer buffer, VkBufferCreateInfo const* create_info) {
+  if (!Emit().CategoryEnabled("Device")) return;
   if (Emit().Enabled())
     return EmitCreateBufferEvent(device, buffer, create_info);
   return StoreCreateBufferEvent(device, buffer, create_info);
@@ -1476,6 +1479,7 @@ void MemoryTracker::ProcessCreateBufferEvent(
 void MemoryTracker::ProcessBindBufferEvent(VkDevice device, VkBuffer buffer,
                                            VkDeviceMemory memory,
                                            size_t offset) {
+  if (!Emit().CategoryEnabled("Device")) return;
   if (Emit().Enabled())
     return EmitBindBufferEvent(device, buffer, memory, offset);
   return StoreBindBufferEvent(device, buffer, memory, offset);
@@ -1483,12 +1487,14 @@ void MemoryTracker::ProcessBindBufferEvent(VkDevice device, VkBuffer buffer,
 
 void MemoryTracker::ProcessDestroyBufferEvent(VkDevice device,
                                               VkBuffer buffer) {
+  if (!Emit().CategoryEnabled("Device")) return;
   if (Emit().Enabled()) return EmitDestroyBufferEvent(device, buffer);
   return StoreDestroyBufferEvent(device, buffer);
 }
 
 void MemoryTracker::ProcessCreateImageEvent(
     VkDevice device, VkImage image, const VkImageCreateInfo* create_info) {
+  if (!Emit().CategoryEnabled("Device")) return;
   if (Emit().Enabled()) return EmitCreateImageEvent(device, image, create_info);
   return StoreCreateImageEvent(device, image, create_info);
 }
@@ -1496,12 +1502,14 @@ void MemoryTracker::ProcessCreateImageEvent(
 void MemoryTracker::ProcessBindImageEvent(VkDevice device, VkImage image,
                                           VkDeviceMemory memory,
                                           size_t offset) {
+  if (!Emit().CategoryEnabled("Device")) return;
   if (Emit().Enabled())
     return EmitBindImageEvent(device, image, memory, offset);
   return StoreBindImageEvent(device, image, memory, offset);
 }
 
 void MemoryTracker::ProcessDestroyImageEvent(VkDevice device, VkImage image) {
+  if (!Emit().CategoryEnabled("Device")) return;
   if (Emit().Enabled()) return EmitDestroyImageEvent(device, image);
   return StoreDestroyImageEvent(device, image);
 }

--- a/core/vulkan/vk_memory_tracker_layer/cc/memory_tracker_layer_impl.h
+++ b/core/vulkan/vk_memory_tracker_layer/cc/memory_tracker_layer_impl.h
@@ -441,7 +441,6 @@ using HostAllocationMap = std::unordered_map<uintptr_t, HostAllocationPtr>;
 class MemoryTracker {
  public:
   MemoryTracker();
-  void EnableTrackHostMemory() { track_host_memory_ = true; }
 
   const VkAllocationCallbacks* GetTrackedAllocator(const VkAllocationCallbacks*,
                                                    const std::string& caller);
@@ -491,7 +490,6 @@ class MemoryTracker {
   rwlock rwl_physical_devices;
   PhysicalDeviceMap physical_devices;
 
-  bool track_host_memory_;
   bool initial_state_is_sent_;
 
   rwlock rwl_device_memory_type_map;

--- a/gapic/src/main/com/google/gapid/models/Settings.java
+++ b/gapic/src/main/com/google/gapid/models/Settings.java
@@ -113,7 +113,9 @@ public class Settings {
   public boolean perfettoVulkanCPUTimingInstance = false;
   public boolean perfettoVulkanCPUTimingPhysicalDevice = false;
   public boolean perfettoVulkanCPUTimingQueue = false;
-  public boolean perfettoVulkanMemoryTracker = false;
+  public boolean perfettoVulkanMemoryTracking = false;
+  public boolean perfettoVulkanMemoryTrackingDevice = false;
+  public boolean perfettoVulkanMemoryTrackingDriver = false;
 
   public static Settings load() {
     Settings result = new Settings();
@@ -288,8 +290,9 @@ public class Settings {
     perfettoVulkanCPUTimingInstance = getBoolean(properties, "perfetto.vulkan.cpu_timing.instance", perfettoVulkanCPUTimingInstance);
     perfettoVulkanCPUTimingQueue = getBoolean(properties, "perfetto.vulkan.cpu_timing.queue", perfettoVulkanCPUTimingQueue);
     perfettoVulkanCPUTimingPhysicalDevice = getBoolean(properties, "perfetto.vulkan.cpu_timing.physical_device", perfettoVulkanCPUTimingPhysicalDevice);
-    perfettoVulkanMemoryTracker =
-        getBoolean(properties, "perfetto.vulkan.memory_tracker", perfettoVulkanMemoryTracker);
+    perfettoVulkanMemoryTracking = getBoolean(properties, "perfetto.vulkan.memory_tracking", perfettoVulkanMemoryTracking);
+    perfettoVulkanMemoryTrackingDevice = getBoolean(properties, "perfetto.vulkan.memory_tracking.device", perfettoVulkanMemoryTrackingDevice);
+    perfettoVulkanMemoryTrackingDriver = getBoolean(properties, "perfetto.vulkan.memory_tracking.driver", perfettoVulkanMemoryTrackingDriver);
   }
 
   private void updateTo(Properties properties) {
@@ -354,8 +357,9 @@ public class Settings {
     properties.setProperty("perfetto.vulkan.cpu_timing.instance", Boolean.toString(perfettoVulkanCPUTimingInstance));
     properties.setProperty("perfetto.vulkan.cpu_timing.queue", Boolean.toString(perfettoVulkanCPUTimingQueue));
     properties.setProperty("perfetto.vulkan.cpu_timing.physical_device", Boolean.toString(perfettoVulkanCPUTimingPhysicalDevice));
-    properties.setProperty(
-        "perfetto.vulkan.memory_tracker", Boolean.toString(perfettoVulkanMemoryTracker));
+    properties.setProperty("perfetto.vulkan.memory_tracking", Boolean.toString(perfettoVulkanMemoryTracking));
+    properties.setProperty("perfetto.vulkan.memory_tracking.device", Boolean.toString(perfettoVulkanMemoryTrackingDevice));
+    properties.setProperty("perfetto.vulkan.memory_tracking.driver", Boolean.toString(perfettoVulkanMemoryTrackingDriver));
   }
 
   private static Point getPoint(Properties properties, String name) {


### PR DESCRIPTION
This change updates the GAPID profiler UI such that device and/or
driver memry tracking can be selected for Vulkan memory tracking.