### PR TITLE
Crash early upon cmd.Mutate() error in all MutateAndWrite()

### DIFF
--- a/gapis/api/sync/BUILD.bazel
+++ b/gapis/api/sync/BUILD.bazel
@@ -24,6 +24,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//core/app/status:go_default_library",
+        "//core/log:go_default_library",
         "//gapis/api:go_default_library",
         "//gapis/api/transform:go_default_library",
         "//gapis/capture:go_default_library",

--- a/gapis/api/sync/sync.go
+++ b/gapis/api/sync/sync.go
@@ -24,6 +24,7 @@ import (
 	"context"
 
 	"github.com/google/gapid/core/app/status"
+	"github.com/google/gapid/core/log"
 	"github.com/google/gapid/gapis/api"
 	"github.com/google/gapid/gapis/api/transform"
 	"github.com/google/gapid/gapis/capture"
@@ -80,7 +81,10 @@ type writer struct {
 func (s *writer) State() *api.GlobalState { return s.state }
 
 func (s *writer) MutateAndWrite(ctx context.Context, id api.CmdID, cmd api.Cmd) {
-	cmd.Mutate(ctx, id, s.state, nil, nil)
+	err := cmd.Mutate(ctx, id, s.state, nil, nil)
+	if err != nil {
+		log.F(ctx, true, "Fail to mutate command %v: %v", cmd, err)
+	}
 	s.cmds = append(s.cmds, cmd)
 }
 

--- a/gapis/api/transform/recorder.go
+++ b/gapis/api/transform/recorder.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"reflect"
 
+	"github.com/google/gapid/core/log"
 	"github.com/google/gapid/gapis/api"
 )
 
@@ -38,7 +39,10 @@ func (r *Recorder) State() *api.GlobalState {
 // and if the Recorder has a state, mutates this state object.
 func (r *Recorder) MutateAndWrite(ctx context.Context, id api.CmdID, cmd api.Cmd) {
 	if r.S != nil {
-		cmd.Mutate(ctx, id, r.S, nil, nil)
+		err := cmd.Mutate(ctx, id, r.S, nil, nil)
+		if err != nil {
+			log.F(ctx, true, "Fail to mutate command %v: %v", cmd, err)
+		}
 	}
 	r.Cmds = append(r.Cmds, cmd)
 	r.CmdsAndIDs = append(r.CmdsAndIDs, CmdAndID{cmd, id})

--- a/gapis/api/transform/transformer.go
+++ b/gapis/api/transform/transformer.go
@@ -55,7 +55,8 @@ type Writer interface {
 	// State returns the state object associated with this writer.
 	State() *api.GlobalState
 	// MutateAndWrite mutates the state object associated with this writer,
-	// and it passes the command to further consumers.
+	// and it passes the command to further consumers. It must panic if the
+	// mutation fails with an error.
 	MutateAndWrite(ctx context.Context, id api.CmdID, cmd api.Cmd)
 	//Notify next transformer it's ready to start loop the trace.
 	NotifyPreLoop(ctx context.Context)

--- a/gapis/api/transform/transforms.go
+++ b/gapis/api/transform/transforms.go
@@ -17,6 +17,7 @@ package transform
 import (
 	"context"
 
+	"github.com/google/gapid/core/log"
 	"github.com/google/gapid/gapis/api"
 	"github.com/google/gapid/gapis/config"
 )
@@ -104,7 +105,10 @@ func (p TransformWriter) State() *api.GlobalState {
 
 func (p TransformWriter) MutateAndWrite(ctx context.Context, id api.CmdID, cmd api.Cmd) {
 	if config.SeparateMutateStates || p.O.State() != p.S {
-		cmd.Mutate(ctx, id, p.S, nil, nil /* no builder, no watcher, just mutate */)
+		err := cmd.Mutate(ctx, id, p.S, nil, nil /* no builder, no watcher, just mutate */)
+		if err != nil {
+			log.F(ctx, true, "Fail to mutate command %v: %v", cmd, err)
+		}
 	}
 	p.T.Transform(ctx, id, cmd, p.O)
 }

--- a/gapis/replay/batch.go
+++ b/gapis/replay/batch.go
@@ -401,7 +401,7 @@ func (w *adapter) MutateAndWrite(ctx context.Context, id api.CmdID, cmd api.Cmd)
 		w.builder.CommitCommand()
 	} else {
 		w.builder.RevertCommand(err)
-		log.W(ctx, "Failed to write command %v %v for replay: %v", id, cmd, err)
+		log.F(ctx, true, "Failed to write command %v %v for replay: %v", id, cmd, err)
 	}
 }
 func (w *adapter) NotifyPreLoop(ctx context.Context)  {}


### PR DESCRIPTION
If cmd.Mutate() leads to an error, then we cannot trust the state to
be valid anymore. MutateAndWrite() wraps calls to cmd.Mutate(), this
change makes sure to crash early (here, using log.F()) upon any
cmd.Mutate() error.

We can think of propagating the error above MutateAndWrite(). Yet,
MutateAndWrite() is part of the TransformWriter interface, and there
is no obvious way to enforce developers working on Transforms to
properly handle possible errors returned by MutateAndWrite() in the
logic of their transform.

As a middle ground, we choose to have MutateAndWrite() crash early
upon any cmd.Mutate(). Again, we cannot strictly enforce that, it is
just documented in the interface comment.

Bug: b/145003736