### PR TITLE
Add systematic cmd.Mutate() error propagation

### DIFF
--- a/gapis/api/cmd_foreach.go
+++ b/gapis/api/cmd_foreach.go
@@ -73,7 +73,10 @@ func ForeachCmd(ctx context.Context, cmds []Cmd, onlyTerminated bool, cb func(co
 func MutateCmds(ctx context.Context, state *GlobalState, builder *builder.Builder,
 	watcher StateWatcher, cmds ...Cmd) error {
 	return ForeachCmd(ctx, cmds, true, func(ctx context.Context, id CmdID, cmd Cmd) error {
-		return cmd.Mutate(ctx, id, state, builder, watcher)
+		if err := cmd.Mutate(ctx, id, state, builder, watcher); err != nil {
+			return fmt.Errorf("Fail to mutate command %v: %v", cmd, err)
+		}
+		return nil
 	})
 }
 

--- a/gapis/api/gles/compat_test.go
+++ b/gapis/api/gles/compat_test.go
@@ -16,6 +16,7 @@ package gles_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/google/gapid/core/assert"
@@ -132,7 +133,7 @@ func TestGlVertexAttribPointerCompatTest(t *testing.T) {
 	var found bool
 	err = api.ForeachCmd(ctx, r.Cmds, true, func(ctx context.Context, id api.CmdID, cmd api.Cmd) error {
 		if err := cmd.Mutate(ctx, id, s, nil, nil); err != nil {
-			return err
+			return fmt.Errorf("Fail to mutate command %v: %v", cmd, err)
 		}
 
 		if _, ok := cmd.(*gles.GlDrawElements); ok {

--- a/gapis/api/gvr/framebindings.go
+++ b/gapis/api/gvr/framebindings.go
@@ -16,6 +16,7 @@ package gvr
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/google/gapid/gapis/api"
 	"github.com/google/gapid/gapis/api/gles"
@@ -73,7 +74,7 @@ func (r *FrameBindingsResolvable) Resolve(ctx context.Context) (interface{}, err
 	}
 	frameToBuffer := map[GvrFrameᵖ]gles.FramebufferId{}
 
-	api.ForeachCmd(ctx, cmds, true, func(ctx context.Context, id api.CmdID, cmd api.Cmd) error {
+	err = api.ForeachCmd(ctx, cmds, true, func(ctx context.Context, id api.CmdID, cmd api.Cmd) error {
 		switch cmd := cmd.(type) {
 		case *Gvr_frame_submit:
 			// Annoyingly gvr_frame_submit takes a pointer to the frame pointer,
@@ -97,9 +98,15 @@ func (r *FrameBindingsResolvable) Resolve(ctx context.Context) (interface{}, err
 				}
 			}
 		}
-		cmd.Mutate(ctx, id, s, nil, nil)
+		if err := cmd.Mutate(ctx, id, s, nil, nil); err != nil {
+			return fmt.Errorf("Fail to mutate cmd %v: %v", cmd, err)
+		}
 		return nil
 	})
+
+	if err != nil {
+		return nil, err
+	}
 
 	return out, nil
 }

--- a/gapis/api/test/mutate_test.go
+++ b/gapis/api/test/mutate_test.go
@@ -61,7 +61,8 @@ func (test test) check(ctx context.Context, ca, ra *device.MemoryLayout) {
 
 	api.ForeachCmd(ctx, test.cmds, true, func(ctx context.Context, id api.CmdID, cmd api.Cmd) error {
 		b.BeginCommand(uint64(id), 0)
-		cmd.Mutate(ctx, id, s, b, nil)
+		err := cmd.Mutate(ctx, id, s, b, nil)
+		assert.For(ctx, "Mutate command").ThatError(err).Succeeded()
 		b.CommitCommand()
 		return nil
 	})

--- a/gapis/api/vulkan/custom_replay.go
+++ b/gapis/api/vulkan/custom_replay.go
@@ -436,6 +436,9 @@ func (a *VkAcquireNextImageKHR) Mutate(ctx context.Context, id api.CmdID, s *api
 	// This is to pass the returned image index value captured in the trace, into the replay device to acquire for the specific image.
 	// Note that this is only necessary for building replay instructions
 	err := a.mutate(ctx, id, s, nil, w)
+	if err != nil {
+		return err
+	}
 	if b != nil {
 		l := s.MemoryLayout
 		// Ensure that the builder reads pImageIndex (which points to the correct image index at this point).
@@ -450,6 +453,9 @@ func (a *VkAcquireNextImage2KHR) Mutate(ctx context.Context, id api.CmdID, s *ap
 	// This is to pass the returned image index value captured in the trace, into the replay device to acquire for the specific image.
 	// Note that this is only necessary for building replay instructions
 	err := a.mutate(ctx, id, s, nil, w)
+	if err != nil {
+		return err
+	}
 	if b != nil {
 		l := s.MemoryLayout
 		// Ensure that the builder reads pImageIndex (which points to the correct image index at this point).

--- a/gapis/api/vulkan/vulkan.go
+++ b/gapis/api/vulkan/vulkan.go
@@ -359,7 +359,7 @@ func (API) ResolveSynchronization(ctx context.Context, d *sync.Data, c *path.Cap
 	err = api.ForeachCmd(ctx, cmds, true, func(ctx context.Context, id api.CmdID, cmd api.Cmd) error {
 		i = id
 		if err := cmd.Mutate(ctx, id, st, nil, nil); err != nil {
-			return err
+			return fmt.Errorf("Fail to mutate command %v: %v", cmd, err)
 		}
 		return nil
 	})
@@ -703,8 +703,8 @@ func (API) MutateSubcommands(ctx context.Context, id api.CmdID, cmd api.Cmd,
 			preSubCmdCb(s, append(api.SubCmdIdx{uint64(id)}, c.SubCmdIdx...), cmd)
 		}
 	}
-	if err := cmd.Mutate(ctx, id, s, nil, nil); err != nil && err == context.Canceled {
-		return err
+	if err := cmd.Mutate(ctx, id, s, nil, nil); err != nil {
+		return fmt.Errorf("Fail to mutate command %v: %v", cmd, err)
 	}
 	return nil
 }

--- a/gapis/resolve/contexts.go
+++ b/gapis/resolve/contexts.go
@@ -101,7 +101,9 @@ func (r *ContextListResolvable) Resolve(ctx context.Context) (interface{}, error
 
 	s := c.NewState(ctx)
 	err = api.ForeachCmd(ctx, c.Commands, true, func(ctx context.Context, i api.CmdID, cmd api.Cmd) error {
-		cmd.Mutate(ctx, i, s, nil, nil)
+		if err := cmd.Mutate(ctx, i, s, nil, nil); err != nil {
+			return fmt.Errorf("Fail to mutate command %v: %v", cmd, err)
+		}
 
 		api := cmd.API()
 		if api == nil {

--- a/gapis/resolve/events.go
+++ b/gapis/resolve/events.go
@@ -16,6 +16,7 @@ package resolve
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/google/gapid/gapis/api"
 	"github.com/google/gapid/gapis/capture"
@@ -79,8 +80,10 @@ func Events(ctx context.Context, p *path.Events, r *path.ResolveConfig) (*servic
 		}
 		return 0
 	}
-	api.ForeachCmd(ctx, c.Commands, true, func(ctx context.Context, id api.CmdID, cmd api.Cmd) error {
-		cmd.Mutate(ctx, id, s, nil, nil)
+	err = api.ForeachCmd(ctx, c.Commands, true, func(ctx context.Context, id api.CmdID, cmd api.Cmd) error {
+		if err := cmd.Mutate(ctx, id, s, nil, nil); err != nil {
+			return fmt.Errorf("Fail to mutate command %v: %v", cmd, err)
+		}
 
 		// TODO: Add event generation to the API files.
 		if !filter(id, cmd, s) {
@@ -231,6 +234,10 @@ func Events(ctx context.Context, p *path.Events, r *path.ResolveConfig) (*servic
 		lastCmd = id
 		return nil
 	})
+
+	if err != nil {
+		return nil, err
+	}
 
 	return &service.Events{List: events}, nil
 }

--- a/gapis/resolve/memory.go
+++ b/gapis/resolve/memory.go
@@ -16,6 +16,7 @@ package resolve
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 	"sort"
 
@@ -107,7 +108,9 @@ func Memory(ctx context.Context, p *path.Memory, rc *path.ResolveConfig) (*servi
 		return nil, err
 	}
 	err = api.ForeachCmd(ctx, cmds[:len(cmds)-1], true, func(ctx context.Context, id api.CmdID, cmd api.Cmd) error {
-		cmd.Mutate(ctx, id, s, nil, nil)
+		if err := cmd.Mutate(ctx, id, s, nil, nil); err != nil {
+			return fmt.Errorf("Fail to mutate command %v: %v", cmd, err)
+		}
 		return nil
 	})
 	if err != nil {
@@ -233,7 +236,9 @@ func MemoryAsType(ctx context.Context, p *path.MemoryAsType, rc *path.ResolveCon
 		return nil, err
 	}
 	err = api.ForeachCmd(ctx, cmds, true, func(ctx context.Context, id api.CmdID, cmd api.Cmd) error {
-		cmd.Mutate(ctx, id, s, nil, nil)
+		if err := cmd.Mutate(ctx, id, s, nil, nil); err != nil {
+			return fmt.Errorf("Fail to mutate command %v: %v", cmd, err)
+		}
 		return nil
 	})
 	if err != nil {

--- a/gapis/resolve/state.go
+++ b/gapis/resolve/state.go
@@ -16,6 +16,7 @@ package resolve
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/google/gapid/core/app/analytics"
 	"github.com/google/gapid/gapis/api"
@@ -73,7 +74,9 @@ func (r *GlobalStateResolvable) Resolve(ctx context.Context) (interface{}, error
 	}
 
 	err = api.ForeachCmd(ctx, cmds, true, func(ctx context.Context, id api.CmdID, cmd api.Cmd) error {
-		cmd.Mutate(ctx, id, s, nil, nil)
+		if err := cmd.Mutate(ctx, id, s, nil, nil); err != nil {
+			return fmt.Errorf("Fail to mutate command %v: %v", cmd, err)
+		}
 		return nil
 	})
 	if err != nil {

--- a/gapis/resolve/stats.go
+++ b/gapis/resolve/stats.go
@@ -16,6 +16,7 @@ package resolve
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/google/gapid/gapis/api"
 	"github.com/google/gapid/gapis/api/sync"
@@ -126,9 +127,8 @@ func drawCallStats(ctx context.Context, capt *path.Capture, stats *service.Stats
 
 	processCmd := func(idx uint64) error {
 		cmd := cmds[idx]
-		err := cmd.Mutate(ctx, api.CmdID(idx), st, nil, nil)
-		if err != nil {
-			return err
+		if err := cmd.Mutate(ctx, api.CmdID(idx), st, nil, nil); err != nil {
+			return fmt.Errorf("Fail to mutate command %v: %v", cmd, err)
 		}
 		flags[idx] = cmd.CmdFlags(ctx, api.CmdID(idx), st)
 


### PR DESCRIPTION
This change adds systematic error propagation for cmd.Mutate() calls,
wherever the enclosing function can return an error. Places where
cmd.Mutate() is called without the possibility to propagate the error
up are left as-is.

Bug: b/145003736
