### PR TITLE
Allow easier time highlight modification in Pan/Zoom mode.

### DIFF
--- a/gapic/src/main/com/google/gapid/perfetto/views/RootPanel.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/RootPanel.java
@@ -178,15 +178,12 @@ public abstract class RootPanel<S extends State> extends Panel.Base implements S
           }
         }
 
+        // Draw drag-able hint on highlighted timeline's edge when hovered.
         ctx.setForegroundColor(colors().timeHighlightEmphasize);
-        if (isHighlightStartHovered && mouseMode == MouseMode.TimeSelect) {
-          ctx.drawLine(x1, 0, x1, height, 3); // Draw across the whole root panel in y direction.
-        } else if (isHighlightStartHovered) {
-          ctx.drawLine(x1, 0, x1, timeline.getPreferredHeight(), 3); // Draw only in time ruler.
-        } else if (isHighlightEndHovered && mouseMode == MouseMode.TimeSelect) {
-          ctx.drawLine(x2, 0, x2, height, 3);
+        if (isHighlightStartHovered) {
+          ctx.drawLine(x1, 0, x1, height, 3);
         } else if (isHighlightEndHovered) {
-          ctx.drawLine(x2, 0, x2, timeline.getPreferredHeight(), 3);
+          ctx.drawLine(x2, 0, x2, height, 3);
         }
       });
     }
@@ -214,8 +211,8 @@ public abstract class RootPanel<S extends State> extends Panel.Base implements S
       return Dragger.NONE;
     }
 
-    if (sy <= timeline.getPreferredHeight()) {
-      return timeHighlightDragger(sx, sy, mods);
+    if (sy <= timeline.getPreferredHeight() || isHighlightStartHovered || isHighlightEndHovered) {
+      return timeSelectDragger(sx);
     }
 
     MouseMode mode = mouseMode;
@@ -234,21 +231,6 @@ public abstract class RootPanel<S extends State> extends Panel.Base implements S
       case TimeSelect: return timeSelectDragger(sx);
       default: return Dragger.NONE;
     }
-  }
-
-  private Dragger timeHighlightDragger(double sx, double sy, int mods) {
-    double hFixedEnd = findHighlightFixedEnd(sx);
-    return new Dragger() {
-      @Override
-      public Area onDrag(double x, double y) {
-        return updateHighlight(hFixedEnd, x);
-      }
-
-      @Override
-      public Area onDragEnd(double x, double y) {
-        return onDrag(x, y);
-      }
-    };
   }
 
   private Dragger selectDragger(double sx, double sy, int mods) {
@@ -425,13 +407,8 @@ public abstract class RootPanel<S extends State> extends Panel.Base implements S
     boolean nearStart = Math.abs(x - hStart) <= HIGHLIGHT_EDGE_NEARBY_WIDTH;
     boolean nearEnd = Math.abs(x - hEnd) <= HIGHLIGHT_EDGE_NEARBY_WIDTH;
     boolean closerToStart = Math.abs(x - hStart) < Math.abs(x - hEnd);
-    if (mouseMode != MouseMode.TimeSelect) {
-      isHighlightStartHovered = nearStart && closerToStart && y <= timeline.getPreferredHeight();
-      isHighlightEndHovered = nearEnd && !closerToStart && y <= timeline.getPreferredHeight();
-    } else if (mouseMode == MouseMode.TimeSelect) {
-      isHighlightStartHovered = nearStart && closerToStart;
-      isHighlightEndHovered = nearEnd && !closerToStart;
-    }
+    isHighlightStartHovered = nearStart && closerToStart;
+    isHighlightEndHovered = nearEnd && !closerToStart;
     return preStartStatus != isHighlightStartHovered || preEndStatus != isHighlightEndHovered;
   }
 


### PR DESCRIPTION
 - Before this change: in Pan/Zoom mode, to do a time highlight range
 modification, you have to Ctrl-drag the edge in time ruler panel. And
 there's no yellow bold edge rendering searving as a hint.
 - After this change: in Selection/Pan/Zoom mode, modification can be
 done in a same manner by a plain dragging on edge in the time ruler panel.
 - The idea behind this commit is to have at least one place, where time
 highlight dragging always works, no matter in which mouse mode.
 - Related ticket: http://b/148789881.