### PR TITLE
Update time of extracted files

### DIFF
--- a/tools/build/rules/zip.bzl
+++ b/tools/build/rules/zip.bzl
@@ -24,7 +24,7 @@ def _extract_impl(ctx):
         ctx.actions.run_shell(
             inputs = [ctx.file.zip],
             outputs = [out],
-            command = "unzip -q -d {} {} {}".format(to, ctx.file.zip.path, entry),
+            command = "unzip -q -DD -d {} {} {}".format(to, ctx.file.zip.path, entry),
         )
     return struct(
         files = depset(outs)


### PR DESCRIPTION
Skip restoration of timestamps for extracted files, which triggers Bazel to check if the file content has changed.
Fixes b/146132677
