### PR TITLE
Add defensive check on inFlightRPCs counter

### DIFF
--- a/gapis/server/grpc.go
+++ b/gapis/server/grpc.go
@@ -114,6 +114,9 @@ func (s *grpcServer) inRPC() func() {
 		case s.keepAlive <- struct{}{}:
 		default:
 		}
+		if atomic.LoadInt64(&s.inFlightRPCs) == 0 {
+			panic("Should never happen: inFlightRPCs counter is going below zero")
+		}
 		atomic.AddInt64(&s.inFlightRPCs, -1)
 	}
 }


### PR DESCRIPTION
This is to chase a flaky issue of connection being lost between a
client and a server, without apparent reason.

Bug: b/144158856