### PR TITLE
Force prerelease driver for tracing and replay

### DIFF
--- a/core/os/android/adb/device.go
+++ b/core/os/android/adb/device.go
@@ -26,7 +26,6 @@ import (
 	"github.com/google/gapid/core/event/task"
 	"github.com/google/gapid/core/fault"
 	"github.com/google/gapid/core/log"
-	"github.com/google/gapid/core/os/android"
 	"github.com/google/gapid/core/os/device"
 	"github.com/google/gapid/core/os/device/bind"
 	"github.com/google/gapid/core/os/shell"
@@ -114,18 +113,18 @@ func Devices(ctx context.Context) (DeviceList, error) {
 	return out, nil
 }
 
-func SetupPrereleaseDriver(ctx context.Context, d Device, p *android.InstalledPackage) (app.Cleanup, error) {
+func SetupPrereleaseDriver(ctx context.Context, d Device, packageName string) (app.Cleanup, error) {
 	oldOptinApps, err := d.SystemSetting(ctx, "global", prereleaseDriverSettingVariable)
 	if err != nil {
 		return nil, log.Err(ctx, err, "Failed to get prerelease driver opt in apps.")
 	}
-	if strings.Contains(oldOptinApps, p.Name) {
+	if strings.Contains(oldOptinApps, packageName) {
 		return nil, nil
 	}
-	newOptinApps := oldOptinApps + "," + p.Name
+	newOptinApps := oldOptinApps + "," + packageName
 	// TODO(b/145893290) Check whether application has developer driver enabled once b/145893290 is fixed.
 	if err := d.SetSystemSetting(ctx, "global", prereleaseDriverSettingVariable, newOptinApps); err != nil {
-		return nil, log.Errf(ctx, err, "Failed to set up prerelease driver for app: %v.", p.Name)
+		return nil, log.Errf(ctx, err, "Failed to set up prerelease driver for app: %v.", packageName)
 	}
 	return func(ctx context.Context) {
 		d.SetSystemSetting(ctx, "global", prereleaseDriverSettingVariable, oldOptinApps)

--- a/gapic/src/main/com/google/gapid/views/TracerDialog.java
+++ b/gapic/src/main/com/google/gapid/views/TracerDialog.java
@@ -232,7 +232,7 @@ public class TracerDialog {
       createButton(parent, IDialogConstants.CANCEL_ID, IDialogConstants.CANCEL_LABEL, false);
 
       Listener modifyListener = e -> {
-        ok.setEnabled(traceInput.isReady());
+        ok.setEnabled(traceInput.isReady() && traceInput.getDeviceHasProfilingCapability());
       };
       traceInput.addModifyListener(modifyListener);
 
@@ -265,7 +265,7 @@ public class TracerDialog {
       private static final String MEC_LABEL_WARNING =
           "NOTE: Mid-Execution capture for %s is experimental";
       private static final String PERFETTO_LABEL = "Profile Config: ";
-      private static final String NO_GPU_PROFILING_CAPABILITY = "Warning: Selected device has no GPU profiling capability.";
+      private static final String NO_GPU_PROFILING_CAPABILITY = "Error: Selected device has no GPU profiling capability.";
       private static final String EMPTY_APP_WITH_RENDER_STAGE =
           "Warning: Application needs to be specified for GPU profiling data.";
 
@@ -301,12 +301,13 @@ public class TracerDialog {
       private final Label fileLabel;
       private final Label pcsWarning;
       private final Label requiredFieldMessage;
-      private final Label gpuProfilingCapabilityWarning;
       private final Label emptyAppWarning;
+      private final Label gpuProfilingCapabilityErrorMessage;
 
       protected String friendlyName = "";
       protected boolean userHasChangedOutputFile = false;
       protected boolean userHasChangedTarget = false;
+      protected boolean deviceHasProfilingCapability = false;
 
       public TraceInput(Composite parent, Models models, Widgets widgets, Runnable refreshDevices) {
         super(parent, SWT.NONE);
@@ -450,11 +451,11 @@ public class TracerDialog {
         requiredFieldMessage.setForeground(getDisplay().getSystemColor(SWT.COLOR_RED));
         requiredFieldMessage.setVisible(false);
 
-        gpuProfilingCapabilityWarning = withLayoutData(
+        gpuProfilingCapabilityErrorMessage = withLayoutData(
             createLabel(this, NO_GPU_PROFILING_CAPABILITY),
             new GridData(SWT.FILL, SWT.FILL, true, false));
-        gpuProfilingCapabilityWarning.setForeground(getDisplay().getSystemColor(SWT.COLOR_DARK_YELLOW));
-        gpuProfilingCapabilityWarning.setVisible(false);
+        gpuProfilingCapabilityErrorMessage.setForeground(getDisplay().getSystemColor(SWT.COLOR_RED));
+        gpuProfilingCapabilityErrorMessage.setVisible(false);
 
         Link adbWarning = withLayoutData(
             createLink(this, "Path to adb invalid/missing. " +
@@ -470,18 +471,8 @@ public class TracerDialog {
             e -> updateOnApiChange(trace, getSelectedDevice(), getSelectedApi()));
 
         Listener gpuProfilingCapabilityListener = e -> {
-          // Skip if the device is not Android device, or trace type is not Perfetto.
-          if (getSelectedDevice() == null || !getSelectedDevice().isAndroid() ||
-              getSelectedApi() == null || getSelectedApi().getType() != TraceType.Perfetto) {
-            gpuProfilingCapabilityWarning.setVisible(false);
-            return;
-          }
-          Device.GPUProfiling gpuCaps = getPerfettoCaps().getGpuProfiling();
-          if (gpuCaps.getHasRenderStage() && gpuCaps.getGpuCounterDescriptor().getSpecsCount() > 0) {
-            gpuProfilingCapabilityWarning.setVisible(false);
-            return;
-          }
-          gpuProfilingCapabilityWarning.setVisible(true);
+          cacheHasProfilingCapability();
+          gpuProfilingCapabilityErrorMessage.setVisible(!deviceHasProfilingCapability);
         };
         device.getCombo().addListener(SWT.Selection, gpuProfilingCapabilityListener);
         api.getCombo().addListener(SWT.Selection, gpuProfilingCapabilityListener);
@@ -531,6 +522,18 @@ public class TracerDialog {
 
         updateDevicesDropDown(trace);
         colorFilledInput(widgets.theme);
+      }
+
+      private void cacheHasProfilingCapability() {
+        // Skip if the device is not Android device, or trace type is not Perfetto.
+        if (getSelectedDevice() == null || !getSelectedDevice().isAndroid() ||
+            getSelectedApi() == null || getSelectedApi().getType() != TraceType.Perfetto) {
+          deviceHasProfilingCapability = true;
+        } else {
+          Device.GPUProfiling gpuCaps = getPerfettoCaps().getGpuProfiling();
+          deviceHasProfilingCapability =
+              gpuCaps.getHasRenderStage() && gpuCaps.getGpuCounterDescriptor().getSpecsCount() > 0;
+        }
       }
 
       private void colorFilledInput(Theme theme) {
@@ -815,6 +818,10 @@ public class TracerDialog {
         return getSelectedDevice() != null && config != null &&
             (!config.getRequiresApplication() || !traceTarget.getText().isEmpty()) &&
             !directory.getText().isEmpty() && !file.getText().isEmpty();
+      }
+
+      public boolean getDeviceHasProfilingCapability() {
+        return deviceHasProfilingCapability;
       }
 
       public void addModifyListener(Listener listener) {

--- a/gapidapk/deviceinfo.go
+++ b/gapidapk/deviceinfo.go
@@ -116,7 +116,7 @@ func fetchDeviceInfo(ctx context.Context, d adb.Device) error {
 	var cleanup app.Cleanup
 
 	// Set up device info service to use prerelease driver.
-	nextCleanup, err := adb.SetupPrereleaseDriver(ctx, d, apk.InstalledPackage)
+	nextCleanup, err := adb.SetupPrereleaseDriver(ctx, d, apk.InstalledPackage.Name)
 	cleanup = cleanup.Then(nextCleanup)
 	if err != nil {
 		cleanup.Invoke(ctx)

--- a/gapii/client/adb.go
+++ b/gapii/client/adb.go
@@ -72,6 +72,23 @@ func Start(ctx context.Context, p *android.InstalledPackage, a *android.Activity
 		abi = p.Device.Instance().GetConfiguration().PreferredABI(nil)
 	}
 
+	driver, err := d.GraphicsDriver(ctx)
+	if err != nil {
+		return nil, nil, log.Err(ctx, err, "Failed to locate pre-release driver package")
+	}
+
+	cleanup := app.Cleanup(func(ctx context.Context) {})
+	// Force the traced app to use the pre-release driver, or fail early
+	if driver.Package != "" && a != nil && a.Package != nil {
+		nextCleanup, err := adb.SetupPrereleaseDriver(ctx, d, a.Package.Name)
+		cleanup = cleanup.Then(nextCleanup)
+		if err != nil {
+			return nil, cleanup.Invoke(ctx), err
+		}
+	} else {
+		return nil, cleanup.Invoke(ctx), log.Err(ctx, nil, "Failed to locate pre-release driver package")
+	}
+
 	// For NativeBridge emulated devices opt for the native ABI of the emulator.
 	abi = d.NativeBridgeABI(ctx, abi)
 
@@ -106,7 +123,7 @@ func Start(ctx context.Context, p *android.InstalledPackage, a *android.Activity
 	if err := d.Forward(ctx, adb.TCPPort(port), adb.NamedAbstractSocket(pipe)); err != nil {
 		return nil, nil, log.Err(ctx, err, "Setting up port forwarding for gapii")
 	}
-	cleanup := app.Cleanup(func(ctx context.Context) {
+	cleanup = cleanup.Then(func(ctx context.Context) {
 		d.RemoveForward(ctx, port)
 	})
 


### PR DESCRIPTION
This forces use of the prerelease driver in all tracing and turns missing profiling capabilities into an error that blocks tracing.