### PR TITLE
Gapit video now reports frame differences when there are no draws.

### DIFF
--- a/cmd/gapit/sxs_video.go
+++ b/cmd/gapit/sxs_video.go
@@ -106,8 +106,17 @@ func (verb *videoVerb) sxsVideoSource(
 	// These would result in a failed comparison as the observed frame could
 	// be anything and the replayed frame will show the undefined framebuffer
 	// pattern.
-	// Permit the first run of frames to have no content.
-	permitNoMatch := true
+	// Permit the first run of frames to have no content. If there are no
+	// draw-calls or clear calls at all however, then do not permit this.
+	permitNoMatch := false
+
+	for _, e := range events {
+		if e.Kind == service.EventKind_Clear ||
+			e.Kind == service.EventKind_DrawCall {
+			permitNoMatch = true
+			break
+		}
+	}
 
 	var lastFrameEvent *path.Command
 	for _, e := range events {


### PR DESCRIPTION
gapit video was not reporting error frames for casese where
framebuffers were potentially uninitialzied. This logic however
was less fitting for Vulkan, (where we don't have draw-calls).

So in this case, if there are NO draw-calls at all in the
trace, then we should compare all images regardless.

Bug: b/148941796