### PR TITLE
GAPID profiler - add Vulkan memory usage counters to the UI

### DIFF
--- a/core/vulkan/vk_memory_tracker_layer/cc/memory_tracker_layer_impl.cpp
+++ b/core/vulkan/vk_memory_tracker_layer/cc/memory_tracker_layer_impl.cpp
@@ -981,7 +981,7 @@ VulkanMemoryEventPtr HostAllocation::GetVulkanMemoryEvent() {
 // --------------------------- Memory events tracker ---------------------------
 
 MemoryTracker::MemoryTracker()
-    : track_host_memory_(false), initial_state_is_sent_(false) {}
+    : track_host_memory_(true), initial_state_is_sent_(false) {}
 
 const VkAllocationCallbacks* MemoryTracker::GetTrackedAllocator(
     const VkAllocationCallbacks* pUserAllocator, const std::string& caller) {

--- a/gapic/src/main/com/google/gapid/perfetto/models/Tracks.java
+++ b/gapic/src/main/com/google/gapid/perfetto/models/Tracks.java
@@ -34,6 +34,7 @@ import com.google.gapid.perfetto.views.GpuQueuePanel;
 import com.google.gapid.perfetto.views.ProcessSummaryPanel;
 import com.google.gapid.perfetto.views.ThreadPanel;
 import com.google.gapid.perfetto.views.TitlePanel;
+import com.google.gapid.perfetto.views.VulkanCounterPanel;
 
 import java.util.Collections;
 import java.util.List;
@@ -188,6 +189,21 @@ public class Tracks {
         final int idleCount = threads.size() - firstIdle;
         data.tracks.addLabelGroup(summary.getId(), summary.getId() + "_idle", "Idle Threads",
             group(state -> new TitlePanel(idleCount + " Idle Threads (< 0.1%)"), false));
+      }
+
+      // For each process, add Vulkan memory usage counters if any exist
+      List<CounterInfo> counters = data.getCounters().values().stream()
+      .filter(c -> (c.count > 0) && (c.name.startsWith("vulkan")))
+      .collect(toList());
+
+      if (!counters.isEmpty()) {
+        data.tracks.addLabelGroup(summary.getId(), "vulkan_counters", "Vulkan Counters",
+            group(state -> new TitlePanel("Vulkan Memory Usage Counters"), true));
+        for (CounterInfo counter : counters) {
+          CounterTrack track = new CounterTrack(counter);
+          data.tracks.addTrack("vulkan_counters", track.getId(), counter.name,
+              single(state -> new VulkanCounterPanel(state, track), true));
+        }
       }
     });
 

--- a/gapic/src/main/com/google/gapid/perfetto/views/VulkanCounterPanel.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/VulkanCounterPanel.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2019 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.gapid.perfetto.views;
+
+import com.google.gapid.perfetto.models.CounterTrack;
+
+import java.util.List;
+
+public class VulkanCounterPanel extends CounterPanel implements Selectable {
+
+  public VulkanCounterPanel(State state, CounterTrack track) {
+    super(state, track);
+  }
+
+  @Override
+  public VulkanCounterPanel copy() {
+    return new VulkanCounterPanel(state, track);
+  }
+
+  @Override
+  public String getTitle() {
+    // Perfetto convention for Vulkan counter names:
+    // Device: vulkan.mem.device.memory.type.{}.{allocation|bind}
+    // Driver: vulkan.mem.driver.scope.{COMMAND|OBJECT|CACHE|DEVICE|INSTANCE}
+    String name = track.getCounter()
+                      .name.replace("vulkan.mem.", "")
+                      .replace("driver.", "Driver, ")
+                      .replace("device.", "GPU, ")
+                      .replace("scope.", "Scope: ")
+                      .replace("memory.type.", "MemoryType: ")
+                      .replace(".allocation", ", Allocated")
+                      .replace(".bind", ", Bound");
+    return name;
+  }
+}


### PR DESCRIPTION
This change adds Vulkan memory usage counters to the profiler UI and also turns on driver memory usage tracking for now, until we merge https://github.com/google/gapid/pull/3478.