### PR TITLE
Add replay profile command to GAPIT

### DIFF
--- a/cmd/gapit/BUILD.bazel
+++ b/cmd/gapit/BUILD.bazel
@@ -19,6 +19,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "benchmark.go",
+        "coarse_profile.go",
         "commands.go",
         "common.go",
         "create_graph_visualization.go",

--- a/cmd/gapit/coarse_profile.go
+++ b/cmd/gapit/coarse_profile.go
@@ -1,0 +1,112 @@
+// Copyright (C) 2019 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"encoding/csv"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/google/gapid/core/app"
+	"github.com/google/gapid/core/log"
+	"github.com/google/gapid/gapis/service"
+	"github.com/google/gapid/gapis/service/path"
+)
+
+type coarseProfileVerb struct{ GetTimestampsFlags }
+
+func init() {
+	verb := &coarseProfileVerb{GetTimestampsFlags{LoopCount: 1}}
+	app.AddVerb(&app.Verb{
+		Name:      "coarse_profile",
+		ShortHelp: "Profile a replay to get the time of executing the commands.",
+		Action:    verb,
+	})
+}
+
+func (verb *coarseProfileVerb) Run(ctx context.Context, flags flag.FlagSet) error {
+	if flags.NArg() != 1 {
+		app.Usage(ctx, "Exactly one gfx trace file expected, got %d", flags.NArg())
+		return nil
+	}
+	capture, err := filepath.Abs(flags.Arg(0))
+	if err != nil {
+		log.Errf(ctx, err, "Could not find capture file: %v", flags.Arg(0))
+	}
+
+	client, err := getGapis(ctx, verb.Gapis, verb.Gapir)
+	if err != nil {
+		return log.Err(ctx, err, "Failed to connect to the GAPIS server")
+	}
+	defer client.Close()
+
+	capturePath, err := client.LoadCapture(ctx, capture)
+	if err != nil {
+		return log.Err(ctx, err, "Failed to load the capture file")
+	}
+
+	device, err := getDevice(ctx, client, capturePath, verb.Gapir)
+	if err != nil {
+		return err
+	}
+
+	var out io.Writer = os.Stdout
+	if verb.Out != "" {
+		f, err := os.OpenFile(verb.Out, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0644)
+		if err != nil {
+			return log.Err(ctx, err, "Failed to open report output file")
+		}
+		defer f.Close()
+		out = f
+	}
+
+	reportWriter := csv.NewWriter(out)
+	defer reportWriter.Flush()
+
+	header := []string{"BeginCmd", "EndCmd", "Time(ns)"}
+	if err = reportWriter.Write(header); err != nil {
+		log.Err(ctx, err, "Failed to write header")
+	}
+
+	cmdToString := func(cmd *path.Command) string {
+		return strings.Trim(strings.Join(strings.Fields(fmt.Sprint(cmd.Indices)), "."), "[]")
+	}
+
+	req := &service.GetTimestampsRequest{
+		Capture:   capturePath,
+		Device:    device,
+		LoopCount: int32(verb.LoopCount),
+	}
+
+	client.GetTimestamps(ctx, req, func(r *service.GetTimestampsResponse) error {
+		if ts := r.GetTimestamps(); ts != nil {
+			for _, t := range ts.Timestamps {
+				begin := cmdToString(t.Begin)
+				end := cmdToString(t.End)
+				record := []string{begin, end, fmt.Sprint(t.TimeInNanoseconds)}
+				if err := reportWriter.Write(record); err != nil {
+					log.Err(ctx, err, "Failed to write record")
+				}
+			}
+		}
+		return nil
+	})
+	return nil
+}

--- a/cmd/gapit/flags.go
+++ b/cmd/gapit/flags.go
@@ -381,6 +381,11 @@ type (
 		Out       string `help:"output file to save the profiling result"`
 	}
 
