### PR TITLE
Add GPU render stages validation for Adreno.

### DIFF
--- a/gapis/trace/android/adreno/BUILD.bazel
+++ b/gapis/trace/android/adreno/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "github.com/google/gapid/gapis/trace/android/adreno",
     visibility = ["//visibility:public"],
     deps = [
+        "//core/log:go_default_library",
         "//gapis/perfetto:go_default_library",
         "//gapis/trace/android/validate:go_default_library",
     ],

--- a/gapis/trace/android/adreno/validate.go
+++ b/gapis/trace/android/adreno/validate.go
@@ -16,9 +16,19 @@ package adreno
 
 import (
 	"context"
+	"fmt"
 
+	"github.com/google/gapid/core/log"
 	"github.com/google/gapid/gapis/perfetto"
 	"github.com/google/gapid/gapis/trace/android/validate"
+)
+
+const (
+	renderStageSlicesQuery = "" +
+		"select name, depth, parent_stack_id " +
+		"from gpu_slice " +
+		"where track_id = %v " +
+		"order by slice_id"
 )
 
 var (
@@ -34,17 +44,76 @@ var (
 		{37, "% Time Shading Fragments", validate.And(validate.IsNumber, validate.CheckLargerThanZero)},
 		{38, "% Time Shading Vertices", validate.And(validate.IsNumber, validate.CheckLargerThanZero)},
 		{39, "% Time Compute", validate.And(validate.IsNumber, validate.CheckEqualTo(0.0))},
-		{58, "Avg Memory Latency Cycles", validate.And(validate.IsNumber, validate.CheckLargerThanZero)},
 	}
 )
 
 type AdrenoValidator struct {
 }
 
+func (v *AdrenoValidator) validateRenderStage(ctx context.Context, processor *perfetto.Processor) error {
+	tIds, err := validate.GetRenderStageTrackIDs(ctx, processor)
+	if err != nil {
+		return err
+	}
+	for _, tId := range tIds {
+		queryResult, err := processor.Query(fmt.Sprintf(renderStageSlicesQuery, tId))
+		if err != nil || queryResult.GetNumRecords() <= 0 {
+			return log.Errf(ctx, err, "Failed to query with %v", fmt.Sprintf(renderStageSlicesQuery, tId))
+		}
+		columns := queryResult.GetColumns()
+		names := columns[0].GetStringValues()
+
+		// Skip slices until we hit the first 'Surface' slice.
+		skipNum := -1
+		hasSurfaceSlice := false
+		hasRenderSlice := false
+		for i, name := range names {
+			if name == "Surface" {
+				hasSurfaceSlice = true
+				if skipNum == -1 {
+					skipNum = i
+				}
+			}
+			if name == "Render" {
+				hasRenderSlice = true
+			}
+		}
+		if !hasSurfaceSlice {
+			return log.Errf(ctx, err, "Render stage verification failed: No Surface slice found")
+		}
+		if !hasRenderSlice {
+			return log.Errf(ctx, err, "Render stage verification failed: No Render slice found")
+		}
+		depths := columns[1].GetLongValues()
+		parentStackId := columns[2].GetLongValues()
+
+		for i := skipNum; i < len(names); i++ {
+			// Surface slice must be the top level slice, hence its depth is 0 and
+			// it has no parent stack id.
+			// Render slice must be a non-top-level slice, hence its depth must not be 0
+			// and it must have a parent stack id.
+			if names[i] == "Surface" {
+				if depths[i] != 0 || parentStackId[i] != 0 {
+					return log.Errf(ctx, err, "Render stage verification failed on Surface slice")
+				}
+			} else if names[i] == "Render" {
+				if depths[i] <= 0 || parentStackId[i] <= 0 {
+					return log.Errf(ctx, err, "Render stage verification failed on Render slice")
+				}
+			}
+		}
+	}
+	return nil
+}
+
 func (v *AdrenoValidator) Validate(ctx context.Context, processor *perfetto.Processor) error {
 	if err := validate.ValidateGpuCounters(ctx, processor, v.GetCounters()); err != nil {
 		return err
 	}
+	if err := v.validateRenderStage(ctx, processor); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/gapis/trace/android/trace.go
+++ b/gapis/trace/android/trace.go
@@ -171,12 +171,13 @@ func (t *androidTracer) Validate(ctx context.Context) error {
 		doneSignal, doneFunc := task.NewSignal()
 
 		crash.Go(func() {
+			// TODO(b/142824856): This is a workaround to a problem that render stages data
+			// is not captured if the application starts after tracing.
+			time.Sleep(2 * time.Second)
 			_, err = process.Capture(ctx, startSignal, stopSignal, readyFunc, &buf, &written)
 			doneFunc(ctx)
 		})
 
-		// TODO(lpy): If we start tracing too early, the data has a lot of noise
-		// at the beginning, need to figure out a sweet spot.
 		startFunc(ctx)
 		if !doneSignal.Wait(ctx) {
 			err = log.Err(ctx, err, "Fail to wait for done signal from Perfetto.")

--- a/gapis/trace/android/validate/validate.go
+++ b/gapis/trace/android/validate/validate.go
@@ -32,6 +32,9 @@ const (
 		"select value from counter_values " +
 		"where counter_id = %v order by ts " +
 		"limit %v offset 10"
+	renderStageTrackIdsQuery = "" +
+		"select id from gpu_track " +
+		"where scope = 'gpu_render_stage'"
 	sampleCounter = 100
 )
 
@@ -154,4 +157,17 @@ func ValidateGpuCounters(ctx context.Context, processor *perfetto.Processor, cou
 		}
 	}
 	return nil
+}
+
+// GetRenderStageTrackIDs returns all track ids from gpu_track where the scope is gpu_render_stage
+func GetRenderStageTrackIDs(ctx context.Context, processor *perfetto.Processor) ([]int64, error) {
+	queryResult, err := processor.Query(renderStageTrackIdsQuery)
+	if err != nil || queryResult.GetNumRecords() <= 0 {
+		return []int64{}, log.Err(ctx, err, "Failed to query GPU render stage track ids")
+	}
+	result := make([]int64, queryResult.GetNumRecords())
+	for i, v := range queryResult.GetColumns()[0].GetLongValues() {
+		result[i] = v
+	}
+	return result, nil
 }


### PR DESCRIPTION
This patch adds the simple shape of gpu render stages validation for Adreno.
The gpu render stages validation on Adreno will succeed if:

1) there's at least one 'Surface' and/or one 'Render' slice, and
2) 'Surface' slices are top-level slices, and
3) 'Render' slices are nested slices.

Minor: Remove out-dated GPU counter.

BUG: b/138717619
Test: bazel run gapit -- validate_gpu_profiling --os android