### PR TITLE
Add keyboard/mouse help window to Perfetto view

### DIFF
--- a/gapic/res/text/keyboard-mouse-help.html
+++ b/gapic/res/text/keyboard-mouse-help.html
@@ -77,7 +77,7 @@
 
       <tr class="pair">
         <td class="command">space-drag</td>
-        <td class="action">Vertical pan</td>
+        <td class="action">Pan</td>
       </tr>
 
       <tr class="pair">

--- a/gapic/res/text/keyboard-mouse-help.html
+++ b/gapic/res/text/keyboard-mouse-help.html
@@ -28,7 +28,7 @@
     }
 
     table.centered{
-	margin-left:auto; margin-right:auto; 
+	margin-left:auto; margin-right:auto;
     }
     .column {
       padding: 0 40px 40px 0;
@@ -55,7 +55,7 @@
 
     <table class="centered">
     <tr>
-     
+
     <td class="column">
       <table>
       <tr><td colspan=2><h2>General</h2></td></tr>
@@ -101,7 +101,7 @@
       </tr>
 
       <tr class="pair">
-        <td class="command">?</td>
+        <td class="command">h/?</td>
         <td class="action">Show help</td>
       </tr>
 
@@ -137,7 +137,7 @@
      <td class="column">
 
       <table>
-      <tr><td colspan=2><h2>   
+      <tr><td colspan=2><h2>
         Modes
       </h2></td></tr>
 

--- a/gapic/res/text/keyboard-mouse-help.html
+++ b/gapic/res/text/keyboard-mouse-help.html
@@ -1,0 +1,165 @@
+<!DOCTYPE html>
+<html>
+<head i18n-values="dir:textdirection;">
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+<meta charset="utf-8"/>
+<title>Keyboard/Mouse Help</title>
+<body>
+   <style>
+    :host {
+      flex: 1 1 auto;
+      flex-direction: row;
+      display: flex;
+      width: 700px;
+    }
+    .pair {
+      flex: 1 1 auto;
+      flex-direction: row;
+      display: flex;
+    }
+    .column {
+      padding: 0 40px 40px 0;
+      vertical-align: top;
+    }
+    .command {
+      font-family: monospace;
+      display:inline;
+      margin-right: 5px;
+      text-align: right;
+      min-width: 200px;
+    }
+    .action {
+      font-size: 0.8em;
+      display:inline;
+      text-align: left;
+      min-width: 400px;
+    }
+    h4 {
+      font-weight: bold;
+      font-size: 0.9em;
+    }
+
+    </style>
+
+    <table>
+    <tr>
+     
+    <td class="column">
+      <h2>General</h2>
+      <div class="pair">
+        <div class="command">1-4</div>
+        <div class="action">Switch mouse mode</div>
+      </div>
+
+      <div class="pair">
+        <div class="command">shift</div>
+        <div class="action">Hold for temporary select</div>
+      </div>
+
+      <div class="pair">
+        <div class="command">space</div>
+        <div class="action">Hold for temporary pan</div>
+      </div>
+
+      <div class="pair">
+        <div class="command">f</div>
+        <div class="action">Zoom into selection</div>
+      </div>
+
+      <div class="pair">
+        <div class="command">z/0</div>
+        <div class="action">Reset zoom and pan</div>
+      </div>
+
+      <div class="pair">
+        <div class="command">v</div>
+        <div class="action">Highlight VSync</div>
+      </div>
+      <div class="pair">
+        <div class="command">m</div>
+        <div class="action">Mark current selection</div>
+      </div>
+
+      <div class="pair">
+        <div class="command">?</div>
+        <div class="action">Show help</div>
+      </div>
+
+      <h2>Navigation</h2>
+      <div class="pair">
+        <div class="command">w/s</div><div class="action">Zoom in/out (+shift: faster)</div>
+      </div>
+
+      <div class="pair">
+        <div class="command">a/d</div>
+        <div class="action">Pan left/right (+shift: faster)</div>
+      </div>
+
+      <h2>Mouse Controls</h2>
+      <div class="pair">
+        <div class="command">click</div>
+        <div class="action">Select event</div>
+      </div>
+      <div class="pair">
+        <div class="command">alt-mousewheel</div>
+        <div class="action">Zoom in/out</div>
+      </div>
+
+    </td>
+
+     <td class="column">
+
+      <h2>   
+        Modes
+      </h2>
+      <h4> Select Mode </h4>
+      <div class="pair">
+        <div class="command">drag</div>
+        <div class="action">Box select</div>
+      </div>
+
+      <div class="pair">
+        <div class="command"><span class="mod"></span>-click/drag</div>
+        <div class="action">Add events to the current selection</div>
+      </div>
+
+      <div class="pair">
+        <div class="command">double click</div>
+        <div class="action">Select all events with same title</div>
+      </div>
+
+      <h4>
+        Pan mode
+      </h4>
+      <div class="pair">
+        <div class="command">drag</div>
+        <div class="action">Pan the view</div>
+      </div>
+
+      <h4>
+        Zoom mode
+      </h4>
+      <div class="pair">
+        <div class="command">drag</div>
+        <div class="action">Zoom in/out by dragging up/down</div>
+      </div>
+
+      <h4>
+        Timing mode
+      </h4>
+      <div class="pair">
+        <div class="command">drag</div>
+        <div class="action">Create or move markers</div>
+      </div>
+
+      <div class="pair">
+        <div class="command">double click</div>
+        <div class="action">Set marker range to slice</div>
+      </div>
+    </td>
+    </tr>
+   </table>
+
+</body>
+</html>
+

--- a/gapic/res/text/keyboard-mouse-help.html
+++ b/gapic/res/text/keyboard-mouse-help.html
@@ -1,3 +1,17 @@
+<!-- Copyright (C) 2019 Google Inc.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
 <!DOCTYPE html>
 <html>
 <head i18n-values="dir:textdirection;">
@@ -12,154 +26,160 @@
       display: flex;
       width: 700px;
     }
