### PR TITLE
Set write_info_file with big period with Vulkan CPU Timing

### DIFF
--- a/gapic/src/main/com/google/gapid/perfetto/views/TraceConfigDialog.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/TraceConfigDialog.java
@@ -229,17 +229,22 @@ public class TraceConfigDialog extends DialogBase {
     if (settings.perfettoVulkanCPUTiming) {
       largeBuffer = true;
       config.addDataSourcesBuilder()
-        .getConfigBuilder()
-          .setName("VulkanCPUTiming");
+          .getConfigBuilder()
+              .setName("VulkanCPUTiming");
+    }
+
+    config.addBuffers(PerfettoConfig.TraceConfig.BufferConfig.newBuilder()
+        .setSizeKb((largeBuffer ? 8 : 1) * BUFFER_SIZE));
+
+    if (largeBuffer) {
       config.setWriteIntoFile(true);
       config.setFileWritePeriodMs((int)HOURS.toMillis(1));
     }
 
-    config.addBuffers(PerfettoConfig.TraceConfig.BufferConfig.newBuilder()
-      .setSizeKb((largeBuffer ? 8 : 1) * BUFFER_SIZE));
-
     if (settings.perfettoVulkanMemoryTracker) {
-      config.addDataSourcesBuilder().getConfigBuilder().setName("VulkanMemoryTracker");
+      config.addDataSourcesBuilder()
+          .getConfigBuilder()
+              .setName("VulkanMemoryTracker");
     }
 
     return config;

--- a/gapic/src/main/com/google/gapid/perfetto/views/TraceConfigDialog.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/TraceConfigDialog.java
@@ -23,6 +23,7 @@ import static com.google.gapid.widgets.Widgets.createSpinner;
 import static com.google.gapid.widgets.Widgets.withIndents;
 import static com.google.gapid.widgets.Widgets.withLayoutData;
 import static com.google.gapid.widgets.Widgets.withMargin;
+import static java.util.concurrent.TimeUnit.HOURS;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.stream.Collectors.toSet;
 
@@ -230,6 +231,8 @@ public class TraceConfigDialog extends DialogBase {
       config.addDataSourcesBuilder()
         .getConfigBuilder()
           .setName("VulkanCPUTiming");
+      config.setWriteIntoFile(true);
+      config.setFileWritePeriodMs((int)HOURS.toMillis(1));
     }
 
     config.addBuffers(PerfettoConfig.TraceConfig.BufferConfig.newBuilder()


### PR DESCRIPTION
Sets write_into_file and one-hour file_write_period_ms in the Perfetto
config when collecting Vulkan CPU Timing. This was suggested in
b/145341050#comment21 and makes traced write the trace file directly,
instead of sending the content of the big trace back to the perfetto
command over several IPC messages, making the finalization of the
trace at least one third faster.

Bug: b/145341050