### PR TITLE
Implement vulkan enum translation in memory struct view.

### DIFF
--- a/cmd/gapit/dump_pipeline.go
+++ b/cmd/gapit/dump_pipeline.go
@@ -189,7 +189,7 @@ func getConstantSetMap(ctx context.Context, c client.Client, api *path.API, inde
 	if index != -1 {
 		boxedConstants, err := c.Get(ctx, (&path.ConstantSet{
 			API:   api,
-			Index: uint32(index),
+			Index: index,
 		}).Path(), nil)
 		if err != nil {
 			return nil, log.Errf(ctx, err, "Failed to load constant set (%v, %v)", api, index)

--- a/cmd/gapit/memory.go
+++ b/cmd/gapit/memory.go
@@ -78,7 +78,7 @@ func (verb *memoryVerb) Run(ctx context.Context, flags flag.FlagSet) error {
 	if mem.AllocationFlagsIndex != -1 {
 		boxedConstants, err := client.Get(ctx, (&path.ConstantSet{
 			API:   mem.API,
-			Index: uint32(mem.AllocationFlagsIndex),
+			Index: mem.AllocationFlagsIndex,
 		}).Path(), nil)
 		if err != nil {
 			return log.Errf(ctx, err, "Failed to load allocation flag names")

--- a/gapic/src/main/com/google/gapid/models/ConstantSets.java
+++ b/gapic/src/main/com/google/gapid/models/ConstantSets.java
@@ -20,11 +20,13 @@ import static com.google.gapid.util.Paths.constantSet;
 import com.google.common.collect.Lists;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
+import com.google.gapid.proto.core.pod.Pod;
 import com.google.gapid.proto.device.Device.Instance;
 import com.google.gapid.proto.service.Service;
 import com.google.gapid.proto.service.api.API;
 import com.google.gapid.proto.service.box.Box;
 import com.google.gapid.proto.service.path.Path;
+import com.google.gapid.proto.service.types.TypeInfo;
 import com.google.gapid.server.Client;
 import com.google.gapid.util.FutureCache;
 import com.google.gapid.util.MoreFutures;
@@ -70,15 +72,29 @@ public class ConstantSets {
     return loadConstants(node.getConstants());
   }
 
+  public ListenableFuture<Service.ConstantSet> loadConstants(TypeInfo.EnumType enumType) {
+    if (!enumType.hasConstants() || !enumType.getConstants().hasAPI()) {
+      return Futures.immediateFuture(null);
+    }
+    return loadConstants(enumType.getConstants());
+  }
+
   public Service.ConstantSet getConstants(Path.ConstantSet path) {
     return cache.getIfPresent(path);
   }
 
   public static Service.Constant find(Service.ConstantSet constants, Box.Value value) {
-    if (value.getValCase() != Box.Value.ValCase.POD || !Pods.mayBeConstant(value.getPod())) {
+    if (value.getValCase() != Box.Value.ValCase.POD) {
       return Service.Constant.getDefaultInstance();
     }
-    long numValue = Pods.getConstant(value.getPod());
+    return find(constants, value.getPod());
+  }
+
+  public static Service.Constant find(Service.ConstantSet constants, Pod.Value value) {
+    if (!Pods.mayBeConstant(value)) {
+      return Service.Constant.getDefaultInstance();
+    }
+    long numValue = Pods.getConstant(value);
     for (Service.Constant constant : constants.getConstantsList()) {
       if (constant.getValue() == numValue) {
         return constant;

--- a/gapic/src/main/com/google/gapid/models/Memory.java
+++ b/gapic/src/main/com/google/gapid/models/Memory.java
@@ -493,6 +493,7 @@ public class Memory extends DeviceDependentModel<Memory.Data, Memory.Source, Voi
   public static class StructNode {
     private static final int MAX_CHILDREN_SIZE = 100;
 
+    private final Path.API api;
     private final TypeInfo.Type type;
     private final MemoryBox.Value value;
     private final long rootAddress;     // The root address of the observation this node belongs to.
@@ -501,8 +502,9 @@ public class Memory extends DeviceDependentModel<Memory.Data, Memory.Source, Voi
     private String structName = "";     // Name information for node of type TypeInfo.StructField.
     private boolean isLargeArray = false;   // True if this node denotes a large array or slice.
 
-    public StructNode(TypeInfo.Type type, MemoryBox.Value value, long rootAddress,
+    public StructNode(Path.API api, TypeInfo.Type type, MemoryBox.Value value, long rootAddress,
         MemoryTypes typesModel) {
+      this.api = api;
       this.type = type;
       this.value = value;
       this.rootAddress = rootAddress;
@@ -531,7 +533,12 @@ public class Memory extends DeviceDependentModel<Memory.Data, Memory.Source, Voi
     }
 
     public String getValueFormatted() {
-      return MemoryBoxes.format(value, rootAddress);
+      if (type.getTyCase() == TyCase.ENUM && type.getEnum().hasConstants()) {
+        return ConstantSets.find(typesModel.constants.getConstants(type.getEnum().getConstants()),
+            value.getPod()).getName();
+      } else {
+        return MemoryBoxes.format(value, rootAddress);
+      }
     }
 
     public long getRootAddress() {
@@ -576,9 +583,9 @@ public class Memory extends DeviceDependentModel<Memory.Data, Memory.Source, Voi
           // Don't create and append children nodes if it's a large slice.
           if (value.getSlice().getValuesCount() < MAX_CHILDREN_SIZE) {
             TypeInfo.SliceType slice = type.getSlice();
-            childType = typesModel.getType(type(slice.getUnderlying()));
+            childType = typesModel.getType(type(slice.getUnderlying(), api));
             for (MemoryBox.Value childValue : value.getSlice().getValuesList()) {
-              children.add(new StructNode(childType, childValue, rootAddress, typesModel));
+              children.add(new StructNode(api, childType, childValue, rootAddress, typesModel));
             }
           } else {
             isLargeArray = true;
@@ -589,8 +596,8 @@ public class Memory extends DeviceDependentModel<Memory.Data, Memory.Source, Voi
           List<TypeInfo.StructField> childrenTypes = struct.getFieldsList();
           List<MemoryBox.Value> childrenValues = value.getStruct().getFieldsList();
           for (int i = 0; i < childrenValues.size(); i++) {
-            StructNode childNode = new StructNode(
-                typesModel.getType(type(childrenTypes.get(i).getType())), childrenValues.get(i),
+            StructNode childNode = new StructNode(api,
+                typesModel.getType(type(childrenTypes.get(i).getType(), api)), childrenValues.get(i),
                 rootAddress, typesModel);
             childNode.setStructName(childrenTypes.get(i).getName());
             children.add(childNode);
@@ -600,9 +607,9 @@ public class Memory extends DeviceDependentModel<Memory.Data, Memory.Source, Voi
           // Don't create and append children nodes if it's a large array.
           if (value.getArray().getEntriesCount() < MAX_CHILDREN_SIZE) {
             TypeInfo.ArrayType array = type.getArray();
-            childType = typesModel.getType(type(array.getElementType()));
+            childType = typesModel.getType(type(array.getElementType(), api));
             for (MemoryBox.Value childValue : value.getArray().getEntriesList()) {
-              children.add(new StructNode(childType, childValue, rootAddress, typesModel));
+              children.add(new StructNode(api, childType, childValue, rootAddress, typesModel));
             }
           } else {
             isLargeArray = true;
@@ -610,8 +617,8 @@ public class Memory extends DeviceDependentModel<Memory.Data, Memory.Source, Voi
           break;
         case PSEUDONYM:
           TypeInfo.PseudonymType pseudonym = type.getPseudonym();
-          childType = typesModel.getType(type(pseudonym.getUnderlying()));
-          children.add(new StructNode(childType, value, rootAddress, typesModel));
+          childType = typesModel.getType(type(pseudonym.getUnderlying(), api));
+          children.add(new StructNode(api, childType, value, rootAddress, typesModel));
           break;
         default:
           break;

--- a/gapic/src/main/com/google/gapid/models/MemoryTypes.java
+++ b/gapic/src/main/com/google/gapid/models/MemoryTypes.java
@@ -42,9 +42,11 @@ public class MemoryTypes {
   protected static final Logger LOG = Logger.getLogger(ApiState.class.getName());
 
   protected final FutureCache<Path.Type, TypeInfo.Type> cache;
+  protected final ConstantSets constants;
   private final Client client;
 
-  public MemoryTypes(Client client, Devices devices) {
+  public MemoryTypes(Client client, Devices devices, ConstantSets constants) {
+    this.constants = constants;
     this.client = client;
 
     Function<Path.Type, ListenableFuture<TypeInfo.Type>> fetcher = path -> {
@@ -73,17 +75,19 @@ public class MemoryTypes {
     return transformAsync(cache.get(path), intermediate -> {
       switch (intermediate.getTyCase()) {
         case SLICE:
-          return loadTypes(type(intermediate.getSlice().getUnderlying()));
+          return loadTypes(type(intermediate.getSlice().getUnderlying(), path.getAPI()));
         case STRUCT:
           List<ListenableFuture<Void>> structChildrenTypes = Lists.newArrayList();
           for (TypeInfo.StructField childField : intermediate.getStruct().getFieldsList()) {
-            structChildrenTypes.add(loadTypes(type(childField.getType())));
+            structChildrenTypes.add(loadTypes(type(childField.getType(), path.getAPI())));
           }
           return combine(structChildrenTypes, $ -> null);
         case ARRAY:
-          return loadTypes(type(intermediate.getArray().getElementType()));
+          return loadTypes(type(intermediate.getArray().getElementType(), path.getAPI()));
         case PSEUDONYM:
-          return loadTypes(type(intermediate.getPseudonym().getUnderlying()));
+          return loadTypes(type(intermediate.getPseudonym().getUnderlying(), path.getAPI()));
+        case ENUM:
+          return transform(constants.loadConstants(intermediate.getEnum()), $ -> null);
         default:
           return Futures.immediateFuture(null);
       }
@@ -106,7 +110,8 @@ public class MemoryTypes {
     Path.Any memoryAsType = memoryAsType(structOb.source.command, structOb.source.pool, structOb.range);
     return transformAsync(client.get(memoryAsType, structOb.device),
         val -> transform(loadTypes(structOb.getRange().getType()),
-            $ -> new StructNode(getType(structOb.getRange().getType()), val.getMemoryBox(),
+            $ -> new StructNode(structOb.getRange().getType().getAPI(),
+                getType(structOb.getRange().getType()), val.getMemoryBox(),
                 structOb.range.getRoot(), this)));
   }
 

--- a/gapic/src/main/com/google/gapid/models/Models.java
+++ b/gapic/src/main/com/google/gapid/models/Models.java
@@ -84,7 +84,7 @@ public class Models {
     ImagesModel images = new ImagesModel(client, devices, capture, settings);
     Geometries geometries = new Geometries(shell, analytics, client, devices, commands);
     Memory memory = new Memory(shell, analytics, client, devices, commands);
-    MemoryTypes types = new MemoryTypes(client, devices);
+    MemoryTypes types = new MemoryTypes(client, devices, constants);
     Perfetto perfetto = new Perfetto(shell, analytics, client, capture, status);
     return new Models(settings, analytics, follower, capture, devices, commands, contexts, timeline,
         resources, state, reports, images, constants, geometries, memory, types, perfetto, status);

--- a/gapic/src/main/com/google/gapid/util/Paths.java
+++ b/gapic/src/main/com/google/gapid/util/Paths.java
@@ -367,9 +367,10 @@ public class Paths {
         .build();
   }
 
-  public static Path.Type type(long typeIndex) {
+  public static Path.Type type(long typeIndex, Path.API api) {
     return Path.Type.newBuilder()
         .setTypeIndex(typeIndex)
+        .setAPI(api)
         .build();
   }
 

--- a/gapis/api/api.go
+++ b/gapis/api/api.go
@@ -86,6 +86,9 @@ type ID id.ID
 func (i ID) IsValid() bool  { return id.ID(i).IsValid() }
 func (i ID) String() string { return id.ID(i).String() }
 
+// CoreId return id in gapid/core/data/id.ID type instead of api.ID type.
+func (i ID) CoreId() id.ID { return id.ID(i) }
+
 // APIObject is the interface implemented by types that belong to an API.
 type APIObject interface {
 	// API returns the API identifier that this type belongs to.

--- a/gapis/api/cmd_service.go
+++ b/gapis/api/cmd_service.go
@@ -44,7 +44,10 @@ func CmdToService(c Cmd) (*Command, error) {
 		param := &Parameter{
 			Name:  p.Name,
 			Value: box.NewValue(p.Get()),
-			Type:  &path.Type{TypeIndex: t},
+			Type: &path.Type{
+				TypeIndex: t,
+				API:       out.API,
+			},
 		}
 		if p.Constants > 0 {
 			param.Constants = out.API.ConstantSet(p.Constants)

--- a/gapis/api/templates/api.go.tmpl
+++ b/gapis/api/templates/api.go.tmpl
@@ -286,7 +286,7 @@ import (
     return {{$name}}({{Template "Go.Decode" $.NumberType}})
   }
 
-  func {{$name}}Constants() int {
+  func {{$name}}Constants() int32 {
     return {{ConstantSetIndex $}}
   }
 {{end}}
@@ -1168,7 +1168,7 @@ import (
     }
     if pool, err := ϟg.Memory.Get(s.Pool()); err == nil {
       if f := pool.OnRead; f != nil {
-        f(s.Range(),  s.root, {{$slice_ty}}TypeIndex)
+        f(s.Range(),  s.root, {{$slice_ty}}TypeIndex, ϟc.API().ID().CoreId())
       }
     }
     if ϟb != nil && s.Pool() == ϟmem.ApplicationPool {
@@ -1225,7 +1225,7 @@ import (
     }
     if pool, err := ϟg.Memory.Get(s.Pool()); err == nil {
       if f := pool.OnWrite; f != nil {
-        f(s.Range(), s.root, {{$slice_ty}}TypeIndex)
+        f(s.Range(), s.root, {{$slice_ty}}TypeIndex, ϟc.API().ID().CoreId())
       }
     }
     if ϟb != nil && s.Pool() == ϟmem.ApplicationPool {

--- a/gapis/api/templates/api_types.go.tmpl
+++ b/gapis/api/templates/api_types.go.tmpl
@@ -30,9 +30,9 @@
 import (
     "reflect"
 
+    "github.com/google/gapid/gapis/service/path"
     ϟt "github.com/google/gapid/gapis/service/types"
 )
-
 
 const api_index       = uint64({{$.Index}}) << 59
 const pseudonym_index = uint64(1 << 55)
@@ -240,7 +240,10 @@ const slice_index     = uint64(8 << 55)
       TypeId: {{$ptr_ty}}TypeIndex,
       Name: "E_{{Template "Go.Type" $.Type}}",
       Ty: &ϟt.Type_Enum{
-        &ϟt.EnumType{ Underlying: {{Template "GetIndex" $.Type.NumberType}} },
+        &ϟt.EnumType{
+          Underlying: {{Template "GetIndex" $.Type.NumberType}},
+          Constants : &path.ConstantSet{Index: {{$ptr_ty}}Constants()},
+        },
       },
     }
   }

--- a/gapis/api/vulkan/api/bitfields.api
+++ b/gapis/api/vulkan/api/bitfields.api
@@ -41,7 +41,6 @@ type VkFlags VkInstanceCreateFlags
 
 /// Format capability flags
 @unused
-@analyze_usage
 bitfield VkFormatFeatureFlagBits {
   VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT                  = 0x00000001, /// Format can be used for sampled images (SAMPLED_IMAGE and COMBINED_IMAGE_SAMPLER descriptor types)
   VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT                  = 0x00000002, /// Format can be used for storage images (STORAGE_IMAGE descriptor type)
@@ -535,7 +534,6 @@ bitfield VkExternalSemaphoreHandleTypeFlagBits {
 type VkFlags VkExternalSemaphoreHandleTypeFlags
 
 @unused
-@analyze_usage
 bitfield VkFenceImportFlagBits {
   VK_FENCE_IMPORT_TEMPORARY_BIT     = 0x000000001,
   VK_FENCE_IMPORT_TEMPORARY_BIT_KHR = 0x000000001, // VK_FENCE_IMPORT_TEMPORARY_BIT,
@@ -558,7 +556,6 @@ bitfield VkPeerMemoryFeatureFlagBits {
 type VkFlags VkPeerMemoryFeatureFlags
 
 @unused
-@analyze_usage
 bitfield VkSemaphoreImportFlagBits {
   VK_SEMAPHORE_IMPORT_TEMPORARY_BIT     = 0x00000001,
   VK_SEMAPHORE_IMPORT_TEMPORARY_BIT_KHR = 0x00000001, // VK_SEMAPHORE_IMPORT_TEMPORARY_BIT,

--- a/gapis/api/vulkan/api/enums.api
+++ b/gapis/api/vulkan/api/enums.api
@@ -95,7 +95,6 @@ enum VkResult : u32 {
 }
 
 /// Structure type enumerant
-@analyze_usage
 enum VkStructureType: u32 {
   VK_STRUCTURE_TYPE_APPLICATION_INFO                          = 0,
   VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO                      = 1,
@@ -354,7 +353,6 @@ enum VkStructureType: u32 {
   VK_STRUCTURE_TYPE_DEVICE_GROUP_SWAPCHAIN_CREATE_INFO_KHR = 1000060012,
 }
 
-@analyze_usage
 enum VkObjectType: u32 {
   VK_OBJECT_TYPE_UNKNOWN                        = 0,
   VK_OBJECT_TYPE_INSTANCE                       = 1,

--- a/gapis/memory/pool.go
+++ b/gapis/memory/pool.go
@@ -46,8 +46,8 @@ import (
 //      always be a slice at this point.
 type Pool struct {
 	writes  poolWriteList
-	OnRead  func(rng Range, root uint64, t uint64)
-	OnWrite func(rng Range, root uint64, t uint64)
+	OnRead  func(rng Range, root uint64, t uint64, api id.ID)
+	OnWrite func(rng Range, root uint64, t uint64, api id.ID)
 }
 
 // PoolID is an identifier of a Pool.

--- a/gapis/resolve/constant_set.go
+++ b/gapis/resolve/constant_set.go
@@ -33,7 +33,7 @@ func ConstantSet(ctx context.Context, p *path.ConstantSet, r *path.ResolveConfig
 
 	cs := api.ConstantSets()
 
-	if count := uint32(len(cs.Sets)); p.Index >= count {
+	if count := int32(len(cs.Sets)); p.Index >= count {
 		return nil, errPathOOB(uint64(p.Index), "Index", 0, uint64(count)-1, p)
 	}
 

--- a/gapis/resolve/resolve.go
+++ b/gapis/resolve/resolve.go
@@ -100,7 +100,11 @@ func Field(ctx context.Context, p *path.Field, r *path.ResolveConfig) (interface
 }
 
 func Type(ctx context.Context, p *path.Type, r *path.ResolveConfig) (interface{}, error) {
-	return types.GetType(p.TypeIndex)
+	t, err := types.GetType(p.TypeIndex)
+	if _, isEnum := t.GetTy().(*types.Type_Enum); isEnum {
+		t.GetEnum().Constants.API = p.API
+	}
+	return t, err
 }
 
 func Messages(ctx context.Context, p *path.Messages) (interface{}, error) {

--- a/gapis/service/path/path.go
+++ b/gapis/service/path/path.go
@@ -542,7 +542,7 @@ func NewSlice(s, e uint64, n Node) *Slice {
 func (n *API) ConstantSet(i int) *ConstantSet {
 	return &ConstantSet{
 		API:   n,
-		Index: uint32(i),
+		Index: int32(i),
 	}
 }
 

--- a/gapis/service/path/path.proto
+++ b/gapis/service/path/path.proto
@@ -148,7 +148,7 @@ message Commands {
 // Resolves to a service.ConstantSet.
 message ConstantSet {
   API API = 1;
-  uint32 index = 2;
+  int32 index = 2;
 }
 
 // Events is a path to a list of events in a capture.
@@ -179,6 +179,7 @@ message Parameter {
 // Type is the path to a type used in an API.
 message Type {
   uint64 type_index = 1;
+  API API = 2;
 }
 
 // Result is the path to the result value of a command.

--- a/gapis/service/types/BUILD.bazel
+++ b/gapis/service/types/BUILD.bazel
@@ -34,7 +34,10 @@ proto_library(
     name = "types_proto",
     srcs = ["types.proto"],
     visibility = ["//visibility:public"],
-    deps = ["//core/data/pod:pod_proto"],
+    deps = [
+        "//core/data/pod:pod_proto",
+        "//gapis/service/path:path_proto",
+    ],
 )
 
 go_proto_library(
@@ -42,7 +45,10 @@ go_proto_library(
     importpath = "github.com/google/gapid/gapis/service/types",
     proto = ":types_proto",
     visibility = ["//visibility:public"],
-    deps = ["//core/data/pod:go_default_library"],
+    deps = [
+        "//core/data/pod:go_default_library",
+        "//gapis/service/path:go_default_library",
+    ],
 )
 
 java_proto_library(

--- a/gapis/service/types/types.proto
+++ b/gapis/service/types/types.proto
@@ -15,6 +15,7 @@
 syntax = "proto3";
 
 import "core/data/pod/pod.proto";
+import "gapis/service/path/path.proto";
 
 package types;
 option java_package = "com.google.gapid.proto.service.types";
@@ -77,6 +78,7 @@ message PseudonymType {
 
 message EnumType {
   uint64 underlying = 1;
+  path.ConstantSet constants = 2;
 }
 
 enum SizedType {


### PR DESCRIPTION
 - Visualize the enum fields in meaningful strings rather than
 abstract index numbers. The translation is based on enum mapping
 defined in gapis/api/<api>/api/enums.api file.