-    .pair {
-      flex: 1 1 auto;
-      flex-direction: row;
-      display: flex;
+
+    table.centered{
+	margin-left:auto; margin-right:auto; 
     }
     .column {
       padding: 0 40px 40px 0;
-      vertical-align: top;
+      vertical-align:top;
     }
     .command {
       font-family: monospace;
-      display:inline;
+      font-weight: bold;
       margin-right: 5px;
-      text-align: right;
-      min-width: 200px;
     }
     .action {
       font-size: 0.8em;
-      display:inline;
-      text-align: left;
-      min-width: 400px;
+    }
+    h2 {
+      font-weight: bold;
+      font-size: 1.2em;
     }
     h4 {
-      font-weight: bold;
+      padding: 3 0 0 0;
       font-size: 0.9em;
     }
 
     </style>
 
-    <table>
+    <table class="centered">
     <tr>
      
     <td class="column">
-      <h2>General</h2>
-      <div class="pair">
-        <div class="command">1-4</div>
-        <div class="action">Switch mouse mode</div>
-      </div>
+      <table>
+      <tr><td colspan=2><h2>General</h2></td></tr>
 
-      <div class="pair">
-        <div class="command">shift</div>
-        <div class="action">Hold for temporary select</div>
-      </div>
+      <tr class="pair">
+        <td class="command">1-4</td>
+        <td class="action">Switch mouse mode</td>
+      </tr>
 
-      <div class="pair">
-        <div class="command">space</div>
-        <div class="action">Hold for temporary pan</div>
-      </div>
+      <tr class="pair">
+        <td class="command">shift-drag</td>
+        <td class="action">Box-select</td>
+      </tr>
 
-      <div class="pair">
-        <div class="command">f</div>
-        <div class="action">Zoom into selection</div>
-      </div>
+      <tr class="pair">
+        <td class="command">ctrl-drag</td>
+        <td class="action">Time-select</td>
+      </tr>
 
-      <div class="pair">
-        <div class="command">z/0</div>
-        <div class="action">Reset zoom and pan</div>
-      </div>
+      <tr class="pair">
+        <td class="command">space-drag</td>
+        <td class="action">Vertical pan</td>
+      </tr>
 
-      <div class="pair">
-        <div class="command">v</div>
-        <div class="action">Highlight VSync</div>
-      </div>
-      <div class="pair">
-        <div class="command">m</div>
-        <div class="action">Mark current selection</div>
-      </div>
+      <tr class="pair">
+        <td class="command">f</td>
+        <td class="action">Zoom into selection</td>
+      </tr>
 
-      <div class="pair">
-        <div class="command">?</div>
-        <div class="action">Show help</div>
-      </div>
+      <tr class="pair">
+        <td class="command">z/0</td>
+        <td class="action">Reset zoom and pan</td>
+      </tr>
 
-      <h2>Navigation</h2>
-      <div class="pair">
-        <div class="command">w/s</div><div class="action">Zoom in/out (+shift: faster)</div>
-      </div>
+<!--      <tr class="pair">
+        <td class="command">v</td>
+        <td class="action">Highlight VSync</td>
+      </tr>
+-->
+      <tr class="pair">
+        <td class="command">m</td>
+        <td class="action">Mark current selection</td>
+      </tr>
 
-      <div class="pair">
-        <div class="command">a/d</div>
-        <div class="action">Pan left/right (+shift: faster)</div>
-      </div>
+      <tr class="pair">
+        <td class="command">?</td>
+        <td class="action">Show help</td>
+      </tr>
 
-      <h2>Mouse Controls</h2>
-      <div class="pair">
-        <div class="command">click</div>
-        <div class="action">Select event</div>
-      </div>
-      <div class="pair">
-        <div class="command">alt-mousewheel</div>
-        <div class="action">Zoom in/out</div>
-      </div>
+      <tr><td colspan=2><h2>Navigation</h2></td></tr>
+      <tr class="pair">
+        <td class="command">w/s (or Ctrl +/-) </td><td class="action">Zoom in/out (+shift: faster)</td>
+      </tr>
+
+      <tr class="pair">
+        <td class="command">a/d</td>
+        <td class="action">Pan left/right (+shift: faster)</td>
+      </tr>
+
+      <tr class="pair">
+        <td class="command">q/e</td>
+        <td class="action">Pan up/down (+shift: faster)</td>
+      </tr>
+
+
+      <tr><td colspan=2><h2>Mouse Controls</h2></td></tr>
+      <tr class="pair">
+        <td class="command">click</td>
+        <td class="action">Select event</td>
+      </tr>
+      <tr class="pair">
+        <td class="command">ctrl-mousewheel</td>
+        <td class="action">Zoom in/out</td>
+      </tr>
+      </table>
 
     </td>
 
      <td class="column">
 
-      <h2>   
+      <table>
+      <tr><td colspan=2><h2>   
         Modes
-      </h2>
-      <h4> Select Mode </h4>
-      <div class="pair">
-        <div class="command">drag</div>
-        <div class="action">Box select</div>
-      </div>
+      </h2></td></tr>
 
-      <div class="pair">
-        <div class="command"><span class="mod"></span>-click/drag</div>
-        <div class="action">Add events to the current selection</div>
-      </div>
+      <tr><td colspan=2><h4> Select Mode </h4></td></tr>
+      <tr class="pair">
+        <td class="command">drag</td>
+        <td class="action">Box select</td>
+      </tr>
 
-      <div class="pair">
-        <div class="command">double click</div>
-        <div class="action">Select all events with same title</div>
-      </div>
+<!--      <tr class="pair">
+        <td class="command"><span class="mod"></span>-click/drag</td>
+        <td class="action">Add events to the current selection</td>
+      </tr>
+-->
 
-      <h4>
+      <tr><td colspan=2><h4>
         Pan mode
-      </h4>
-      <div class="pair">
-        <div class="command">drag</div>
-        <div class="action">Pan the view</div>
-      </div>
+      </h4></td></tr>
+      <tr class="pair">
+        <td class="command">drag</td>
+        <td class="action">Pan the view</td>
+      </tr>
 
-      <h4>
+      <tr><td colspan=2><h4>
         Zoom mode
-      </h4>
-      <div class="pair">
-        <div class="command">drag</div>
-        <div class="action">Zoom in/out by dragging up/down</div>
-      </div>
+      </h4></td></tr>
+      <tr class="pair">
+        <td class="command">drag</td>
+        <td class="action">Zoom in/out by dragging up/down</td>
+      </tr>
 
-      <h4>
+      <tr><td colspan=2><h4>
         Timing mode
-      </h4>
-      <div class="pair">
-        <div class="command">drag</div>
-        <div class="action">Create or move markers</div>
-      </div>
-
-      <div class="pair">
-        <div class="command">double click</div>
-        <div class="action">Set marker range to slice</div>
-      </div>
+      </h4></td></tr>
+      <tr class="pair">
+        <td class="command">drag</td>
+        <td class="action">Create or move markers</td>
+      </tr>
+      </table>
     </td>
     </tr>
    </table>
-
 </body>
 </html>
 

--- a/gapic/src/main/com/google/gapid/models/Analytics.java
+++ b/gapic/src/main/com/google/gapid/models/Analytics.java
@@ -32,7 +32,7 @@ public class Analytics implements ExceptionHandler {
 
   public static enum View {
     Main, FilmStrip, LeftTabs, RightTabs,
-    About, GotoCommand, GotoMemory, Licenses, Settings, Trace, Welcome,
+    About, Help, GotoCommand, GotoMemory, Licenses, Settings, Trace, Welcome,
     // See MainWindow.MainTab.Type
     Commands, Framebuffer, Textures, Geometry, Shaders, Report, Log, State, Memory,
     ContextSelector, ReplayDeviceSelector;

--- a/gapic/src/main/com/google/gapid/perfetto/TraceView.java
+++ b/gapic/src/main/com/google/gapid/perfetto/TraceView.java
@@ -22,7 +22,7 @@ import static com.google.gapid.perfetto.views.StyleConstants.KB_ZOOM_FAST;
 import static com.google.gapid.perfetto.views.StyleConstants.KB_ZOOM_SLOW;
 import static com.google.gapid.perfetto.views.StyleConstants.ZOOM_FACTOR_SCALE;
 import static com.google.gapid.widgets.Widgets.createLabel;
-import static com.google.gapid.widgets.Widgets.createButton;
+import static com.google.gapid.widgets.Widgets.createButtonWithImage;
 import static com.google.gapid.widgets.Widgets.withLayoutData;
 import static com.google.gapid.widgets.Widgets.withMargin;
 
@@ -345,7 +345,7 @@ public class TraceView extends Composite
       createLabel(this, "Mode:");
       toolBar = withLayoutData(new ToolBar(this, SWT.FLAT | SWT.HORIZONTAL | SWT.TRAIL),
           new GridData(SWT.FILL, SWT.FILL, true, true));
-      createButton(this, "[?]", e -> KeyboardMouseHelpDialog.showHelp(getShell(), models.analytics, widgets));
+      createButtonWithImage(this, widgets.theme.help(), e -> KeyboardMouseHelpDialog.showHelp(getShell(), models.analytics, widgets));
     }
 
     public Consumer<RootPanel.MouseMode> buildModeActions(Theme theme, Consumer<MouseMode> onClick) {

--- a/gapic/src/main/com/google/gapid/perfetto/TraceView.java
+++ b/gapic/src/main/com/google/gapid/perfetto/TraceView.java
@@ -32,6 +32,7 @@ import com.google.gapid.perfetto.canvas.Area;
 import com.google.gapid.perfetto.canvas.PanelCanvas;
 import com.google.gapid.perfetto.models.Selection;
 import com.google.gapid.perfetto.models.Selection.MultiSelection;
+import com.google.gapid.perfetto.views.KeyboardMouseHelpDialog;
 import com.google.gapid.perfetto.views.RootPanel;
 import com.google.gapid.perfetto.views.RootPanel.MouseMode;
 import com.google.gapid.perfetto.views.SelectionView;
@@ -190,6 +191,9 @@ public class TraceView extends Composite
         case 'z':
         case '0':
           redraw = state.setVisibleTime(state.getTraceTime());
+          break;
+        case '?':
+          KeyboardMouseHelpDialog.showHelp(getShell(), models.analytics, widgets);
           break;
       }
 

--- a/gapic/src/main/com/google/gapid/perfetto/TraceView.java
+++ b/gapic/src/main/com/google/gapid/perfetto/TraceView.java
@@ -22,6 +22,7 @@ import static com.google.gapid.perfetto.views.StyleConstants.KB_ZOOM_FAST;
 import static com.google.gapid.perfetto.views.StyleConstants.KB_ZOOM_SLOW;
 import static com.google.gapid.perfetto.views.StyleConstants.ZOOM_FACTOR_SCALE;
 import static com.google.gapid.widgets.Widgets.createLabel;
+import static com.google.gapid.widgets.Widgets.createButton;
 import static com.google.gapid.widgets.Widgets.withLayoutData;
 import static com.google.gapid.widgets.Widgets.withMargin;
 
@@ -73,7 +74,9 @@ public class TraceView extends Composite
 
     setLayout(withMargin(new GridLayout(1, false), 0, 0));
 
-    TopBar topBar = withLayoutData(new TopBar(this), new GridData(SWT.FILL, SWT.TOP, true, false));
+    TopBar topBar = withLayoutData(new TopBar(this, models, widgets),
+        new GridData(SWT.FILL, SWT.TOP, true, false));
+
     loading = withLayoutData(
         new LoadablePanel<DrawerComposite>(this, widgets, p ->
           new DrawerComposite(p, SWT.NONE, models.settings.perfettoDrawerHeight, widgets.theme)),
@@ -192,6 +195,7 @@ public class TraceView extends Composite
         case '0':
           redraw = state.setVisibleTime(state.getTraceTime());
           break;
+        case 'h':
         case '?':
           KeyboardMouseHelpDialog.showHelp(getShell(), models.analytics, widgets);
           break;
@@ -335,12 +339,13 @@ public class TraceView extends Composite
   private static class TopBar extends Composite {
     private final ToolBar toolBar;
 
-    public TopBar(Composite parent) {
+    public TopBar(Composite parent, Models models, Widgets widgets) {
       super(parent, SWT.NONE);
-      setLayout(new GridLayout(2, false));
+      setLayout(new GridLayout(3, false));
       createLabel(this, "Mode:");
       toolBar = withLayoutData(new ToolBar(this, SWT.FLAT | SWT.HORIZONTAL | SWT.TRAIL),
           new GridData(SWT.FILL, SWT.FILL, true, true));
+      createButton(this, "[?]", e -> KeyboardMouseHelpDialog.showHelp(getShell(), models.analytics, widgets));
     }
 
     public Consumer<RootPanel.MouseMode> buildModeActions(Theme theme, Consumer<MouseMode> onClick) {

--- a/gapic/src/main/com/google/gapid/perfetto/views/KeyboardMouseHelpDialog.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/KeyboardMouseHelpDialog.java
@@ -44,12 +44,15 @@ import org.eclipse.swt.widgets.Text;
 import java.io.IOException;
 import java.util.logging.Logger;
 
+/**
+ * Dialog showing keyboard and mouse help for the trace view.
+ */
 public class KeyboardMouseHelpDialog {
 
   private static final Logger LOG = Logger.getLogger(KeyboardMouseHelpDialog.class.getName());
 
   public static void showHelp(Shell shell, Analytics analytics, Widgets widgets) {
-    analytics.postInteraction(View.About, ClientAction.Show);
+    analytics.postInteraction(View.Help, ClientAction.Show);
     new DialogBase(shell, widgets.theme) {
       @Override
       public String getTitle() {
@@ -98,8 +101,7 @@ public class KeyboardMouseHelpDialog {
 
   protected static String readKeyboardMouseHelp(boolean html) {
     try {
-      String result = Resources.toString(Resources.getResource("text/keyboard-mouse-help.html"), UTF_8);
-      return result;
+      return Resources.toString(Resources.getResource("text/keyboard-mouse-help.html"), UTF_8);
     } catch (IOException | IllegalArgumentException e) {
       LOG.log(SEVERE, "Failed to load help.", e);
       return "Failed to load help.";

--- a/gapic/src/main/com/google/gapid/perfetto/views/KeyboardMouseHelpDialog.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/KeyboardMouseHelpDialog.java
@@ -18,6 +18,7 @@ package com.google.gapid.perfetto.views;
 import com.google.common.io.Resources;
 import static java.util.logging.Level.SEVERE;
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static com.google.gapid.widgets.Widgets.withSizeHints;
 
 import com.google.gapid.models.Analytics;
 import com.google.gapid.models.Analytics.View;
@@ -71,20 +72,17 @@ public class KeyboardMouseHelpDialog {
           Text text = new Text(
               area, SWT.MULTI | SWT.READ_ONLY | SWT.BORDER | SWT.H_SCROLL | SWT.V_SCROLL);
           text.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
-          text.setText(readKeyboardMouseHelp(false));
+          text.setText(readKeyboardMouseHelp());
           return text;
         }
 
-        GridData data = new GridData(SWT.FILL, SWT.FILL, true, true);
-        data.widthHint = 850;
-        data.heightHint = 650;
-        browser.setLayoutData(data);
-        browser.setText(readKeyboardMouseHelp(true));
+        browser.setLayoutData(withSizeHints(new GridData(SWT.FILL, SWT.FILL, true, true), 1024, 768));
+        browser.setText(readKeyboardMouseHelp());
         browser.addLocationListener(new LocationAdapter() {
           @Override
           public void changing(LocationEvent event) {
             if ("about:blank".equals(event.location)) {
-              browser.setText(readKeyboardMouseHelp(true));
+              browser.setText(readKeyboardMouseHelp());
             }
           }
         });
@@ -99,7 +97,7 @@ public class KeyboardMouseHelpDialog {
     }.open();
   }
 
-  protected static String readKeyboardMouseHelp(boolean html) {
+  protected static String readKeyboardMouseHelp() {
     try {
       return Resources.toString(Resources.getResource("text/keyboard-mouse-help.html"), UTF_8);
     } catch (IOException | IllegalArgumentException e) {

--- a/gapic/src/main/com/google/gapid/perfetto/views/KeyboardMouseHelpDialog.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/KeyboardMouseHelpDialog.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (C) 2019 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.gapid.perfetto.views;
+
+import com.google.common.io.Resources;
+import static java.util.logging.Level.SEVERE;
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import com.google.gapid.models.Analytics;
+import com.google.gapid.models.Analytics.View;
+import com.google.gapid.models.Info;
+import com.google.gapid.proto.service.Service.ClientAction;
+import com.google.gapid.util.Logging;
+import com.google.gapid.util.Messages;
+import com.google.gapid.util.OS;
+import com.google.gapid.widgets.DialogBase;
+import com.google.gapid.widgets.Widgets;
+
+import org.eclipse.jface.dialogs.IDialogConstants;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.SWTError;
+import org.eclipse.swt.browser.Browser;
+import org.eclipse.swt.browser.LocationAdapter;
+import org.eclipse.swt.browser.LocationEvent;
+import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Control;
+import org.eclipse.swt.widgets.Shell;
+import org.eclipse.swt.widgets.Text;
+
+import java.io.IOException;
+import java.util.logging.Logger;
+
+public class KeyboardMouseHelpDialog {
+
+  private static final Logger LOG = Logger.getLogger(KeyboardMouseHelpDialog.class.getName());
+
+  public static void showHelp(Shell shell, Analytics analytics, Widgets widgets) {
+    analytics.postInteraction(View.About, ClientAction.Show);
+    new DialogBase(shell, widgets.theme) {
+      @Override
+      public String getTitle() {
+        return Messages.KEYBOARD_MOUSE_HELP_TITLE;
+      }
+
+      @Override
+      protected Control createDialogArea(Composite parent) {
+        Composite area = (Composite)super.createDialogArea(parent);
+
+        Browser browser;
+        try {
+          browser = new Browser(area, SWT.NONE);
+        } catch (SWTError e) {
+          // Failed to initialize the browser. Show it as a plain text widget.
+          Text text = new Text(
+              area, SWT.MULTI | SWT.READ_ONLY | SWT.BORDER | SWT.H_SCROLL | SWT.V_SCROLL);
+          text.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
+          text.setText(readKeyboardMouseHelp(false));
+          return text;
+        }
+
+        GridData data = new GridData(SWT.FILL, SWT.FILL, true, true);
+        data.widthHint = 800;
+        data.heightHint = 600;
+        browser.setLayoutData(data);
+        browser.setText(readKeyboardMouseHelp(true));
+        browser.addLocationListener(new LocationAdapter() {
+          @Override
+          public void changing(LocationEvent event) {
+            if ("about:blank".equals(event.location)) {
+              browser.setText(readKeyboardMouseHelp(true));
+            }
+          }
+        });
+        return area;
+      }
+
+      @Override
+      protected void createButtonsForButtonBar(Composite parent) {
+        createButton(parent, IDialogConstants.OK_ID, IDialogConstants.OK_LABEL, true);
+      }
+
+    }.open();
+  }
+
+  protected static String readKeyboardMouseHelp(boolean html) {
+    try {
+      String result = Resources.toString(Resources.getResource("text/keyboard-mouse-help.html"), UTF_8);
+      return result;
+    } catch (IOException | IllegalArgumentException e) {
+      LOG.log(SEVERE, "Failed to load help.", e);
+      return "Failed to load help.";
+    }
+  }
+}

--- a/gapic/src/main/com/google/gapid/perfetto/views/KeyboardMouseHelpDialog.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/KeyboardMouseHelpDialog.java
@@ -73,8 +73,8 @@ public class KeyboardMouseHelpDialog {
         }
 
         GridData data = new GridData(SWT.FILL, SWT.FILL, true, true);
-        data.widthHint = 800;
-        data.heightHint = 600;
+        data.widthHint = 850;
+        data.heightHint = 650;
         browser.setLayoutData(data);
         browser.setText(readKeyboardMouseHelp(true));
         browser.addLocationListener(new LocationAdapter() {

--- a/gapic/src/main/com/google/gapid/util/Messages.java
+++ b/gapic/src/main/com/google/gapid/util/Messages.java
@@ -82,5 +82,5 @@ public interface Messages {
   public static final String GEO_SEMANTICS_TITLE = "Vertex Semantics";
   public static final String GEO_SEMANTICS_HINT = "Manually configure the vertex stream semantics:";
   public static final String QUERY_VIEW_WINDOW_TITLE = "GAPID - Query Shell";
-  public static final String KEYBOARD_MOUSE_HELP_TITLE = "Keyboard/Mouse shortcut help";
+  public static final String KEYBOARD_MOUSE_HELP_TITLE = "Keyboard/Mouse Shortcut Help";
 }

--- a/gapic/src/main/com/google/gapid/util/Messages.java
+++ b/gapic/src/main/com/google/gapid/util/Messages.java
@@ -82,4 +82,5 @@ public interface Messages {
   public static final String GEO_SEMANTICS_TITLE = "Vertex Semantics";
   public static final String GEO_SEMANTICS_HINT = "Manually configure the vertex stream semantics:";
   public static final String QUERY_VIEW_WINDOW_TITLE = "GAPID - Query Shell";
+  public static final String KEYBOARD_MOUSE_HELP_TITLE = "Keyboard/Mouse shortcut help";
 }

--- a/gapic/src/main/com/google/gapid/widgets/Widgets.java
+++ b/gapic/src/main/com/google/gapid/widgets/Widgets.java
@@ -368,6 +368,13 @@ public class Widgets {
     return result;
   }
 
+  public static Button createButtonWithImage(Composite parent, Image image, Listener listener) {
+    Button result = new Button(parent, SWT.PUSH);
+    result.setImage(image);
+    result.addListener(SWT.Selection, listener);
+    return result;
+  }
+
   public static Spinner createSpinner(Composite parent, int value, int min, int max) {
     Spinner result = new Spinner(parent, SWT.BORDER);
     // Avoid not being able to update the minimum value.


### PR DESCRIPTION
Added a browser-based dialog to display help about keyboard / mouse shortcuts.

It includes a basic HTML with the data, it can be greatly improved with some love. UX-wise, the dialog requires a click into the browser widget before it can be closed pressing Escape. Apparently it's a difficult problem.