### PR TITLE
Add error reporting to Transforms

### DIFF
--- a/gapis/api/gles/find_issues.go
+++ b/gapis/api/gles/find_issues.go
@@ -87,7 +87,7 @@ func (e ErrUnexpectedDriverTraceError) Error() string {
 		e.DriverError.ErrorString(), e.ExpectedError.ErrorString())
 }
 
-func (t *findIssues) Transform(ctx context.Context, id api.CmdID, cmd api.Cmd, out transform.Writer) {
+func (t *findIssues) Transform(ctx context.Context, id api.CmdID, cmd api.Cmd, out transform.Writer) error {
 	ctx = log.Enter(ctx, "findIssues")
 	cb := CommandBuilder{Thread: cmd.Thread(), Arena: t.state.Arena}
 	t.lastGlError = GLenum_GL_NO_ERROR
@@ -112,7 +112,8 @@ func (t *findIssues) Transform(ctx context.Context, id api.CmdID, cmd api.Cmd, o
 
 	if mutateErr != nil {
 		// Ignore since downstream transform layers can only consume valid commands
-		return
+		// This transform want to see all possible errors, but won't propagate them up
+		return nil
 	}
 
 	out.MutateAndWrite(ctx, id, cmd)
@@ -121,7 +122,7 @@ func (t *findIssues) Transform(ctx context.Context, id api.CmdID, cmd api.Cmd, o
 	s := GetState(t.state)
 	c := s.GetContext(cmd.Thread())
 	if c.IsNil() {
-		return
+		return nil
 	}
 
 	// Check the result of glGetError after every command.
@@ -164,7 +165,7 @@ func (t *findIssues) Transform(ctx context.Context, id api.CmdID, cmd api.Cmd, o
 		st, err := shader.Type().ShaderType()
 		if err != nil {
 			t.onIssue(cmd, id, service.Severity_ErrorLevel, err)
-			return
+			return nil
 		}
 
 		if !t.targetVersion.IsES {
@@ -288,6 +289,7 @@ func (t *findIssues) Transform(ctx context.Context, id api.CmdID, cmd api.Cmd, o
 				c.Constants().Vendor(), c.Constants().Version(), glDev.Vendor, glDev.Version))
 		}
 	}
+	return nil
 }
 
 func (t *findIssues) Flush(ctx context.Context, out transform.Writer) error {

--- a/gapis/api/gles/find_issues.go
+++ b/gapis/api/gles/find_issues.go
@@ -290,6 +290,7 @@ func (t *findIssues) Transform(ctx context.Context, id api.CmdID, cmd api.Cmd, o
 	}
 }
 
-func (t *findIssues) Flush(ctx context.Context, out transform.Writer) {
+func (t *findIssues) Flush(ctx context.Context, out transform.Writer) error {
 	t.AddNotifyInstruction(ctx, out, func() interface{} { return t.issues })
+	return nil
 }

--- a/gapis/api/gles/replay.go
+++ b/gapis/api/gles/replay.go
@@ -293,8 +293,7 @@ func (a API) Replay(
 	if profile == nil {
 		cmds = []api.Cmd{} // DeadCommandRemoval generates commands.
 	}
-	transforms.Transform(ctx, cmds, out)
-	return nil
+	return transforms.Transform(ctx, cmds, out)
 }
 
 func (a API) QueryIssues(

--- a/gapis/api/gles/replay.go
+++ b/gapis/api/gles/replay.go
@@ -377,8 +377,8 @@ func (a API) Profile(
 type destroyResourcesAtEOS struct {
 }
 
-func (t *destroyResourcesAtEOS) Transform(ctx context.Context, id api.CmdID, cmd api.Cmd, out transform.Writer) {
-	out.MutateAndWrite(ctx, id, cmd)
+func (t *destroyResourcesAtEOS) Transform(ctx context.Context, id api.CmdID, cmd api.Cmd, out transform.Writer) error {
+	return out.MutateAndWrite(ctx, id, cmd)
 }
 
 func (t *destroyResourcesAtEOS) Flush(ctx context.Context, out transform.Writer) error {

--- a/gapis/api/gles/wireframe.go
+++ b/gapis/api/gles/wireframe.go
@@ -31,20 +31,18 @@ import (
 // triangle primitives with draw calls of a wireframe equivalent.
 func wireframe(ctx context.Context, framebuffer FramebufferId) transform.Transformer {
 	ctx = log.Enter(ctx, "Wireframe")
-	return transform.Transform("Wireframe", func(ctx context.Context, id api.CmdID, cmd api.Cmd, out transform.Writer) {
+	return transform.Transform("Wireframe", func(ctx context.Context, id api.CmdID, cmd api.Cmd, out transform.Writer) error {
 		if dc, ok := cmd.(drawCall); ok {
 			s := out.State()
 			c := GetContext(s, cmd.Thread())
 
 			fb := c.Bound().DrawFramebuffer()
 			if fb.IsNil() {
-				out.MutateAndWrite(ctx, id, cmd)
-				return
+				return out.MutateAndWrite(ctx, id, cmd)
 			}
 
 			if fb.ID() != framebuffer {
-				out.MutateAndWrite(ctx, id, cmd)
-				return
+				return out.MutateAndWrite(ctx, id, cmd)
 			}
 
 			dID := id.Derived()
@@ -62,8 +60,9 @@ func wireframe(ctx context.Context, framebuffer FramebufferId) transform.Transfo
 
 			t.revert(ctx)
 		} else {
-			out.MutateAndWrite(ctx, id, cmd)
+			return out.MutateAndWrite(ctx, id, cmd)
 		}
+		return nil
 	})
 }
 
@@ -71,7 +70,7 @@ func wireframe(ctx context.Context, framebuffer FramebufferId) transform.Transfo
 // the mesh over of the specified draw call.
 func wireframeOverlay(ctx context.Context, i api.CmdID) transform.Transformer {
 	ctx = log.Enter(ctx, "DrawMode_WIREFRAME_OVERLAY")
-	return transform.Transform("DrawMode_WIREFRAME_OVERLAY", func(ctx context.Context, id api.CmdID, cmd api.Cmd, out transform.Writer) {
+	return transform.Transform("DrawMode_WIREFRAME_OVERLAY", func(ctx context.Context, id api.CmdID, cmd api.Cmd, out transform.Writer) error {
 		if i == id {
 			if dc, ok := cmd.(drawCall); ok {
 				s := out.State()
@@ -93,11 +92,11 @@ func wireframeOverlay(ctx context.Context, i api.CmdID) transform.Transformer {
 				}
 
 				t.revert(ctx)
-				return
+				return nil
 			}
 		}
 
-		out.MutateAndWrite(ctx, id, cmd)
+		return out.MutateAndWrite(ctx, id, cmd)
 	})
 }
 

--- a/gapis/api/sync/sync.go
+++ b/gapis/api/sync/sync.go
@@ -80,9 +80,12 @@ type writer struct {
 
 func (s *writer) State() *api.GlobalState { return s.state }
 
-func (s *writer) MutateAndWrite(ctx context.Context, id api.CmdID, cmd api.Cmd) {
-	cmd.Mutate(ctx, id, s.state, nil, nil)
+func (s *writer) MutateAndWrite(ctx context.Context, id api.CmdID, cmd api.Cmd) error {
+	if err := cmd.Mutate(ctx, id, s.state, nil, nil); err != nil {
+		return err
+	}
 	s.cmds = append(s.cmds, cmd)
+	return nil
 }
 
 func (s *writer) NotifyPreLoop(ctx context.Context)  {}

--- a/gapis/api/sync/sync.go
+++ b/gapis/api/sync/sync.go
@@ -149,7 +149,9 @@ func MutationCmdsFor(ctx context.Context, c *path.Capture, data *Data, cmds []ap
 		return cmds[0 : id+1], nil
 	}
 	w := &writer{rc.NewState(ctx), nil}
-	transforms.Transform(ctx, cmds, w)
+	if err := transforms.Transform(ctx, cmds, w); err != nil {
+		return nil, err
+	}
 
 	return w.cmds, nil
 }

--- a/gapis/api/transform/capture_log.go
+++ b/gapis/api/transform/capture_log.go
@@ -51,7 +51,7 @@ func NewCaptureLog(ctx context.Context, sourceCapture *capture.GraphicsCapture, 
 	}
 }
 
-func (t *captureLog) Transform(ctx context.Context, id api.CmdID, cmd api.Cmd, out Writer) {
+func (t *captureLog) Transform(ctx context.Context, id api.CmdID, cmd api.Cmd, out Writer) error {
 	// Don't write out the custom commands (e.g. replay.Custom)
 	if cmd.API() != nil {
 		if id.IsReal() {
@@ -59,7 +59,7 @@ func (t *captureLog) Transform(ctx context.Context, id api.CmdID, cmd api.Cmd, o
 		}
 		t.cmds = append(t.cmds, cmd)
 	}
-	out.MutateAndWrite(ctx, id, cmd)
+	return out.MutateAndWrite(ctx, id, cmd)
 }
 
 func (t *captureLog) Flush(ctx context.Context, out Writer) error {

--- a/gapis/api/transform/capture_log.go
+++ b/gapis/api/transform/capture_log.go
@@ -62,7 +62,7 @@ func (t *captureLog) Transform(ctx context.Context, id api.CmdID, cmd api.Cmd, o
 	out.MutateAndWrite(ctx, id, cmd)
 }
 
-func (t *captureLog) Flush(ctx context.Context, out Writer) {
+func (t *captureLog) Flush(ctx context.Context, out Writer) error {
 	a := arena.New()
 	defer a.Dispose()
 
@@ -82,13 +82,14 @@ func (t *captureLog) Flush(ctx context.Context, out Writer) {
 	c, err := capture.NewGraphicsCapture(ctx, a, "capturelog", t.header, nil, t.cmds)
 	if err != nil {
 		log.E(ctx, "Failed to create replay storage capture: %v", err)
-		return
+		return err
 	}
 	if err := c.Export(ctx, t.file); err != nil {
 		log.E(ctx, "Failed to write capture to file %v: %v", t.file, err)
-		return
+		return err
 	}
 	t.file.Close()
+	return nil
 }
 
 func (t *captureLog) PreLoop(ctx context.Context, output Writer)  {}

--- a/gapis/api/transform/early_terminator.go
+++ b/gapis/api/transform/early_terminator.go
@@ -52,7 +52,7 @@ func (t *earlyTerminator) Transform(ctx context.Context, id api.CmdID, cmd api.C
 	}
 }
 
-func (t *earlyTerminator) Flush(ctx context.Context, out Writer)       {}
+func (t *earlyTerminator) Flush(ctx context.Context, out Writer) error { return nil }
 func (t *earlyTerminator) PreLoop(ctx context.Context, output Writer)  {}
 func (t *earlyTerminator) PostLoop(ctx context.Context, output Writer) {}
 func (t *earlyTerminator) BuffersCommands() bool                       { return false }

--- a/gapis/api/transform/early_terminator.go
+++ b/gapis/api/transform/early_terminator.go
@@ -39,17 +39,19 @@ func (t *earlyTerminator) Add(ctx context.Context, extraCommands int, id api.Cmd
 	return nil
 }
 
-func (t *earlyTerminator) Transform(ctx context.Context, id api.CmdID, cmd api.Cmd, out Writer) {
+func (t *earlyTerminator) Transform(ctx context.Context, id api.CmdID, cmd api.Cmd, out Writer) error {
 	if t.done && (cmd.API() == nil || cmd.API().ID() == t.api) {
-		return
+		return nil
 	}
 
-	out.MutateAndWrite(ctx, id, cmd)
+	if err := out.MutateAndWrite(ctx, id, cmd); err != nil {
+		return err
+	}
 	// Keep a.API() == nil so that we can test without an API
 	if t.lastID == id {
 		t.done = true
-		return
 	}
+	return nil
 }
 
 func (t *earlyTerminator) Flush(ctx context.Context, out Writer) error { return nil }

--- a/gapis/api/transform/file_log.go
+++ b/gapis/api/transform/file_log.go
@@ -39,7 +39,7 @@ func NewFileLog(ctx context.Context, path string) Transformer {
 	return &fileLog{file: f}
 }
 
-func (t *fileLog) Transform(ctx context.Context, id api.CmdID, cmd api.Cmd, out Writer) {
+func (t *fileLog) Transform(ctx context.Context, id api.CmdID, cmd api.Cmd, out Writer) error {
 	if cmd.API() != nil {
 		t.file.WriteString(fmt.Sprintf("%v: %v\n", id, cmd))
 	} else {
@@ -60,7 +60,7 @@ func (t *fileLog) Transform(ctx context.Context, id api.CmdID, cmd api.Cmd, out 
 			}
 		}
 	}
-	out.MutateAndWrite(ctx, id, cmd)
+	return out.MutateAndWrite(ctx, id, cmd)
 }
 
 func (t *fileLog) Flush(ctx context.Context, out Writer) error {

--- a/gapis/api/transform/file_log.go
+++ b/gapis/api/transform/file_log.go
@@ -63,8 +63,9 @@ func (t *fileLog) Transform(ctx context.Context, id api.CmdID, cmd api.Cmd, out 
 	out.MutateAndWrite(ctx, id, cmd)
 }
 
-func (t *fileLog) Flush(ctx context.Context, out Writer) {
+func (t *fileLog) Flush(ctx context.Context, out Writer) error {
 	t.file.Close()
+	return nil
 }
 
 func (t *fileLog) PreLoop(ctx context.Context, output Writer) {

--- a/gapis/api/transform/injector.go
+++ b/gapis/api/transform/injector.go
@@ -35,15 +35,20 @@ func (t *Injector) Inject(after api.CmdID, cmd api.Cmd) {
 }
 
 // Transform implements the Transformer interface.
-func (t *Injector) Transform(ctx context.Context, id api.CmdID, cmd api.Cmd, out Writer) {
-	out.MutateAndWrite(ctx, id, cmd)
+func (t *Injector) Transform(ctx context.Context, id api.CmdID, cmd api.Cmd, out Writer) error {
+	if err := out.MutateAndWrite(ctx, id, cmd); err != nil {
+		return err
+	}
 
 	if r, ok := t.injections[id]; ok {
 		for _, injection := range r {
-			out.MutateAndWrite(ctx, api.CmdNoID, injection)
+			if err := out.MutateAndWrite(ctx, api.CmdNoID, injection); err != nil {
+				return err
+			}
 		}
 		delete(t.injections, id)
 	}
+	return nil
 }
 
 // Flush implements the Transformer interface.

--- a/gapis/api/transform/injector.go
+++ b/gapis/api/transform/injector.go
@@ -47,7 +47,7 @@ func (t *Injector) Transform(ctx context.Context, id api.CmdID, cmd api.Cmd, out
 }
 
 // Flush implements the Transformer interface.
-func (t *Injector) Flush(ctx context.Context, out Writer) {}
+func (t *Injector) Flush(ctx context.Context, out Writer) error { return nil }
 
 func (t *Injector) PreLoop(ctx context.Context, output Writer)  {}
 func (t *Injector) PostLoop(ctx context.Context, output Writer) {}

--- a/gapis/api/transform/recorder.go
+++ b/gapis/api/transform/recorder.go
@@ -36,12 +36,15 @@ func (r *Recorder) State() *api.GlobalState {
 
 // MutateAndWrite records the command and id into the Cmds and CmdsAndIDs lists
 // and if the Recorder has a state, mutates this state object.
-func (r *Recorder) MutateAndWrite(ctx context.Context, id api.CmdID, cmd api.Cmd) {
+func (r *Recorder) MutateAndWrite(ctx context.Context, id api.CmdID, cmd api.Cmd) error {
 	if r.S != nil {
-		cmd.Mutate(ctx, id, r.S, nil, nil)
+		if err := cmd.Mutate(ctx, id, r.S, nil, nil); err != nil {
+			return err
+		}
 	}
 	r.Cmds = append(r.Cmds, cmd)
 	r.CmdsAndIDs = append(r.CmdsAndIDs, CmdAndID{cmd, id})
+	return nil
 }
 
 // Required to implement Writer interface

--- a/gapis/api/transform/tasks.go
+++ b/gapis/api/transform/tasks.go
@@ -60,12 +60,13 @@ func (t *Tasks) Transform(ctx context.Context, id api.CmdID, cmd api.Cmd, out Wr
 	out.MutateAndWrite(ctx, id, cmd)
 }
 
-func (t *Tasks) Flush(ctx context.Context, out Writer) {
+func (t *Tasks) Flush(ctx context.Context, out Writer) error {
 	t.sort()
 	for _, task := range t.tasks {
 		task.work(ctx, out)
 	}
 	t.tasks = nil
+	return nil
 }
 
 func (t *Tasks) PreLoop(ctx context.Context, output Writer)  {}

--- a/gapis/api/transform/tasks.go
+++ b/gapis/api/transform/tasks.go
@@ -49,7 +49,7 @@ func (t *Tasks) sort() {
 	}
 }
 
-func (t *Tasks) Transform(ctx context.Context, id api.CmdID, cmd api.Cmd, out Writer) {
+func (t *Tasks) Transform(ctx context.Context, id api.CmdID, cmd api.Cmd, out Writer) error {
 	if id.IsReal() {
 		t.sort()
 		for len(t.tasks) > 0 && t.tasks[0].at < id {
@@ -57,7 +57,7 @@ func (t *Tasks) Transform(ctx context.Context, id api.CmdID, cmd api.Cmd, out Wr
 			t.tasks = t.tasks[1:]
 		}
 	}
-	out.MutateAndWrite(ctx, id, cmd)
+	return out.MutateAndWrite(ctx, id, cmd)
 }
 
 func (t *Tasks) Flush(ctx context.Context, out Writer) error {

--- a/gapis/api/transform/transformer.go
+++ b/gapis/api/transform/transformer.go
@@ -56,7 +56,7 @@ type Writer interface {
 	State() *api.GlobalState
 	// MutateAndWrite mutates the state object associated with this writer,
 	// and it passes the command to further consumers.
-	MutateAndWrite(ctx context.Context, id api.CmdID, cmd api.Cmd)
+	MutateAndWrite(ctx context.Context, id api.CmdID, cmd api.Cmd) error
 	//Notify next transformer it's ready to start loop the trace.
 	NotifyPreLoop(ctx context.Context)
 	//Notify next transformer it's the end of the loop.

--- a/gapis/api/transform/transformer.go
+++ b/gapis/api/transform/transformer.go
@@ -28,7 +28,7 @@ type Transformer interface {
 	Transform(ctx context.Context, id api.CmdID, cmd api.Cmd, output Writer)
 	// Flush is called at the end of a command stream to cause Transformers
 	// that cache commands to send any they have stored into the output.
-	Flush(ctx context.Context, output Writer)
+	Flush(ctx context.Context, output Writer) error
 	// Preloop is called at the beginning of the loop if the trace is going to
 	// be looped.
 	PreLoop(ctx context.Context, output Writer)

--- a/gapis/api/transform/transformer.go
+++ b/gapis/api/transform/transformer.go
@@ -25,7 +25,7 @@ type Transformer interface {
 	// Transform takes a given command and identifier and Writes out a possibly
 	// transformed set of commands to the output.
 	// Transform must not modify cmd in any way.
-	Transform(ctx context.Context, id api.CmdID, cmd api.Cmd, output Writer)
+	Transform(ctx context.Context, id api.CmdID, cmd api.Cmd, output Writer) error
 	// Flush is called at the end of a command stream to cause Transformers
 	// that cache commands to send any they have stored into the output.
 	Flush(ctx context.Context, output Writer) error

--- a/gapis/api/transform/transforms.go
+++ b/gapis/api/transform/transforms.go
@@ -85,7 +85,7 @@ func (t transform) Transform(ctx context.Context, id api.CmdID, cmd api.Cmd, out
 	t.F(ctx, id, cmd, output)
 }
 
-func (t transform) Flush(ctx context.Context, output Writer) {}
+func (t transform) Flush(ctx context.Context, output Writer) error { return nil }
 
 func (t transform) Name() string { return t.N }
 

--- a/gapis/api/transform/transforms.go
+++ b/gapis/api/transform/transforms.go
@@ -50,7 +50,9 @@ func (l Transforms) Transform(ctx context.Context, cmds []api.Cmd, out Writer) e
 	}
 	for p, ok := chain.(TransformWriter); ok; p, ok = chain.(TransformWriter) {
 		chain = p.O
-		p.T.Flush(ctx, chain)
+		if err := p.T.Flush(ctx, chain); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/gapis/api/transform/transforms.go
+++ b/gapis/api/transform/transforms.go
@@ -72,17 +72,17 @@ func (l *Transforms) Prepend(t Transformer) {
 
 // Transform is a helper for building simple Transformers that are implemented
 // by function f. name is used to identify the transform when logging.
-func Transform(name string, f func(ctx context.Context, id api.CmdID, cmd api.Cmd, output Writer)) Transformer {
+func Transform(name string, f func(ctx context.Context, id api.CmdID, cmd api.Cmd, output Writer) error) Transformer {
 	return transform{name, f}
 }
 
 type transform struct {
-	N string                                            // Transform name. Used for debugging.
-	F func(context.Context, api.CmdID, api.Cmd, Writer) // The transform function.
+	N string                                                  // Transform name. Used for debugging.
+	F func(context.Context, api.CmdID, api.Cmd, Writer) error // The transform function.
 }
 
-func (t transform) Transform(ctx context.Context, id api.CmdID, cmd api.Cmd, output Writer) {
-	t.F(ctx, id, cmd, output)
+func (t transform) Transform(ctx context.Context, id api.CmdID, cmd api.Cmd, output Writer) error {
+	return t.F(ctx, id, cmd, output)
 }
 
 func (t transform) Flush(ctx context.Context, output Writer) error { return nil }
@@ -111,8 +111,7 @@ func (p TransformWriter) MutateAndWrite(ctx context.Context, id api.CmdID, cmd a
 			return err
 		}
 	}
-	p.T.Transform(ctx, id, cmd, p.O)
-	return nil
+	return p.T.Transform(ctx, id, cmd, p.O)
 }
 
 // NotifyPreLoop notifies next transformer in the chain about the beginning of the loop

--- a/gapis/api/transform/transforms.go
+++ b/gapis/api/transform/transforms.go
@@ -26,7 +26,7 @@ type Transforms []Transformer
 
 // Transform sequentially transforms the commands by each of the transformers in
 // the list, before writing the final output to the output command Writer.
-func (l Transforms) Transform(ctx context.Context, cmds []api.Cmd, out Writer) {
+func (l Transforms) Transform(ctx context.Context, cmds []api.Cmd, out Writer) error {
 	chain := out
 	for i := len(l) - 1; i >= 0; i-- {
 		s := chain.State()
@@ -50,6 +50,7 @@ func (l Transforms) Transform(ctx context.Context, cmds []api.Cmd, out Writer) {
 		chain = p.O
 		p.T.Flush(ctx, chain)
 	}
+	return nil
 }
 
 // Add is a convenience function for appending the list of Transformers t to the

--- a/gapis/api/vulkan/find_issues.go
+++ b/gapis/api/vulkan/find_issues.go
@@ -82,13 +82,13 @@ func newFindIssues(ctx context.Context, c *capture.GraphicsCapture, numInitialCm
 	return t
 }
 
-func (t *findIssues) Transform(ctx context.Context, id api.CmdID, cmd api.Cmd, out transform.Writer) {
+func (t *findIssues) Transform(ctx context.Context, id api.CmdID, cmd api.Cmd, out transform.Writer) error {
 	ctx = log.Enter(ctx, "findIssues")
 
 	mutateErr := cmd.Mutate(ctx, id, t.state, nil /* no builder */, nil /* no watcher */)
 	if mutateErr != nil {
 		// Ignore since downstream transform layers can only consume valid commands
-		return
+		return nil
 	}
 
 	s := out.State()
@@ -261,6 +261,7 @@ func (t *findIssues) Transform(ctx context.Context, id api.CmdID, cmd api.Cmd, o
 		))
 		t.reportCallbacks[inst] = callbackHandle
 	}
+	return nil
 }
 
 func (t *findIssues) Flush(ctx context.Context, out transform.Writer) error {

--- a/gapis/api/vulkan/frame_loop.go
+++ b/gapis/api/vulkan/frame_loop.go
@@ -486,18 +486,20 @@ func (f *frameLoop) writeLoopContents(ctx context.Context, cmd api.Cmd, out tran
 	out.NotifyPostLoop(ctx)
 }
 
-func (f *frameLoop) Flush(ctx context.Context, out transform.Writer) {
+func (f *frameLoop) Flush(ctx context.Context, out transform.Writer) error {
 
 	log.W(ctx, "FrameLoop FLUSH")
 
 	if f.loopTerminated == false {
 		if f.lastObservedCommand == api.CmdNoID {
 			log.W(ctx, "FrameLoop transform was applied to whole trace (Flush() has been called) without the loop starting.")
+			return fmt.Errorf("FrameLoop transform was applied to whole trace (Flush() has been called) without the loop starting.")
 		} else {
 			log.E(ctx, "FrameLoop: current frame is %v cmdId %v, cmd is %v.", f.frameNum, f.capturedLoopCmdIds[len(f.capturedLoopCmdIds)-1], f.capturedLoopCmds[len(f.capturedLoopCmds)-1])
 			log.F(ctx, true, "FrameLoop transform was applied to whole trace (Flush() has been called) mid loop. Cannot end transformation in this state.")
 		}
 	}
+	return nil
 }
 
 func (f *frameLoop) PreLoop(ctx context.Context, out transform.Writer) {

--- a/gapis/api/vulkan/frame_loop.go
+++ b/gapis/api/vulkan/frame_loop.go
@@ -314,12 +314,11 @@ func newFrameLoop(ctx context.Context, graphicsCapture *capture.GraphicsCapture,
 	}
 }
 
-func (f *frameLoop) Transform(ctx context.Context, cmdId api.CmdID, cmd api.Cmd, out transform.Writer) {
+func (f *frameLoop) Transform(ctx context.Context, cmdId api.CmdID, cmd api.Cmd, out transform.Writer) error {
 
 	// If we're looping only once we can just passthrough commands
 	if f.loopCount == 1 {
-		out.MutateAndWrite(ctx, cmdId, cmd)
-		return
+		return out.MutateAndWrite(ctx, cmdId, cmd)
 	}
 
 	ctx = log.Enter(ctx, "FrameLoop Transform")
@@ -331,7 +330,7 @@ func (f *frameLoop) Transform(ctx context.Context, cmdId api.CmdID, cmd api.Cmd,
 	f.lastObservedCommand = cmdId
 
 	if lastObservedCommand != api.CmdNoID && lastObservedCommand > api.CmdID.Real(cmdId) {
-		log.F(ctx, true, "FrameLoop: expected next observed command ID to be >= last observed command ID")
+		return fmt.Errorf("FrameLoop: expected next observed command ID to be >= last observed command ID")
 	}
 
 	// Walk the frame count forwards if we just hit the end of one.
@@ -350,13 +349,12 @@ func (f *frameLoop) Transform(ctx context.Context, cmdId api.CmdID, cmd api.Cmd,
 			f.capturedLoopCmds = append(f.capturedLoopCmds, cmd)
 			f.capturedLoopCmdIds = append(f.capturedLoopCmdIds, cmdId)
 
-			return
+			return nil
 
 		} else {
 			// The current command is before the loop begins and needs no special treatment. Just pass-through.
 			log.D(ctx, "FrameLoop: before loop at frame %v, cmdId %v, cmd %v.", f.frameNum, cmdId, cmd)
-			out.MutateAndWrite(ctx, cmdId, cmd)
-			return
+			return out.MutateAndWrite(ctx, cmdId, cmd)
 		}
 
 	} else if f.loopTerminated == false { // We're not before or at the start of the loop: thus, are we inside the loop or just at the end of it?
@@ -365,11 +363,11 @@ func (f *frameLoop) Transform(ctx context.Context, cmdId api.CmdID, cmd api.Cmd,
 		if api.CmdID.Real(cmdId) >= f.loopEndIdx && cmdId != api.CmdNoID {
 
 			if lastObservedCommand == api.CmdNoID {
-				log.F(ctx, true, "FrameLoop: Somehow, the FrameLoop ended before it began. Did an earlier transform delete the whole loop? Were your loop indexes realistic?")
+				return fmt.Errorf("FrameLoop: Somehow, the FrameLoop ended before it began. Did an earlier transform delete the whole loop? Were your loop indexes realistic?")
 			}
 
 			if len(f.capturedLoopCmdIds) != len(f.capturedLoopCmds) {
-				log.F(ctx, true, "FrameLoop: Control flow error: Somehow, the number of captured commands and commandIds are not equal.")
+				return fmt.Errorf("FrameLoop: Control flow error: Somehow, the number of captured commands and commandIds are not equal.")
 			}
 
 			f.loopTerminated = true
@@ -383,7 +381,7 @@ func (f *frameLoop) Transform(ctx context.Context, cmdId api.CmdID, cmd api.Cmd,
 			if f.loopCount == 0 {
 				f.capturedLoopCmds = make([]api.Cmd, 0)
 				f.capturedLoopCmdIds = make([]api.CmdID, 0)
-				return
+				return nil
 			}
 
 			// Some things we're going to need for the next work...
@@ -402,14 +400,15 @@ func (f *frameLoop) Transform(ctx context.Context, cmdId api.CmdID, cmd api.Cmd,
 
 				// Back up the resources that change in the loop (as indentified above)
 				if err := f.backupChangedResources(ctx, stateBuilder); err != nil {
-					log.E(ctx, "FrameLoop: Failed to backup changed resources: %v", err)
-					return
+					return fmt.Errorf("FrameLoop: Failed to backup changed resources: %v", err)
 				}
 
 			}
 
 			// Do first iteration of mid-loop stuff.
-			f.writeLoopContents(ctx, cmd, out)
+			if err := f.writeLoopContents(ctx, cmd, out); err != nil {
+				return err
+			}
 
 			// Mark branch target for loop jump
 			{
@@ -427,13 +426,14 @@ func (f *frameLoop) Transform(ctx context.Context, cmdId api.CmdID, cmd api.Cmd,
 			{
 				// Now we need to emit the instructions to reset the state, before the conditional branch back to the start of the loop.
 				if err := f.resetResources(ctx, stateBuilder); err != nil {
-					log.E(ctx, "FrameLoop: Failed to reset changed resources %v.", err)
-					return
+					return fmt.Errorf("FrameLoop: Failed to reset changed resources %v.", err)
 				}
 			}
 
 			// Do first iteration mid-loop stuff.
-			f.writeLoopContents(ctx, cmd, out)
+			if err := f.writeLoopContents(ctx, cmd, out); err != nil {
+				return err
+			}
 
 			// Write out the conditional jump to the start of the state rewind code to provide the actual looping behaviour
 			{
@@ -448,7 +448,7 @@ func (f *frameLoop) Transform(ctx context.Context, cmdId api.CmdID, cmd api.Cmd,
 			}
 
 			// Finally, we've done all the processing for a loop. Nothing left to do.
-			return
+			return nil
 
 		} else { // We're currently inside the loop.
 
@@ -460,30 +460,33 @@ func (f *frameLoop) Transform(ctx context.Context, cmdId api.CmdID, cmd api.Cmd,
 
 			log.D(ctx, "FrameLoop: inside loop at frame %v, cmdId %v, cmd %v.", f.frameNum, cmdId, cmd)
 
-			return
+			return nil
 		}
 
 	} else { // We're after the loop. Again, we can simply pass-through commands.
-		out.MutateAndWrite(ctx, cmdId, cmd)
-		return
+		return out.MutateAndWrite(ctx, cmdId, cmd)
 	}
 
 	// Should have early out-ed before this point.
-	log.F(ctx, true, "FrameLoop: Internal control flow error: Should not be possible to reach this statement.")
+	return fmt.Errorf("FrameLoop: Internal control flow error: Should not be possible to reach this statement.")
 }
 
-func (f *frameLoop) writeLoopContents(ctx context.Context, cmd api.Cmd, out transform.Writer) {
+func (f *frameLoop) writeLoopContents(ctx context.Context, cmd api.Cmd, out transform.Writer) error {
 
 	// Notify the other transforms that we're about to emit the start of the loop.
 	out.NotifyPreLoop(ctx)
 
 	// Iterate through the loop contents, emitting instructions one by one.
 	for cmdIndex, cmd := range f.capturedLoopCmds {
-		out.MutateAndWrite(ctx, f.capturedLoopCmdIds[cmdIndex], cmd)
+		if err := out.MutateAndWrite(ctx, f.capturedLoopCmdIds[cmdIndex], cmd); err != nil {
+			return err
+		}
 	}
 
 	// Notify the other transforms that we're about to emit the end of the loop.
 	out.NotifyPostLoop(ctx)
+
+	return nil
 }
 
 func (f *frameLoop) Flush(ctx context.Context, out transform.Writer) error {

--- a/gapis/api/vulkan/minimize_viewport.go
+++ b/gapis/api/vulkan/minimize_viewport.go
@@ -26,7 +26,7 @@ import (
 func minimizeViewport(ctx context.Context) transform.Transformer {
 	ctx = log.Enter(ctx, "Minimize viewport")
 	return transform.Transform("Minimize viewport", func(ctx context.Context,
-		id api.CmdID, cmd api.Cmd, out transform.Writer) {
+		id api.CmdID, cmd api.Cmd, out transform.Writer) error {
 
 		const width = 1
 		const height = 1
@@ -179,5 +179,6 @@ func minimizeViewport(ctx context.Context) transform.Transformer {
 		default:
 			out.MutateAndWrite(ctx, id, cmd)
 		}
+		return nil
 	})
 }

--- a/gapis/api/vulkan/overdraw.go
+++ b/gapis/api/vulkan/overdraw.go
@@ -2199,7 +2199,7 @@ func (s *stencilOverdraw) rewriteQueueSubmit(ctx context.Context,
 	return renderInfo.image, nil
 }
 
-func (*stencilOverdraw) Flush(ctx context.Context, out transform.Writer) {}
+func (*stencilOverdraw) Flush(ctx context.Context, out transform.Writer) error { return nil }
 
 func (*stencilOverdraw) PreLoop(ctx context.Context, output transform.Writer)  {}
 func (*stencilOverdraw) PostLoop(ctx context.Context, output transform.Writer) {}

--- a/gapis/api/vulkan/overdraw.go
+++ b/gapis/api/vulkan/overdraw.go
@@ -69,7 +69,7 @@ func (s *stencilOverdraw) add(ctx context.Context, extraCommands uint64, after [
 	})
 }
 
-func (s *stencilOverdraw) Transform(ctx context.Context, id api.CmdID, cmd api.Cmd, out transform.Writer) {
+func (s *stencilOverdraw) Transform(ctx context.Context, id api.CmdID, cmd api.Cmd, out transform.Writer) error {
 	gs := out.State()
 	st := GetState(gs)
 	arena := gs.Arena
@@ -97,20 +97,17 @@ func (s *stencilOverdraw) Transform(ctx context.Context, id api.CmdID, cmd api.C
 		// Need to make sure depth images are created with transfer
 		// source mode, just in case they're being used in load mode
 		// and we need to copy from them.
-		s.rewriteImageCreate(ctx, cb, gs, st, arena, id, c, mustAllocData, out)
-		return
+		return s.rewriteImageCreate(ctx, cb, gs, st, arena, id, c, mustAllocData, out)
 	}
 	res, ok := s.rewrite[id]
 	if !ok {
-		out.MutateAndWrite(ctx, id, cmd)
-		return
+		return out.MutateAndWrite(ctx, id, cmd)
 	}
 
 	submit, ok := cmd.(*VkQueueSubmit)
 	if !ok {
 		res(nil, &service.ErrDataUnavailable{Reason: messages.ErrMessage("Overdraw change marked for non-VkQueueSubmit")})
-		out.MutateAndWrite(ctx, id, cmd)
-		return
+		return out.MutateAndWrite(ctx, id, cmd)
 	}
 
 	lastRenderPassArgs, lastRenderPassIdx, err :=
@@ -119,14 +116,12 @@ func (s *stencilOverdraw) Transform(ctx context.Context, id api.CmdID, cmd api.C
 		res(nil, &service.ErrDataUnavailable{
 			Reason: messages.ErrMessage(fmt.Sprintf(
 				"Could not get overdraw: %v", err))})
-		out.MutateAndWrite(ctx, id, cmd)
-		return
+		return out.MutateAndWrite(ctx, id, cmd)
 	}
 
 	if lastRenderPassArgs.IsNil() {
 		res(nil, &service.ErrDataUnavailable{Reason: messages.ErrMessage("No render pass in queue submit")})
-		out.MutateAndWrite(ctx, id, cmd)
-		return
+		return out.MutateAndWrite(ctx, id, cmd)
 	}
 
 	img, err := s.rewriteQueueSubmit(ctx, cb, gs, st, arena, submit,
@@ -136,8 +131,7 @@ func (s *stencilOverdraw) Transform(ctx context.Context, id api.CmdID, cmd api.C
 		res(nil, &service.ErrDataUnavailable{
 			Reason: messages.ErrMessage(fmt.Sprintf(
 				"Could not get overdraw: %v", err))})
-		out.MutateAndWrite(ctx, id, cmd)
-		return
+		return out.MutateAndWrite(ctx, id, cmd)
 	}
 
 	checkImage := func(img *image.Data) error {
@@ -171,6 +165,7 @@ func (s *stencilOverdraw) Transform(ctx context.Context, id api.CmdID, cmd api.C
 	for i := len(cleanups) - 1; i >= 0; i-- {
 		cleanups[i]()
 	}
+	return nil
 }
 
 func (*stencilOverdraw) rewriteImageCreate(ctx context.Context,
@@ -182,7 +177,7 @@ func (*stencilOverdraw) rewriteImageCreate(ctx context.Context,
 	cmd *VkCreateImage,
 	alloc func(...interface{}) api.AllocResult,
 	out transform.Writer,
-) {
+) error {
 	allReads := []api.AllocResult{}
 	allocAndRead := func(v ...interface{}) api.AllocResult {
 		res := alloc(v)
@@ -194,9 +189,7 @@ func (*stencilOverdraw) rewriteImageCreate(ctx context.Context,
 	createInfo := cmd.PCreateInfo().MustRead(ctx, cmd, gs, nil)
 	mask := VkImageUsageFlags(VkImageUsageFlagBits_VK_IMAGE_USAGE_TRANSFER_SRC_BIT)
 	if !isDepthFormat(createInfo.Fmt()) || (createInfo.Usage()&mask == mask) {
-
-		out.MutateAndWrite(ctx, id, cmd)
-		return
+		return out.MutateAndWrite(ctx, id, cmd)
 	}
 
 	newCreateInfo := createInfo.Clone(a, api.CloneContext{})
@@ -230,7 +223,7 @@ func (*stencilOverdraw) rewriteImageCreate(ctx context.Context,
 		newCmd.AddRead(read.Data())
 	}
 
-	out.MutateAndWrite(ctx, id, newCmd)
+	return out.MutateAndWrite(ctx, id, newCmd)
 }
 
 func (*stencilOverdraw) getLastRenderPass(ctx context.Context,

--- a/gapis/api/vulkan/profiling_layers.go
+++ b/gapis/api/vulkan/profiling_layers.go
@@ -92,7 +92,7 @@ func (t *profilingLayers) PreLoop(ctx context.Context, out transform.Writer) {
 func (t *profilingLayers) PostLoop(ctx context.Context, out transform.Writer) {
 	out.NotifyPostLoop(ctx)
 }
-func (t *profilingLayers) Flush(ctx context.Context, out transform.Writer) {}
+func (t *profilingLayers) Flush(ctx context.Context, out transform.Writer) error { return nil }
 func (t *profilingLayers) BuffersCommands() bool {
 	return false
 }

--- a/gapis/api/vulkan/profiling_layers.go
+++ b/gapis/api/vulkan/profiling_layers.go
@@ -26,7 +26,7 @@ var renderStagesLayer = "VkRenderStagesProducer"
 
 type profilingLayers struct{}
 
-func (t *profilingLayers) Transform(ctx context.Context, id api.CmdID, cmd api.Cmd, out transform.Writer) {
+func (t *profilingLayers) Transform(ctx context.Context, id api.CmdID, cmd api.Cmd, out transform.Writer) error {
 	ctx = log.Enter(ctx, "ProfilingLayers")
 
 	s := out.State()
@@ -78,12 +78,14 @@ func (t *profilingLayers) Transform(ctx context.Context, id api.CmdID, cmd api.C
 		for _, w := range cmd.Extras().Observations().Writes {
 			newCmd.AddWrite(w.Range, w.ID)
 		}
-		out.MutateAndWrite(ctx, id, newCmd)
+		return out.MutateAndWrite(ctx, id, newCmd)
 
 	default:
-		out.MutateAndWrite(ctx, id, cmd)
+		return out.MutateAndWrite(ctx, id, cmd)
 
 	}
+
+	return nil
 }
 
 func (t *profilingLayers) PreLoop(ctx context.Context, out transform.Writer) {

--- a/gapis/api/vulkan/query_timestamps.go
+++ b/gapis/api/vulkan/query_timestamps.go
@@ -270,7 +270,7 @@ func (t *queryTimestamps) rewriteQueueSubmit(ctx context.Context,
 	device VkDevice,
 	queryPoolInfo *queryPoolInfo,
 	commandPool VkCommandPool,
-	cmd *VkQueueSubmit) {
+	cmd *VkQueueSubmit) error {
 
 	s := out.State()
 	l := s.MemoryLayout
@@ -386,7 +386,7 @@ func (t *queryTimestamps) rewriteQueueSubmit(ctx context.Context,
 	for _, read := range reads {
 		newCmd.AddRead(read.Data())
 	}
-	out.MutateAndWrite(ctx, id, newCmd)
+	return out.MutateAndWrite(ctx, id, newCmd)
 }
 
 func (t *queryTimestamps) GetQueryResults(ctx context.Context,
@@ -476,11 +476,10 @@ func (t *queryTimestamps) processNotification(ctx context.Context, s *api.Global
 	})
 }
 
-func (t *queryTimestamps) Transform(ctx context.Context, id api.CmdID, cmd api.Cmd, out transform.Writer) {
+func (t *queryTimestamps) Transform(ctx context.Context, id api.CmdID, cmd api.Cmd, out transform.Writer) error {
 	ctx = log.Enter(ctx, "queryTimestamps")
 	if t.willLoop && !t.readyToLoop {
-		out.MutateAndWrite(ctx, id, cmd)
-		return
+		return out.MutateAndWrite(ctx, id, cmd)
 	}
 	s := out.State()
 	cb := CommandBuilder{Thread: cmd.Thread(), Arena: s.Arena}
@@ -518,10 +517,12 @@ func (t *queryTimestamps) Transform(ctx context.Context, id api.CmdID, cmd api.C
 		if numSlotAvailable < queryCount {
 			t.GetQueryResults(ctx, cb, out, queryPoolInfo)
 		}
-		t.rewriteQueueSubmit(ctx, cb, out, id, vkDevice, queryPoolInfo, commandPool, cmd)
+		return t.rewriteQueueSubmit(ctx, cb, out, id, vkDevice, queryPoolInfo, commandPool, cmd)
+
 	default:
-		out.MutateAndWrite(ctx, id, cmd)
+		return out.MutateAndWrite(ctx, id, cmd)
 	}
+	return nil
 }
 
 func (t *queryTimestamps) Flush(ctx context.Context, out transform.Writer) error {

--- a/gapis/api/vulkan/query_timestamps.go
+++ b/gapis/api/vulkan/query_timestamps.go
@@ -524,7 +524,7 @@ func (t *queryTimestamps) Transform(ctx context.Context, id api.CmdID, cmd api.C
 	}
 }
 
-func (t *queryTimestamps) Flush(ctx context.Context, out transform.Writer) {
+func (t *queryTimestamps) Flush(ctx context.Context, out transform.Writer) error {
 	s := out.State()
 	cb := CommandBuilder{Thread: 0, Arena: s.Arena}
 	for _, queryPoolInfo := range t.queryPools {
@@ -532,6 +532,7 @@ func (t *queryTimestamps) Flush(ctx context.Context, out transform.Writer) {
 	}
 	t.cleanup(ctx, out)
 	t.AddNotifyInstruction(ctx, out, func() interface{} { return t.replayResult })
+	return nil
 }
 
 func (t *queryTimestamps) PreLoop(ctx context.Context, out transform.Writer) {

--- a/gapis/api/vulkan/read_framebuffer.go
+++ b/gapis/api/vulkan/read_framebuffer.go
@@ -44,19 +44,21 @@ func newReadFramebuffer(ctx context.Context) *readFramebuffer {
 
 // If we are acutally swapping, we really do want to show the image before
 // the framebuffer read.
-func (t *readFramebuffer) Transform(ctx context.Context, id api.CmdID, cmd api.Cmd, out transform.Writer) {
+func (t *readFramebuffer) Transform(ctx context.Context, id api.CmdID, cmd api.Cmd, out transform.Writer) error {
 	s := out.State()
 	isEOF := cmd.CmdFlags(ctx, id, s).IsEndOfFrame()
-	doMutate := func() {
-		out.MutateAndWrite(ctx, id, cmd)
+	doMutate := func() error {
+		return out.MutateAndWrite(ctx, id, cmd)
 	}
 
 	if !isEOF {
-		doMutate()
+		return doMutate()
 	} else {
 		// This is a VkQueuePresent, we need to extract the information out of this,
 		// so that we can correctly display the image.
-		cmd.Mutate(ctx, id, out.State(), nil, nil)
+		if err := cmd.Mutate(ctx, id, out.State(), nil, nil); err != nil {
+			return fmt.Errorf("Fail to mutate command %v: %v", cmd, err)
+		}
 	}
 
 	if r, ok := t.injections[id-api.CmdID(t.numInitialCommands)]; ok {
@@ -67,8 +69,9 @@ func (t *readFramebuffer) Transform(ctx context.Context, id api.CmdID, cmd api.C
 	}
 
 	if isEOF {
-		doMutate()
+		return doMutate()
 	}
+	return nil
 }
 
 func (t *readFramebuffer) Flush(ctx context.Context, out transform.Writer) error { return nil }

--- a/gapis/api/vulkan/read_framebuffer.go
+++ b/gapis/api/vulkan/read_framebuffer.go
@@ -71,7 +71,7 @@ func (t *readFramebuffer) Transform(ctx context.Context, id api.CmdID, cmd api.C
 	}
 }
 
-func (t *readFramebuffer) Flush(ctx context.Context, out transform.Writer)       {}
+func (t *readFramebuffer) Flush(ctx context.Context, out transform.Writer) error { return nil }
 func (t *readFramebuffer) PreLoop(ctx context.Context, output transform.Writer)  {}
 func (t *readFramebuffer) PostLoop(ctx context.Context, output transform.Writer) {}
 func (t *readFramebuffer) BuffersCommands() bool                                 { return false }

--- a/gapis/api/vulkan/replay.go
+++ b/gapis/api/vulkan/replay.go
@@ -801,8 +801,7 @@ func (a API) GetInitialPayload(ctx context.Context,
 	initialCmds, im, _ := initialcmds.InitialCommands(ctx, capture)
 	out.State().Allocator.ReserveRanges(im)
 
-	transforms.Transform(ctx, initialCmds, out)
-	return nil
+	return transforms.Transform(ctx, initialCmds, out)
 }
 
 func (a API) CleanupResources(ctx context.Context,
@@ -810,8 +809,7 @@ func (a API) CleanupResources(ctx context.Context,
 	out transform.Writer) error {
 	transforms := transform.Transforms{}
 	transforms.Add(&destroyResourcesAtEOS{})
-	transforms.Transform(ctx, []api.Cmd{}, out)
-	return nil
+	return transforms.Transform(ctx, []api.Cmd{}, out)
 }
 
 func (a API) Replay(
@@ -1116,8 +1114,7 @@ func (a API) Replay(
 		transforms.Add(replay.NewMappingExporterWithPrint(ctx, "mappings.txt"))
 	}
 
-	transforms.Transform(ctx, cmds, out)
-	return nil
+	return transforms.Transform(ctx, cmds, out)
 }
 
 func (a API) QueryFramebufferAttachment(

--- a/gapis/api/vulkan/replay.go
+++ b/gapis/api/vulkan/replay.go
@@ -157,7 +157,7 @@ func patchBufferusage(usage VkBufferUsageFlags) (VkBufferUsageFlags, bool) {
 	return VkBufferUsageFlags(uint32(usage) | uint32(VkBufferUsageFlagBits_VK_BUFFER_USAGE_TRANSFER_SRC_BIT)), true
 }
 
-func (t *makeAttachementReadable) Transform(ctx context.Context, id api.CmdID, cmd api.Cmd, out transform.Writer) {
+func (t *makeAttachementReadable) Transform(ctx context.Context, id api.CmdID, cmd api.Cmd, out transform.Writer) error {
 	s := out.State()
 	l := s.MemoryLayout
 	cb := CommandBuilder{Thread: cmd.Thread(), Arena: s.Arena}
@@ -196,8 +196,7 @@ func (t *makeAttachementReadable) Transform(ctx context.Context, id api.CmdID, c
 			for _, w := range observations.Writes {
 				newCmd.AddWrite(w.Range, w.ID)
 			}
-			out.MutateAndWrite(ctx, id, newCmd)
-			return
+			return out.MutateAndWrite(ctx, id, newCmd)
 		}
 	} else if swapchain, ok := cmd.(*VkCreateSwapchainKHR); ok {
 		pinfo := swapchain.PCreateInfo()
@@ -227,8 +226,7 @@ func (t *makeAttachementReadable) Transform(ctx context.Context, id api.CmdID, c
 			for _, w := range observations.Writes {
 				newCmd.AddWrite(w.Range, w.ID)
 			}
-			out.MutateAndWrite(ctx, id, newCmd)
-			return
+			return out.MutateAndWrite(ctx, id, newCmd)
 		}
 	} else if createRenderPass, ok := cmd.(*VkCreateRenderPass); ok && !t.imagesOnly {
 		pInfo := createRenderPass.PCreateInfo()
@@ -244,8 +242,7 @@ func (t *makeAttachementReadable) Transform(ctx context.Context, id api.CmdID, c
 		}
 		// Returns if no attachment description needs to be changed
 		if !changed {
-			out.MutateAndWrite(ctx, id, cmd)
-			return
+			return out.MutateAndWrite(ctx, id, cmd)
 		}
 		// Build new attachments data, new create info and new command
 		newAttachments := s.AllocDataOrPanic(ctx, attachments)
@@ -269,14 +266,12 @@ func (t *makeAttachementReadable) Transform(ctx context.Context, id api.CmdID, c
 		for _, w := range createRenderPass.Extras().Observations().Writes {
 			newCmd.AddWrite(w.Range, w.ID)
 		}
-		out.MutateAndWrite(ctx, id, newCmd)
-		return
+		return out.MutateAndWrite(ctx, id, newCmd)
 	} else if e, ok := cmd.(*VkEnumeratePhysicalDevices); ok && !t.imagesOnly {
 		if e.PPhysicalDevices() == 0 {
 			// Querying for the number of devices.
 			// No changes needed here.
-			out.MutateAndWrite(ctx, id, cmd)
-			return
+			return out.MutateAndWrite(ctx, id, cmd)
 		}
 		l := s.MemoryLayout
 		cmd.Extras().Observations().ApplyWrites(s.Memory.ApplicationPool())
@@ -292,8 +287,7 @@ func (t *makeAttachementReadable) Transform(ctx context.Context, id api.CmdID, c
 		for _, e := range cmd.Extras().All() {
 			newEnumerate.Extras().Add(e)
 		}
-		out.MutateAndWrite(ctx, id, newEnumerate)
-		return
+		return out.MutateAndWrite(ctx, id, newEnumerate)
 	} else if buffer, ok := cmd.(*VkCreateBuffer); ok {
 		pinfo := buffer.PCreateInfo()
 		info := pinfo.MustRead(ctx, buffer, s, nil)
@@ -317,11 +311,10 @@ func (t *makeAttachementReadable) Transform(ctx context.Context, id api.CmdID, c
 			for _, w := range observations.Writes {
 				newCmd.AddWrite(w.Range, w.ID)
 			}
-			out.MutateAndWrite(ctx, id, newCmd)
-			return
+			return out.MutateAndWrite(ctx, id, newCmd)
 		}
 	}
-	out.MutateAndWrite(ctx, id, cmd)
+	return out.MutateAndWrite(ctx, id, cmd)
 }
 
 func (t *makeAttachementReadable) Flush(ctx context.Context, out transform.Writer) error { return nil }
@@ -352,7 +345,7 @@ func buildReplayEnumeratePhysicalDevices(
 // whose destroying targets are not recorded in the state.
 type dropInvalidDestroy struct{ tag string }
 
-func (t *dropInvalidDestroy) Transform(ctx context.Context, id api.CmdID, cmd api.Cmd, out transform.Writer) {
+func (t *dropInvalidDestroy) Transform(ctx context.Context, id api.CmdID, cmd api.Cmd, out transform.Writer) error {
 	s := out.State()
 	l := s.MemoryLayout
 	cb := CommandBuilder{Thread: cmd.Thread(), Arena: s.Arena}
@@ -366,12 +359,12 @@ func (t *dropInvalidDestroy) Transform(ctx context.Context, id api.CmdID, cmd ap
 	case *VkDestroyInstance:
 		if !GetState(s).Instances().Contains(cmd.Instance()) {
 			warnDropCmd(cmd.Instance())
-			return
+			return nil
 		}
 	case *VkDestroyDevice:
 		if !GetState(s).Devices().Contains(cmd.Device()) {
 			warnDropCmd(cmd.Device())
-			return
+			return nil
 		}
 	case *VkFreeCommandBuffers:
 		cmdBufCount := cmd.CommandBufferCount()
@@ -390,7 +383,7 @@ func (t *dropInvalidDestroy) Transform(ctx context.Context, id api.CmdID, cmd ap
 			if len(newCmdBufs) == 0 {
 				// no need to have this command
 				warnDropCmd(cmdBufs)
-				return
+				return nil
 			}
 			if len(newCmdBufs) != len(cmdBufs) {
 				// need to modify the command to drop the command buffers not
@@ -399,8 +392,7 @@ func (t *dropInvalidDestroy) Transform(ctx context.Context, id api.CmdID, cmd ap
 				newCmdBufsData := s.AllocDataOrPanic(ctx, newCmdBufs)
 				defer newCmdBufsData.Free()
 				newCmd := cb.VkFreeCommandBuffers(cmd.Device(), cmd.CommandPool(), uint32(len(newCmdBufs)), newCmdBufsData.Ptr()).AddRead(newCmdBufsData.Data())
-				out.MutateAndWrite(ctx, id, newCmd)
-				return
+				return out.MutateAndWrite(ctx, id, newCmd)
 			}
 			// No need to modify the command, just mutate and write the command
 			// like others.
@@ -408,53 +400,53 @@ func (t *dropInvalidDestroy) Transform(ctx context.Context, id api.CmdID, cmd ap
 	case *VkFreeMemory:
 		if !GetState(s).DeviceMemories().Contains(cmd.Memory()) {
 			warnDropCmd(cmd.Memory())
-			return
+			return nil
 		}
 	case *VkDestroyBuffer:
 		if !GetState(s).Buffers().Contains(cmd.Buffer()) {
 			warnDropCmd(cmd.Buffer())
-			return
+			return nil
 		}
 	case *VkDestroyBufferView:
 		if !GetState(s).BufferViews().Contains(cmd.BufferView()) {
 			warnDropCmd(cmd.BufferView())
-			return
+			return nil
 		}
 	case *VkDestroyImage:
 		if !GetState(s).Images().Contains(cmd.Image()) {
 			warnDropCmd(cmd.Image())
-			return
+			return nil
 		}
 	case *VkDestroyImageView:
 		if !GetState(s).ImageViews().Contains(cmd.ImageView()) {
 			warnDropCmd(cmd.ImageView())
-			return
+			return nil
 		}
 	case *VkDestroyShaderModule:
 		if !GetState(s).ShaderModules().Contains(cmd.ShaderModule()) {
 			warnDropCmd(cmd.ShaderModule())
-			return
+			return nil
 		}
 	case *VkDestroyPipeline:
 		if !GetState(s).GraphicsPipelines().Contains(cmd.Pipeline()) &&
 			!GetState(s).ComputePipelines().Contains(cmd.Pipeline()) {
 			warnDropCmd(cmd.Pipeline())
-			return
+			return nil
 		}
 	case *VkDestroyPipelineLayout:
 		if !GetState(s).PipelineLayouts().Contains(cmd.PipelineLayout()) {
 			warnDropCmd(cmd.PipelineLayout())
-			return
+			return nil
 		}
 	case *VkDestroyPipelineCache:
 		if !GetState(s).PipelineCaches().Contains(cmd.PipelineCache()) {
 			warnDropCmd(cmd.PipelineCache())
-			return
+			return nil
 		}
 	case *VkDestroySampler:
 		if !GetState(s).Samplers().Contains(cmd.Sampler()) {
 			warnDropCmd(cmd.Sampler())
-			return
+			return nil
 		}
 	case *VkFreeDescriptorSets:
 		descSetCount := cmd.DescriptorSetCount()
@@ -473,7 +465,7 @@ func (t *dropInvalidDestroy) Transform(ctx context.Context, id api.CmdID, cmd ap
 			if len(newDescSets) == 0 {
 				// no need to have this command
 				warnDropCmd(descSets)
-				return
+				return nil
 			}
 			if len(newDescSets) != len(descSets) {
 				// need to modify the command to drop the command buffers not
@@ -484,8 +476,7 @@ func (t *dropInvalidDestroy) Transform(ctx context.Context, id api.CmdID, cmd ap
 				newCmd := cb.VkFreeDescriptorSets(
 					cmd.Device(), cmd.DescriptorPool(), uint32(len(newDescSets)),
 					newDescSetsData.Ptr(), VkResult_VK_SUCCESS).AddRead(newDescSetsData.Data())
-				out.MutateAndWrite(ctx, id, newCmd)
-				return
+				return out.MutateAndWrite(ctx, id, newCmd)
 			}
 			// No need to modify the command, just mutate and write the command
 			// like others.
@@ -493,66 +484,65 @@ func (t *dropInvalidDestroy) Transform(ctx context.Context, id api.CmdID, cmd ap
 	case *VkDestroyDescriptorSetLayout:
 		if !GetState(s).DescriptorSetLayouts().Contains(cmd.DescriptorSetLayout()) {
 			warnDropCmd(cmd.DescriptorSetLayout())
-			return
+			return nil
 		}
 	case *VkDestroyDescriptorPool:
 		if !GetState(s).DescriptorPools().Contains(cmd.DescriptorPool()) {
 			warnDropCmd(cmd.DescriptorPool())
-			return
+			return nil
 		}
 	case *VkDestroyFence:
 		if !GetState(s).Fences().Contains(cmd.Fence()) {
 			warnDropCmd(cmd.Fence())
-			return
+			return nil
 		}
 	case *VkDestroySemaphore:
 		if !GetState(s).Semaphores().Contains(cmd.Semaphore()) {
 			warnDropCmd(cmd.Semaphore())
-			return
+			return nil
 		}
 	case *VkDestroyEvent:
 		if !GetState(s).Events().Contains(cmd.Event()) {
 			warnDropCmd(cmd.Event())
-			return
+			return nil
 		}
 	case *VkDestroyQueryPool:
 		if !GetState(s).QueryPools().Contains(cmd.QueryPool()) {
 			warnDropCmd(cmd.QueryPool())
-			return
+			return nil
 		}
 	case *VkDestroyFramebuffer:
 		if !GetState(s).Framebuffers().Contains(cmd.Framebuffer()) {
 			warnDropCmd(cmd.Framebuffer())
-			return
+			return nil
 		}
 	case *VkDestroyRenderPass:
 		if !GetState(s).RenderPasses().Contains(cmd.RenderPass()) {
 			warnDropCmd(cmd.RenderPass())
-			return
+			return nil
 		}
 	case *VkDestroyCommandPool:
 		if !GetState(s).CommandPools().Contains(cmd.CommandPool()) {
 			warnDropCmd(cmd.CommandPool())
-			return
+			return nil
 		}
 	case *VkDestroySurfaceKHR:
 		if !GetState(s).Surfaces().Contains(cmd.Surface()) {
 			warnDropCmd(cmd.Surface())
-			return
+			return nil
 		}
 	case *VkDestroySwapchainKHR:
 		if !GetState(s).Swapchains().Contains(cmd.Swapchain()) {
 			warnDropCmd(cmd.Swapchain())
-			return
+			return nil
 		}
 	case *VkDestroyDebugReportCallbackEXT:
 		if !GetState(s).DebugReportCallbacks().Contains(cmd.Callback()) {
 			warnDropCmd(cmd.Callback())
-			return
+			return nil
 		}
 	}
-	out.MutateAndWrite(ctx, id, cmd)
-	return
+	return out.MutateAndWrite(ctx, id, cmd)
 }
 
 func (t *dropInvalidDestroy) Flush(ctx context.Context, out transform.Writer) error { return nil }
@@ -565,8 +555,8 @@ func (t *dropInvalidDestroy) BuffersCommands() bool                             
 type destroyResourcesAtEOS struct {
 }
 
-func (t *destroyResourcesAtEOS) Transform(ctx context.Context, id api.CmdID, cmd api.Cmd, out transform.Writer) {
-	out.MutateAndWrite(ctx, id, cmd)
+func (t *destroyResourcesAtEOS) Transform(ctx context.Context, id api.CmdID, cmd api.Cmd, out transform.Writer) error {
+	return out.MutateAndWrite(ctx, id, cmd)
 }
 
 func (t *destroyResourcesAtEOS) Flush(ctx context.Context, out transform.Writer) error {
@@ -766,7 +756,7 @@ func newDisplayToSurface() *DisplayToSurface {
 
 // DisplayToSurface is a transformation that enables rendering during replay to
 // the original surface.
-func (t *DisplayToSurface) Transform(ctx context.Context, id api.CmdID, cmd api.Cmd, out transform.Writer) {
+func (t *DisplayToSurface) Transform(ctx context.Context, id api.CmdID, cmd api.Cmd, out transform.Writer) error {
 	switch c := cmd.(type) {
 	case *VkCreateSwapchainKHR:
 		newCmd := c.clone(out.State().Arena)
@@ -774,8 +764,7 @@ func (t *DisplayToSurface) Transform(ctx context.Context, id api.CmdID, cmd api.
 		// Add an extra to indicate to custom_replay to add a flag to
 		// the virtual swapchain pNext
 		newCmd.extras = append(api.CmdExtras{t}, cmd.Extras().All()...)
-		out.MutateAndWrite(ctx, id, newCmd)
-		return
+		return out.MutateAndWrite(ctx, id, newCmd)
 	case *VkCreateAndroidSurfaceKHR:
 		cmd.Extras().Observations().ApplyWrites(out.State().Memory.ApplicationPool())
 		surface := c.PSurface().MustRead(ctx, cmd, out.State(), nil)
@@ -805,7 +794,7 @@ func (t *DisplayToSurface) Transform(ctx context.Context, id api.CmdID, cmd api.
 		surface := c.PSurface().MustRead(ctx, cmd, out.State(), nil)
 		t.SurfaceTypes[uint64(surface)] = uint32(VkStructureType_VK_STRUCTURE_TYPE_STREAM_DESCRIPTOR_SURFACE_CREATE_INFO_GGP)
 	}
-	out.MutateAndWrite(ctx, id, cmd)
+	return out.MutateAndWrite(ctx, id, cmd)
 }
 
 func (t *DisplayToSurface) Flush(ctx context.Context, out transform.Writer) error { return nil }

--- a/gapis/api/vulkan/simplify_fragment_shader.go
+++ b/gapis/api/vulkan/simplify_fragment_shader.go
@@ -91,7 +91,7 @@ func simplifyFragmentShader(ctx context.Context) transform.Transformer {
 	ctx = log.Enter(ctx, "simplifyFragmentShader")
 
 	return transform.Transform("simplifyFragmentShader", func(ctx context.Context,
-		id api.CmdID, cmd api.Cmd, out transform.Writer) {
+		id api.CmdID, cmd api.Cmd, out transform.Writer) error {
 
 		s := out.State()
 		l := s.MemoryLayout
@@ -153,9 +153,9 @@ func simplifyFragmentShader(ctx context.Context) transform.Transformer {
 			}
 			newCmd.AddRead(nameData.Data())
 
-			out.MutateAndWrite(ctx, id, newCmd)
+			return out.MutateAndWrite(ctx, id, newCmd)
 		default:
-			out.MutateAndWrite(ctx, id, cmd)
+			return out.MutateAndWrite(ctx, id, cmd)
 		}
 	})
 }

--- a/gapis/api/vulkan/simplify_sampling.go
+++ b/gapis/api/vulkan/simplify_sampling.go
@@ -27,7 +27,7 @@ import (
 func simplifySampling(ctx context.Context) transform.Transformer {
 	ctx = log.Enter(ctx, "Simplify sampling")
 	return transform.Transform("Simplify sampling", func(ctx context.Context,
-		id api.CmdID, cmd api.Cmd, out transform.Writer) {
+		id api.CmdID, cmd api.Cmd, out transform.Writer) error {
 
 		s := out.State()
 		cb := CommandBuilder{Thread: cmd.Thread(), Arena: s.Arena}
@@ -53,9 +53,9 @@ func simplifySampling(ctx context.Context) transform.Transformer {
 			for _, w := range cmd.Extras().Observations().Writes {
 				newCmd.AddWrite(w.Range, w.ID)
 			}
-			out.MutateAndWrite(ctx, id, newCmd)
+			return out.MutateAndWrite(ctx, id, newCmd)
 		default:
-			out.MutateAndWrite(ctx, id, cmd)
+			return out.MutateAndWrite(ctx, id, cmd)
 		}
 	})
 }

--- a/gapis/api/vulkan/vulkan_terminator.go
+++ b/gapis/api/vulkan/vulkan_terminator.go
@@ -442,7 +442,7 @@ func (t *VulkanTerminator) Transform(ctx context.Context, id api.CmdID, cmd api.
 	}
 }
 
-func (t *VulkanTerminator) Flush(ctx context.Context, out transform.Writer)       {}
+func (t *VulkanTerminator) Flush(ctx context.Context, out transform.Writer) error { return nil }
 func (t *VulkanTerminator) PreLoop(ctx context.Context, output transform.Writer)  {}
 func (t *VulkanTerminator) PostLoop(ctx context.Context, output transform.Writer) {}
 func (t *VulkanTerminator) BuffersCommands() bool                                 { return false }

--- a/gapis/api/vulkan/vulkan_terminator.go
+++ b/gapis/api/vulkan/vulkan_terminator.go
@@ -398,9 +398,9 @@ func cutCommandBuffer(ctx context.Context, id api.CmdID,
 	newSubmitData.Free()
 }
 
-func (t *VulkanTerminator) Transform(ctx context.Context, id api.CmdID, cmd api.Cmd, out transform.Writer) {
+func (t *VulkanTerminator) Transform(ctx context.Context, id api.CmdID, cmd api.Cmd, out transform.Writer) error {
 	if t.stopped {
-		return
+		return nil
 	}
 
 	doCut := false
@@ -440,6 +440,7 @@ func (t *VulkanTerminator) Transform(ctx context.Context, id api.CmdID, cmd api.
 	if id == t.lastRequest {
 		t.stopped = true
 	}
+	return nil
 }
 
 func (t *VulkanTerminator) Flush(ctx context.Context, out transform.Writer) error { return nil }

--- a/gapis/api/vulkan/wait_for_perfetto.go
+++ b/gapis/api/vulkan/wait_for_perfetto.go
@@ -52,11 +52,11 @@ func (t *WaitForPerfetto) waitTest(ctx context.Context, id api.CmdID, cmd api.Cm
 	return false
 }
 
-func (t *WaitForPerfetto) Transform(ctx context.Context, id api.CmdID, cmd api.Cmd, out transform.Writer) {
+func (t *WaitForPerfetto) Transform(ctx context.Context, id api.CmdID, cmd api.Cmd, out transform.Writer) error {
 	if t.waitTest(ctx, id, cmd) {
 		addVkDeviceWaitIdle(ctx, out)
 	}
-	t.wff.Transform(ctx, id, cmd, out)
+	return t.wff.Transform(ctx, id, cmd, out)
 }
 
 func (t *WaitForPerfetto) Flush(ctx context.Context, out transform.Writer) error {

--- a/gapis/api/vulkan/wait_for_perfetto.go
+++ b/gapis/api/vulkan/wait_for_perfetto.go
@@ -59,9 +59,9 @@ func (t *WaitForPerfetto) Transform(ctx context.Context, id api.CmdID, cmd api.C
 	t.wff.Transform(ctx, id, cmd, out)
 }
 
-func (t *WaitForPerfetto) Flush(ctx context.Context, out transform.Writer) {
+func (t *WaitForPerfetto) Flush(ctx context.Context, out transform.Writer) error {
 	addVkDeviceWaitIdle(ctx, out)
-	t.wff.Flush(ctx, out)
+	return t.wff.Flush(ctx, out)
 }
 
 func (t *WaitForPerfetto) PreLoop(ctx context.Context, out transform.Writer)  {}

--- a/gapis/api/vulkan/wireframe.go
+++ b/gapis/api/vulkan/wireframe.go
@@ -27,7 +27,7 @@ import (
 func wireframe(ctx context.Context) transform.Transformer {
 	ctx = log.Enter(ctx, "Wireframe")
 	return transform.Transform("Wireframe", func(ctx context.Context,
-		id api.CmdID, cmd api.Cmd, out transform.Writer) {
+		id api.CmdID, cmd api.Cmd, out transform.Writer) error {
 		s := out.State()
 		l := s.MemoryLayout
 		cb := CommandBuilder{Thread: cmd.Thread(), Arena: s.Arena}
@@ -56,9 +56,9 @@ func wireframe(ctx context.Context) transform.Transformer {
 			for _, w := range cmd.Extras().Observations().Writes {
 				newCmd.AddWrite(w.Range, w.ID)
 			}
-			out.MutateAndWrite(ctx, id, newCmd)
+			return out.MutateAndWrite(ctx, id, newCmd)
 		default:
-			out.MutateAndWrite(ctx, id, cmd)
+			return out.MutateAndWrite(ctx, id, cmd)
 		}
 	})
 }

--- a/gapis/replay/batch.go
+++ b/gapis/replay/batch.go
@@ -395,14 +395,17 @@ func (w *adapter) State() *api.GlobalState {
 	return w.state
 }
 
-func (w *adapter) MutateAndWrite(ctx context.Context, id api.CmdID, cmd api.Cmd) {
+func (w *adapter) MutateAndWrite(ctx context.Context, id api.CmdID, cmd api.Cmd) error {
 	w.builder.BeginCommand(uint64(id), cmd.Thread())
-	if err := cmd.Mutate(ctx, id, w.state, w.builder, nil); err == nil {
+	err := cmd.Mutate(ctx, id, w.state, w.builder, nil)
+	if err == nil {
 		w.builder.CommitCommand()
 	} else {
 		w.builder.RevertCommand(err)
 		log.W(ctx, "Failed to write command %v %v for replay: %v", id, cmd, err)
 	}
+	return err
 }
+
 func (w *adapter) NotifyPreLoop(ctx context.Context)  {}
 func (w *adapter) NotifyPostLoop(ctx context.Context) {}

--- a/gapis/replay/end_of_replay.go
+++ b/gapis/replay/end_of_replay.go
@@ -41,8 +41,9 @@ func (t *EndOfReplay) Transform(ctx context.Context, id api.CmdID, cmd api.Cmd, 
 	out.MutateAndWrite(ctx, id, cmd)
 }
 
-func (t *EndOfReplay) Flush(ctx context.Context, out transform.Writer) {
+func (t *EndOfReplay) Flush(ctx context.Context, out transform.Writer) error {
 	t.AddNotifyInstruction(ctx, out, func() interface{} { return nil })
+	return nil
 }
 
 func (t *EndOfReplay) PreLoop(ctx context.Context, out transform.Writer)  {}

--- a/gapis/replay/end_of_replay.go
+++ b/gapis/replay/end_of_replay.go
@@ -37,8 +37,8 @@ func (t *EndOfReplay) AddResult(r Result) {
 	t.res = append(t.res, r)
 }
 
-func (t *EndOfReplay) Transform(ctx context.Context, id api.CmdID, cmd api.Cmd, out transform.Writer) {
-	out.MutateAndWrite(ctx, id, cmd)
+func (t *EndOfReplay) Transform(ctx context.Context, id api.CmdID, cmd api.Cmd, out transform.Writer) error {
+	return out.MutateAndWrite(ctx, id, cmd)
 }
 
 func (t *EndOfReplay) Flush(ctx context.Context, out transform.Writer) error {

--- a/gapis/replay/mapping_exporter.go
+++ b/gapis/replay/mapping_exporter.go
@@ -157,9 +157,9 @@ func (m *MappingExporter) ExtractRemappings(ctx context.Context, s *api.GlobalSt
 	return nil
 }
 
-func (m *MappingExporter) Transform(ctx context.Context, id api.CmdID, cmd api.Cmd, out transform.Writer) {
+func (m *MappingExporter) Transform(ctx context.Context, id api.CmdID, cmd api.Cmd, out transform.Writer) error {
 	m.thread = cmd.Thread()
-	out.MutateAndWrite(ctx, id, cmd)
+	return out.MutateAndWrite(ctx, id, cmd)
 }
 
 func printToFile(ctx context.Context, path string, mappings *map[uint64][]service.VulkanHandleMappingItem) {

--- a/gapis/replay/mapping_exporter.go
+++ b/gapis/replay/mapping_exporter.go
@@ -185,8 +185,8 @@ func printToFile(ctx context.Context, path string, mappings *map[uint64][]servic
 	f.Close()
 }
 
-func (m *MappingExporter) Flush(ctx context.Context, out transform.Writer) {
-	out.MutateAndWrite(ctx, api.CmdNoID, Custom{m.thread,
+func (m *MappingExporter) Flush(ctx context.Context, out transform.Writer) error {
+	return out.MutateAndWrite(ctx, api.CmdNoID, Custom{m.thread,
 		func(ctx context.Context, s *api.GlobalState, b *builder.Builder) error {
 			return m.ExtractRemappings(ctx, s, b)
 		},

--- a/gapis/replay/wait_for_fence.go
+++ b/gapis/replay/wait_for_fence.go
@@ -29,11 +29,11 @@ type WaitForFence struct {
 	ShouldWait        func(ctx context.Context, id api.CmdID, cmd api.Cmd) bool
 }
 
-func (t *WaitForFence) Transform(ctx context.Context, id api.CmdID, cmd api.Cmd, out transform.Writer) {
+func (t *WaitForFence) Transform(ctx context.Context, id api.CmdID, cmd api.Cmd, out transform.Writer) error {
 	if t.TransformCallback != nil && t.ShouldWait != nil && t.ShouldWait(ctx, id, cmd) {
 		t.AddTransformWait(ctx, id, out)
 	}
-	out.MutateAndWrite(ctx, id, cmd)
+	return out.MutateAndWrite(ctx, id, cmd)
 }
 
 func (t *WaitForFence) Flush(ctx context.Context, out transform.Writer) error {

--- a/gapis/replay/wait_for_fence.go
+++ b/gapis/replay/wait_for_fence.go
@@ -36,10 +36,11 @@ func (t *WaitForFence) Transform(ctx context.Context, id api.CmdID, cmd api.Cmd,
 	out.MutateAndWrite(ctx, id, cmd)
 }
 
-func (t *WaitForFence) Flush(ctx context.Context, out transform.Writer) {
+func (t *WaitForFence) Flush(ctx context.Context, out transform.Writer) error {
 	if t.FlushCallback != nil {
-		t.AddFlushWait(ctx, out)
+		return t.AddFlushWait(ctx, out)
 	}
+	return nil
 }
 
 func (t *WaitForFence) PreLoop(ctx context.Context, out transform.Writer)  {}
@@ -57,8 +58,8 @@ func (t *WaitForFence) AddTransformWait(ctx context.Context, id api.CmdID, out t
 	}})
 }
 
-func (t *WaitForFence) AddFlushWait(ctx context.Context, out transform.Writer) {
-	out.MutateAndWrite(ctx, api.CmdNoID, Custom{T: 0, F: func(ctx context.Context, s *api.GlobalState, b *builder.Builder) error {
+func (t *WaitForFence) AddFlushWait(ctx context.Context, out transform.Writer) error {
+	return out.MutateAndWrite(ctx, api.CmdNoID, Custom{T: 0, F: func(ctx context.Context, s *api.GlobalState, b *builder.Builder) error {
 		fenceID := uint32(0x3ffffff)
 		b.Wait(fenceID)
 		fcb := func(p *gapir.FenceReadyRequest) {

--- a/gapis/resolve/dependencygraph/dead_code_elimination.go
+++ b/gapis/resolve/dependencygraph/dead_code_elimination.go
@@ -83,24 +83,23 @@ func (t *DeadCodeElimination) PreLoop(ctx context.Context, out transform.Writer)
 func (t *DeadCodeElimination) PostLoop(ctx context.Context, out transform.Writer) {}
 func (t *DeadCodeElimination) BuffersCommands() bool                              { return false }
 
-func (t *DeadCodeElimination) Flush(ctx context.Context, out transform.Writer) {
+func (t *DeadCodeElimination) Flush(ctx context.Context, out transform.Writer) error {
 	ctx = status.Start(ctx, "DCE Flush")
 	defer status.Finish(ctx)
 
 	if t.KeepAllAlive {
-		api.ForeachCmd(ctx, t.depGraph.Commands, true, func(ctx context.Context, index api.CmdID, cmd api.Cmd) error {
-			out.MutateAndWrite(ctx, t.depGraph.GetCmdID(int(index)), cmd)
-			return nil
+		err := api.ForeachCmd(ctx, t.depGraph.Commands, true, func(ctx context.Context, index api.CmdID, cmd api.Cmd) error {
+			return out.MutateAndWrite(ctx, t.depGraph.GetCmdID(int(index)), cmd)
 		})
-		return
+		return err
 	}
 	t0 := deadCodeEliminationCounter.Start()
 	isLive := t.propagateLiveness(ctx)
 	deadCodeEliminationCounter.Stop(t0)
-	api.ForeachCmd(ctx, t.depGraph.Commands[:len(isLive)], true, func(ctx context.Context, index api.CmdID, cmd api.Cmd) error {
+	return api.ForeachCmd(ctx, t.depGraph.Commands[:len(isLive)], true, func(ctx context.Context, index api.CmdID, cmd api.Cmd) error {
 		id := t.depGraph.GetCmdID(int(index))
 		if isLive[index] {
-			out.MutateAndWrite(ctx, id, cmd)
+			return out.MutateAndWrite(ctx, id, cmd)
 		} else if debugDCE {
 			log.I(ctx, "Dropped %v %v", id, cmd)
 		}

--- a/gapis/resolve/dependencygraph/dead_code_elimination.go
+++ b/gapis/resolve/dependencygraph/dead_code_elimination.go
@@ -75,7 +75,7 @@ func (t *DeadCodeElimination) Request(id api.CmdID) {
 	}
 }
 
-func (t *DeadCodeElimination) Transform(ctx context.Context, id api.CmdID, c api.Cmd, out transform.Writer) {
+func (t *DeadCodeElimination) Transform(ctx context.Context, id api.CmdID, c api.Cmd, out transform.Writer) error {
 	panic(fmt.Errorf("This transform does not accept input commands"))
 }
 

--- a/gapis/resolve/dependencygraph2/dce.go
+++ b/gapis/resolve/dependencygraph2/dce.go
@@ -380,7 +380,7 @@ func (*DCEBuilder) Transform(ctx context.Context, id api.CmdID, c api.Cmd, out t
 
 // Flush is to comform the interface of Transformer. Flush performs DCE, and
 // sends the live commands to the writer
-func (b *DCEBuilder) Flush(ctx context.Context, out transform.Writer) {
+func (b *DCEBuilder) Flush(ctx context.Context, out transform.Writer) error {
 	b.Build(ctx)
 	for i, cmd := range b.LiveCmds() {
 		liveCmdID := api.CmdID(i)
@@ -393,8 +393,11 @@ func (b *DCEBuilder) Flush(ctx context.Context, out transform.Writer) {
 		if config.DebugDeadCodeElimination {
 			log.D(ctx, "Flushing [%v / %v] %v", cmdID, liveCmdID, cmd)
 		}
-		out.MutateAndWrite(ctx, cmdID, cmd)
+		if err := out.MutateAndWrite(ctx, cmdID, cmd); err != nil {
+			return err
+		}
 	}
+	return nil
 }
 
 func (b *DCEBuilder) PreLoop(ctx context.Context, out transform.Writer)  {}

--- a/gapis/resolve/dependencygraph2/dce.go
+++ b/gapis/resolve/dependencygraph2/dce.go
@@ -374,7 +374,7 @@ func (b *DCEBuilder) Request(ctx context.Context, fci api.SubCmdIdx) error {
 
 // Transform is to comform the interface of Transformer, but does not accept
 // any input.
-func (*DCEBuilder) Transform(ctx context.Context, id api.CmdID, c api.Cmd, out transform.Writer) {
+func (*DCEBuilder) Transform(ctx context.Context, id api.CmdID, c api.Cmd, out transform.Writer) error {
 	panic(fmt.Errorf("This transform does not accept input commands"))
 }
 

--- a/test/integration/gles/replay/shaders.go
+++ b/test/integration/gles/replay/shaders.go
@@ -29,7 +29,7 @@ uniform float angle;
 void main() {
 	float c = cos(angle);
 	float s = sin(angle);
-	mat3 rotation = mat3(vec3(c, -s, 0.0), vec3(s, c, 0.0), vec3(0.0, 0.0, 1.0));
+		mat3 rotation = mat3(vec3(c, -s, 0.0), vec3(s, c, 0.0), vec3(0.0, 0.0, 1.0));
 	gl_Position = vec4(rotation * position, 1.0);
 }`
 

--- a/test/integration/gles/replay/shaders.go
+++ b/test/integration/gles/replay/shaders.go
@@ -29,7 +29,7 @@ uniform float angle;
 void main() {
 	float c = cos(angle);
 	float s = sin(angle);
-		mat3 rotation = mat3(vec3(c, -s, 0.0), vec3(s, c, 0.0), vec3(0.0, 0.0, 1.0));
+	mat3 rotation = mat3(vec3(c, -s, 0.0), vec3(s, c, 0.0), vec3(0.0, 0.0, 1.0));
 	gl_Position = vec4(rotation * position, 1.0);
 }`
 


### PR DESCRIPTION
Add systematic error reporting to Transforms. In practice, this means adding
error reporting the following:
- gapis/api/transform.Transforms.Tranform()
- gapis/api/transform.Writer:MutateAndWrite()
- gapis/api/transform.Writer:Flush()
- gapis/api/transform.Writer:Transform()

This PR is split in separate commits for each of those.

Bug: b/145003736