+	GpuProfileFlags struct {
+		Gapis GapisFlags
+		Gapir GapirFlags
+	}
+
 	CreateGraphVisualizationFlags struct {
 		Gapis  GapisFlags
 		Out    string `help:"path to save graph visualization"`

--- a/core/os/android/layers.go
+++ b/core/os/android/layers.go
@@ -64,13 +64,15 @@ func SetupLayers(ctx context.Context, d Device, appPkg string, layerPkgs []strin
 	if err := pushSetting("global", "gpu_debug_layer_app", "\""+strings.Join(layerPkgs, ":")+"\""); err != nil {
 		return cleanup.Invoke(ctx), err
 	}
-	if vulkan {
-		if err := pushSetting("global", "gpu_debug_layers", "\""+strings.Join(layers, ";")+"\""); err != nil {
-			return cleanup.Invoke(ctx), err
-		}
-	} else {
-		if err := pushSetting("global", "gpu_debug_layers_gles", "\""+strings.Join(layers, ";")+"\""); err != nil {
-			return cleanup.Invoke(ctx), err
+	if len(layers) > 0 {
+		if vulkan {
+			if err := pushSetting("global", "gpu_debug_layers", "\""+strings.Join(layers, ";")+"\""); err != nil {
+				return cleanup.Invoke(ctx), err
+			}
+		} else {
+			if err := pushSetting("global", "gpu_debug_layers_gles", "\""+strings.Join(layers, ";")+"\""); err != nil {
+				return cleanup.Invoke(ctx), err
+			}
 		}
 	}
 

--- a/gapir/client/BUILD.bazel
+++ b/gapir/client/BUILD.bazel
@@ -46,6 +46,7 @@ go_library(
         "//gapidapk:go_default_library",
         "//gapir:go_default_library",
         "//gapir/replay_service:go_default_library",
+        "//gapis/perfetto/android:go_default_library",
         "@org_golang_google_grpc//:go_default_library",
         "@org_golang_google_grpc//metadata:go_default_library",
     ],

--- a/gapir/client/session.go
+++ b/gapir/client/session.go
@@ -329,7 +329,7 @@ func (s *session) newADB(ctx context.Context, d adb.Device, abi *device.ABI, lau
 
 	log.I(ctx, "Launching GAPIR...")
 	// Configure GAPIR to be traceable for replay profiling
-	cleanup, err := perfetto_android.SetupProfileLayers(ctx, d, apk.Name, true, abi, []string{})
+	cleanup, err := perfetto_android.SetupProfileLayersSource(ctx, d, apk.Name, abi)
 	s.onClose(func() {
 		cleanup.Invoke(ctx)
 	})

--- a/gapis/api/gles/replay.go
+++ b/gapis/api/gles/replay.go
@@ -363,14 +363,13 @@ func (a API) Profile(
 	mgr replay.Manager,
 	hints *service.UsageHints,
 	traceOptions *service.TraceOptions,
-	handler *replay.SignalHandler,
-	overrides *path.OverrideConfig) error {
+	overrides *path.OverrideConfig) (*service.ProfilingData, error) {
 
 	c := uniqueConfig()
 	r := profileRequest{overrides}
 
 	_, err := mgr.Replay(ctx, intent, c, r, a, hints, true)
-	return err
+	return nil, err
 }
 
 // destroyResourcesAtEOS is a transform that destroys all textures,

--- a/gapis/api/vulkan/BUILD.bazel
+++ b/gapis/api/vulkan/BUILD.bazel
@@ -82,6 +82,7 @@ go_library(
         "minimize_viewport.go",
         "overdraw.go",
         "primeable_image_data.go",
+        "profiling_layers.go",
         "query_timestamps.go",
         "queue_task.go",
         "read_framebuffer.go",

--- a/gapis/api/vulkan/profiling_layers.go
+++ b/gapis/api/vulkan/profiling_layers.go
@@ -1,0 +1,95 @@
+// Copyright (C) 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vulkan
+
+import (
+	"context"
+
+	"github.com/google/gapid/core/log"
+	"github.com/google/gapid/gapis/api"
+	"github.com/google/gapid/gapis/api/transform"
+)
+
+var renderStagesLayer = "VkRenderStagesProducer"
+
+type profilingLayers struct{}
+
+func (t *profilingLayers) Transform(ctx context.Context, id api.CmdID, cmd api.Cmd, out transform.Writer) {
+	ctx = log.Enter(ctx, "ProfilingLayers")
+
+	s := out.State()
+	cb := CommandBuilder{Thread: cmd.Thread(), Arena: out.State().Arena}
+	l := s.MemoryLayout
+	allocated := []api.AllocResult{}
+	defer func() {
+		for _, d := range allocated {
+			d.Free()
+		}
+	}()
+	mustAlloc := func(ctx context.Context, v ...interface{}) api.AllocResult {
+		res := s.AllocDataOrPanic(ctx, v...)
+		allocated = append(allocated, res)
+		return res
+	}
+
+	switch cmd := cmd.(type) {
+	// TODO(apbodnar) Check that the layer is available before transforming
+	case *VkCreateInstance:
+		cmd.Extras().Observations().ApplyReads(s.Memory.ApplicationPool())
+		info := cmd.PCreateInfo().MustRead(ctx, cmd, s, nil)
+		layerCount := info.EnabledLayerCount()
+		layers := []Charᶜᵖ{}
+		for _, l := range info.PpEnabledLayerNames().Slice(0, uint64(layerCount), l).MustRead(ctx, cmd, s, nil) {
+			layers = append(layers, l)
+		}
+
+		renderStagesLayerData := mustAlloc(ctx, renderStagesLayer)
+		layers = append(layers, NewCharᶜᵖ(renderStagesLayerData.Ptr()))
+		layersData := mustAlloc(ctx, layers)
+
+		info.SetEnabledLayerCount(uint32(len(layers)))
+		info.SetPpEnabledLayerNames(NewCharᶜᵖᶜᵖ(layersData.Ptr()))
+		infoData := mustAlloc(ctx, info)
+
+		newCmd := cb.VkCreateInstance(infoData.Ptr(), cmd.PAllocator(), cmd.PInstance(), cmd.Result())
+		newCmd.AddRead(
+			renderStagesLayerData.Data(),
+		).AddRead(
+			infoData.Data(),
+		).AddRead(
+			layersData.Data(),
+		)
+		// Also add back all the other read/write observations of the original vkCreateInstance
+		for _, r := range cmd.Extras().Observations().Reads {
+			newCmd.AddRead(r.Range, r.ID)
+		}
+		for _, w := range cmd.Extras().Observations().Writes {
+			newCmd.AddWrite(w.Range, w.ID)
+		}
+		out.MutateAndWrite(ctx, id, newCmd)
+
+	default:
+		out.MutateAndWrite(ctx, id, cmd)
+
+	}
+}
+
+func (t *profilingLayers) PreLoop(ctx context.Context, out transform.Writer) {
+	out.NotifyPreLoop(ctx)
+}
+func (t *profilingLayers) PostLoop(ctx context.Context, out transform.Writer) {
+	out.NotifyPostLoop(ctx)
+}
+func (t *profilingLayers) Flush(ctx context.Context, out transform.Writer) {}

--- a/gapis/api/vulkan/wait_for_perfetto.go
+++ b/gapis/api/vulkan/wait_for_perfetto.go
@@ -1,6 +1,7 @@
 package vulkan
 
 import (
+	"bytes"
 	"context"
 
 	"github.com/google/gapid/gapir"
@@ -49,10 +50,10 @@ func (t *WaitForPerfetto) Flush(ctx context.Context, out transform.Writer) {
 func (t *WaitForPerfetto) PreLoop(ctx context.Context, out transform.Writer)  {}
 func (t *WaitForPerfetto) PostLoop(ctx context.Context, out transform.Writer) {}
 
-func NewWaitForPerfetto(traceOptions *service.TraceOptions, h *replay.SignalHandler) *WaitForPerfetto {
+func NewWaitForPerfetto(traceOptions *service.TraceOptions, h *replay.SignalHandler, buffer *bytes.Buffer) *WaitForPerfetto {
 	tcb := func(ctx context.Context, p *gapir.FenceReadyRequest) {
 		go func() {
-			trace.Trace(ctx, traceOptions.Device, h.StartSignal, h.StopSignal, h.ReadyFunc, traceOptions, &h.Written)
+			trace.TraceBuffered(ctx, traceOptions.Device, h.StartSignal, h.StopSignal, h.ReadyFunc, traceOptions, buffer)
 			if !h.DoneSignal.Fired() {
 				h.DoneFunc(ctx)
 			}

--- a/gapis/client/client.go
+++ b/gapis/client/client.go
@@ -529,8 +529,15 @@ func (c *client) UpdateSettings(ctx context.Context, req *service.UpdateSettings
 	return nil
 }
 
-func (c *client) GpuProfile(ctx context.Context, req *service.GpuProfileRequest) (*service.GpuProfileResponse, error) {
-	return c.client.GpuProfile(ctx, req)
+func (c *client) GpuProfile(ctx context.Context, req *service.GpuProfileRequest) (*service.ProfilingData, error) {
+	res, err := c.client.GpuProfile(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	if err := res.GetError(); err != nil {
+		return nil, err.Get()
+	}
+	return res.GetProfilingData(), nil
 }
 
 func (c *client) GetTimestamps(ctx context.Context, req *service.GetTimestampsRequest, handler service.TimeStampsHandler) error {

--- a/gapis/client/client.go
+++ b/gapis/client/client.go
@@ -529,6 +529,10 @@ func (c *client) UpdateSettings(ctx context.Context, req *service.UpdateSettings
 	return nil
 }
 
+func (c *client) GpuProfile(ctx context.Context, req *service.GpuProfileRequest) (*service.GpuProfileResponse, error) {
+	return c.client.GpuProfile(ctx, req)
+}
+
 func (c *client) GetTimestamps(ctx context.Context, req *service.GetTimestampsRequest, handler service.TimeStampsHandler) error {
 	stream, err := c.client.GetTimestamps(ctx, req)
 	if err != nil {

--- a/gapis/config/config.go
+++ b/gapis/config/config.go
@@ -22,6 +22,7 @@ const (
 	DeadSubCmdElimination      = false
 	DebugDeadCodeElimination   = false
 	DebugDependencyGraph       = false
+	DumpReplayProfile          = false
 	AllInitialCommandsLive     = false
 	LogExtrasInTransforms      = false // Logs all commands' extras together with transforms
 	LogMemoryInExtras          = false // Logs all commands' read/write memory observation together with extras

--- a/gapis/replay/BUILD.bazel
+++ b/gapis/replay/BUILD.bazel
@@ -27,6 +27,7 @@ go_library(
         "events.go",
         "executor.go",
         "export_replay.go",
+        "gpu_profile.go",
         "id.go",
         "interfaces.go",
         "manager.go",
@@ -70,6 +71,8 @@ go_library(
         "//gapis/resolve/initialcmds:go_default_library",
         "//gapis/service:go_default_library",
         "//gapis/service/path:go_default_library",
+        "//tools/build/third_party/perfetto:config_go_proto",
+        "@com_github_golang_protobuf//proto:go_default_library",
     ],
 )
 

--- a/gapis/replay/gpu_profile.go
+++ b/gapis/replay/gpu_profile.go
@@ -29,15 +29,15 @@ import (
 // Eyeball some generous trace config parameters
 const (
 	bufferSizeKb                            = uint32(256 * 1024)
-	durationMs                              = 10000
+	durationMs                              = 30000
 	gpuRenderStagesDataSourceDescriptorName = "gpu.renderstages"
 )
 
 // GpuProfile replays the trace and writes a Perfetto trace of the replay
-func GpuProfile(ctx context.Context, capturePath *path.Capture, device *path.Device) (*service.GpuProfileResponse, error) {
+func GpuProfile(ctx context.Context, capturePath *path.Capture, device *path.Device) (*service.ProfilingData, error) {
 	c, err := capture.ResolveGraphicsFromPath(ctx, capturePath)
 	if err != nil {
-		return &service.GpuProfileResponse{Res: &service.GpuProfileResponse_Error{Error: service.NewError(err)}}, err
+		return nil, err
 	}
 
 	if device != nil {
@@ -76,13 +76,13 @@ func GpuProfile(ctx context.Context, capturePath *path.Capture, device *path.Dev
 					continue
 				}
 				log.I(ctx, "Replay profiling finished.")
-				return &service.GpuProfileResponse{Res: &service.GpuProfileResponse_ProfilingData{ProfilingData: data}}, nil
+				return data, nil
 			}
 		}
 	} else {
 		err = log.Err(ctx, nil, "Failed to find replay device.")
-		return &service.GpuProfileResponse{Res: &service.GpuProfileResponse_Error{Error: service.NewError(err)}}, err
+		return nil, err
 	}
 	err = log.Err(ctx, nil, "Failed to profile replay")
-	return &service.GpuProfileResponse{Res: &service.GpuProfileResponse_Error{Error: service.NewError(err)}}, err
+	return nil, err
 }

--- a/gapis/replay/gpu_profile.go
+++ b/gapis/replay/gpu_profile.go
@@ -1,0 +1,88 @@
+// Copyright (C) 2019 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package replay
+
+import (
+	"context"
+
+	"github.com/golang/protobuf/proto"
+	"github.com/google/gapid/core/log"
+	"github.com/google/gapid/gapis/capture"
+	"github.com/google/gapid/gapis/service"
+	"github.com/google/gapid/gapis/service/path"
+
+	perfetto_pb "perfetto/config"
+)
+
+// Eyeball some generous trace config parameters
+const (
+	bufferSizeKb                            = uint32(256 * 1024)
+	durationMs                              = 10000
+	gpuRenderStagesDataSourceDescriptorName = "gpu.renderstages"
+)
+
+// GpuProfile replays the trace and writes a Perfetto trace of the replay
+func GpuProfile(ctx context.Context, capturePath *path.Capture, device *path.Device) (*service.GpuProfileResponse, error) {
+	c, err := capture.ResolveGraphicsFromPath(ctx, capturePath)
+	if err != nil {
+		return &service.GpuProfileResponse{Res: &service.GpuProfileResponse_Error{Error: service.NewError(err)}}, err
+	}
+
+	if device != nil {
+		intent := Intent{
+			Capture: capturePath,
+			Device:  device,
+		}
+
+		conf := &perfetto_pb.TraceConfig{
+			Buffers: []*perfetto_pb.TraceConfig_BufferConfig{
+				{SizeKb: proto.Uint32(bufferSizeKb)},
+			},
+			DurationMs: proto.Uint32(durationMs),
+			DataSources: []*perfetto_pb.TraceConfig_DataSource{
+				{
+					Config: &perfetto_pb.DataSourceConfig{
+						Name: proto.String(gpuRenderStagesDataSourceDescriptorName),
+					},
+				},
+			},
+		}
+
+		opts := &service.TraceOptions{
+			Device:         device,
+			Type:           service.TraceType_Perfetto,
+			PerfettoConfig: conf,
+		}
+
+		mgr := GetManager(ctx)
+		hints := &service.UsageHints{Background: true}
+		for _, a := range c.APIs {
+			if pf, ok := a.(Profiler); ok {
+				data, err := pf.Profile(ctx, intent, mgr, hints, opts, nil)
+				if err != nil {
+					log.E(ctx, "Replay profiling failed.")
+					continue
+				}
+				log.I(ctx, "Replay profiling finished.")
+				return &service.GpuProfileResponse{Res: &service.GpuProfileResponse_ProfilingData{ProfilingData: data}}, nil
+			}
+		}
+	} else {
+		err = log.Err(ctx, nil, "Failed to find replay device.")
+		return &service.GpuProfileResponse{Res: &service.GpuProfileResponse_Error{Error: service.NewError(err)}}, err
+	}
+	err = log.Err(ctx, nil, "Failed to profile replay")
+	return &service.GpuProfileResponse{Res: &service.GpuProfileResponse_Error{Error: service.NewError(err)}}, err
+}

--- a/gapis/replay/interfaces.go
+++ b/gapis/replay/interfaces.go
@@ -90,8 +90,7 @@ type Profiler interface {
 		mgr Manager,
 		hints *service.UsageHints,
 		traceOptions *service.TraceOptions,
-		handler *SignalHandler,
-		overrides *path.OverrideConfig) error
+		overrides *path.OverrideConfig) (*service.ProfilingData, error)
 }
 
 // Issue represents a single replay issue reported by QueryIssues.

--- a/gapis/replay/replay.go
+++ b/gapis/replay/replay.go
@@ -129,3 +129,22 @@ type SignalHandler struct {
 	Written     int64
 	Err         error
 }
+
+func NewSignalHandler() *SignalHandler {
+	startSignal, startFunc := task.NewSignal()
+	readySignal, readyFunc := task.NewSignal()
+	stopSignal, stopFunc := task.NewSignal()
+	doneSignal, doneFunc := task.NewSignal()
+
+	handler := &SignalHandler{
+		StartSignal: startSignal,
+		StartFunc:   startFunc,
+		ReadySignal: readySignal,
+		ReadyFunc:   readyFunc,
+		StopSignal:  stopSignal,
+		StopFunc:    stopFunc,
+		DoneSignal:  doneSignal,
+		DoneFunc:    doneFunc,
+	}
+	return handler
+}

--- a/gapis/server/grpc.go
+++ b/gapis/server/grpc.go
@@ -559,6 +559,11 @@ func (s *grpcServer) Find(req *service.FindRequest, server service.Gapid_FindSer
 	return s.handler.Find(s.bindCtx(ctx), req, server.Send)
 }
 
+func (s *grpcServer) GpuProfile(ctx xctx.Context, req *service.GpuProfileRequest) (*service.GpuProfileResponse, error) {
+	defer s.inRPC()()
+	return s.handler.GpuProfile(s.bindCtx(ctx), req)
+}
+
 func (s *grpcServer) UpdateSettings(ctx xctx.Context, req *service.UpdateSettingsRequest) (*service.UpdateSettingsResponse, error) {
 	defer s.inRPC()()
 	err := s.handler.UpdateSettings(s.bindCtx(ctx), req)

--- a/gapis/server/grpc.go
+++ b/gapis/server/grpc.go
@@ -561,7 +561,11 @@ func (s *grpcServer) Find(req *service.FindRequest, server service.Gapid_FindSer
 
 func (s *grpcServer) GpuProfile(ctx xctx.Context, req *service.GpuProfileRequest) (*service.GpuProfileResponse, error) {
 	defer s.inRPC()()
-	return s.handler.GpuProfile(s.bindCtx(ctx), req)
+	res, err := s.handler.GpuProfile(s.bindCtx(ctx), req)
+	if err := service.NewError(err); err != nil {
+		return &service.GpuProfileResponse{Res: &service.GpuProfileResponse_Error{Error: err}}, nil
+	}
+	return &service.GpuProfileResponse{Res: &service.GpuProfileResponse_ProfilingData{ProfilingData: res}}, nil
 }
 
 func (s *grpcServer) UpdateSettings(ctx xctx.Context, req *service.UpdateSettingsRequest) (*service.UpdateSettingsResponse, error) {

--- a/gapis/server/server.go
+++ b/gapis/server/server.go
@@ -914,6 +914,13 @@ func (s *server) GetTimestamps(ctx context.Context, req *service.GetTimestampsRe
 	return replay.GetTimestamps(ctx, req.Capture, req.Device, req.LoopCount, h)
 }
 
+func (s *server) GpuProfile(ctx context.Context, req *service.GpuProfileRequest) (*service.GpuProfileResponse, error) {
+	ctx = status.Start(ctx, "RPC GpuProfile")
+	defer status.Finish(ctx)
+	ctx = log.Enter(ctx, "GpuProfile")
+	return replay.GpuProfile(ctx, req.Capture, req.Device)
+}
+
 func (s *server) PerfettoQuery(ctx context.Context, c *path.Capture, query string) (*perfetto.QueryResult, error) {
 	ctx = status.Start(ctx, "RPC PerfettoQuery")
 	defer status.Finish(ctx)

--- a/gapis/server/server.go
+++ b/gapis/server/server.go
@@ -914,11 +914,15 @@ func (s *server) GetTimestamps(ctx context.Context, req *service.GetTimestampsRe
 	return replay.GetTimestamps(ctx, req.Capture, req.Device, req.LoopCount, h)
 }
 
-func (s *server) GpuProfile(ctx context.Context, req *service.GpuProfileRequest) (*service.GpuProfileResponse, error) {
+func (s *server) GpuProfile(ctx context.Context, req *service.GpuProfileRequest) (*service.ProfilingData, error) {
 	ctx = status.Start(ctx, "RPC GpuProfile")
 	defer status.Finish(ctx)
 	ctx = log.Enter(ctx, "GpuProfile")
-	return replay.GpuProfile(ctx, req.Capture, req.Device)
+	res, err := replay.GpuProfile(ctx, req.Capture, req.Device)
+	if err != nil {
+		return nil, err
+	}
+	return res, nil
 }
 
 func (s *server) PerfettoQuery(ctx context.Context, c *path.Capture, query string) (*perfetto.QueryResult, error) {

--- a/gapis/service/service.go
+++ b/gapis/service/service.go
@@ -184,6 +184,9 @@ type Service interface {
 	// Get timestamps from GPU for commands.
 	GetTimestamps(ctx context.Context, req *GetTimestampsRequest, h TimeStampsHandler) error
 
+	// Get timestamps from GPU for commands.
+	GpuProfile(ctx context.Context, req *GpuProfileRequest) (*GpuProfileResponse, error)
+
 	// Run a perfetto query
 	PerfettoQuery(ctx context.Context, c *path.Capture, query string) (*perfetto.QueryResult, error)
 

--- a/gapis/service/service.go
+++ b/gapis/service/service.go
@@ -185,7 +185,7 @@ type Service interface {
 	GetTimestamps(ctx context.Context, req *GetTimestampsRequest, h TimeStampsHandler) error
 
 	// Get timestamps from GPU for commands.
-	GpuProfile(ctx context.Context, req *GpuProfileRequest) (*GpuProfileResponse, error)
+	GpuProfile(ctx context.Context, req *GpuProfileRequest) (*ProfilingData, error)
 
 	// Run a perfetto query
 	PerfettoQuery(ctx context.Context, c *path.Capture, query string) (*perfetto.QueryResult, error)

--- a/gapis/service/service.proto
+++ b/gapis/service/service.proto
@@ -736,6 +736,10 @@ service Gapid {
   rpc PerfettoQuery(PerfettoQueryRequest) returns (PerfettoQueryResponse) {
   }
 
+  // GpuProfile starts a perfetto trace of a gfxtrace
+  rpc GpuProfile(GpuProfileRequest) returns (GpuProfileResponse) {
+  }
+
   ///////////////////////////////////////////////////////////////
   // Below are debugging APIs which may be removed in the future.
   ///////////////////////////////////////////////////////////////
@@ -1285,6 +1289,53 @@ message TraceTypeCapabilities {
   bool can_enable_unsupported_extensions = 4;
   // Does this trace require starting an application.
   bool requires_application = 6;
+}
+
+message ProfilingData {
+  message GpuSlices {
+    message Slice {
+      message Extra {
+        string name = 1;
+        oneof value {
+          uint64 int_value = 2;
+          double double_value = 3;
+          string string_value = 4;
+        }
+      }
+
+      uint64 ts = 1;
+      uint64 dur = 2;
+      string label = 3;
+      int32 depth = 4;
+      repeated Extra extras = 5;
+
+      path.Commands link = 6;
+      int32 group = 7;  // references Group.id
+    }
+
+    message Group {
+      int32 id = 1;
+      int32 parent = 2;  // references Group.id
+      path.Commands link = 3;
+    }
+
+    repeated Slice slices = 1;
+    repeated Group groups = 2;
+  }
+
+  GpuSlices slices = 1;
+}
+
+message GpuProfileResponse {
+  oneof res {
+    ProfilingData profiling_data = 1;
+    Error error = 2;
+  }
+}
+
+message GpuProfileRequest {
+  path.Capture capture = 1;
+  path.Device device = 2;
 }
 
 // GetTimestampsRequest is the request send to server to get the timestamps for

--- a/gapis/trace/BUILD.bazel
+++ b/gapis/trace/BUILD.bazel
@@ -33,6 +33,7 @@ go_library(
         "//core/os/device:go_default_library",
         "//core/os/device/bind:go_default_library",
         "//gapii/client:go_default_library",
+        "//gapis/config:go_default_library",
         "//gapis/service:go_default_library",
         "//gapis/service/path:go_default_library",
         "//gapis/trace/android:go_default_library",

--- a/gapis/trace/android/adreno/BUILD.bazel
+++ b/gapis/trace/android/adreno/BUILD.bazel
@@ -2,11 +2,15 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "go_default_library",
-    srcs = ["validate.go"],
+    srcs = [
+        "profiling_data.go",
+        "validate.go",
+    ],
     importpath = "github.com/google/gapid/gapis/trace/android/adreno",
     visibility = ["//visibility:public"],
     deps = [
         "//gapis/perfetto:go_default_library",
+        "//gapis/service:go_default_library",
         "//gapis/trace/android/validate:go_default_library",
     ],
 )

--- a/gapis/trace/android/adreno/profiling_data.go
+++ b/gapis/trace/android/adreno/profiling_data.go
@@ -1,0 +1,26 @@
+// Copyright (C) 2019 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package adreno
+
+import (
+	"context"
+
+	"github.com/google/gapid/gapis/perfetto"
+	"github.com/google/gapid/gapis/service"
+)
+
+func ProcessProfilingData(ctx context.Context, processor *perfetto.Processor) (*service.ProfilingData, error) {
+	return &service.ProfilingData{}, nil
+}

--- a/gapis/trace/android/trace.go
+++ b/gapis/trace/android/trace.go
@@ -126,6 +126,7 @@ func (t *androidTracer) ProcessProfilingData(ctx context.Context, buffer *bytes.
 		return nil, log.Err(ctx, err, "Failed to read trace buffer")
 	}
 	processor, err := perfetto.NewProcessor(ctx, rawData)
+	defer processor.Close()
 	if err != nil {
 		return nil, log.Errf(ctx, err, "Failed to create trace processor")
 	}
@@ -216,7 +217,7 @@ func (t *androidTracer) Validate(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-
+	defer processor.Close()
 	ctx = status.Start(ctx, "Validation")
 	defer status.Finish(ctx)
 	return t.v.Validate(ctx, processor)

--- a/gapis/trace/desktop/trace.go
+++ b/gapis/trace/desktop/trace.go
@@ -15,6 +15,7 @@
 package desktop
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"path"
@@ -45,6 +46,10 @@ func NewTracer(dev bind.Device) *DesktopTracer {
 
 func (t *DesktopTracer) GetDevice() bind.Device {
 	return t.b
+}
+
+func (t *DesktopTracer) ProcessProfilingData(ctx context.Context, buffer *bytes.Buffer) (*service.ProfilingData, error) {
+	return nil, log.Err(ctx, nil, "Desktop replay profiling is unsupported.")
 }
 
 func (t *DesktopTracer) Validate(ctx context.Context) error {

--- a/gapis/trace/trace.go
+++ b/gapis/trace/trace.go
@@ -15,7 +15,9 @@
 package trace
 
 import (
+	"bytes"
 	"context"
+	"io"
 	"os"
 	"path/filepath"
 	"time"
@@ -24,39 +26,37 @@ import (
 	"github.com/google/gapid/core/event/task"
 	"github.com/google/gapid/core/log"
 	gapii "github.com/google/gapid/gapii/client"
+	"github.com/google/gapid/gapis/config"
 	"github.com/google/gapid/gapis/service"
 	"github.com/google/gapid/gapis/service/path"
 	"github.com/google/gapid/gapis/trace/tracer"
 )
 
-func Trace(ctx context.Context, device *path.Device, start task.Signal, stop task.Signal, ready task.Task, options *service.TraceOptions, written *int64) error {
+func trace(ctx context.Context, device *path.Device, start task.Signal, stop task.Signal, ready task.Task, options *service.TraceOptions, written *int64, buffer *bytes.Buffer) error {
 	gapiiOpts := tracer.GapiiOptions(options)
 	var process tracer.Process
 	var cleanup app.Cleanup
-	mgr := GetManager(ctx)
-	if device == nil {
-		return log.Errf(ctx, nil, "Invalid device path")
+
+	t, err := getTracer(ctx, device)
+	if err != nil {
+		return err
 	}
-	tracer, ok := mgr.tracers[device.ID.ID()]
-	if !ok {
-		return log.Errf(ctx, nil, "Could not find tracer for device %d", device.ID.ID())
-	}
-	config, err := tracer.TraceConfiguration(ctx)
+	conf, err := t.TraceConfiguration(ctx)
 	if err != nil {
 		return err
 	}
 
-	if !isSupported(config, options) {
+	if !isSupported(conf, options) {
 		return log.Errf(ctx, nil, "Cannot take the requested type of trace on this device")
 	}
 
 	if port := options.GetPort(); port != 0 {
-		if !config.ServerLocalPath {
+		if !conf.ServerLocalPath {
 			return log.Errf(ctx, nil, "Cannot attach to a remote device by port")
 		}
-		process = &gapii.Process{Port: int(port), Device: tracer.GetDevice(), Options: gapiiOpts}
+		process = &gapii.Process{Port: int(port), Device: t.GetDevice(), Options: gapiiOpts}
 	} else {
-		process, cleanup, err = tracer.SetupTrace(ctx, options)
+		process, cleanup, err = t.SetupTrace(ctx, options)
 	}
 
 	if err != nil {
@@ -64,42 +64,80 @@ func Trace(ctx context.Context, device *path.Device, start task.Signal, stop tas
 	}
 	defer cleanup.Invoke(ctx)
 
-	os.MkdirAll(filepath.Dir(options.ServerLocalSavePath), 0755)
-	file, err := os.Create(options.ServerLocalSavePath)
-	if err != nil {
-		return err
+	var writer io.Writer
+	if buffer != nil {
+		writer = buffer
+	} else {
+		os.MkdirAll(filepath.Dir(options.ServerLocalSavePath), 0755)
+		writer, err = os.Create(options.ServerLocalSavePath)
+		if err != nil {
+			return err
+		}
+		defer writer.(*os.File).Close()
 	}
-
-	defer file.Close()
 
 	if options.Duration > 0 {
 		ctx, _ = task.WithTimeout(ctx, time.Duration(options.Duration)*time.Second)
 	}
 
-	_, err = process.Capture(ctx, start, stop, ready, file, written)
+	_, err = process.Capture(ctx, start, stop, ready, writer, written)
+
+	return err
+}
+
+func Trace(ctx context.Context, device *path.Device, start task.Signal, stop task.Signal, ready task.Task, options *service.TraceOptions, written *int64) error {
+	return trace(ctx, device, start, stop, ready, options, written, nil)
+}
+
+func TraceBuffered(ctx context.Context, device *path.Device, start task.Signal, stop task.Signal, ready task.Task, options *service.TraceOptions, buffer *bytes.Buffer) error {
+	var written int64 = 0
+	err := trace(ctx, device, start, stop, ready, options, &written, buffer)
+	if config.DumpReplayProfile {
+		dumpTrace(ctx, buffer)
+	}
 	return err
 }
 
 func TraceConfiguration(ctx context.Context, device *path.Device) (*service.DeviceTraceConfiguration, error) {
-	mgr := GetManager(ctx)
-	tracer, ok := mgr.tracers[device.ID.ID()]
-	if !ok {
-		return nil, log.Errf(ctx, nil, "Could not find tracer for device %d", device.ID.ID())
+	t, err := getTracer(ctx, device)
+	if err != nil {
+		return nil, err
 	}
-
-	return tracer.TraceConfiguration(ctx)
+	return t.TraceConfiguration(ctx)
 }
 
-func Validate(ctx context.Context, p *path.Device) error {
-	if p == nil {
-		return log.Err(ctx, nil, "Invalid device path")
+func ProcessProfilingData(ctx context.Context, device *path.Device, buffer *bytes.Buffer) (*service.ProfilingData, error) {
+	t, err := getTracer(ctx, device)
+	if err != nil {
+		return nil, err
 	}
-	mgr := GetManager(ctx)
-	tracer, ok := mgr.tracers[p.ID.ID()]
-	if !ok || tracer == nil {
-		return log.Errf(ctx, nil, "Could not find tracer for device %d", p.ID.ID())
+	return t.ProcessProfilingData(ctx, buffer)
+}
+
+func Validate(ctx context.Context, device *path.Device) error {
+	t, err := getTracer(ctx, device)
+	if err != nil {
+		return err
 	}
-	return tracer.Validate(ctx)
+	return t.Validate(ctx)
+}
+
+func dumpTrace(ctx context.Context, buffer *bytes.Buffer) {
+	dumpPath, err := filepath.Abs("./dump.perfetto")
+	if err != nil {
+		log.W(ctx, "Unable to resolve working directory")
+	} else {
+		dumpFile, err := os.Create(dumpPath)
+		if err != nil {
+			log.W(ctx, "Unable to create local trace file")
+		} else {
+			_, err = dumpFile.Write(buffer.Bytes())
+			if err != nil {
+				log.W(ctx, "Unable write local trace file")
+			}
+			log.I(ctx, "Saved %v", dumpPath)
+		}
+	}
 }
 
 func isSupported(config *service.DeviceTraceConfiguration, options *service.TraceOptions) bool {
@@ -116,4 +154,16 @@ func isSupported(config *service.DeviceTraceConfiguration, options *service.Trac
 		}
 	}
 	return false
+}
+
+func getTracer(ctx context.Context, device *path.Device) (tracer.Tracer, error) {
+	mgr := GetManager(ctx)
+	if device == nil {
+		return nil, log.Errf(ctx, nil, "Invalid device path")
+	}
+	t, ok := mgr.tracers[device.ID.ID()]
+	if !ok {
+		return nil, log.Errf(ctx, nil, "Could not find tracer for device %d", device.ID.ID())
+	}
+	return t, nil
 }

--- a/gapis/trace/tracer/tracer.go
+++ b/gapis/trace/tracer/tracer.go
@@ -15,6 +15,7 @@
 package tracer
 
 import (
+	"bytes"
 	"context"
 	"io"
 
@@ -69,7 +70,9 @@ type Tracer interface {
 
 	// GetDevice returns the device associated with this tracer
 	GetDevice() bind.Device
-
+	// ProcessProfilingData takes a buffer for a Perfetto trace and translates it into
+	// a ProfilingData
+	ProcessProfilingData(ctx context.Context, buffer *bytes.Buffer) (*service.ProfilingData, error)
 	// Validate validates the GPU profiling capabilities of the given device and returns
 	// an error if validation failed or the GPU profiling data is invalid.
 	Validate(ctx context.Context) error


### PR DESCRIPTION
This renames the current `profile` command to `coarse_profile`.  `profile` now takes a perfetto trace of a replay using a provided config.  It will use a simple render stages only config if no config is provided.