### PR TITLE
Fix bug introduced with simplified command-buffer handling.

### DIFF
--- a/gapis/api/vulkan/api/command_buffer_control.api
+++ b/gapis/api/vulkan/api/command_buffer_control.api
@@ -626,6 +626,21 @@ class vkCmdExecuteCommandsArgs {
 }
 
 sub void dovkCmdExecuteCommands(ref!vkCmdExecuteCommandsArgs cmds) {
+  enterSubcontext()
+  for i in (0 .. len(cmds.CommandBuffers)) {
+    cb := CommandBuffers[cmds.CommandBuffers[as!u32(i)]]
+    enterSubcontext()
+    for j in (0 .. len(cb.CommandReferences)) {
+      cmd := cb.CommandReferences[as!u32(j)]
+      onPreSubcommand(cmd)
+      callCommand(cmd)
+      onPostSubcommand(cmd)
+      nextSubcontext()
+    }
+    leaveSubcontext()
+    nextSubcontext()
+  }
+  leaveSubcontext()
 }
 
 @indirect("VkCommandBuffer", "VkDevice")

--- a/gapis/api/vulkan/api/queue.api
+++ b/gapis/api/vulkan/api/queue.api
@@ -94,6 +94,7 @@ cmd VkResult vkQueueSubmit(
   LastSubmission = SUBMIT
   submitInfo := pSubmits[0:submitCount]
   LastBoundQueue = Queues[queue]
+  clear(LastBoundQueue.ReadCoherentBuffers)
   enterSubcontext()
   for i in (0 .. submitCount) {
     info := submitInfo[i]
@@ -177,7 +178,6 @@ cmd VkResult vkQueueSubmit(
         }
       }
     }
-    clear(LastBoundQueue.ReadCoherentBuffers)
     
     executeSubmit(queue, subm)
     nextSubcontext()


### PR DESCRIPTION
This dropped the simulation(and tracking) of secondary command
buffers. Essentially meaning we failed to track coherent memory
in secondary command-buffers.

Bug: None