### PR TITLE
Improve device selection

### DIFF
--- a/gapic/src/main/com/google/gapid/models/Devices.java
+++ b/gapic/src/main/com/google/gapid/models/Devices.java
@@ -290,5 +290,9 @@ public class Devices {
     public boolean isAndroid() {
       return device.getConfiguration().getOS().getKind() == Device.OSKind.Android;
     }
+
+    public boolean isStadia() {
+      return device.getConfiguration().getOS().getKind() == Device.OSKind.Stadia;
+    }
   }
 }

--- a/gapic/src/main/com/google/gapid/models/Settings.java
+++ b/gapic/src/main/com/google/gapid/models/Settings.java
@@ -67,7 +67,8 @@ public class Settings {
   public int[] reportSplitterWeights = new int[] { 75, 25 };
   public int[] shaderTreeSplitterWeights = new int[] { 20, 80 };
   public int[] texturesSplitterWeights = new int[] { 20, 80 };
-  public String traceDevice = "";
+  public String traceDeviceSerial = "";
+  public String traceDeviceName = "";
   public String traceType = "Graphics";
   public String traceApi = "";
   public String traceUri = "";
@@ -236,7 +237,8 @@ public class Settings {
         getIntList(properties, "shaderTree.splitter.weights", shaderTreeSplitterWeights);
     texturesSplitterWeights =
         getIntList(properties, "texture.splitter.weights", texturesSplitterWeights);
-    traceDevice = properties.getProperty("trace.device", traceDevice);
+    traceDeviceSerial = properties.getProperty("trace.device.serial", traceDeviceSerial);
+    traceDeviceName = properties.getProperty("trace.device.name", traceDeviceName);
     traceType = properties.getProperty("trace.type", traceType);
     traceApi = properties.getProperty("trace.api", traceApi);
     traceUri = properties.getProperty("trace.uri", traceUri);
@@ -297,7 +299,8 @@ public class Settings {
     setIntList(properties, "report.splitter.weights", reportSplitterWeights);
     setIntList(properties, "shaderTree.splitter.weights", shaderTreeSplitterWeights);
     setIntList(properties, "texture.splitter.weights", texturesSplitterWeights);
-    properties.setProperty("trace.device", traceDevice);
+    properties.setProperty("trace.device.serial", traceDeviceSerial);
+    properties.setProperty("trace.device.name", traceDeviceName);
     properties.setProperty("trace.type", traceType);
     properties.setProperty("trace.api", traceApi);
     properties.setProperty("trace.uri", traceUri);

--- a/gapic/src/main/com/google/gapid/views/TracerDialog.java
+++ b/gapic/src/main/com/google/gapid/views/TracerDialog.java
@@ -644,6 +644,12 @@ public class TracerDialog {
               if (firstIsAndroid != secondIsAndroid) {
                 return firstIsAndroid ? devices.get(0) : devices.get(1);
               }
+              // Same reasoning for Stadia instances.
+              boolean firstIsStadia = devices.get(0).isStadia();
+              boolean secondIsStadia = devices.get(1).isStadia();
+              if (firstIsStadia != secondIsStadia) {
+                return firstIsStadia ? devices.get(0) : devices.get(1);
+              }
             }
             return null;
           });
@@ -657,9 +663,18 @@ public class TracerDialog {
       }
 
       private Optional<DeviceCaptureInfo> getPreviouslySelectedDevice(Settings settings) {
-        return (settings.traceDevice.isEmpty()) ? Optional.empty() : devices.stream()
-            .filter(dev -> settings.traceDevice.equals(dev.device.getSerial()))
-            .findAny();
+        if (!settings.traceDeviceSerial.isEmpty()) {
+          return devices.stream()
+              .filter(dev -> settings.traceDeviceSerial.equals(dev.device.getSerial()))
+              .findAny();
+        } else if (!settings.traceDeviceName.isEmpty()) {
+          return devices.stream()
+              .filter(dev -> "".equals(dev.device.getSerial()) &&
+                  settings.traceDeviceName.equals(dev.device.getName()))
+              .findAny();
+        } else {
+          return Optional.empty();
+        }
       }
 
       private void updateApiDropdown(DeviceTraceConfiguration config, Settings settings) {
@@ -763,7 +778,8 @@ public class TracerDialog {
         TraceTypeCapabilities config = getSelectedApi();
         File output = getOutputFile();
 
-        settings.traceDevice = dev.device.getSerial();
+        settings.traceDeviceSerial = dev.device.getSerial();
+        settings.traceDeviceName = dev.device.getName();
         settings.traceType = config.getType().name();
         settings.traceApi = config.getApi();
         settings.traceUri = traceTarget.getText();


### PR DESCRIPTION
The "serial" of the selected trace device is saved and used to automatically
fill the device drop-down when taking a new trace. This only works with Android
devices but not with Stadia as a serial is not available. Fall back to using the
device's/instance's (friendly) name when serial is not available.
Also, extend to Stadia the logic for which if two devices are available and
exactly one is an Android device/Stadia instance, then that one should
automatically be selected if no previous selection is available.

Bug: b/145499378