### PR TITLE
Don't show the GAPID app in the launcher.

### DIFF
--- a/gapidapk/android/apk/AndroidManifest.xml.in
+++ b/gapidapk/android/apk/AndroidManifest.xml.in
@@ -50,7 +50,6 @@
                        android:value="vulkan_sample" />
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
-                <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
         <service


### PR DESCRIPTION
Let's not pollute the user's app launcher. Our users don't really have a need to launch the spinning cube from the app launcher.