### PR TITLE
Lower the counter quantize cut off.

### DIFF
--- a/gapic/src/main/com/google/gapid/perfetto/models/Track.java
+++ b/gapic/src/main/com/google/gapid/perfetto/models/Track.java
@@ -47,7 +47,7 @@ import java.util.logging.Logger;
 public abstract class Track<D extends Track.Data> {
   private static final Logger LOG = Logger.getLogger(Track.class.getName());
 
-  public static final long QUANTIZE_CUT_OFF = 10000;
+  public static final long QUANTIZE_CUT_OFF = 2000;
 
   private static final long REQUEST_DELAY_MS = 50;
   private static final long ACQUIRE_TIMEOUT_MS = 5;


### PR DESCRIPTION
At 2000 it's still > 1 sample per pixel even on large monitors.