### PR TITLE
Log to stderr in launch_producer

### DIFF
--- a/cmd/launch_producer/main.cpp
+++ b/cmd/launch_producer/main.cpp
@@ -24,9 +24,10 @@
 
 #include <string>
 
+// TODO(b/148950543): Figure out why stdout is not captured.
 #define _LOG(lvl, name, msg, ...)                          \
   do {                                                     \
-    printf(name ": " msg "\n", ##__VA_ARGS__);             \
+    fprintf(stderr, name ": " msg "\n", ##__VA_ARGS__);    \
     __android_log_print(lvl, "GAPID", msg, ##__VA_ARGS__); \
   } while (false)
 


### PR DESCRIPTION
The data producer is not required to log anything, previously we check the
output to determine the start of data producer, this patch modifies the
launch_producer to output to stderr to make sure there is at least one
output to be captured.

Bug: #3728