### PR TITLE
Remove unnecessary headers from Vulkan memory tracker

### DIFF
--- a/core/vulkan/vk_memory_tracker_layer/cc/memory_tracker_layer_impl.cpp
+++ b/core/vulkan/vk_memory_tracker_layer/cc/memory_tracker_layer_impl.cpp
@@ -15,8 +15,6 @@
  */
 
 #include <stdlib.h>
-#include <sys/stat.h>
-#include <sys/sysinfo.h>
 #include <algorithm>
 #include <sstream>
 #include <thread>


### PR DESCRIPTION
A couple of unnecessary sys/ headers were failing gapit build on Mac.
This change removes those headers.