### PR TITLE
Marshal ProfilingData message to text instead of json in gapit

### DIFF
--- a/cmd/gapit/flags.go
+++ b/cmd/gapit/flags.go
@@ -384,6 +384,7 @@ type (
 	GpuProfileFlags struct {
 		Gapis GapisFlags
 		Gapir GapirFlags
+		Json  bool `help:"Return replay profiling data as JSON instead of text"`
 	}
 
 	CreateGraphVisualizationFlags struct {

--- a/cmd/gapit/profile.go
+++ b/cmd/gapit/profile.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/golang/protobuf/proto"
 	"github.com/google/gapid/core/app"
 	"github.com/google/gapid/core/log"
 	"github.com/google/gapid/gapis/service"
@@ -73,10 +74,18 @@ func (verb *profileVerb) Run(ctx context.Context, flags flag.FlagSet) error {
 	if err != nil {
 		return err
 	}
-	jsonBytes, err := json.MarshalIndent(res, "", "  ")
-	if err != nil {
-		fmt.Fprintf(os.Stdout, "%v\n", log.Err(ctx, err, "Couldn't marshal trace to JSON"))
+
+	if verb.Json {
+		jsonBytes, err := json.MarshalIndent(res, "", "  ")
+		if err != nil {
+			return log.Err(ctx, err, "Couldn't marshal trace to JSON")
+		}
+		fmt.Fprintln(os.Stdout, string(jsonBytes))
+	} else {
+		err = proto.MarshalText(os.Stdout, res)
+		if err != nil {
+			return log.Err(ctx, err, "Couldn't marshal trace to text")
+		}
 	}
-	fmt.Fprintln(os.Stdout, string(jsonBytes))
 	return nil
 }


### PR DESCRIPTION
Fix for b/147736754  Infinities emitted by the QC producer break converting the proto to json when calling `gapit profile <some.gfxtrace>`  Writing text works fine though.