### PR TITLE
Link Vulkan submission events with GPU queue slices.

### DIFF
--- a/gapic/src/main/com/google/gapid/perfetto/models/GpuInfo.java
+++ b/gapic/src/main/com/google/gapid/perfetto/models/GpuInfo.java
@@ -29,7 +29,8 @@ import java.util.List;
  * Data about a GPU in the trace.
  */
 public class GpuInfo {
-  public static final GpuInfo NONE = new GpuInfo(Collections.emptyList(), Collections.emptyList());
+  public static final GpuInfo NONE = new GpuInfo(Collections.emptyList(), Collections.emptyList(),
+      Collections.emptyList());
 
   private static final String MAX_DEPTH_QUERY =
       "select t.id, t.name, t.scope, max(depth) + 1 " +
@@ -38,10 +39,12 @@ public class GpuInfo {
       "order by t.id";
 
   private final List<Queue> queues;
+  private final List<VkEvent> vkEvents;
   private final List<Buffer> buffers;
 
-  private GpuInfo(List<Queue> queues, List<Buffer> buffers) {
+  private GpuInfo(List<Queue> queues, List<VkEvent> vkEvents, List<Buffer> buffers) {
     this.queues = queues;
+    this.vkEvents = vkEvents;
     this.buffers = buffers;
   }
 
@@ -55,6 +58,14 @@ public class GpuInfo {
 
   public Iterable<Queue> queues() {
     return Iterables.unmodifiableIterable(queues);
+  }
+
+  public int vkEventCount() {
+    return vkEvents.size();
+  }
+
+  public Iterable<VkEvent> vkEvents() {
+    return Iterables.unmodifiableIterable(vkEvents);
   }
 
   public int bufferCount() {
@@ -72,11 +83,15 @@ public class GpuInfo {
   private static ListenableFuture<GpuInfo> info(QueryEngine qe) {
     return transform(qe.queries(MAX_DEPTH_QUERY), res -> {
       List<Queue> queues = Lists.newArrayList();
+      List<VkEvent> vkEvents = Lists.newArrayList();
       List<Buffer> buffers = Lists.newArrayList();
       res.forEachRow(($, r) -> {
         switch (r.getString(2)) {
           case "gpu_render_stage":
             queues.add(new Queue(queues.size(), r));
+            break;
+          case "vulkan_events":
+            vkEvents.add(new VkEvent(r));
             break;
           case "graphics_frame_event":
             buffers.add(new Buffer(r));
@@ -86,7 +101,7 @@ public class GpuInfo {
 
       // Sort buffers by name, the query is sorted by track id for the queues.
       buffers.sort((b1, b2) -> b1.name.compareTo(b2.name));
-      return new GpuInfo(queues, buffers);
+      return new GpuInfo(queues, vkEvents, buffers);
     });
   }
 
@@ -107,6 +122,26 @@ public class GpuInfo {
 
     public String getDisplay() {
       return "GPU Queue " + id;
+    }
+  }
+
+  public static class VkEvent {
+    public final long trackId;
+    public final String name;
+    public final int maxDepth;
+
+    public VkEvent(long trackId, String name, int maxDepth) {
+      this.trackId = trackId;
+      this.name = name;
+      this.maxDepth = maxDepth;
+    }
+
+    public VkEvent(QueryEngine.Row row) {
+      this(row.getLong(0), row.getString(1), row.getInt(3));
+    }
+
+    public String getDisplay() {
+      return name;
     }
   }
 

--- a/gapic/src/main/com/google/gapid/perfetto/models/GpuInfo.java
+++ b/gapic/src/main/com/google/gapid/perfetto/models/GpuInfo.java
@@ -39,12 +39,12 @@ public class GpuInfo {
       "order by t.id";
 
   private final List<Queue> queues;
-  private final List<VkEvent> vkEvents;
+  private final List<VkApiEvent> vkApiEvents;
   private final List<Buffer> buffers;
 
-  private GpuInfo(List<Queue> queues, List<VkEvent> vkEvents, List<Buffer> buffers) {
+  private GpuInfo(List<Queue> queues, List<VkApiEvent> vkApiEvents, List<Buffer> buffers) {
     this.queues = queues;
-    this.vkEvents = vkEvents;
+    this.vkApiEvents = vkApiEvents;
     this.buffers = buffers;
   }
 
@@ -60,12 +60,12 @@ public class GpuInfo {
     return Iterables.unmodifiableIterable(queues);
   }
 
-  public int vkEventCount() {
-    return vkEvents.size();
+  public int vkApiEventCount() {
+    return vkApiEvents.size();
   }
 
-  public Iterable<VkEvent> vkEvents() {
-    return Iterables.unmodifiableIterable(vkEvents);
+  public Iterable<VkApiEvent> vkApiEvents() {
+    return Iterables.unmodifiableIterable(vkApiEvents);
   }
 
   public int bufferCount() {
@@ -83,7 +83,7 @@ public class GpuInfo {
   private static ListenableFuture<GpuInfo> info(QueryEngine qe) {
     return transform(qe.queries(MAX_DEPTH_QUERY), res -> {
       List<Queue> queues = Lists.newArrayList();
-      List<VkEvent> vkEvents = Lists.newArrayList();
+      List<VkApiEvent> vkApiEvents = Lists.newArrayList();
       List<Buffer> buffers = Lists.newArrayList();
       res.forEachRow(($, r) -> {
         switch (r.getString(2)) {
@@ -91,7 +91,7 @@ public class GpuInfo {
             queues.add(new Queue(queues.size(), r));
             break;
           case "vulkan_events":
-            vkEvents.add(new VkEvent(r));
+            vkApiEvents.add(new VkApiEvent(r));
             break;
           case "graphics_frame_event":
             buffers.add(new Buffer(r));
@@ -101,7 +101,7 @@ public class GpuInfo {
 
       // Sort buffers by name, the query is sorted by track id for the queues.
       buffers.sort((b1, b2) -> b1.name.compareTo(b2.name));
-      return new GpuInfo(queues, vkEvents, buffers);
+      return new GpuInfo(queues, vkApiEvents, buffers);
     });
   }
 
@@ -125,18 +125,18 @@ public class GpuInfo {
     }
   }
 
-  public static class VkEvent {
+  public static class VkApiEvent {
     public final long trackId;
     public final String name;
     public final int maxDepth;
 
-    public VkEvent(long trackId, String name, int maxDepth) {
+    public VkApiEvent(long trackId, String name, int maxDepth) {
       this.trackId = trackId;
       this.name = name;
       this.maxDepth = maxDepth;
     }
 
-    public VkEvent(QueryEngine.Row row) {
+    public VkApiEvent(QueryEngine.Row row) {
       this(row.getLong(0), row.getString(1), row.getInt(3));
     }
 

--- a/gapic/src/main/com/google/gapid/perfetto/models/Selection.java
+++ b/gapic/src/main/com/google/gapid/perfetto/models/Selection.java
@@ -192,8 +192,9 @@ public interface Selection<Key> {
     public static final Kind<StateSlice.Key> ThreadState = new Kind<StateSlice.Key>(1);
     public static final Kind<Long> Cpu = new Kind<Long>(2);
     public static final Kind<Slice.Key> Gpu = new Kind<Slice.Key>(3);
-    public static final Kind<Values.Key> Counter = new Kind<Values.Key>(4);
-    public static final Kind<FrameEventsTrack.Slice.Key> FrameEvents = new Kind<FrameEventsTrack.Slice.Key>(5);
+    public static final Kind<Long> VulkanEvent = new Kind<Long>(4);
+    public static final Kind<Values.Key> Counter = new Kind<Values.Key>(5);
+    public static final Kind<FrameEventsTrack.Slice.Key> FrameEvents = new Kind<FrameEventsTrack.Slice.Key>(6);
 
     public int priority;
 

--- a/gapic/src/main/com/google/gapid/perfetto/models/Tracks.java
+++ b/gapic/src/main/com/google/gapid/perfetto/models/Tracks.java
@@ -36,8 +36,8 @@ import com.google.gapid.perfetto.views.ProcessSummaryPanel;
 import com.google.gapid.perfetto.views.ThreadPanel;
 import com.google.gapid.perfetto.views.TitlePanel;
 import com.google.gapid.perfetto.views.VulkanCounterPanel;
+import com.google.gapid.perfetto.views.VulkanEventPanel;
 import com.google.gapid.util.Scheduler;
-
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
@@ -126,6 +126,16 @@ public class Tracks {
         SliceTrack track = SliceTrack.forGpuQueue(data.qe, queue);
         data.tracks.addTrack(parent, track.getId(), queue.getDisplay(),
             single(state -> new GpuQueuePanel(state, queue, track), true));
+      }
+    }
+
+    if (data.getGpu().vkEventCount() > 0) {
+      data.tracks.addLabelGroup(
+          "gpu", "vk_events", "Vulkan Events", group(state -> new TitlePanel("Vulkan Events"), true));
+      for (GpuInfo.VkEvent vkEvent : data.getGpu().vkEvents()) {
+        VulkanEventTrack track = new VulkanEventTrack(data.qe, vkEvent);
+        data.tracks.addTrack("vk_events", track.getId(), vkEvent.getDisplay(),
+            single(state -> new VulkanEventPanel(state, vkEvent, track), true));
       }
     }
 

--- a/gapic/src/main/com/google/gapid/perfetto/models/Tracks.java
+++ b/gapic/src/main/com/google/gapid/perfetto/models/Tracks.java
@@ -129,13 +129,17 @@ public class Tracks {
       }
     }
 
-    if (data.getGpu().vkEventCount() > 0) {
-      data.tracks.addLabelGroup(
-          "gpu", "vk_events", "Vulkan Events", group(state -> new TitlePanel("Vulkan Events"), true));
-      for (GpuInfo.VkEvent vkEvent : data.getGpu().vkEvents()) {
-        VulkanEventTrack track = new VulkanEventTrack(data.qe, vkEvent);
-        data.tracks.addTrack("vk_events", track.getId(), vkEvent.getDisplay(),
-            single(state -> new VulkanEventPanel(state, vkEvent, track), true));
+    if (data.getGpu().vkApiEventCount() > 0) {
+      String parent = "gpu";
+      if (data.getGpu().vkApiEventCount() > 1) {
+        data.tracks.addLabelGroup(
+            "gpu", "vk_api_events", "Vulkan API Events", group(state -> new TitlePanel("Vulkan API Events"), true));
+        parent = "vk_api_events";
+      }
+      for (GpuInfo.VkApiEvent vkApiEvent : data.getGpu().vkApiEvents()) {
+        VulkanEventTrack track = new VulkanEventTrack(data.qe, vkApiEvent);
+        data.tracks.addTrack(parent, track.getId(), vkApiEvent.getDisplay(),
+            single(state -> new VulkanEventPanel(state, vkApiEvent, track), true));
       }
     }
 

--- a/gapic/src/main/com/google/gapid/perfetto/models/VulkanEventTrack.java
+++ b/gapic/src/main/com/google/gapid/perfetto/models/VulkanEventTrack.java
@@ -1,0 +1,274 @@
+/*
+ * Copyright (C) 2020 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.gapid.perfetto.models;
+
+import static com.google.gapid.perfetto.models.QueryEngine.createView;
+import static com.google.gapid.perfetto.models.QueryEngine.createWindow;
+import static com.google.gapid.perfetto.models.QueryEngine.dropTable;
+import static com.google.gapid.perfetto.models.QueryEngine.dropView;
+import static com.google.gapid.perfetto.models.QueryEngine.expectOneRow;
+import static com.google.gapid.util.MoreFutures.transform;
+import static com.google.gapid.util.MoreFutures.transformAsync;
+import static java.lang.String.format;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.gapid.perfetto.TimeSpan;
+import com.google.gapid.perfetto.views.State;
+import com.google.gapid.perfetto.views.StyleConstants;
+import com.google.gapid.perfetto.views.VulkanEventSelectionView;
+import com.google.gapid.perfetto.views.VulkanEventsSelectionView;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.eclipse.swt.graphics.RGBA;
+import org.eclipse.swt.widgets.Composite;
+
+public class VulkanEventTrack extends Track.WithQueryEngine<VulkanEventTrack.Data> {
+  private static final String BASE_COLUMNS =
+      "id, ts, dur, name, depth, command_buffer, submission_id, arg_set_id";
+  private static final String SLICES_VIEW =
+      "select " + BASE_COLUMNS + " from gpu_slice where track_id = %d";
+  private static final String SLICE_SQL =
+      "select " + BASE_COLUMNS + " from gpu_slice where id = %d";
+  private static final String SLICES_SQL =
+      "select " + BASE_COLUMNS + " from %s " +
+          "where ts >= %d - dur and ts <= %d order by ts";
+
+  private final long trackId;
+
+  public VulkanEventTrack(QueryEngine qe, GpuInfo.VkEvent vkEvent) {
+    super(qe, "vk_events_" + vkEvent.trackId);
+    this.trackId = vkEvent.trackId;
+  }
+
+  @Override
+  protected ListenableFuture<?> initialize() {
+    String slices = tableName("slices");
+    String window = tableName("window");
+    return qe.queries(
+        dropView(slices),
+        dropTable(window),
+        createWindow(window),
+        createView(slices, format(SLICES_VIEW, trackId)));
+  }
+
+  @Override
+  protected ListenableFuture<Data> computeData(DataRequest req) {
+    Window window = Window.compute(req);
+    return transformAsync(window.update(qe, tableName("window")), $ -> computeSlices(req));
+  }
+
+  private ListenableFuture<Data> computeSlices(DataRequest req) {
+    return transformAsync(qe.query(slicesSql(req)), res ->
+        transform(qe.getAllArgs(res.stream().mapToLong(r -> r.getLong(7))), args -> {
+          int rows = res.getNumRows();
+          Data data = new Data(req, new long[rows], new long[rows], new long[rows],
+              new String[rows], new int[rows], new long[rows], new long[rows], new ArgSet[rows]);
+          res.forEachRow((i, row) -> {
+            long start = row.getLong(1);
+            data.ids[i] = row.getLong(0);
+            data.starts[i] = start;
+            data.ends[i] = start + row.getLong(2);
+            data.names[i] = row.getString(3);
+            data.depths[i] = row.getInt(4);
+            data.commandBuffers[i] = row.getLong(5);
+            data.submissionIds[i] = row.getLong(6);
+            data.args[i] = args.getOrDefault(row.getLong(7), ArgSet.EMPTY);
+          });
+          return data;
+        }));
+  }
+
+  private String slicesSql(DataRequest req) {
+    return format(SLICES_SQL, tableName("slices"), req.range.start, req.range.end);
+  }
+
+  public ListenableFuture<Slice> getSlice(long id) {
+    return transformAsync(expectOneRow(qe.query(sliceSql(id))), r ->
+        transform(qe.getArgs(r.getLong(7)), args -> buildSlice(r, args)));
+  }
+
+  protected Slice buildSlice(QueryEngine.Row row, ArgSet args) {
+    return new Slice(row, args);
+  }
+
+  private static String sliceSql(long id) {
+    return format(SLICE_SQL, id);
+  }
+
+  public static class Data extends Track.Data {
+    public final long[] ids;
+    public final long[] starts;
+    public final long[] ends;
+    public final String[] names;
+    public final int[] depths;
+    public final long[] commandBuffers;
+    public final long[] submissionIds;
+    public final ArgSet[] args;
+
+    public Data(DataRequest request, long[] ids, long[] starts, long[] ends, String[] names,
+        int[] depths, long[] commandBuffers, long[] submissionIds, ArgSet[] args) {
+      super(request);
+      this.ids = ids;
+      this.starts = starts;
+      this.ends = ends;
+      this.depths = depths;
+      this.names = names;
+      this.commandBuffers = commandBuffers;
+      this.submissionIds = submissionIds;
+      this.args = args;
+    }
+  }
+
+  public static class Slice implements Selection<Long> {
+    public final long id;
+    public final long time;
+    public final long dur;
+    public final String name;
+    public final int depth;
+    public final long commandBuffer;
+    public final long submissionId;
+    public final ArgSet args;
+
+    public Slice(long id, long time, long dur, String name, int depth, long commandBuffer,
+        long submissionId, ArgSet args) {
+      this.id = id;
+      this.time = time;
+      this.dur = dur;
+      this.name = name;
+      this.depth = depth;
+      this.commandBuffer = commandBuffer;
+      this.submissionId = submissionId;
+      this.args = args;
+    }
+
+    public Slice(QueryEngine.Row row, ArgSet args) {
+      this(row.getLong(0), row.getLong(1), row.getLong(2), row.getString(3), row.getInt(4),
+          row.getLong(5), row.getLong(6), args);
+    }
+
+    @Override
+    public String getTitle() {
+      return "Vulkan Events";
+    }
+
+    @Override
+    public boolean contains(Long key) {
+      return id == key;
+    }
+
+    @Override
+    public Composite buildUi(Composite parent, State state) {
+      return new VulkanEventSelectionView(parent, state, this);
+    }
+
+    @Override
+    public Selection.Builder getBuilder() {
+      return new SlicesBuilder(Lists.newArrayList(this));
+    }
+
+    @Override
+    public void markTime(State state) {
+      if (dur > 0) {
+        state.setHighlight(new TimeSpan(time, time + dur));
+      }
+    }
+
+    @Override
+    public void zoom(State state) {
+      if (dur > 0) {
+        state.setVisibleTime(new TimeSpan(time, time + dur));
+      }
+    }
+  }
+
+  public static class Slices implements Selection<Long> {
+    public final List<Slice> slices;
+    public final ImmutableSet<Long> sliceKeys;
+    private final Set<Long> submissionIds;
+
+    public Slices(List<Slice> slices, ImmutableSet<Long> sliceKeys) {
+      this.slices = slices;
+      this.sliceKeys = sliceKeys;
+      this.submissionIds = slices.stream().map(s -> s.submissionId).collect(Collectors.toSet());
+    }
+
+    @Override
+    public String getTitle() {
+      return "Vulkan Event Slices";
+    }
+
+    @Override
+    public boolean contains(Long key) {
+      return sliceKeys.contains(key);
+    }
+
+    @Override
+    public Composite buildUi(Composite parent, State state) {
+      return new VulkanEventsSelectionView(parent, this);
+    }
+
+    @Override
+    public Selection.Builder getBuilder() {
+      return new SlicesBuilder(slices);
+    }
+
+    public Set<Long> getSubmissionIds() {
+      return submissionIds;
+    }
+  }
+
+  public static class SlicesBuilder implements Selection.Builder<SlicesBuilder> {
+    private final List<Slice> slices;
+    private final Set<Long> sliceKeys = Sets.newHashSet();
+
+    public SlicesBuilder(List<Slice> slices) {
+      this.slices = slices;
+      for (Slice slice : slices) {
+        sliceKeys.add(slice.id);
+      }
+    }
+
+    @Override
+    public SlicesBuilder combine(SlicesBuilder other) {
+      this.slices.addAll(other.slices);
+      sliceKeys.addAll(other.sliceKeys);
+      return this;
+    }
+
+    @Override
+    public Selection build() {
+      return new Slices(slices, ImmutableSet.copyOf(sliceKeys));
+    }
+  }
+
+  public static RGBA getColor(String title) {
+    return colorForSlice(title, 0);
+  }
+
+  public static RGBA getBorderColor(String title) {
+    return colorForSlice(title, StyleConstants.isLight() ? -5 : 5);
+  }
+
+  private static RGBA colorForSlice(String title, int shadeIdx) {
+    return StyleConstants.Palette.getColor(
+        (title.hashCode() ^ title.length()) & 0x7fffffff, shadeIdx);
+  }
+}

--- a/gapic/src/main/com/google/gapid/perfetto/models/VulkanEventTrack.java
+++ b/gapic/src/main/com/google/gapid/perfetto/models/VulkanEventTrack.java
@@ -258,17 +258,4 @@ public class VulkanEventTrack extends Track.WithQueryEngine<VulkanEventTrack.Dat
       return new Slices(slices, ImmutableSet.copyOf(sliceKeys));
     }
   }
-
-  public static RGBA getColor(String title) {
-    return colorForSlice(title, 0);
-  }
-
-  public static RGBA getBorderColor(String title) {
-    return colorForSlice(title, StyleConstants.isLight() ? -5 : 5);
-  }
-
-  private static RGBA colorForSlice(String title, int shadeIdx) {
-    return StyleConstants.Palette.getColor(
-        (title.hashCode() ^ title.length()) & 0x7fffffff, shadeIdx);
-  }
 }

--- a/gapic/src/main/com/google/gapid/perfetto/models/VulkanEventTrack.java
+++ b/gapic/src/main/com/google/gapid/perfetto/models/VulkanEventTrack.java
@@ -53,9 +53,9 @@ public class VulkanEventTrack extends Track.WithQueryEngine<VulkanEventTrack.Dat
 
   private final long trackId;
 
-  public VulkanEventTrack(QueryEngine qe, GpuInfo.VkEvent vkEvent) {
-    super(qe, "vk_events_" + vkEvent.trackId);
-    this.trackId = vkEvent.trackId;
+  public VulkanEventTrack(QueryEngine qe, GpuInfo.VkApiEvent vkApiEvent) {
+    super(qe, "vk_api_events_" + vkApiEvent.trackId);
+    this.trackId = vkApiEvent.trackId;
   }
 
   @Override
@@ -166,7 +166,7 @@ public class VulkanEventTrack extends Track.WithQueryEngine<VulkanEventTrack.Dat
 
     @Override
     public String getTitle() {
-      return "Vulkan Events";
+      return "Vulkan API Events";
     }
 
     @Override
@@ -212,7 +212,7 @@ public class VulkanEventTrack extends Track.WithQueryEngine<VulkanEventTrack.Dat
 
     @Override
     public String getTitle() {
-      return "Vulkan Event Slices";
+      return "Vulkan API Event Slices";
     }
 
     @Override

--- a/gapic/src/main/com/google/gapid/perfetto/views/GpuQueuePanel.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/GpuQueuePanel.java
@@ -118,7 +118,7 @@ public class GpuQueuePanel extends TrackPanel<GpuQueuePanel> implements Selectab
         color.applyBase(ctx);
         // Link slices in Vulkan Event Panel and Gpu Queue Panel through submission id.
         if (!selectedSIds.isEmpty() && i < sIds.length && !selectedSIds.contains(sIds[i])) {
-          ctx.setBackgroundColor(StyleConstants.getGrayColor().rgb()); // Grey out unlinked ones.
+          ctx.setBackgroundColor(color.disabled); // Grey out unlinked ones.
         } else if (i < sIds.length && selectedSIds.contains(sIds[i])) {
           linkedIdxs.add(i);
         }
@@ -147,7 +147,7 @@ public class GpuQueuePanel extends TrackPanel<GpuQueuePanel> implements Selectab
       // If a Vulkan API Event slice is selected, draw a bounding rectangle for all the GPU Queue
       // slices with the same submission id.
       for (int index : linkedIdxs) {
-        ctx.setForegroundColor(SliceTrack.getBorderColor(data.titles[index], data.depths[index]));
+        ctx.setForegroundColor(gradient(data.titles[index].hashCode() ^ data.depths[index]).border);
         double rectStart = state.timeToPx(data.starts[index]);
         double rectWidth = Math.max(1, state.timeToPx(data.ends[index]) - rectStart);
         double depth = data.depths[index];

--- a/gapic/src/main/com/google/gapid/perfetto/views/GpuQueuePanel.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/GpuQueuePanel.java
@@ -144,8 +144,8 @@ public class GpuQueuePanel extends TrackPanel<GpuQueuePanel> implements Selectab
         ctx.drawRect(highlight.x, highlight.y, highlight.w, SLICE_HEIGHT, BOUNDING_BOX_LINE_WIDTH);
       }
 
-      // If a Vulkan Event slice is selected, draw a bounding rectangle for all the GPU Queue slices
-      // with the same submission id.
+      // If a Vulkan API Event slice is selected, draw a bounding rectangle for all the GPU Queue
+      // slices with the same submission id.
       for (int index : linkedIdxs) {
         ctx.setForegroundColor(SliceTrack.getBorderColor(data.titles[index], data.depths[index]));
         double rectStart = state.timeToPx(data.starts[index]);

--- a/gapic/src/main/com/google/gapid/perfetto/views/SliceSelectionView.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/SliceSelectionView.java
@@ -105,7 +105,7 @@ public class SliceSelectionView extends Composite {
       }
 
       if (renderStageInfo.submissionId != 0) {
-        propsBuilder.put("VkSubmissionId:", Long.toString(renderStageInfo.submissionId));
+        propsBuilder.put("SubmissionId:", Long.toString(renderStageInfo.submissionId));
       }
 
       ImmutableMap<String, String> props = propsBuilder.build();

--- a/gapic/src/main/com/google/gapid/perfetto/views/VulkanEventPanel.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/VulkanEventPanel.java
@@ -44,32 +44,32 @@ public class VulkanEventPanel extends TrackPanel<VulkanEventPanel> {
   private static final double HOVER_PADDING = 4;
   private static final int BOUNDING_BOX_LINE_WIDTH = 3;
 
-  private final GpuInfo.VkEvent vkEvent;
+  private final GpuInfo.VkApiEvent vkApiEvent;
   protected final VulkanEventTrack track;
 
   protected double mouseXpos, mouseYpos;
   protected String hoveredName;
   protected Size hoveredSize = Size.ZERO;
 
-  public VulkanEventPanel(State state, GpuInfo.VkEvent vkEvent, VulkanEventTrack track) {
+  public VulkanEventPanel(State state, GpuInfo.VkApiEvent vkApiEvent, VulkanEventTrack track) {
     super(state);
-    this.vkEvent = vkEvent;
+    this.vkApiEvent = vkApiEvent;
     this.track = track;
   }
 
   @Override
   public VulkanEventPanel copy() {
-    return new VulkanEventPanel(state, vkEvent, track);
+    return new VulkanEventPanel(state, vkApiEvent, track);
   }
 
   @Override
   public String getTitle() {
-    return vkEvent.getDisplay();
+    return vkApiEvent.getDisplay();
   }
 
   @Override
   public double getHeight() {
-    return SLICE_Y + vkEvent.maxDepth * SLICE_HEIGHT;
+    return SLICE_Y + vkApiEvent.maxDepth * SLICE_HEIGHT;
   }
 
   @Override
@@ -150,7 +150,7 @@ public class VulkanEventPanel extends TrackPanel<VulkanEventPanel> {
     }
 
     int depth = y < SLICE_Y ? -1 : (int)((y - SLICE_Y) / SLICE_HEIGHT);
-    if (depth < 0 || depth > vkEvent.maxDepth) {
+    if (depth < 0 || depth > vkApiEvent.maxDepth) {
       return Hover.NONE;
     }
 
@@ -163,7 +163,7 @@ public class VulkanEventPanel extends TrackPanel<VulkanEventPanel> {
         hoveredSize = Size.vertCombine(HOVER_PADDING, HOVER_PADDING / 2,
             m.measure(Fonts.Style.Normal, hoveredName));
         mouseYpos = Math.max(0, Math.min(mouseYpos - (hoveredSize.h - SLICE_HEIGHT) / 2,
-            (1 + vkEvent.maxDepth) * SLICE_HEIGHT - hoveredSize.h));
+            (1 + vkApiEvent.maxDepth) * SLICE_HEIGHT - hoveredSize.h));
         long id = data.ids[i];
 
         return new Hover() {

--- a/gapic/src/main/com/google/gapid/perfetto/views/VulkanEventPanel.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/VulkanEventPanel.java
@@ -18,6 +18,7 @@ package com.google.gapid.perfetto.views;
 
 import static com.google.gapid.perfetto.views.Loading.drawLoading;
 import static com.google.gapid.perfetto.views.StyleConstants.colors;
+import static com.google.gapid.perfetto.views.StyleConstants.gradient;
 
 import com.google.common.collect.Lists;
 import com.google.gapid.perfetto.TimeSpan;
@@ -29,10 +30,12 @@ import com.google.gapid.perfetto.canvas.Size;
 import com.google.gapid.perfetto.models.GpuInfo;
 import com.google.gapid.perfetto.models.Selection;
 import com.google.gapid.perfetto.models.VulkanEventTrack;
-import java.util.List;
+
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Cursor;
 import org.eclipse.swt.widgets.Display;
+
+import java.util.List;
 
 public class VulkanEventPanel extends TrackPanel<VulkanEventPanel> {
   private static final double ARROW_HEIGHT = 10;
@@ -98,7 +101,7 @@ public class VulkanEventPanel extends TrackPanel<VulkanEventPanel> {
         double rectWidth = Math.max(1, state.timeToPx(tEnd) - rectStart);
         double y = SLICE_Y + depth * SLICE_HEIGHT;
 
-        ctx.setBackgroundColor(VulkanEventTrack.getColor(data.names[i]));
+        gradient(data.names[i].hashCode()).applyBase(ctx);
         ctx.fillRect(rectStart, y, rectWidth, SLICE_HEIGHT);
 
         if (selected.contains(data.ids[i])) {
@@ -110,7 +113,7 @@ public class VulkanEventPanel extends TrackPanel<VulkanEventPanel> {
           continue;
         }
 
-        ctx.setForegroundColor(colors().textInvertedMain);
+        ctx.setForegroundColor(colors().textMain);
         ctx.drawText(
             Fonts.Style.Normal, data.names[i], rectStart + 2, y + 2, rectWidth - 4, SLICE_HEIGHT - 4);
 
@@ -118,7 +121,7 @@ public class VulkanEventPanel extends TrackPanel<VulkanEventPanel> {
 
       // Draw bounding rectangles after all the slices are rendered, so that the border is on the top.
       for (int index : visibleSelected) {
-        ctx.setForegroundColor(VulkanEventTrack.getBorderColor(data.names[index]));
+        ctx.setForegroundColor(gradient(data.names[index].hashCode()).border);
         double rectStart = state.timeToPx(data.starts[index]);
         double rectWidth = Math.max(1, state.timeToPx(data.ends[index]) - rectStart);
         double depth = data.depths[index];

--- a/gapic/src/main/com/google/gapid/perfetto/views/VulkanEventPanel.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/VulkanEventPanel.java
@@ -1,0 +1,203 @@
+/*
+ * Copyright (C) 2019 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.gapid.perfetto.views;
+
+import static com.google.gapid.perfetto.views.Loading.drawLoading;
+import static com.google.gapid.perfetto.views.StyleConstants.colors;
+
+import com.google.common.collect.Lists;
+import com.google.gapid.perfetto.TimeSpan;
+import com.google.gapid.perfetto.canvas.Area;
+import com.google.gapid.perfetto.canvas.Fonts;
+import com.google.gapid.perfetto.canvas.Fonts.TextMeasurer;
+import com.google.gapid.perfetto.canvas.RenderContext;
+import com.google.gapid.perfetto.canvas.Size;
+import com.google.gapid.perfetto.models.GpuInfo;
+import com.google.gapid.perfetto.models.Selection;
+import com.google.gapid.perfetto.models.VulkanEventTrack;
+import java.util.List;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.graphics.Cursor;
+import org.eclipse.swt.widgets.Display;
+
+public class VulkanEventPanel extends TrackPanel<VulkanEventPanel> {
+  private static final double ARROW_HEIGHT = 10;
+  private static final double ARROW_WIDTH = 10;
+  private static final double ARROW_TIP = 2;
+  private static final double SLICE_Y = ARROW_HEIGHT;
+  private static final double SLICE_HEIGHT = 25;
+  private static final double HOVER_MARGIN = 10;
+  private static final double HOVER_PADDING = 4;
+  private static final int BOUNDING_BOX_LINE_WIDTH = 3;
+
+  private final GpuInfo.VkEvent vkEvent;
+  protected final VulkanEventTrack track;
+
+  protected double mouseXpos, mouseYpos;
+  protected String hoveredName;
+  protected Size hoveredSize = Size.ZERO;
+
+  public VulkanEventPanel(State state, GpuInfo.VkEvent vkEvent, VulkanEventTrack track) {
+    super(state);
+    this.vkEvent = vkEvent;
+    this.track = track;
+  }
+
+  @Override
+  public VulkanEventPanel copy() {
+    return new VulkanEventPanel(state, vkEvent, track);
+  }
+
+  @Override
+  public String getTitle() {
+    return vkEvent.getDisplay();
+  }
+
+  @Override
+  public double getHeight() {
+    return SLICE_Y + vkEvent.maxDepth * SLICE_HEIGHT;
+  }
+
+  @Override
+  protected void renderTrack(RenderContext ctx, Repainter repainter, double w, double h) {
+    ctx.trace("VulkanEvents", () -> {
+      VulkanEventTrack.Data data = track.getData(state.toRequest(), onUiThread(repainter));
+      drawLoading(ctx, data, state, h);
+
+      if (data == null) {
+        return;
+      }
+
+      TimeSpan visible = state.getVisibleTime();
+      Selection<Long> selected = state.getSelection(Selection.Kind.VulkanEvent);
+      List<Integer> visibleSelected = Lists.newArrayList();
+
+      for (int i = 0; i < data.starts.length; i++) {
+        long tStart = data.starts[i];
+        long tEnd = data.ends[i];
+        int depth = data.depths[i];
+
+        if (tEnd <= visible.start || tStart >= visible.end) {
+          continue;
+        }
+        double rectStart = state.timeToPx(tStart);
+        double rectWidth = Math.max(1, state.timeToPx(tEnd) - rectStart);
+        double y = SLICE_Y + depth * SLICE_HEIGHT;
+
+        ctx.setBackgroundColor(VulkanEventTrack.getColor(data.names[i]));
+        ctx.fillRect(rectStart, y, rectWidth, SLICE_HEIGHT);
+
+        if (selected.contains(data.ids[i])) {
+          visibleSelected.add(i);
+        }
+
+        // Don't render text when we have less than 7px to play with.
+        if (rectWidth < 7) {
+          continue;
+        }
+
+        ctx.setForegroundColor(colors().textInvertedMain);
+        ctx.drawText(
+            Fonts.Style.Normal, data.names[i], rectStart + 2, y + 2, rectWidth - 4, SLICE_HEIGHT - 4);
+
+      }
+
+      // Draw bounding rectangles after all the slices are rendered, so that the border is on the top.
+      for (int index : visibleSelected) {
+        ctx.setForegroundColor(VulkanEventTrack.getBorderColor(data.names[index]));
+        double rectStart = state.timeToPx(data.starts[index]);
+        double rectWidth = Math.max(1, state.timeToPx(data.ends[index]) - rectStart);
+        double depth = data.depths[index];
+        ctx.drawRect(rectStart, SLICE_Y + depth * SLICE_HEIGHT, rectWidth, SLICE_HEIGHT, BOUNDING_BOX_LINE_WIDTH);
+
+        double mid = rectStart + rectWidth / 2;
+        ctx.drawLine(mid, ARROW_TIP, mid, SLICE_Y);
+        ctx.drawLine(mid, ARROW_TIP, mid + ARROW_WIDTH, ARROW_TIP);
+        ctx.drawLine(mid + ARROW_WIDTH, ARROW_TIP, mid + ARROW_WIDTH - ARROW_TIP, 0);
+        ctx.drawLine(mid + ARROW_WIDTH, ARROW_TIP, mid + ARROW_WIDTH - ARROW_TIP, ARROW_TIP * 2);
+      }
+
+      if (hoveredName != null) {
+        ctx.setBackgroundColor(colors().hoverBackground);
+        ctx.fillRect(
+            mouseXpos + HOVER_MARGIN, mouseYpos, hoveredSize.w + 2 * HOVER_PADDING, hoveredSize.h);
+        ctx.setForegroundColor(colors().textMain);
+        ctx.drawText(Fonts.Style.Normal, hoveredName,
+            mouseXpos + HOVER_MARGIN + HOVER_PADDING, mouseYpos + HOVER_PADDING / 2);
+      }
+    });
+  }
+
+  @Override
+  protected Hover onTrackMouseMove(TextMeasurer m, double x, double y, int mods) {
+    VulkanEventTrack.Data data = track.getData(state.toRequest(), onUiThread());
+    if (data == null) {
+      return Hover.NONE;
+    }
+
+    int depth = y < SLICE_Y ? -1 : (int)((y - SLICE_Y) / SLICE_HEIGHT);
+    if (depth < 0 || depth > vkEvent.maxDepth) {
+      return Hover.NONE;
+    }
+
+    mouseXpos = x;
+    mouseYpos = SLICE_Y + depth * SLICE_HEIGHT;
+    long t = state.pxToTime(x);
+    for (int i = 0; i < data.starts.length; i++) {
+      if (data.depths[i] == depth && data.starts[i] <= t && t <= data.ends[i]) {
+        hoveredName = data.names[i];
+        hoveredSize = Size.vertCombine(HOVER_PADDING, HOVER_PADDING / 2,
+            m.measure(Fonts.Style.Normal, hoveredName));
+        mouseYpos = Math.max(0, Math.min(mouseYpos - (hoveredSize.h - SLICE_HEIGHT) / 2,
+            (1 + vkEvent.maxDepth) * SLICE_HEIGHT - hoveredSize.h));
+        long id = data.ids[i];
+
+        return new Hover() {
+          @Override
+          public Area getRedraw() {
+            return new Area(
+                x + HOVER_MARGIN, mouseYpos, hoveredSize.w + 2 * HOVER_PADDING, hoveredSize.h);
+          }
+
+          @Override
+          public void stop() {
+            hoveredName =  null;
+          }
+
+          @Override
+          public Cursor getCursor(Display display) {
+            return (id < 0) ? null : display.getSystemCursor(SWT.CURSOR_HAND);
+          }
+
+          @Override
+          public boolean click() {
+            if (id < 0) {
+              return false;
+            }
+            if ((mods & SWT.MOD1) == SWT.MOD1) {
+              state.addSelection(Selection.Kind.VulkanEvent, track.getSlice(id));
+            } else {
+              state.setSelection(Selection.Kind.VulkanEvent, track.getSlice(id));
+            }
+            return true;
+          }
+        };
+      }
+    }
+    return Hover.NONE;
+  }
+}

--- a/gapic/src/main/com/google/gapid/perfetto/views/VulkanEventSelectionView.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/VulkanEventSelectionView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Google Inc.
+ * Copyright (C) 2020 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package com.google.gapid.perfetto.views;
 
 import static com.google.gapid.perfetto.TimeSpan.timeToString;
@@ -24,26 +25,21 @@ import static com.google.gapid.widgets.Widgets.withLayoutData;
 import static com.google.gapid.widgets.Widgets.withMargin;
 import static com.google.gapid.widgets.Widgets.withSpans;
 
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
-import com.google.gapid.perfetto.models.ProcessInfo;
-import com.google.gapid.perfetto.models.SliceTrack;
-import com.google.gapid.perfetto.models.SliceTrack.RenderStageInfo;
-import com.google.gapid.perfetto.models.ThreadInfo;
-
+import com.google.gapid.perfetto.models.VulkanEventTrack;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Composite;
 
 /**
- * Displays information about a selected slice.
+ * Displays information about a selected Vulkan event.
  */
-public class SliceSelectionView extends Composite {
+public class VulkanEventSelectionView extends Composite {
   private static final int PROPERTIES_PER_PANEL = 8;
   private static final int PANEL_INDENT = 25;
 
-  public SliceSelectionView(Composite parent, State state, SliceTrack.Slice slice) {
+  public VulkanEventSelectionView(Composite parent, State state, VulkanEventTrack.Slice slice) {
     super(parent, SWT.NONE);
     setLayout(withMargin(new GridLayout(2, false), 0, 0));
 
@@ -51,73 +47,20 @@ public class SliceSelectionView extends Composite {
         new GridData(SWT.LEFT, SWT.TOP, false, false));
     withLayoutData(createBoldLabel(main, "Slice:"), withSpans(new GridData(), 2, 1));
 
+    createLabel(main, "Name:");
+    createLabel(main, slice.name);
+
     createLabel(main, "Time:");
     createLabel(main, timeToString(slice.time - state.getTraceTime().start));
 
     createLabel(main, "Duration:");
     createLabel(main, timeToString(slice.dur));
 
-    ThreadInfo thread = slice.getThread();
-    if (thread != null) {
-      ProcessInfo process = state.getProcessInfo(thread.upid);
-      if (process != null) {
-        createLabel(main, "Process:");
-        createLabel(main, process.getDisplay());
-      }
+    createLabel(main, "Command Buffer:");
+    createLabel(main, Long.toString(slice.commandBuffer));
 
-      createLabel(main, "Thread:");
-      createLabel(main, thread.getDisplay());
-    }
-
-    if (!slice.category.isEmpty()) {
-      createLabel(main, "Category:");
-      createLabel(main, slice.category);
-    }
-
-    if (!slice.name.isEmpty()) {
-      createLabel(main, "Name:");
-      createLabel(main, slice.name);
-    }
-
-    RenderStageInfo renderStageInfo = slice.getRenderStageInfo();
-    if (renderStageInfo != null) {
-      ImmutableMap.Builder<String, String> propsBuilder = ImmutableMap.builder();
-      if (renderStageInfo.frameBufferHandle != 0) {
-        if (renderStageInfo.frameBufferName.isEmpty()) {
-          propsBuilder.put("VkFrameBuffer:", String.format("0x%08X", renderStageInfo.frameBufferHandle));
-        } else {
-          propsBuilder.put("VkFrameBuffer:", renderStageInfo.frameBufferName + " <" + String.format("0x%08X", renderStageInfo.frameBufferHandle) + ">");
-        }
-      }
-      if (renderStageInfo.renderPassHandle != 0) {
-        if (renderStageInfo.renderPassName.isEmpty()) {
-          propsBuilder.put("VkRenderPass:", String.format("0x%08X", renderStageInfo.renderPassHandle));
-        } else {
-          propsBuilder.put("VkRenderPass:", renderStageInfo.renderPassName + " <" + String.format("0x%08X", renderStageInfo.renderPassHandle) + ">");
-        }
-      }
-      if (renderStageInfo.commandBufferHandle != 0) {
-        if (renderStageInfo.commandBufferName.isEmpty()) {
-          propsBuilder.put("VkCommandBuffer:", String.format("0x%08X", renderStageInfo.commandBufferHandle));
-        } else {
-          propsBuilder.put("VkCommandBuffer:", renderStageInfo.commandBufferName + " <" + String.format("0x%08X", renderStageInfo.commandBufferHandle) + ">");
-        }
-      }
-
-      if (renderStageInfo.submissionId != 0) {
-        propsBuilder.put("VkSubmissionId:", Long.toString(renderStageInfo.submissionId));
-      }
-
-      ImmutableMap<String, String> props = propsBuilder.build();
-      if (!props.isEmpty()) {
-        withLayoutData(createBoldLabel(main, "Vulkan Info"),
-            withSpans(new GridData(), 2, 1));
-        props.forEach((key, value) -> {
-          createLabel(main, key);
-          createLabel(main, value);
-        });
-      }
-    }
+    createLabel(main, "Submission ID:");
+    createLabel(main, Long.toString(slice.submissionId));
 
     if (!slice.args.isEmpty()) {
       String[] keys = Iterables.toArray(slice.args.keys(), String.class);

--- a/gapic/src/main/com/google/gapid/perfetto/views/VulkanEventSelectionView.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/VulkanEventSelectionView.java
@@ -33,7 +33,7 @@ import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Composite;
 
 /**
- * Displays information about a selected Vulkan event.
+ * Displays information about a selected Vulkan API event.
  */
 public class VulkanEventSelectionView extends Composite {
   private static final int PROPERTIES_PER_PANEL = 8;

--- a/gapic/src/main/com/google/gapid/perfetto/views/VulkanEventsSelectionView.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/VulkanEventsSelectionView.java
@@ -29,7 +29,7 @@ import org.eclipse.swt.layout.FillLayout;
 import org.eclipse.swt.widgets.Composite;
 
 /**
- * Displays information about a list of selected vulkan events.
+ * Displays information about a list of selected vulkan API events.
  */
 public class VulkanEventsSelectionView extends Composite {
   public VulkanEventsSelectionView(Composite parent, VulkanEventTrack.Slices sel) {

--- a/gapic/src/main/com/google/gapid/perfetto/views/VulkanEventsSelectionView.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/VulkanEventsSelectionView.java
@@ -1,0 +1,60 @@
+package com.google.gapid.perfetto.views;
+
+import static com.google.gapid.widgets.Widgets.createTreeColumn;
+import static com.google.gapid.widgets.Widgets.createTreeViewer;
+import static com.google.gapid.widgets.Widgets.packColumns;
+
+import com.google.gapid.perfetto.models.VulkanEventTrack;
+import org.eclipse.jface.viewers.ITreeContentProvider;
+import org.eclipse.jface.viewers.LabelProvider;
+import org.eclipse.jface.viewers.TreeViewer;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.layout.FillLayout;
+import org.eclipse.swt.widgets.Composite;
+
+/**
+ * Displays information about a list of selected vulkan events.
+ */
+public class VulkanEventsSelectionView extends Composite {
+  public VulkanEventsSelectionView(Composite parent, VulkanEventTrack.Slices sel) {
+    super(parent, SWT.NONE);
+    setLayout(new FillLayout());
+
+    TreeViewer viewer = createTreeViewer(this, SWT.NONE);
+    viewer.getTree().setHeaderVisible(true);
+    viewer.setContentProvider(new ITreeContentProvider() {
+      @Override
+      public Object[] getElements(Object inputElement) {
+        return sel.slices.toArray();
+      }
+
+      @Override
+      public boolean hasChildren(Object element) {
+        return false;
+      }
+
+      @Override
+      public Object getParent(Object element) {
+        return null;
+      }
+
+      @Override
+      public Object[] getChildren(Object element) {
+        return null;
+      }
+    });
+    viewer.setLabelProvider(new LabelProvider());
+
+    createTreeColumn(viewer, "Slice ID", e -> Long.toString(n(e).id));
+    createTreeColumn(viewer, "Start Time", e -> Long.toString(n(e).time));
+    createTreeColumn(viewer, "Duration", e -> Long.toString(n(e).dur));
+    createTreeColumn(viewer, "Event Name", e -> n(e).name);
+    createTreeColumn(viewer, "Submission ID", e -> Long.toString(n(e).submissionId));
+    viewer.setInput(sel);
+    packColumns(viewer.getTree());
+  }
+
+  protected static VulkanEventTrack.Slice n(Object o) {
+    return (VulkanEventTrack.Slice)o;
+  }
+}

--- a/gapic/src/main/com/google/gapid/perfetto/views/VulkanEventsSelectionView.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/VulkanEventsSelectionView.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.google.gapid.perfetto.views;
 
 import static com.google.gapid.widgets.Widgets.createTreeColumn;


### PR DESCRIPTION
 - Create a new panel for showing vulkan events.
 - Show submission ID for vulkan event slices and GPU queue slices.
 - When selecting a submission slice in Vulkan Event Panel, all the
 slices with the same submission ID in GPU Queue Panel will get a
 bounding box for easy noticing, other slices will gray out.