### PR TITLE
Allocate a new destination binding if it does not exist

### DIFF
--- a/gapis/api/vulkan/api/descriptor.api
+++ b/gapis/api/vulkan/api/descriptor.api
@@ -642,9 +642,15 @@ cmd void vkUpdateDescriptorSets(
     srcSet := DescriptorSets[c.SrcSet]
     dstSet := DescriptorSets[c.DstSet]
     srcBinding := srcSet.Bindings[c.SrcBinding]
-    dstBinding := dstSet.Bindings[c.DstBinding]
 
-    if ((srcBinding == null) || (dstBinding == null)) {
+    dstBinding := switch dstSet.Bindings[c.DstBinding] == null {
+      case false:
+        dstSet.Bindings[c.DstBinding]
+      case true:
+        new!DescriptorBinding(BindingType: dstSet.Layout.Bindings[c.DstBinding].Type)
+    }
+
+    if ((srcBinding == null) || (srcBinding.BindingType != dstBinding.BindingType)) {
       vkErrorInvalidDescriptorCopy(c.SrcSet, c.SrcBinding, c.DstSet, c.DstBinding)
     } else {
       switch (srcBinding.BindingType) {


### PR DESCRIPTION
during the copy of the descriptor set. Previously copy was
incorrectly dropped if the destination binding had not been
allocated