### PR TITLE
Add null check for vulkanCPUTiming checkbox.

### DIFF
--- a/gapic/src/main/com/google/gapid/perfetto/views/TraceConfigDialog.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/TraceConfigDialog.java
@@ -525,6 +525,9 @@ public class TraceConfigDialog extends DialogBase {
     }
 
     private void updateVulkan() {
+      if (vulkanCPUTiming == null) {
+        return;
+      }
       boolean enabled = vulkanCPUTiming.getSelection();
       vulkanCPUTimingInstance.setEnabled(enabled);
       vulkanCPUTimingPhysicalDevice.setEnabled(enabled);


### PR DESCRIPTION
The vulkanCPUTiming checkbox may not be created, hence do an early return if it
doesn't exist.

BUG: N/A
Test: build gapid, manually select System Profile and click on Configure button.