### PR TITLE
Detect render stage capability from prerelease driver

### DIFF
--- a/core/os/android/layers.go
+++ b/core/os/android/layers.go
@@ -74,6 +74,12 @@ func SetupLayers(ctx context.Context, d Device, appPkg string, layerPkgs []strin
 				return cleanup.Invoke(ctx), err
 			}
 		}
+	} else {
+		if vulkan {
+			d.DeleteSystemSetting(ctx, "global", "gpu_debug_layers")
+		} else {
+			d.DeleteSystemSetting(ctx, "global", "gpu_debug_layers_gles")
+		}
 	}
 
 	return cleanup, nil

--- a/core/os/device/device.proto
+++ b/core/os/device/device.proto
@@ -191,6 +191,7 @@ message GPUProfiling {
   // The GPU performance counters.
   GpuCounterDescriptor gpu_counter_descriptor = 2;
   bool hasFrameLifecycle = 3;
+  bool has_render_stage_producer_layer = 4;
 }
 
 // Instance represents a physical device.

--- a/gapidapk/BUILD.bazel
+++ b/gapidapk/BUILD.bazel
@@ -25,6 +25,7 @@ go_library(
     importpath = "github.com/google/gapid/gapidapk",
     visibility = ["//visibility:public"],
     deps = [
+        "//core/app:go_default_library",
         "//core/app/crash:go_default_library",
         "//core/app/layout:go_default_library",
         "//core/event/task:go_default_library",


### PR DESCRIPTION
The gpu.renderstages producer can be implemented in prerelease driver
UMD or the VkRenderStagesProducer layer.  To properly detect render
stage capacbility, we need to properly set up the environement for
device info service.

Bug: b/142480442