### PR TITLE
Make sure Perfetto daemons are running and persistent.

### DIFF
--- a/core/os/android/adb/adb_data_test.go
+++ b/core/os/android/adb/adb_data_test.go
@@ -194,11 +194,12 @@ untagSocket(48) failed with errno -22
 `),
 
 		// Common responses to all devices
-		stub.Regex(`adb -s .* shell getprop ro\.build\.product`, stub.Respond("hammerhead")),
-		stub.Regex(`adb -s .* shell getprop ro\.build\.version\.release`, stub.Respond("6.0.1")),
-		stub.Regex(`adb -s .* shell getprop ro\.build\.description`, stub.Respond("hammerhead-user 6.0.1 MMB29Q 2480792 release-keys")),
-		stub.Regex(`adb -s .* shell getprop ro\.product\.cpu\.abi`, stub.Respond("armeabi-v7a")),
-		stub.Regex(`adb -s .* shell getprop ro\.build\.version\.sdk`, stub.Respond("26")),
+		stub.Regex(`adb -s .* shell getprop ro\.build\.product`, stub.Respond("flame")),
+		stub.Regex(`adb -s .* shell getprop ro\.build\.version\.release`, stub.Respond("10")),
+		stub.Regex(`adb -s .* shell getprop ro\.build\.description`, stub.Respond("flame-user 10 QQ1A.191003.005 5926727 release-keys")),
+		stub.Regex(`adb -s .* shell getprop ro\.product\.cpu\.abi`, stub.Respond("arm64-v8a")),
+		stub.Regex(`adb -s .* shell getprop ro\.build\.version\.sdk`, stub.Respond("29")),
+		stub.Regex(`adb -s .* shell setprop persist\.traced\.enable 1`, stub.Respond("")),
 
 		stub.Regex(`adb -s .* shell input .*`, stub.Respond("")),
 	)

--- a/core/os/android/adb/adb_test.go
+++ b/core/os/android/adb/adb_test.go
@@ -41,6 +41,6 @@ func mustConnect(ctx context.Context, serial string) adb.Device {
 func TestADBShell(t_ *testing.T) {
 	ctx := log.Testing(t_)
 	d := mustConnect(ctx, "production_device")
-	assert.For(ctx, "Device").ThatString(d).Equals("hammerhead")
-	assert.For(ctx, "Device shell").ThatString(d.Shell("").Target).Equals("shell:hammerhead")
+	assert.For(ctx, "Device").ThatString(d).Equals("flame")
+	assert.For(ctx, "Device shell").ThatString(d.Shell("").Target).Equals("shell:flame")
 }

--- a/core/os/android/adb/commands.go
+++ b/core/os/android/adb/commands.go
@@ -304,6 +304,20 @@ func (b *binding) ConnectPerfetto(ctx context.Context) (*perfetto.Client, error)
 	return perfetto.NewClient(ctx, conn, cleanup)
 }
 
+// EnsurePerfettoPersistent ensures that Perfetto daemons, traced and
+// traced_probes, are running. Note that there is a delay between setting the
+// system property and daemons finish starting, hence this function needs to be
+// called as early as possible.
+func (b *binding) EnsurePerfettoPersistent(ctx context.Context) error {
+	if !b.SupportsPerfetto(ctx) {
+		return fmt.Errorf("Perfetto is not supported on this device")
+	}
+	if err := b.SetSystemProperty(ctx, "persist.traced.enable", "1"); err != nil {
+		return err
+	}
+	return nil
+}
+
 func (b *binding) QueryPerfettoServiceState(ctx context.Context) (*device.PerfettoCapability, error) {
 	result := b.To.Configuration.PerfettoCapability
 	if result == nil {

--- a/core/os/android/adb/device.go
+++ b/core/os/android/adb/device.go
@@ -189,6 +189,11 @@ func newDevice(ctx context.Context, serial string, status bind.Status) (*binding
 		}
 	}
 
+	// Make sure Perfetto daemons are running.
+	if err := d.EnsurePerfettoPersistent(ctx); err != nil {
+		return nil, err
+	}
+
 	// Run device info providers only if the API is supported
 	if d.To.Configuration.OS != nil && d.To.Configuration.OS.APIVersion >= device.AndroidMinimalSupportedAPIVersion {
 		devInfoProvidersMutex.Lock()

--- a/core/os/android/adb/device_test.go
+++ b/core/os/android/adb/device_test.go
@@ -30,21 +30,21 @@ func TestParseDevices(t_ *testing.T) {
 	defer func() { devices.Handlers[0] = validDevices }()
 	expected := &device.Instance{
 		Serial: "production_device",
-		Name:   "hammerhead",
+		Name:   "flame",
 		Configuration: &device.Configuration{
 			OS: &device.OS{
 				Kind:         device.Android,
-				Name:         "Marshmallow",
-				Build:        "hammerhead-user 6.0.1 MMB29Q 2480792 release-keys",
-				MajorVersion: 6,
+				Name:         "Android 10",
+				Build:        "flame-user 10 QQ1A.191003.005 5926727 release-keys",
+				MajorVersion: 10,
 				MinorVersion: 0,
-				PointVersion: 1,
-				APIVersion:   26,
+				PointVersion: 0,
+				APIVersion:   29,
 			},
 			Hardware: &device.Hardware{
-				Name: "hammerhead",
+				Name: "flame",
 			},
-			ABIs: []*device.ABI{device.AndroidARMv7a},
+			ABIs: []*device.ABI{device.AndroidARM64v8a},
 		},
 	}
 	expected.GenID()


### PR DESCRIPTION
Perfetto daemons are not required to run on the device, and the daemons must be
running in order to allow the data producers register themselves, hence before
we do any interaction between the tool and Perfetto, we must make sure Perfetto
daemons are running and persistent.

Note that there's a delay between setting the system property and the daemons
finish starting, hence we need to set the system property as early as possible.

Also update the test faked device to Android 10.

Bug: b/148566762