### PR TITLE
Check command Mutate errors when calling MutateCmds

### DIFF
--- a/gapis/api/cmd_foreach.go
+++ b/gapis/api/cmd_foreach.go
@@ -71,10 +71,9 @@ func ForeachCmd(ctx context.Context, cmds []Cmd, onlyTerminated bool, cb func(co
 
 // MutateCmds calls Mutate on each of cmds.
 func MutateCmds(ctx context.Context, state *GlobalState, builder *builder.Builder,
-	watcher StateWatcher, cmds ...Cmd) {
-	ForeachCmd(ctx, cmds, true, func(ctx context.Context, id CmdID, cmd Cmd) error {
-		cmd.Mutate(ctx, id, state, builder, watcher)
-		return nil
+	watcher StateWatcher, cmds ...Cmd) error {
+	return ForeachCmd(ctx, cmds, true, func(ctx context.Context, id CmdID, cmd Cmd) error {
+		return cmd.Mutate(ctx, id, state, builder, watcher)
 	})
 }
 

--- a/gapis/api/test/intrinsics_test.go
+++ b/gapis/api/test/intrinsics_test.go
@@ -33,10 +33,11 @@ func TestClone(t *testing.T) {
 	s := api.NewStateWithEmptyAllocator(device.Little32)
 	cb := CommandBuilder{Thread: 0, Arena: s.Arena}
 	expected := []byte{0x54, 0x33, 0x42, 0x43, 0x46, 0x34, 0x63, 0x24, 0x14, 0x24}
-	api.MutateCmds(ctx, s, nil, nil,
+	err := api.MutateCmds(ctx, s, nil, nil,
 		cb.CmdClone(p(0x1234), 10).
 			AddRead(memory.Store(ctx, s.MemoryLayout, p(0x1234), expected)),
 	)
+	assert.For(ctx, "err").ThatError(err).Succeeded()
 	got, err := GetState(s).U8s().Read(ctx, nil, s, nil)
 	if assert.For(ctx, "err").ThatError(err).Succeeded() {
 		assert.For(ctx, "got").ThatSlice(got).Equals(expected)
@@ -50,9 +51,10 @@ func TestMake(t *testing.T) {
 	cb := CommandBuilder{Thread: 0, Arena: s.Arena}
 	idOfFirstPool, _ := s.Memory.New()
 	assert.For(ctx, "initial NextPoolID").That(idOfFirstPool).Equals(memory.PoolID(1))
-	api.MutateCmds(ctx, s, nil, nil,
+	err := api.MutateCmds(ctx, s, nil, nil,
 		cb.CmdMake(10),
 	)
+	assert.For(ctx, "err").ThatError(err).Succeeded()
 	assert.For(ctx, "buffer count").That(GetState(s).U8s().Size()).Equals(uint64(10))
 	idOfOneAfterLastPool, _ := s.Memory.New()
 	assert.For(ctx, "final NextPoolID").That(idOfOneAfterLastPool).Equals(memory.PoolID(3))
@@ -65,11 +67,12 @@ func TestCopy(t *testing.T) {
 	s := api.NewStateWithEmptyAllocator(device.Little32)
 	cb := CommandBuilder{Thread: 0, Arena: s.Arena}
 	expected := []byte{0x54, 0x33, 0x42, 0x43, 0x46, 0x34, 0x63, 0x24, 0x14, 0x24}
-	api.MutateCmds(ctx, s, nil, nil,
+	err := api.MutateCmds(ctx, s, nil, nil,
 		cb.CmdMake(10),
 		cb.CmdCopy(p(0x1234), 10).
 			AddRead(memory.Store(ctx, s.MemoryLayout, p(0x1234), expected)),
 	)
+	assert.For(ctx, "err").ThatError(err).Succeeded()
 	got, err := GetState(s).U8s().Read(ctx, nil, s, nil)
 	if assert.For(ctx, "err").ThatError(err).Succeeded() {
 		assert.For(ctx, "got").ThatSlice(got).Equals(expected)
@@ -82,10 +85,11 @@ func TestCharsliceToString(t *testing.T) {
 	s := api.NewStateWithEmptyAllocator(device.Little32)
 	cb := CommandBuilder{Thread: 0, Arena: s.Arena}
 	expected := "ħęľĺő ŵōřŀď"
-	api.MutateCmds(ctx, s, nil, nil,
+	err := api.MutateCmds(ctx, s, nil, nil,
 		cb.CmdCharsliceToString(p(0x1234), uint32(len(expected))).
 			AddRead(memory.Store(ctx, s.MemoryLayout, p(0x1234), expected)),
 	)
+	assert.For(ctx, "err").ThatError(err).Succeeded()
 	assert.For(ctx, "Data").That(GetState(s).Str()).Equals(expected)
 }
 
@@ -95,10 +99,11 @@ func TestCharptrToString(t *testing.T) {
 	s := api.NewStateWithEmptyAllocator(device.Little32)
 	cb := CommandBuilder{Thread: 0, Arena: s.Arena}
 	expected := "ħęľĺő ŵōřŀď"
-	api.MutateCmds(ctx, s, nil, nil,
+	err := api.MutateCmds(ctx, s, nil, nil,
 		cb.CmdCharptrToString(p(0x1234)).
 			AddRead(memory.Store(ctx, s.MemoryLayout, p(0x1234), expected)),
 	)
+	assert.For(ctx, "err").ThatError(err).Succeeded()
 	assert.For(ctx, "Data").That(GetState(s).Str()).Equals(expected)
 }
 
@@ -110,9 +115,10 @@ func TestSliceCasts(t *testing.T) {
 	l := s.MemoryLayout.Clone()
 	l.Integer.Size = 6 // non-multiple of u16
 	s.MemoryLayout = l
-	api.MutateCmds(ctx, s, nil, nil,
+	err := api.MutateCmds(ctx, s, nil, nil,
 		cb.CmdSliceCasts(p(0x1234), 10),
 	)
+	assert.For(ctx, "err").ThatError(err).Succeeded()
 	for _, test := range []struct {
 		name        string
 		got, expect memory.Slice

--- a/gapis/api/test/subroutines_test.go
+++ b/gapis/api/test/subroutines_test.go
@@ -33,7 +33,8 @@ func TestSubAdd(t *testing.T) {
 	defer a.Dispose()
 	cb := CommandBuilder{Thread: 0, Arena: a}
 	s := api.NewStateWithEmptyAllocator(device.Little32)
-	api.MutateCmds(ctx, s, nil, nil, cb.CmdAdd(10, 20))
+	err := api.MutateCmds(ctx, s, nil, nil, cb.CmdAdd(10, 20))
+	assert.For(ctx, "err").ThatError(err).Succeeded()
 	got, err := GetState(s).Ints().Read(ctx, nil, s, nil)
 	expected := []memory.Int{30}
 	if assert.For(ctx, "err").ThatError(err).Succeeded() {

--- a/gapis/resolve/memory.go
+++ b/gapis/resolve/memory.go
@@ -164,7 +164,10 @@ func Memory(ctx context.Context, p *path.Memory, rc *path.ResolveConfig) (*servi
 	})
 
 	lastCmd := cmds[len(cmds)-1]
-	api.MutateCmds(ctx, s, nil, nil, lastCmd)
+	err = api.MutateCmds(ctx, s, nil, nil, lastCmd)
+	if err != nil {
+		return nil, err
+	}
 
 	typedRanges = filterTypedRanges(typedRanges)
 


### PR DESCRIPTION
cmd.Mutate() may return an error. MutateCmds() is wrapping calls to
cmd.Mutate(), but did not do proper error checking. This change adds
error checking there, and in all callers of MutateCmds().