### PR TITLE
Make validate_gpu_profiling return non-zero on validation failure

### DIFF
--- a/cmd/gapit/validate_gpu_profiling.go
+++ b/cmd/gapit/validate_gpu_profiling.go
@@ -47,14 +47,20 @@ func (verb *validateGpuProfilingVerb) Run(ctx context.Context, flags flag.FlagSe
 		return log.Err(ctx, err, "Failed to get device list.")
 	}
 	stdout := os.Stdout
+	someDeviceFailed := false
 	for i, p := range devices {
 		fmt.Fprintf(stdout, "-- Device %v: %v --\n", i, p.ID.ID())
 		err = client.ValidateDevice(ctx, p)
 		if err != nil {
 			fmt.Fprintf(stdout, "%v\n", log.Err(ctx, err, "Failed to validate device"))
+			someDeviceFailed = true
 			continue
 		}
 		fmt.Fprintf(stdout, "Device is validated.\n")
+	}
+	if someDeviceFailed {
+		err := fmt.Errorf("Some device failed validation")
+		return err
 	}
 	return nil
 }

--- a/cmd/gapit/validate_gpu_profiling.go
+++ b/cmd/gapit/validate_gpu_profiling.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -59,8 +60,7 @@ func (verb *validateGpuProfilingVerb) Run(ctx context.Context, flags flag.FlagSe
 		fmt.Fprintf(stdout, "Device is validated.\n")
 	}
 	if someDeviceFailed {
-		err := fmt.Errorf("Some device failed validation")
-		return err
+		return errors.New("Some device failed validation")
 	}
 	return nil
 }


### PR DESCRIPTION
This enables to use `gapit validate_gpu_profiling` return code to detect failing validation in automated testing.