### PR TITLE
Frame Lifecycle - Add highlight for selected events

### DIFF
--- a/gapic/src/main/com/google/gapid/perfetto/canvas/RenderContext.java
+++ b/gapic/src/main/com/google/gapid/perfetto/canvas/RenderContext.java
@@ -177,6 +177,15 @@ public class RenderContext implements Fonts.TextMeasurer, AutoCloseable {
     gc.fillPolygon(points);
   }
 
+  public void drawPolygon(double[] xPoints, double[] yPoints, int n) {
+    int[] points = new int[2 * n];
+    for (int i = 0, j = 0; i < n; i++, j += 2) {
+      points[j + 0] = scale(xPoints[i]);
+      points[j + 1] = scale(yPoints[i]);
+    }
+    gc.drawPolygon(points);
+  }
+
   // x, y is top left corner of text.
   public void drawText(Fonts.Style style, String text, double x, double y) {
     if (style != lastFontStyle) {

--- a/gapic/src/main/com/google/gapid/perfetto/models/FrameEventsTrack.java
+++ b/gapic/src/main/com/google/gapid/perfetto/models/FrameEventsTrack.java
@@ -35,7 +35,9 @@ import com.google.gapid.perfetto.TimeSpan;
 import com.google.gapid.perfetto.views.FrameEventsMultiSelectionView;
 import com.google.gapid.perfetto.views.FrameEventsSelectionView;
 import com.google.gapid.perfetto.views.State;
+import com.google.gapid.perfetto.views.StyleConstants;
 
+import org.eclipse.swt.graphics.RGBA;
 import org.eclipse.swt.widgets.Composite;
 
 import java.util.List;
@@ -73,6 +75,19 @@ public class FrameEventsTrack extends Track.WithQueryEngine<FrameEventsTrack.Dat
 
   public static FrameEventsTrack forBuffer(QueryEngine qe, GpuInfo.Buffer buffer) {
     return new FrameEventsTrack(qe, buffer.trackId);
+  }
+
+  public static RGBA getColor(String title) {
+    return colorForSlice(title, 0);
+  }
+
+  public static RGBA getBorderColor(String title) {
+    return colorForSlice(title, StyleConstants.isLight() ? -5 : 5);
+  }
+
+  private static RGBA colorForSlice(String title, int shadeIdx) {
+    return StyleConstants.Palette.getColor(
+        (title.hashCode() ^ title.length()) & 0x7fffffff, shadeIdx);
   }
 
   @Override

--- a/gapic/src/main/com/google/gapid/perfetto/views/FrameEventsSelectionView.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/FrameEventsSelectionView.java
@@ -47,6 +47,9 @@ public class FrameEventsSelectionView extends Composite {
         new GridData(SWT.LEFT, SWT.TOP, false, false));
     withLayoutData(createBoldLabel(main, "Slice:"), withSpans(new GridData(), 2, 1));
 
+    createLabel(main, "Name:");
+    createLabel(main, slice.name);
+
     createLabel(main, "Time:");
     createLabel(main, timeToString(slice.time - state.getTraceTime().start));
 


### PR DESCRIPTION
The frame lifecycle events did not highlight when selected and this can get confusing. This patch adds a few fixes to it and a minor refactor to the color scheme as well.