### PR TITLE
Remove unaccessible counter.

### DIFF
--- a/gapis/trace/android/adreno/validate.go
+++ b/gapis/trace/android/adreno/validate.go
@@ -36,7 +36,6 @@ var (
 	// All counters must be inside this array.
 	counters = []validate.GpuCounter{
 		{1, "Clocks / Second", validate.And(validate.IsNumber, validate.CheckLargerThanZero)},
-		{3, "GPU % Utilization", validate.And(validate.IsNumber, validate.CheckLargerThanZero)},
 		{21, "% Shaders Busy", validate.And(validate.IsNumber, validate.CheckLargerThanZero)},
 		{26, "Fragment ALU Instructions / Sec (Full)", validate.And(validate.IsNumber, validate.CheckLargerThanZero)},
 		{30, "Textures / Vertex", validate.And(validate.IsNumber, validate.CheckEqualTo(0.0))},


### PR DESCRIPTION
Some counters are not available on production build, hence remove them.

Bug: b/138717619
Test: bazel run gapit -- validate_gpu_profiling --os android