### PR TITLE
Handle completely idle CPU core/threads correctly.

### DIFF
--- a/gapic/src/main/com/google/gapid/models/CpuInfo.java
+++ b/gapic/src/main/com/google/gapid/models/CpuInfo.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (C) 2019 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.gapid.models;
+
+import static com.google.gapid.util.MoreFutures.transform;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.gapid.perfetto.models.QueryEngine;
+
+import java.util.Collections;
+import java.util.List;
+
+public class CpuInfo {
+  public static final CpuInfo NONE = new CpuInfo(Collections.emptyList());
+
+  private static final String CPU_FREQ_IDLE_QUERY =
+      "with freq as (" +
+        "select cpu, cd.id freq_id, max(value) freq " +
+        "from cpu_counter_track cd left join counter_values cv on cd.id = cv.counter_id " +
+        "where name = 'cpufreq' group by cd.id), " +
+      "idle as (select cpu, id idle_id from cpu_counter_track where name = 'cpuidle'), " +
+      "cpus as (select distinct(cpu) from sched union select distinct(cpu) from idle) " +
+      "select cpu, freq_id, freq, idle_id " +
+      "from cpus left join idle using (cpu) left join freq using (cpu) " +
+      "order by cpu";
+
+  private final List<Cpu> cpus;
+
+  private CpuInfo(List<Cpu> cpus) {
+    this.cpus = cpus;
+  }
+
+  public int count() {
+    return cpus.size();
+  }
+
+  public boolean hasCpus() {
+    return !cpus.isEmpty();
+  }
+
+  public Cpu get(int idx) {
+    return cpus.get(idx);
+  }
+
+  public Iterable<Cpu> cpus() {
+    return Iterables.unmodifiableIterable(cpus);
+  }
+
+  public static ListenableFuture<Perfetto.Data.Builder> listCpus(Perfetto.Data.Builder data) {
+    return transform(data.qe.query(CPU_FREQ_IDLE_QUERY), res -> {
+      ImmutableList.Builder<Cpu> cpus = ImmutableList.builderWithExpectedSize(res.getNumRows());
+      res.forEachRow(($, r) -> {
+        cpus.add(Cpu.of(r));
+      });
+      return data.setCpu(new CpuInfo(cpus.build()));
+    });
+  }
+
+  public static class Cpu {
+    public final int id;
+    public final long freqId;
+    public final double maxFreq;
+    public final long idleId;
+
+    private Cpu(int id) {
+      this.id = id;
+      this.freqId = -1;
+      this.maxFreq = Double.NaN;
+      this.idleId = -1;
+    }
+
+    private Cpu(int id, long freqId, double maxFreq, long idleId) {
+      this.id = id;
+      this.freqId = freqId;
+      this.maxFreq = maxFreq;
+      this.idleId = idleId;
+    }
+
+    public static Cpu of(QueryEngine.Row r) {
+      int cpu = r.getInt(0);
+      return (r.isNull(1) || r.isNull(3)) ? new Cpu(cpu) :
+          new Cpu(cpu, r.getLong(1), r.getDouble(2), r.getLong(3));
+    }
+
+    public boolean hasFrequency() {
+      return freqId >= 0;
+    }
+  }
+}

--- a/gapic/src/main/com/google/gapid/models/Perfetto.java
+++ b/gapic/src/main/com/google/gapid/models/Perfetto.java
@@ -96,7 +96,7 @@ public class Perfetto extends ModelBase<Perfetto.Data, Path.Capture, Loadable.Me
   private static ListenableFuture<Data.Builder> examineTrace(Data.Builder data) {
     return transformAsync(data.qe.getTraceTimeBounds(), traceTime -> {
       data.setTraceTime(traceTime);
-      return transform(data.qe.getNumberOfCpus(), numCpus -> data.setNumCpus(numCpus));
+      return CpuInfo.listCpus(data);
     });
   }
 
