### PR TITLE
Add 'Report a bug' option in the menu.

### DIFF
--- a/gapic/src/main/com/google/gapid/MainWindow.java
+++ b/gapic/src/main/com/google/gapid/MainWindow.java
@@ -45,6 +45,7 @@ import com.google.gapid.util.Messages;
 import com.google.gapid.util.OS;
 import com.google.gapid.util.StatusWatcher;
 import com.google.gapid.util.UpdateWatcher;
+import com.google.gapid.util.URLs;
 import com.google.gapid.views.StatusBar;
 import com.google.gapid.widgets.CopyPaste;
 import com.google.gapid.widgets.LoadablePanel;
@@ -374,6 +375,8 @@ public class MainWindow extends ApplicationWindow {
     manager.add(MenuItems.HelpShowLogs.create(() -> showLogDir(models.analytics)));
     manager.add(MenuItems.HelpLicenses.create(
         () -> showLicensesDialog(getShell(), models.analytics, widgets.theme)));
+    manager.add(MenuItems.HelpFileBug.create(
+        () -> Program.launch(URLs.FILE_BUG_URL)));
     return manager;
   }
 
@@ -438,7 +441,8 @@ public class MainWindow extends ApplicationWindow {
     HelpOnlineHelp("&Online Help\tF1", SWT.F1),
     HelpAbout("&About"),
     HelpShowLogs("Open &Log Directory"),
-    HelpLicenses("&Licenses");
+    HelpLicenses("&Licenses"),
+    HelpFileBug("File a &Bug on Github");
 
     public static final String FILE_ID = "file";
     public static final String VIEW_ID = "view";

--- a/gapic/src/main/com/google/gapid/MainWindow.java
+++ b/gapic/src/main/com/google/gapid/MainWindow.java
@@ -442,7 +442,7 @@ public class MainWindow extends ApplicationWindow {
     HelpAbout("&About"),
     HelpShowLogs("Open &Log Directory"),
     HelpLicenses("&Licenses"),
-    HelpFileBug("File a &Bug on Github");
+    HelpFileBug("File a &Bug");
 
     public static final String FILE_ID = "file";
     public static final String VIEW_ID = "view";

--- a/gapic/src/main/com/google/gapid/util/URLs.java
+++ b/gapic/src/main/com/google/gapid/util/URLs.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2019 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.gapid.util;
+
+public interface URLs {
+  public static final String FILE_BUG_URL =
+      "https://github.com/google/gapid/issues/new?template=standard-bug-report-for-gapid.md";
+}

--- a/gapic/src/main/com/google/gapid/views/ErrorDialog.java
+++ b/gapic/src/main/com/google/gapid/views/ErrorDialog.java
@@ -24,8 +24,6 @@ import static com.google.gapid.widgets.Widgets.withLayoutData;
 import static com.google.gapid.widgets.Widgets.withSizeHints;
 import static com.google.gapid.widgets.Widgets.withSpans;
 
-import com.google.common.escape.Escaper;
-import com.google.common.net.UrlEscapers;
 import com.google.gapid.models.Analytics;
 import com.google.gapid.models.Analytics.View;
 import com.google.gapid.proto.service.Service.ClientAction;
@@ -135,7 +133,7 @@ public class ErrorDialog {
         Composite inner = createComposite(details, new GridLayout(1, false));
         withLayoutData(createTextbox(inner, DETAILS_STYLE, detailString),
             new GridData(SWT.FILL, SWT.FILL, true, true));
-        withLayoutData(createLink(inner, "<a>File a bug</a> on GitHub", e -> {
+        withLayoutData(createLink(inner, "<a>File a bug</a>", e -> {
           Program.launch(URLs.FILE_BUG_URL);
         }), new GridData(SWT.RIGHT, SWT.BOTTOM, false, false));
         withLayoutData(createLink(inner, "<a>Show logs</a> directory", e -> {

--- a/gapic/src/main/com/google/gapid/views/ErrorDialog.java
+++ b/gapic/src/main/com/google/gapid/views/ErrorDialog.java
@@ -30,6 +30,7 @@ import com.google.gapid.models.Analytics;
 import com.google.gapid.models.Analytics.View;
 import com.google.gapid.proto.service.Service.ClientAction;
 import com.google.gapid.util.Messages;
+import com.google.gapid.util.URLs;
 
 import org.eclipse.jface.dialogs.IDialogConstants;
 import org.eclipse.jface.dialogs.IconAndMessageDialog;
@@ -54,8 +55,6 @@ public class ErrorDialog {
   private static final int MAX_DETAILS_SIZE = 300;
   private static final int DETAILS_STYLE =
       SWT.MULTI | SWT.BORDER | SWT.H_SCROLL | SWT.V_SCROLL | SWT.READ_ONLY;
-  private static final String FILE_BUG_URL =
-      "https://github.com/google/gapid/issues/new?title=%s&body=%s&labels=user";
 
   public static void showErrorDialog(
       Shell shell, Analytics analytics, String text, Throwable exception) {
@@ -137,16 +136,11 @@ public class ErrorDialog {
         withLayoutData(createTextbox(inner, DETAILS_STYLE, detailString),
             new GridData(SWT.FILL, SWT.FILL, true, true));
         withLayoutData(createLink(inner, "<a>File a bug</a> on GitHub", e -> {
-          Program.launch(getFileBugUrl());
+          Program.launch(URLs.FILE_BUG_URL);
         }), new GridData(SWT.RIGHT, SWT.BOTTOM, false, false));
         withLayoutData(createLink(inner, "<a>Show logs</a> directory", e -> {
           AboutDialog.showLogDir(analytics);
         }), new GridData(SWT.RIGHT, SWT.BOTTOM, false, false));
-      }
-
-      private String getFileBugUrl() {
-        Escaper esc = UrlEscapers.urlFormParameterEscaper();
-        return String.format(FILE_BUG_URL, esc.escape(text), esc.escape(Messages.BUG_BODY));
       }
 
       @Override


### PR DESCRIPTION
Also, use the standard bug template by default in the menu and in the error dialog. This way the title is empty and the user is forced to give a meaningful one before submitting it).