### PR TITLE
Show name for pseudonym type fields within Struct

### DIFF
--- a/gapic/src/main/com/google/gapid/models/Memory.java
+++ b/gapic/src/main/com/google/gapid/models/Memory.java
@@ -605,7 +605,6 @@ public class Memory extends DeviceDependentModel<Memory.Data, Memory.Source, Voi
         case STRUCT:
           TypeInfo.StructType struct = type.getStruct();
           List<TypeInfo.StructField> childrenTypes = struct.getFieldsList();
-
           List<MemoryBox.Value> childrenValues = value.getStruct().getFieldsList();
           for (int i = 0; i < childrenValues.size(); i++) {
             StructNode childNode = new StructNode(api,
@@ -629,7 +628,9 @@ public class Memory extends DeviceDependentModel<Memory.Data, Memory.Source, Voi
         case PSEUDONYM:
           TypeInfo.PseudonymType pseudonym = type.getPseudonym();
           childType = typesModel.getType(type(pseudonym.getUnderlying(), api));
-          children.add(new StructNode(api, childType, value, rootAddress, typesModel, structName));
+          StructNode childNode = new StructNode(api, childType, value, rootAddress, typesModel);
+          children.add(childNode);
+          childNode.setStructName(structName);
           break;
         default:
           break;

--- a/gapic/src/main/com/google/gapid/models/Memory.java
+++ b/gapic/src/main/com/google/gapid/models/Memory.java
@@ -512,6 +512,17 @@ public class Memory extends DeviceDependentModel<Memory.Data, Memory.Source, Voi
       this.children = loadChildren();
     }
 
+    public StructNode(Path.API api, TypeInfo.Type type, MemoryBox.Value value, long rootAddress,
+        MemoryTypes typesModel, String name) {
+      this.api = api;
+      this.type = type;
+      this.value = value;
+      this.rootAddress = rootAddress;
+      this.typesModel = typesModel;
+      this.structName = name;
+      this.children = loadChildren();
+    }
+
     public TypeInfo.Type getType() {
       return type;
     }
@@ -594,12 +605,12 @@ public class Memory extends DeviceDependentModel<Memory.Data, Memory.Source, Voi
         case STRUCT:
           TypeInfo.StructType struct = type.getStruct();
           List<TypeInfo.StructField> childrenTypes = struct.getFieldsList();
+
           List<MemoryBox.Value> childrenValues = value.getStruct().getFieldsList();
           for (int i = 0; i < childrenValues.size(); i++) {
             StructNode childNode = new StructNode(api,
                 typesModel.getType(type(childrenTypes.get(i).getType(), api)), childrenValues.get(i),
-                rootAddress, typesModel);
-            childNode.setStructName(childrenTypes.get(i).getName());
+                rootAddress, typesModel, childrenTypes.get(i).getName());
             children.add(childNode);
           }
           break;
@@ -618,7 +629,7 @@ public class Memory extends DeviceDependentModel<Memory.Data, Memory.Source, Voi
         case PSEUDONYM:
           TypeInfo.PseudonymType pseudonym = type.getPseudonym();
           childType = typesModel.getType(type(pseudonym.getUnderlying(), api));
-          children.add(new StructNode(api, childType, value, rootAddress, typesModel));
+          children.add(new StructNode(api, childType, value, rootAddress, typesModel, structName));
           break;
         default:
           break;


### PR DESCRIPTION
If a member of a struct is typedef'd multiple times, the name is lost due to the way Pseudonym children are created. This fixes the creation of children by passing the name all the way down to the innermost pseudonym.
http://b/142882406