### PR TITLE
Fixes hovers causing loading tracks not to repaint.

### DIFF
--- a/gapic/src/main/com/google/gapid/perfetto/views/RootPanel.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/RootPanel.java
@@ -468,12 +468,8 @@ public abstract class RootPanel<S extends State> extends Panel.Base implements S
 
     private void renderVSync(RenderContext ctx, Repainter repainter, Panel panel, VSync vsync) {
       ctx.trace("VSync", () -> {
-        VSync.Data data = vsync.getData(state.toRequest(), (future, consumer) -> {
-          state.thenOnUiThread(future, result -> {
-            consumer.accept(result);
-            repainter.repaint(new Area(0, 0, width, height));
-          });
-        });
+        VSync.Data data = vsync.getData(state.toRequest(),
+            TrackPanel.onUiThread(state, () -> repainter.repaint(new Area(0, 0, width, height))));
         if (data == null) {
           return;
         }


### PR DESCRIPTION
There was a race between the renders and the hovers, where if the hover computation happend before the render of the track, the data request of the render was deduped against the one from the hover computation, causing the render repaint callback to be dropped. This fixes this by combining the callbacks when deduping and invoking all encountered callbacks, when the data is finally ready.