### PR TITLE
Set flush_period_ms and fill_policy=DISCARD in Perfetto config

### DIFF
--- a/gapic/src/main/com/google/gapid/perfetto/views/TraceConfigDialog.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/TraceConfigDialog.java
@@ -25,6 +25,7 @@ import static com.google.gapid.widgets.Widgets.withLayoutData;
 import static com.google.gapid.widgets.Widgets.withMargin;
 import static java.util.concurrent.TimeUnit.HOURS;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static java.util.stream.Collectors.toSet;
 
 import com.google.gapid.models.Models;
@@ -57,6 +58,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import perfetto.protos.PerfettoConfig;
+import perfetto.protos.PerfettoConfig.TraceConfig.BufferConfig.FillPolicy;
 
 public class TraceConfigDialog extends DialogBase {
   private static final int BUFFER_SIZE = 131072;
@@ -234,7 +236,9 @@ public class TraceConfigDialog extends DialogBase {
     }
 
     config.addBuffers(PerfettoConfig.TraceConfig.BufferConfig.newBuilder()
-        .setSizeKb((largeBuffer ? 8 : 1) * BUFFER_SIZE));
+        .setSizeKb((largeBuffer ? 8 : 1) * BUFFER_SIZE)
+        .setFillPolicy(FillPolicy.DISCARD));
+    config.setFlushPeriodMs((int)SECONDS.toMillis(5));
 
     if (largeBuffer) {
       config.setWriteIntoFile(true);


### PR DESCRIPTION
As we are using a single trace buffer for all data sources, set its fill_policy
to DISCARD and set flush_period_ms. This solves issues with losing information
when the size of the buffer is exceeded.

Bug: b/146036410