### PR TITLE
Fix gofmt following update on gLinux

### DIFF
--- a/gapis/replay/asm/instructions_test.go
+++ b/gapis/replay/asm/instructions_test.go
@@ -31,7 +31,9 @@ import (
 
 type testPtrResolver struct{}
 
-func (testPtrResolver) ResolveTemporaryPointer(value.TemporaryPointer) value.VolatilePointer { return 0 }
+func (testPtrResolver) ResolveTemporaryPointer(value.TemporaryPointer) value.VolatilePointer {
+	return 0
+}
 func (testPtrResolver) ResolveObservedPointer(ptr value.ObservedPointer) (protocol.Type, uint64) {
 	return protocol.Type_VolatilePointer, uint64(ptr)
 }


### PR DESCRIPTION
Presubmit fails on gLinux because of this gofmt issue, which is introduced by
an update of Golang on gLinux.

Test: ./kokoro/presubmit/presubmit.sh
Bug: none
