### PR TITLE
Add vulkan sample to Kokoro builds

### DIFF
--- a/cmd/vulkan_sample/main.cpp
+++ b/cmd/vulkan_sample/main.cpp
@@ -109,7 +109,7 @@ bool CreateNativeWindow(int width, int height) {
     write_error(kOutHandle, "Could not register class");
     return false;
   }
-  RECT rect = {0, 0, LONG(width), LONG(heigth)};
+  RECT rect = {0, 0, LONG(width), LONG(height)};
 
   AdjustWindowRect(&rect, WS_OVERLAPPEDWINDOW, FALSE);
 
@@ -379,7 +379,7 @@ uint32_t inline GetMemoryIndex(
 
 void usage() {
   std::cout << "Options: \n";
-  std::cout << "-h=<height> Set desktop window heigth (default: 768)\n";
+  std::cout << "-h=<height> Set desktop window height (default: 768)\n";
   std::cout << "-w=<width>  Set desktop window width (default: 1024)\n";
 }
 

--- a/kokoro/linux/build.sh
+++ b/kokoro/linux/build.sh
@@ -63,6 +63,9 @@ done
 # Build the package and symbol file.
 build //:pkg //cmd/gapir/cc:gapir.sym
 
+# Build the Vulkan sample
+build //cmd/vulkan_sample:vulkan_sample
+
 # Build and run the smoketests.
 build //cmd/smoketests:smoketests
 echo $(date): Run smoketests...

--- a/kokoro/windows/build.bat
+++ b/kokoro/windows/build.bat
@@ -83,7 +83,7 @@ REM Build everything else.
 %BUILD_ROOT%\bazel build -c opt --config symbols ^
     --define GAPID_BUILD_NUMBER="%KOKORO_BUILD_NUMBER%" ^
     --define GAPID_BUILD_SHA="%BUILD_SHA%" ^
-    //:pkg //cmd/gapir/cc:gapir.sym //cmd/smoketests
+    //:pkg //cmd/gapir/cc:gapir.sym //cmd/smoketests //cmd/vulkan_sample:vulkan_sample
 if %ERRORLEVEL% GEQ 1 exit /b %ERRORLEVEL%
 echo %DATE% %TIME%
 


### PR DESCRIPTION
Add for Linux and Windows, as the sample is not ported to MacOS.
Fix typos in the sample along the way.