### PR TITLE
Always vulkan sample app run in portrait mode on Android.

### DIFF
--- a/gapidapk/android/apk/AndroidManifest.xml.in
+++ b/gapidapk/android/apk/AndroidManifest.xml.in
@@ -31,6 +31,9 @@
         android:supportsRtl="true"
         android:debuggable="true"
         >
+        <meta-data
+            android:name="com.android.graphics.developerdriver.enable"
+            android:value="true" />
         <activity android:name="com.google.android.gapid.ReplayerActivity"
                   android:label="GAPID - ${name}">
             <meta-data android:name="android.app.lib_name"
@@ -40,7 +43,9 @@
             </intent-filter>
         </activity>
         <activity android:name="com.google.android.gapid.VkSampleActivity"
-                  android:label="GAPID - Vulkan Sample">
+                  android:label="GAPID - Vulkan Sample"
+                  android:configChanges="orientation|screenSize"
+                  android:screenOrientation="portrait">
             <meta-data android:name="android.app.lib_name"
                        android:value="vulkan_sample" />
             <intent-filter>


### PR DESCRIPTION
Currently on Android the vulkan sample app doesn't handle screen rotation, and
we don't need it to react to screen rotation. Hence always run it in portrait
mode.

This patch also enables the apk to use developer driver.

Bug: b/148104724