@@ -168,19 +168,19 @@ public class Perfetto extends ModelBase<Perfetto.Data, Path.Capture, Loadable.Me
   public static class Data {
     public final QueryEngine qe;
     public final TimeSpan traceTime;
-    public final int numCpus;
+    public final CpuInfo cpu;
     public final ImmutableMap<Long, ProcessInfo> processes;
     public final ImmutableMap<Long, ThreadInfo> threads;
     public final GpuInfo gpu;
     public final ImmutableMap<Long, CounterInfo> counters;
     public final TrackConfig tracks;
 
-    public Data(QueryEngine queries, TimeSpan traceTime, int numCpus,
+    public Data(QueryEngine queries, TimeSpan traceTime, CpuInfo cpu,
         ImmutableMap<Long, ProcessInfo> processes, ImmutableMap<Long, ThreadInfo> threads,
         GpuInfo gpu, ImmutableMap<Long, CounterInfo> counters, TrackConfig tracks) {
       this.qe = queries;
       this.traceTime = traceTime;
-      this.numCpus = numCpus;
+      this.cpu = cpu;
       this.processes = processes;
       this.threads = threads;
       this.gpu = gpu;
@@ -191,7 +191,7 @@ public class Perfetto extends ModelBase<Perfetto.Data, Path.Capture, Loadable.Me
     public static class Builder {
       public final QueryEngine qe;
       private TimeSpan traceTime;
-      private int numCpus;
+      private CpuInfo cpu = CpuInfo.NONE;
       private ImmutableMap<Long, ProcessInfo> processes;
       private ImmutableMap<Long, ThreadInfo> threads;
       private GpuInfo gpu = GpuInfo.NONE;
@@ -212,12 +212,12 @@ public class Perfetto extends ModelBase<Perfetto.Data, Path.Capture, Loadable.Me
         return this;
       }
 
-      public int getNumCpus() {
-        return numCpus;
+      public CpuInfo getCpu() {
+        return cpu;
       }
 
-      public Builder setNumCpus(int numCpus) {
-        this.numCpus = numCpus;
+      public Builder setCpu(CpuInfo cpu) {
+        this.cpu = cpu;
         return this;
       }
 
@@ -264,7 +264,7 @@ public class Perfetto extends ModelBase<Perfetto.Data, Path.Capture, Loadable.Me
       }
 
       public Data build() {
-        return new Data(qe, traceTime, numCpus, processes, threads, gpu, counters, tracks.build());
+        return new Data(qe, traceTime, cpu, processes, threads, gpu, counters, tracks.build());
       }
     }
   }

--- a/gapic/src/main/com/google/gapid/perfetto/models/ProcessSummaryTrack.java
+++ b/gapic/src/main/com/google/gapid/perfetto/models/ProcessSummaryTrack.java
@@ -35,10 +35,8 @@ public class ProcessSummaryTrack extends Track<ProcessSummaryTrack.Data> {
   private static final String PROCESS_VIEW_SQL = "select * from sched where utid in (%s)";
   private static final String SUMMARY_SQL =
       "select quantum_ts, sum(dur)/cast(%d * %d as float) " +
-      "from %s where cpu < %d " +
-      "group by quantum_ts";
-  private static final String SLICES_SQL =
-      "select ts, dur, cpu, utid, row_id from %s where cpu < %d";
+      "from %s group by quantum_ts";
+  private static final String SLICES_SQL = "select ts, dur, cpu, utid, row_id from %s";
 
   private final int numCpus;
   private final ProcessInfo process;
@@ -84,7 +82,7 @@ public class ProcessSummaryTrack extends Track<ProcessSummaryTrack.Data> {
   }
 
   private String summarySql(long ns) {
-    return format(SUMMARY_SQL, numCpus, ns, tableName("span"), numCpus);
+    return format(SUMMARY_SQL, numCpus, ns, tableName("span"));
   }
 
   private ListenableFuture<Data> computeSlices(QueryEngine qe, DataRequest req) {
@@ -105,7 +103,7 @@ public class ProcessSummaryTrack extends Track<ProcessSummaryTrack.Data> {
   }
 
   private String slicesSql() {
-    return format(SLICES_SQL, tableName("span"), numCpus);
+    return format(SLICES_SQL, tableName("span"));
   }
 
   public static class Data extends Track.Data {

--- a/gapic/src/main/com/google/gapid/perfetto/models/Tracks.java
+++ b/gapic/src/main/com/google/gapid/perfetto/models/Tracks.java
@@ -69,12 +69,11 @@ public class Tracks {
     boolean hasAnyFrequency = false;
     for (CpuInfo.Cpu cpu : data.getCpu().cpus()) {
       CpuTrack track = new CpuTrack(cpu);
-      data.tracks.addTrack(summary.getId(), track.getId(), "CPU " + (cpu.id + 1),
+      data.tracks.addTrack(summary.getId(), track.getId(), "CPU " + cpu.id,
           single(state -> new CpuPanel(state, track), false));
       if (cpu.hasFrequency()) {
         CpuFrequencyTrack freqTrack = new CpuFrequencyTrack(cpu);
-        data.tracks.addTrack(summary.getId(), freqTrack.getId(),
-            "CPU " + (cpu.id + 1) + " Frequency",
+        data.tracks.addTrack(summary.getId(), freqTrack.getId(), "CPU " + cpu.id + " Frequency",
             single(state -> new CpuFrequencyPanel(state, freqTrack), false));
         hasAnyFrequency = true;
       }

--- a/gapic/src/main/com/google/gapid/perfetto/views/CpuFrequencyPanel.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/CpuFrequencyPanel.java
@@ -52,7 +52,7 @@ public class CpuFrequencyPanel extends TrackPanel<CpuFrequencyPanel> {
 
   @Override
   public String getTitle() {
-    return "CPU " + (track.getCpu() + 1) + " Frequency";
+    return "CPU " + (track.getCpu().id + 1) + " Frequency";
   }
 
   @Override
@@ -77,16 +77,16 @@ public class CpuFrequencyPanel extends TrackPanel<CpuFrequencyPanel> {
       double endPx = state.timeToPx(visible.end);
 
       final String[] kUnits = new String[] { "", "K", "M", "G", "T", "E" };
-      double exp = Math.ceil(Math.log10(Math.max(data.maximumValue, 1)));
+      double exp = Math.ceil(Math.log10(Math.max(track.getCpu().maxFreq, 1)));
       double pow10 = Math.pow(10, exp);
-      double yMax = Math.ceil(data.maximumValue / (pow10 / 4)) * (pow10 / 4);
+      double yMax = Math.ceil(track.getCpu().maxFreq / (pow10 / 4)) * (pow10 / 4);
       int unitGroup = (int)Math.floor(exp / 3);
       // The values we have for cpufreq are in kHz so +1 to unitGroup.
       String yLabel = (yMax / Math.pow(10, unitGroup * 3)) + " " + kUnits[unitGroup + 1] + "Hz";
 
       // Draw the CPU frequency graph.
-      ctx.setBackgroundColor(StyleConstants.Palette.getColor(track.getCpu(), 3));
-      ctx.setForegroundColor(StyleConstants.Palette.getColor(track.getCpu()));
+      ctx.setBackgroundColor(StyleConstants.Palette.getColor(track.getCpu().id, 3));
+      ctx.setForegroundColor(StyleConstants.Palette.getColor(track.getCpu().id));
       ctx.path(path -> {
         double lastX = startPx, lastY = h;
         path.moveTo(lastX, lastY);
@@ -129,8 +129,8 @@ public class CpuFrequencyPanel extends TrackPanel<CpuFrequencyPanel> {
       }
 
       if (hoveredValue != null && hoveredTs != null) {
-        ctx.setBackgroundColor(StyleConstants.Palette.getColor(track.getCpu(), 3));
-        ctx.setForegroundColor(StyleConstants.Palette.getColor(track.getCpu()));
+        ctx.setBackgroundColor(StyleConstants.Palette.getColor(track.getCpu().id, 3));
+        ctx.setForegroundColor(StyleConstants.Palette.getColor(track.getCpu().id));
 
         Size textSize = ctx.measure(Fonts.Style.Normal, hoverLabel);
         double xStart = Math.floor(state.timeToPx(hoveredTs));

--- a/gapic/src/main/com/google/gapid/perfetto/views/CpuFrequencyPanel.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/CpuFrequencyPanel.java
@@ -52,7 +52,7 @@ public class CpuFrequencyPanel extends TrackPanel<CpuFrequencyPanel> {
 
   @Override
   public String getTitle() {
-    return "CPU " + (track.getCpu().id + 1) + " Frequency";
+    return "CPU " + track.getCpu().id + " Frequency";
   }
 
   @Override

--- a/gapic/src/main/com/google/gapid/perfetto/views/CpuPanel.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/CpuPanel.java
@@ -67,7 +67,7 @@ public class CpuPanel extends TrackPanel<CpuPanel> implements Selectable {
 
   @Override
   public String getTitle() {
-    return "CPU " + (track.getCpu() + 1);
+    return "CPU " + (track.getCpu().id + 1);
   }
 
   @Override
@@ -97,7 +97,7 @@ public class CpuPanel extends TrackPanel<CpuPanel> implements Selectable {
   private void renderSummary(RenderContext ctx, CpuTrack.Data data, double w, double h) {
     long tStart = data.request.range.start;
     int start = Math.max(0, (int)((state.getVisibleTime().start - tStart) / data.bucketSize));
-    ctx.setBackgroundColor(StyleConstants.Palette.getColor(track.getCpu()));
+    ctx.setBackgroundColor(StyleConstants.Palette.getColor(track.getCpu().id));
     ctx.path(path -> {
       path.moveTo(0, h);
       double y = h, x = 0;
@@ -282,7 +282,7 @@ public class CpuPanel extends TrackPanel<CpuPanel> implements Selectable {
   public void computeSelection(CombiningBuilder builder, Area area, TimeSpan ts) {
     if (area.h / height >= SELECTION_THRESHOLD) {
       builder.add(Selection.Kind.Cpu, transform(
-          CpuTrack.getSlices(state.getQueryEngine(), track.getCpu(), ts), r -> {
+          CpuTrack.getSlices(state.getQueryEngine(), track.getCpu().id, ts), r -> {
             r.stream().forEach(s -> state.addSelectedThread(state.getThreadInfo(s.utid)));
             return new CpuTrack.Slices(state, r);
           }));

--- a/gapic/src/main/com/google/gapid/perfetto/views/CpuPanel.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/CpuPanel.java
@@ -67,7 +67,7 @@ public class CpuPanel extends TrackPanel<CpuPanel> implements Selectable {
 
   @Override
   public String getTitle() {
-    return "CPU " + (track.getCpu().id + 1);
+    return "CPU " + track.getCpu().id;
   }
 
   @Override

--- a/gapic/src/main/com/google/gapid/perfetto/views/ProcessSummaryPanel.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/ProcessSummaryPanel.java
@@ -26,6 +26,7 @@ import com.google.gapid.perfetto.canvas.Area;
 import com.google.gapid.perfetto.canvas.Fonts;
 import com.google.gapid.perfetto.canvas.RenderContext;
 import com.google.gapid.perfetto.canvas.Size;
+import com.google.gapid.perfetto.models.CpuInfo;
 import com.google.gapid.perfetto.models.CpuTrack;
 import com.google.gapid.perfetto.models.ProcessSummaryTrack;
 import com.google.gapid.perfetto.models.Selection;
@@ -155,15 +156,15 @@ public class ProcessSummaryPanel extends TrackPanel<ProcessSummaryPanel> {
     for (int i = 0; i < data.starts.length; i++) {
       long tStart = data.starts[i];
       long tEnd = data.ends[i];
-      int cpu = data.cpus[i];
+      CpuInfo.Cpu cpu = state.getData().cpu.getById(data.cpus[i]);
       long utid = data.utids[i];
-      if (tEnd <= visible.start || tStart >= visible.end) {
+      if (cpu == null || tEnd <= visible.start || tStart >= visible.end) {
         continue;
       }
       double rectStart = state.timeToPx(tStart);
       double rectWidth = Math.max(1, state.timeToPx(tEnd) - rectStart);
 
-      double y = cpuH * cpu + cpu;
+      double y = cpuH * cpu.index + cpu.index;
       ctx.setBackgroundColor(ThreadInfo.getColor(state, utid));
       ctx.fillRect(rectStart, y, rectWidth, cpuH);
 
@@ -177,8 +178,9 @@ public class ProcessSummaryPanel extends TrackPanel<ProcessSummaryPanel> {
       ctx.setForegroundColor(ThreadInfo.getBorderColor(state, data.utids[index]));
       double rectStart = state.timeToPx(data.starts[index]);
       double rectWidth = Math.max(1, state.timeToPx(data.ends[index]) - rectStart);
-      double cpu = data.cpus[index];
-      ctx.drawRect(rectStart, cpuH * cpu + cpu, rectWidth, cpuH, BOUNDING_BOX_LINE_WIDTH);
+      CpuInfo.Cpu cpu = state.getData().cpu.getById(data.cpus[index]);
+      ctx.drawRect(
+          rectStart, cpuH * cpu.index + cpu.index, rectWidth, cpuH, BOUNDING_BOX_LINE_WIDTH);
     }
 
     if (hoveredThread != null) {

--- a/gapic/src/main/com/google/gapid/perfetto/views/ProcessSummaryPanel.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/ProcessSummaryPanel.java
@@ -150,7 +150,8 @@ public class ProcessSummaryPanel extends TrackPanel<ProcessSummaryPanel> {
     TimeSpan visible = state.getVisibleTime();
     Selection<Long> selected = state.getSelection(Selection.Kind.Cpu);
     List<Integer> visibleSelected = Lists.newArrayList();
-    double cpuH = (h - state.getData().numCpus + 1) / state.getData().numCpus;
+    int cpuCount = state.getData().cpu.count();
+    double cpuH = (h - cpuCount + 1) / cpuCount;
     for (int i = 0; i < data.starts.length; i++) {
       long tStart = data.starts[i];
       long tEnd = data.ends[i];
@@ -210,10 +211,12 @@ public class ProcessSummaryPanel extends TrackPanel<ProcessSummaryPanel> {
 
   private Hover sliceHover(
       ProcessSummaryTrack.Data data, Fonts.TextMeasurer m, double x, double y) {
-    int cpu = (int)(y * state.getData().numCpus / HEIGHT);
-    if (cpu < 0 || cpu >= state.getData().numCpus) {
+    int cpuCount = state.getData().cpu.count();
+    int cpuIdx = (int)(y * cpuCount / HEIGHT);
+    if (cpuIdx < 0 || cpuIdx >= cpuCount) {
       return Hover.NONE;
     }
+    int cpu = state.getData().cpu.get(cpuIdx).id;
 
     mouseXpos = x;
     long t = state.pxToTime(x);


### PR DESCRIPTION
 - Adds a new CpuInfo class to track data about the CPU cores/threads.
 - When determining the available CPU IDs, use both the sched and idle counter tables. Thus, if a completely idle CPU is present, it will show up as long as the idle counter is present.
 - Don't assume CPU ids are contiguous, i.e. handle absent CPU ids.
 - Use the new cpu_counter_track table to get rid of ref/ref_type.

Fixes #3512