### PR TITLE
Rename ggp --env option to --vars, as --env is being deprecated.

### DIFF
--- a/gapis/trace/desktop/ggp_trace.go
+++ b/gapis/trace/desktop/ggp_trace.go
@@ -150,16 +150,16 @@ func (t *GGPTracer) StartOnDevice(ctx context.Context, name string, opts *proces
 			cmdArgs = append(cmdArgs, "--cmd", execArgStr)
 		}
 
-		envs := ""
+		vars := ""
 		for _, e := range opts.Env.Vars() {
-			if envs != "" {
-				envs += ";"
+			if vars != "" {
+				vars += ";"
 			}
-			envs += text.Quote([]string{e})[0]
+			vars += text.Quote([]string{e})[0]
 		}
 
-		if envs != "" {
-			cmdArgs = append(cmdArgs, "--env", envs)
+		if vars != "" {
+			cmdArgs = append(cmdArgs, "--vars", vars)
 		}
 
 		execCmd := ggpExecutable.System()


### PR DESCRIPTION
Ggp is deprecating the --env option and replacing it with --vars. This changes switches to the new --vars option and also updates variable names accordingly.