### PR TITLE
Revert "Fix and document capture-time tweak of vkCreateImage (#3736)"

### DIFF
--- a/gapii/README.md
+++ b/gapii/README.md
@@ -59,13 +59,3 @@ GAPII needs to support all of these cases.
 
 Each encoded command holds an identifier of the thread that made the call.
 Commands from all threads are encoded into a single chronological stream.
-
-## Command modifications during capture
-
-Some commands may have to be modified for the capture to be possible.
-The following lists are maintained as a best-effort, they may not be exhaustive nor up-to-date.
-
-### Vulkan
-
-- `vkCreateImage`: the `VK_IMAGE_USAGE_TRANSFER_SRC_BIT` is always set, in order to be able to read the image contents.
-  The `VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT` is cleared accordingly, because it is incompatible with the transfer bit.

--- a/gapii/cc/vulkan_extras.cpp
+++ b/gapii/cc/vulkan_extras.cpp
@@ -890,12 +890,8 @@ uint32_t VulkanSpy::SpyOverride_vkCreateImage(
     VkDevice device, const VkImageCreateInfo* pCreateInfo,
     const VkAllocationCallbacks* pAllocator, VkImage* pImage) {
   VkImageCreateInfo override_create_info = *pCreateInfo;
-  // Make it possible to read the image contents
   override_create_info.musage |=
       VkImageUsageFlagBits::VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
-  // Unset TRANSIENT_ATTACHMENT, which is incompatible with TRANSFER_SRC
-  override_create_info.musage &=
-      ~(VkImageUsageFlagBits::VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT);
   return mImports.mVkDeviceFunctions[device].vkCreateImage(
       device, &override_create_info, pAllocator, pImage);
 }


### PR DESCRIPTION
This reverts commit 5bd13e91eb95cbe5143e966a785f4eb612202a75.

This change did not seem to break things on mobile, but it does break
capture on some desktop apps. The relevant fix to be done is tracked
with b/148857112

Bug: b/148857112