### PR TITLE
Fix "Capturing" window title: could be any type of trace

### DIFF
--- a/gapic/src/main/com/google/gapid/util/Messages.java
+++ b/gapic/src/main/com/google/gapid/util/Messages.java
@@ -47,7 +47,7 @@ public interface Messages {
   public static final String MEMORY_STRUCT_TAB_TEXT = "Struct";
   public static final String CAPTURE_TRACE_GRAPHICS = "Capture Graphics Trace";
   public static final String CAPTURE_TRACE_PERFETTO = "Capture System Profile";
-  public static final String CAPTURING_TRACE = "Capturing Graphics Trace...";
+  public static final String CAPTURING_TRACE = "Capturing...";
   public static final String CAPTURE_DIRECTORY = "Capture output directory...";
   public static final String CAPTURE_EXECUTABLE = "Executable to trace...";
   public static final String CAPTURE_CWD = "Application working directory...";


### PR DESCRIPTION
The window title use to be "Capture Graphics Trace", which is
incorrect when a system trace is being captured. This fix changes it
to the generic "Capturing...".

It would be possible to have different window title based on which
type of trace is being captured, but I feel this adds unecessary
complexity for an additional information which is probably not worth
it. If the user does not remember which type of capture has been
started, the capture output file name already gives a hint.