### PR TITLE
Add a 250ms sleep after starting a Perfetto trace

### DIFF
--- a/core/event/task/task.go
+++ b/core/event/task/task.go
@@ -37,6 +37,17 @@ func Once(task Task) Task {
 	}
 }
 
+// Delay wraps a task in a coroutine to asynchronously execute after a specified duration
+func Delay(task Task, duration time.Duration) Task {
+	return func(ctx context.Context) error {
+		crash.Go(func() {
+			time.Sleep(duration)
+			task(ctx)
+		})
+		return nil
+	}
+}
+
 func Noop() Task {
 	return func(context.Context) error {
 		return nil

--- a/core/os/android/adb/perfetto.go
+++ b/core/os/android/adb/perfetto.go
@@ -23,6 +23,7 @@ import (
 	"io"
 	"regexp"
 	"strings"
+	"time"
 
 	perfetto_pb "protos/perfetto/config"
 
@@ -45,7 +46,8 @@ func (b *binding) StartPerfettoTrace(ctx context.Context, config *perfetto_pb.Tr
 
 	reader, stdout := io.Pipe()
 	logRing := ring.New(10)
-	readyOnce := task.Once(ready)
+	// TODO(apbodnar) Find a way to reliably know when Perfetto/producers are ready (b/147388497)
+	readyOnce := task.Once(task.Delay(ready, 250*time.Millisecond))
 	data, err := proto.Marshal(config)
 	if err != nil {
 		return err


### PR DESCRIPTION
Hack to unblock @pmuetschard . In some cases, the producer isn't quite ready.