### PR TITLE
Remove hasGpuRenderStages from being required for GPU capabilities

### DIFF
--- a/gapic/src/main/com/google/gapid/perfetto/views/TraceConfigDialog.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/TraceConfigDialog.java
@@ -220,7 +220,7 @@ public class TraceConfigDialog extends DialogBase {
 
       Device.GPUProfiling gpuCaps = caps.getGpuProfiling();
       SettingsProto.Perfetto.GPUOrBuilder gpu = p.getGpuOrBuilder();
-      if (gpuCaps.getHasRenderStage() && gpu.getSlices()) {
+      if (gpu.getSlices()) {
         config.addDataSourcesBuilder()
             .getConfigBuilder()
                 .setName("gpu.renderstages");
@@ -381,11 +381,7 @@ public class TraceConfigDialog extends DialogBase {
         Composite gpuGroup = withLayoutData(
             createComposite(this, withMargin(new GridLayout(1, false), 5, 0)),
             withIndents(new GridData(), GROUP_INDENT, 0));
-        if (gpuCaps.getHasRenderStage()) {
-          gpuSlices = createCheckbox(gpuGroup, "Renderstage slices", sGpu.getSlices());
-        } else {
-          gpuSlices = null;
-        }
+        gpuSlices = createCheckbox(gpuGroup, "Renderstage slices", sGpu.getSlices());
 
         if (gpuCaps.getGpuCounterDescriptor().getSpecsCount() > 0) {
           gpuCounters = createCheckbox(

--- a/gapic/src/main/com/google/gapid/views/TracerDialog.java
+++ b/gapic/src/main/com/google/gapid/views/TracerDialog.java
@@ -486,7 +486,7 @@ public class TracerDialog {
             return;
           }
           Device.GPUProfiling gpuCaps = getPerfettoCaps().getGpuProfiling();
-          if (gpuCaps.getHasRenderStage() && gpuCaps.getGpuCounterDescriptor().getSpecsCount() > 0) {
+          if (gpuCaps.getGpuCounterDescriptor().getSpecsCount() > 0) {
             gpuProfilingCapabilityWarning.setVisible(false);
             return;
           }


### PR DESCRIPTION
Lack of gpu.renderstages producer should not disable GPU profiling
when doing a System profile.

The gpu.renderstages producer may be part of the graphics driver and
would not be running until the app started.

Bug: b/147723153