### PR TITLE
Fix a problem the frame loop will crash .

### DIFF
--- a/gapis/api/vulkan/frame_loop.go
+++ b/gapis/api/vulkan/frame_loop.go
@@ -2986,7 +2986,9 @@ func (f *frameLoop) resetQueryPools(ctx context.Context, stateBuilder *stateBuil
 	for toCreate := range f.queryPoolToCreate {
 		// Write the commands needed to recreate the destroyed object
 		queryPool := GetState(f.loopStartState).queryPools.Get(toCreate)
-		stateBuilder.createQueryPool(queryPool)
+		if !queryPool.IsNil() {
+			stateBuilder.createQueryPool(queryPool)
+		}
 	}
 
 	return nil


### PR DESCRIPTION
currently the query pool will be re-created if the pool has been
written to. If the trace is captured from beginning, then the device
will be re-created when looping, thus make the pool object invalid.

This fixed issue #3623 