### PR TITLE
Update GPU slices validation.

### DIFF
--- a/gapis/trace/android/adreno/validate.go
+++ b/gapis/trace/android/adreno/validate.go
@@ -16,20 +16,9 @@ package adreno
 
 import (
 	"context"
-	"fmt"
-	"strings"
 
-	"github.com/google/gapid/core/log"
 	"github.com/google/gapid/gapis/perfetto"
 	"github.com/google/gapid/gapis/trace/android/validate"
-)
-
-const (
-	renderStageSlicesQuery = "" +
-		"select name, depth, parent_stack_id " +
-		"from gpu_slice " +
-		"where track_id = %v " +
-		"order by id"
 )
 
 var (
@@ -50,67 +39,14 @@ var (
 type AdrenoValidator struct {
 }
 
-func (v *AdrenoValidator) validateRenderStage(ctx context.Context, processor *perfetto.Processor) error {
-	tIds, err := validate.GetRenderStageTrackIDs(ctx, processor)
-	if err != nil {
-		return err
-	}
-	for _, tId := range tIds {
-		queryResult, err := processor.Query(fmt.Sprintf(renderStageSlicesQuery, tId))
-		if err != nil || queryResult.GetNumRecords() <= 0 {
-			return log.Errf(ctx, err, "Failed to query with %v", fmt.Sprintf(renderStageSlicesQuery, tId))
-		}
-		columns := queryResult.GetColumns()
-		names := columns[0].GetStringValues()
-
-		// Skip slices until we hit the first 'Surface' slice.
-		skipNum := -1
-		hasSurfaceSlice := false
-		hasRenderSlice := false
-		for i, name := range names {
-			if strings.Contains(name, "Surface") {
-				hasSurfaceSlice = true
-				if skipNum == -1 {
-					skipNum = i
-				}
-			}
-			if strings.Contains(name, "Render") {
-				hasRenderSlice = true
-			}
-		}
-		if !hasSurfaceSlice {
-			return log.Errf(ctx, err, "Render stage verification failed: No Surface slice found")
-		}
-		if !hasRenderSlice {
-			return log.Errf(ctx, err, "Render stage verification failed: No Render slice found")
-		}
-		depths := columns[1].GetLongValues()
-		parentStackId := columns[2].GetLongValues()
-
-		for i := skipNum; i < len(names); i++ {
-			// Surface slice must be the top level slice, hence its depth is 0 and
-			// it has no parent stack id.
-			// Render slice must be a non-top-level slice, hence its depth must not be 0
-			// and it must have a parent stack id.
-			if strings.Contains(names[i], "Surface") {
-				if depths[i] != 0 || parentStackId[i] != 0 {
-					return log.Errf(ctx, err, "Render stage verification failed on Surface slice")
-				}
-			} else if strings.Contains(names[i], "Render") {
-				if depths[i] <= 0 || parentStackId[i] == 0 {
-					return log.Errf(ctx, err, "Render stage verification failed on Render slice")
-				}
-			}
-		}
-	}
-	return nil
-}
-
 func (v *AdrenoValidator) Validate(ctx context.Context, processor *perfetto.Processor) error {
 	if err := validate.ValidateGpuCounters(ctx, processor, v.GetCounters()); err != nil {
 		return err
 	}
-	if err := v.validateRenderStage(ctx, processor); err != nil {
+	if err := validate.ValidateGpuSlices(ctx, processor); err != nil {
+		return err
+	}
+	if err := validate.ValidateVulkanEvents(ctx, processor); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Render stages slices must have one render target, one command buffer and one
submission id associated with it. Vulkan events slices must have a submission
id associated with it if it's a vkQueueSubmit event.

Bug: b/148490745