### PR TITLE
Perfetto Client Tracing Support

### DIFF
--- a/cmd/perfetto/BUILD.bazel
+++ b/cmd/perfetto/BUILD.bazel
@@ -34,6 +34,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//core/app:go_default_library",
+        "//core/app/crash:go_default_library",
         "//core/log:go_default_library",
         "//core/os/android/adb:go_default_library",
         "//core/os/device/bind:go_default_library",

--- a/cmd/perfetto/BUILD.bazel
+++ b/cmd/perfetto/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
     srcs = [
         "main.go",
         "query.go",
+        "trace.go",
     ],
     data = select({
         "//tools/build:no-android": [],
@@ -38,7 +39,10 @@ go_library(
         "//core/os/device/bind:go_default_library",
         "//core/os/device/remotessh:go_default_library",
         "//gapidapk:go_default_library",
+        "//gapis/perfetto:go_default_library",
         "//tools/build/third_party/perfetto:common_go_proto",
+        "//tools/build/third_party/perfetto:config_go_proto",
+        "@com_github_golang_protobuf//proto:go_default_library",
     ],
 )
 

--- a/cmd/perfetto/main.go
+++ b/cmd/perfetto/main.go
@@ -21,10 +21,12 @@ import (
 	"os"
 
 	"github.com/google/gapid/core/app"
+	"github.com/google/gapid/core/log"
 	"github.com/google/gapid/core/os/android/adb"
 	"github.com/google/gapid/core/os/device/bind"
 	"github.com/google/gapid/core/os/device/remotessh"
 	_ "github.com/google/gapid/gapidapk"
+	"github.com/google/gapid/gapis/perfetto"
 )
 
 var (
@@ -62,4 +64,15 @@ func setupContext(ctx context.Context) context.Context {
 	}
 
 	return ctx
+}
+
+func connectToPerfetto(ctx context.Context, d bind.Device) (*perfetto.Client, error) {
+	log.I(ctx, "Connecting to Perfetto...")
+	c, err := d.ConnectPerfetto(ctx)
+	if err != nil {
+		log.E(ctx, "Failed to connect to perfetto: %s", err)
+		return nil, err
+	}
+	log.I(ctx, "Connected.")
+	return c, nil
 }

--- a/cmd/perfetto/query.go
+++ b/cmd/perfetto/query.go
@@ -50,14 +50,11 @@ func (verb *queryVerb) Run(ctx context.Context, flags flag.FlagSet) error {
 			continue
 		}
 
-		log.I(ctx, "Connecting to Perfetto...")
-		c, err := d.ConnectPerfetto(ctx)
+		c, err := connectToPerfetto(ctx, d)
 		if err != nil {
-			log.E(ctx, "Failed to connect to perfetto: %s", err)
 			return err
 		}
 		defer c.Close(ctx)
-		log.I(ctx, "Connected.")
 
 		if err := c.Query(ctx, func(r *common.TracingServiceState) error {
 			jsonBytes, err := json.MarshalIndent(r, "", "  ")

--- a/cmd/perfetto/trace.go
+++ b/cmd/perfetto/trace.go
@@ -15,14 +15,17 @@
 package main
 
 import (
+	"bufio"
 	"context"
 	"errors"
 	"flag"
+	"fmt"
 	"io/ioutil"
 	"os"
 
 	"github.com/golang/protobuf/proto"
 	"github.com/google/gapid/core/app"
+	"github.com/google/gapid/core/app/crash"
 	"github.com/google/gapid/core/log"
 	"github.com/google/gapid/core/os/device/bind"
 
@@ -78,6 +81,15 @@ func (verb *traceVerb) Run(ctx context.Context, flags flag.FlagSet) error {
 	if err != nil {
 		return log.Errf(ctx, err, "Failed to start Perfetto trace")
 	}
+
+	crash.Go(func() {
+		reader := bufio.NewReader(os.Stdin)
+		fmt.Println("Press enter to stop capturing...")
+		if _, err := reader.ReadString('\n'); err != nil {
+			return
+		}
+		sess.Stop(ctx)
+	})
 
 	if err := sess.Wait(ctx); err != nil {
 		return log.Errf(ctx, err, "Perfetto trace failed")

--- a/cmd/perfetto/trace.go
+++ b/cmd/perfetto/trace.go
@@ -84,6 +84,14 @@ func (verb *traceVerb) Run(ctx context.Context, flags flag.FlagSet) error {
 
 	crash.Go(func() {
 		reader := bufio.NewReader(os.Stdin)
+		if cfg.GetDeferredStart() {
+			fmt.Println("Press enter to start capturing...")
+			if _, err := reader.ReadString('\n'); err != nil {
+				return
+			}
+			sess.Start(ctx)
+		}
+
 		fmt.Println("Press enter to stop capturing...")
 		if _, err := reader.ReadString('\n'); err != nil {
 			return

--- a/cmd/perfetto/trace.go
+++ b/cmd/perfetto/trace.go
@@ -1,0 +1,110 @@
+// Copyright (C) 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"io/ioutil"
+	"os"
+
+	"github.com/golang/protobuf/proto"
+	"github.com/google/gapid/core/app"
+	"github.com/google/gapid/core/log"
+	"github.com/google/gapid/core/os/device/bind"
+
+	config "protos/perfetto/config"
+)
+
+type traceVerb struct {
+	Config string `help:"File containing the trace configuration proto."`
+	Out    string `help:"The file to store the trace data in."`
+}
+
+func init() {
+	verb := &traceVerb{
+		Out: "trace.perfetto",
+	}
+	app.AddVerb(&app.Verb{
+		Name:      "trace",
+		ShortHelp: "Captures a Perfetto trace",
+		Action:    verb,
+	})
+}
+
+func (verb *traceVerb) Run(ctx context.Context, flags flag.FlagSet) error {
+	if verb.Config == "" {
+		app.Usage(ctx, "The Perfetto trace config is required.")
+		return nil
+	}
+	cfg, err := verb.readConfig(ctx)
+	if err != nil {
+		return err
+	}
+
+	out, err := os.Create(verb.Out)
+	if err != nil {
+		return log.Errf(ctx, err, "Failed to create output file")
+	}
+	defer out.Close()
+
+	ctx = setupContext(ctx)
+
+	d, err := findDevice(ctx)
+	if err != nil {
+		return err
+	}
+
+	c, err := connectToPerfetto(ctx, d)
+	if err != nil {
+		return err
+	}
+	defer c.Close(ctx)
+
+	sess, err := c.Trace(ctx, cfg, out)
+	if err != nil {
+		return log.Errf(ctx, err, "Failed to start Perfetto trace")
+	}
+
+	if err := sess.Wait(ctx); err != nil {
+		return log.Errf(ctx, err, "Perfetto trace failed")
+	}
+
+	return nil
+}
+
+func (verb *traceVerb) readConfig(ctx context.Context) (*config.TraceConfig, error) {
+	data, err := ioutil.ReadFile(verb.Config)
+	if err != nil {
+		return nil, log.Errf(ctx, err, "Failed to read the trace config")
+	}
+	cfg := &config.TraceConfig{}
+	if err := proto.UnmarshalText(string(data), cfg); err != nil {
+		return nil, log.Errf(ctx, err, "Failed to parse Perfetto config")
+	}
+	return cfg, nil
+}
+
+func findDevice(ctx context.Context) (bind.Device, error) {
+	for _, d := range bind.GetRegistry(ctx).Devices() {
+		if !d.SupportsPerfetto(ctx) {
+			log.I(ctx, "Device %s doesn't support Perfetto", d)
+			continue
+		}
+		return d, nil
+	}
+	return nil, errors.New("No Perfetto supporting device found")
+}

--- a/gapis/perfetto/BUILD.bazel
+++ b/gapis/perfetto/BUILD.bazel
@@ -27,10 +27,12 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//core/app:go_default_library",
+        "//core/event/task:go_default_library",
         "//core/log:go_default_library",
         "//gapis/perfetto/client:go_default_library",
         "//gapis/perfetto/service:go_default_library",
         "//tools/build/third_party/perfetto:common_go_proto",
+        "//tools/build/third_party/perfetto:config_go_proto",
         "//tools/build/third_party/perfetto:ipc_go_proto",
         "@com_github_golang_protobuf//proto:go_default_library",
     ],

--- a/gapis/perfetto/client.go
+++ b/gapis/perfetto/client.go
@@ -33,6 +33,7 @@ const (
 	consumerService = "ConsumerPort"
 	queryMethod     = "QueryServiceState"
 	traceMethod     = "EnableTracing"
+	startMethod     = "StartTracing"
 	stopMethod      = "DisableTracing"
 	readMethod      = "ReadBuffers"
 )
@@ -89,11 +90,12 @@ func (c *Client) Query(ctx context.Context, cb func(*common.TracingServiceState)
 
 // TraceSession is the interface to a currently running Perfetto trace.
 type TraceSession struct {
-	conn *client.Connection
-	wait task.Signal
-	done task.Task
-	stop *client.Method
-	err  error
+	conn  *client.Connection
+	wait  task.Signal
+	done  task.Task
+	start *client.Method
+	stop  *client.Method
+	err   error
 }
 
 // Trace initiates a new Perfetto trace session using the given config. The
@@ -101,18 +103,24 @@ type TraceSession struct {
 // RPC that can be controlled/waited on using the returned trace session.
 func (c *Client) Trace(ctx context.Context, cfg *config.TraceConfig, out io.Writer) (*TraceSession, error) {
 	trace, okTrace := c.methods[traceMethod]
+	start, _ := c.methods[startMethod] // ignore missing start
 	stop, okStop := c.methods[stopMethod]
 	read, okRead := c.methods[readMethod]
 	if !okTrace || !okStop || !okRead {
 		return nil, errors.New("Remote service doesn't have the trace methods")
 	}
 
+	if !cfg.GetDeferredStart() {
+		start = nil
+	}
+
 	wait, done := task.NewSignal()
 	s := &TraceSession{
-		conn: c.conn,
-		wait: wait,
-		done: done,
-		stop: stop,
+		conn:  c.conn,
+		wait:  wait,
+		done:  done,
+		start: start,
+		stop:  stop,
 	}
 
 	pw := client.NewPacketWriter(out)
@@ -147,6 +155,22 @@ func (c *Client) readBuffers(ctx context.Context, m *client.Method, s *TraceSess
 	s.onResult(ctx, c.conn.Invoke(ctx, m, &ipc.ReadBuffersRequest{}, h))
 }
 
+// Start starts the currently deferred trace of this session. Does nothing, if
+// the Perfetto service doesn't support deferred tracing or the trace was not
+// started in deferred mode.
+func (s *TraceSession) Start(ctx context.Context) {
+	if s.start == nil || s.wait.Fired() {
+		// Ignore any starts if the trace was not defferred or after we've
+		// already marked this session as done
+		return
+	}
+
+	h := client.NewIgnoreHandler(ctx, func(err error) {
+		s.onResult(ctx, err)
+	})
+	s.onResult(ctx, s.conn.Invoke(ctx, s.start, &ipc.StartTracingRequest{}, h))
+}
+
 // Stop stops the currently running trace of this session.
 func (s *TraceSession) Stop(ctx context.Context) {
 	if s.wait.Fired() {
@@ -154,15 +178,9 @@ func (s *TraceSession) Stop(ctx context.Context) {
 		return
 	}
 
-	h := func(data []byte, more bool, err error) {
-		if s.onResult(ctx, err) {
-			return
-		}
-		if more {
-			s.onResult(ctx, errors.New("Got a streaming response to a DisableTrace request"))
-			return
-		}
-	}
+	h := client.NewIgnoreHandler(ctx, func(err error) {
+		s.onResult(ctx, err)
+	})
 	s.onResult(ctx, s.conn.Invoke(ctx, s.stop, &ipc.DisableTracingRequest{}, h))
 }
 

--- a/gapis/perfetto/client.go
+++ b/gapis/perfetto/client.go
@@ -17,18 +17,24 @@ package perfetto
 import (
 	"context"
 	"errors"
+	"io"
 	"net"
 
 	"github.com/google/gapid/core/app"
+	"github.com/google/gapid/core/event/task"
 	"github.com/google/gapid/gapis/perfetto/client"
 
 	common "protos/perfetto/common"
+	config "protos/perfetto/config"
 	ipc "protos/perfetto/ipc"
 )
 
 const (
 	consumerService = "ConsumerPort"
 	queryMethod     = "QueryServiceState"
+	traceMethod     = "EnableTracing"
+	stopMethod      = "DisableTracing"
+	readMethod      = "ReadBuffers"
 )
 
 // Client is a client ("consumer") of a Perfetto service.
@@ -79,6 +85,92 @@ func (c *Client) Query(ctx context.Context, cb func(*common.TracingServiceState)
 		return err
 	}
 	return query.Wait(ctx)
+}
+
+// TraceSession is the interface to a currently running Perfetto trace.
+type TraceSession struct {
+	wait task.Signal
+	done task.Task
+	err  error
+}
+
+// Trace initiates a new Perfetto trace session using the given config. The
+// trace buffers will be serialized to the given writer. This is an asynchronous
+// RPC that can be controlled/waited on using the returned trace session.
+func (c *Client) Trace(ctx context.Context, cfg *config.TraceConfig, out io.Writer) (*TraceSession, error) {
+	trace, okTrace := c.methods[traceMethod]
+	stop, okStop := c.methods[stopMethod]
+	read, okRead := c.methods[readMethod]
+	if !okTrace || !okStop || !okRead {
+		return nil, errors.New("Remote service doesn't have the trace methods")
+	}
+	_ = stop
+
+	wait, done := task.NewSignal()
+	s := &TraceSession{
+		wait: wait,
+		done: done,
+	}
+
+	pw := client.NewPacketWriter(out)
+
+	h := client.NewTraceHandler(ctx, func(r *ipc.EnableTracingResponse, err error) {
+		if s.err == nil && err != nil {
+			s.err = err
+		}
+
+		if err != nil {
+			s.done(ctx)
+			return
+		}
+		c.readBuffers(ctx, read, s, pw)
+	})
+
+	if err := c.conn.Invoke(ctx, trace, &ipc.EnableTracingRequest{TraceConfig: cfg}, h); err != nil {
+		return nil, err
+	}
+
+	return s, nil
+}
+
+func (c *Client) readBuffers(ctx context.Context, m *client.Method, s *TraceSession, out *client.PacketWriter) {
+	h := client.NewReadHandler(ctx, func(r *ipc.ReadBuffersResponse, more bool, err error) {
+		if s.err == nil && err != nil {
+			s.err = err
+		}
+
+		if err != nil {
+			s.done(ctx)
+			return
+		}
+
+		if err := out.Write(r.Slices); err != nil {
+			if s.err == nil {
+				s.err = err
+			}
+			s.done(ctx)
+			return
+		}
+
+		if !more {
+			s.done(ctx)
+		}
+	})
+	if err := c.conn.Invoke(ctx, m, &ipc.ReadBuffersRequest{}, h); err != nil {
+		if s.err == nil {
+			s.err = err
+		}
+		s.done(ctx)
+	}
+}
+
+// Wait waits for this trace session to finish and returns any error encountered
+// during the trace.
+func (s *TraceSession) Wait(ctx context.Context) error {
+	if !s.wait.Wait(ctx) {
+		return task.StopReason(ctx)
+	}
+	return s.err
 }
 
 // Close closes the underlying connection to the Perfetto service of this client.

--- a/gapis/perfetto/client/BUILD.bazel
+++ b/gapis/perfetto/client/BUILD.bazel
@@ -21,6 +21,7 @@ go_library(
         "doc.go",
         "proto.go",
         "sync.go",
+        "writer.go",
     ],
     importpath = "github.com/google/gapid/gapis/perfetto/client",
     visibility = ["//visibility:public"],

--- a/gapis/perfetto/client/proto.go
+++ b/gapis/perfetto/client/proto.go
@@ -16,6 +16,7 @@ package client
 
 import (
 	"context"
+	"errors"
 
 	"github.com/golang/protobuf/proto"
 
@@ -33,4 +34,42 @@ func NewQuerySync(ctx context.Context, cb func(*common.TracingServiceState) erro
 		}
 		return cb(resp.GetServiceState())
 	})
+}
+
+// NewTraceHandler returns an InvokeHandler that handles unmarshalling the proto
+// bytes of an EnableTrace response and invokes the given callback.
+func NewTraceHandler(ctx context.Context, cb func(*ipc.EnableTracingResponse, error)) InvokeHandler {
+	return func(data []byte, more bool, err error) {
+		if err != nil {
+			cb(nil, err)
+			return
+		}
+		if more {
+			cb(nil, errors.New("Got a streaming reply to the non-stream EnableTracing RPC"))
+			return
+		}
+		resp := &ipc.EnableTracingResponse{}
+		if err := proto.Unmarshal(data, resp); err != nil {
+			cb(nil, err)
+			return
+		}
+		cb(resp, nil)
+	}
+}
+
+// NewReadHandler returns an InvokeHandler that handles unmarshalling the proto
+// bytes of a ReadBuffers response and invokes the given callback.
+func NewReadHandler(ctx context.Context, cb func(*ipc.ReadBuffersResponse, bool, error)) InvokeHandler {
+	return func(data []byte, more bool, err error) {
+		if err != nil {
+			cb(nil, false, err)
+			return
+		}
+		resp := &ipc.ReadBuffersResponse{}
+		if err := proto.Unmarshal(data, resp); err != nil {
+			cb(nil, false, err)
+			return
+		}
+		cb(resp, more, nil)
+	}
 }

--- a/gapis/perfetto/client/proto.go
+++ b/gapis/perfetto/client/proto.go
@@ -73,3 +73,19 @@ func NewReadHandler(ctx context.Context, cb func(*ipc.ReadBuffersResponse, bool,
 		cb(resp, more, nil)
 	}
 }
+
+// NewIgnoreHandler returns an InvokeHanlder that ignores the returned result,
+// but propagates errors and ensure the response is not streaming.
+func NewIgnoreHandler(ctx context.Context, cb func(error)) InvokeHandler {
+	return func(data []byte, more bool, err error) {
+		if err != nil {
+			cb(err)
+			return
+		}
+		if more {
+			cb(errors.New("Got a streaming response to non-streaming request"))
+			return
+		}
+		cb(nil)
+	}
+}

--- a/gapis/perfetto/client/writer.go
+++ b/gapis/perfetto/client/writer.go
@@ -1,0 +1,65 @@
+// Copyright (C) 2019 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+import (
+	"io"
+
+	"github.com/golang/protobuf/proto"
+
+	ipc "protos/perfetto/ipc"
+)
+
+const (
+	tag = (1 << 3) /* tag id */ | 2 /* type */
+)
+
+// PacketWriter serializes Perfetto packets to a Writer.
+type PacketWriter struct {
+	out    io.Writer
+	buffer []byte
+}
+
+// NewPacketWriter returns a packet writer that serializes to the given writer.
+func NewPacketWriter(out io.Writer) *PacketWriter {
+	return &PacketWriter{out: out}
+}
+
+// Write serializes the given packet slices.
+func (w *PacketWriter) Write(slices []*ipc.ReadBuffersResponse_Slice) error {
+	b := w.buffer
+	for _, s := range slices {
+		b = append(b, s.Data...)
+		if s.GetLastSliceForPacket() {
+			if err := w.write(b); err != nil {
+				w.buffer = nil
+				return err
+			}
+			b = nil
+		}
+	}
+	w.buffer = b
+	return nil
+}
+
+func (w *PacketWriter) write(packet []byte) error {
+	buf := make([]byte, 0, 1+10)
+	b := proto.NewBuffer(buf)
+	b.EncodeVarint(tag)
+	b.EncodeVarint(uint64(len(packet)))
+	buf = append(b.Bytes(), packet...)
+	_, err := w.out.Write(buf)
+	return err
+}


### PR DESCRIPTION
Adds support for tracing (including deferred tracing) to the Perfetto client. This can be tested via the `cmd/perfetto` utility, but is not yet actually used for tracing inside `gapis`.