### PR TITLE
Add "InlineResource" VLIW instruction to interpreter bytecode

### DIFF
--- a/gapir/cc/interpreter.h
+++ b/gapir/cc/interpreter.h
@@ -125,15 +125,18 @@ class Interpreter {
     CHANGE_THREAD,
   };
 
-  // Get type information out from an opcode. The type is always stored in the
-  // 7th to 13th MSB (both inclusive) of the opcode
-  BaseType extractType(uint32_t opcode) const;
+  // Get 6 bits from the opcode:     ******XXXXXX********************
+  uint32_t extract6bitData(uint32_t opcode) const;
 
-  // Get 20 bit data out from an opcode located in the 20 LSB of the opcode.
+  // Get 20 bits out from an opcode: ************XXXXXXXXXXXXXXXXXXXX
   uint32_t extract20bitData(uint32_t opcode) const;
 
-  // Get 26 bit data out from an opcode located in the 26 LSB of the opcode.
+  // Get 26 bits out from an opcode: ******XXXXXXXXXXXXXXXXXXXXXXXXXX
   uint32_t extract26bitData(uint32_t opcode) const;
+
+  // Get type information out from an opcode. The type is always stored in the
+  // 7th to 13th MSB (both inclusive) of the opcode (see extract6bitData())
+  BaseType extractType(uint32_t opcode) const;
 
   // Implementation of the opcodes supported by the interpreter.
   Result call(uint32_t opcode);
@@ -145,6 +148,7 @@ class Interpreter {
   Result storeV(uint32_t opcode);
   Result store();
   Result resource(uint32_t);
+  Result inlineResource(uint32_t opcode);
   Result post();
   Result copy(uint32_t opcode);
   Result clone(uint32_t opcode);

--- a/gapir/replay_service/vm.h
+++ b/gapir/replay_service/vm.h
@@ -47,6 +47,8 @@ enum class Opcode {
   JUMP_Z = 19,
   NOTIFICATION = 20,
   WAIT = 21,
+  INLINE_RESOURCE = 22,
+  NUM_OPCODES = 23,
 };
 
 // Unique ID for each supported data type. The ID have to fit into 6 bits (0-63)

--- a/gapis/api/test/mutate_test.go
+++ b/gapis/api/test/mutate_test.go
@@ -63,7 +63,7 @@ func (test test) check(ctx context.Context, ca, ra *device.MemoryLayout) {
 		b.BeginCommand(uint64(id), 0)
 		err := cmd.Mutate(ctx, id, s, b, nil)
 		assert.For(ctx, "Mutate command").ThatError(err).Succeeded()
-		b.CommitCommand()
+		b.CommitCommand(ctx, false)
 		return nil
 	})
 

--- a/gapis/replay/batch.go
+++ b/gapis/replay/batch.go
@@ -400,7 +400,7 @@ func (w *adapter) MutateAndWrite(ctx context.Context, id api.CmdID, cmd api.Cmd)
 	w.builder.BeginCommand(uint64(id), cmd.Thread())
 	err := cmd.Mutate(ctx, id, w.state, w.builder, nil)
 	if err == nil {
-		w.builder.CommitCommand()
+		w.builder.CommitCommand(ctx, true)
 	} else {
 		w.builder.RevertCommand(err)
 		log.W(ctx, "Failed to write command %v %v for replay: %v", id, cmd, err)

--- a/gapis/replay/builder/builder_test.go
+++ b/gapis/replay/builder/builder_test.go
@@ -42,7 +42,7 @@ func TestCommitCommand(t *testing.T) {
 				b.Push(value.U8(1))
 				b.Call(FunctionInfo{0, 123, protocol.Type_Uint8, 1})
 				b.Store(value.AbsolutePointer(0x10000))
-				b.CommitCommand()
+				b.CommitCommand(ctx, false)
 			},
 			[]asm.Instruction{
 				asm.Label{Value: 10},
@@ -57,7 +57,7 @@ func TestCommitCommand(t *testing.T) {
 				b.BeginCommand(10, 0)
 				b.Push(value.U8(1))
 				b.Call(FunctionInfo{1, 123, protocol.Type_Uint8, 1})
-				b.CommitCommand()
+				b.CommitCommand(ctx, false)
 			},
 			[]asm.Instruction{
 				asm.Label{Value: 10},
@@ -70,7 +70,7 @@ func TestCommitCommand(t *testing.T) {
 			func(b *Builder) {
 				b.BeginCommand(10, 0)
 				b.Push(value.U32(12))
-				b.CommitCommand()
+				b.CommitCommand(ctx, false)
 			},
 			[]asm.Instruction{
 				asm.Label{Value: 10},
@@ -83,7 +83,7 @@ func TestCommitCommand(t *testing.T) {
 				b.Push(value.U32(12))
 				b.Push(value.U32(34))
 				b.Push(value.U32(56))
-				b.CommitCommand()
+				b.CommitCommand(ctx, false)
 			},
 			[]asm.Instruction{
 				asm.Label{Value: 10},
@@ -95,7 +95,7 @@ func TestCommitCommand(t *testing.T) {
 				b.BeginCommand(10, 0)
 				b.Call(FunctionInfo{0, 123, protocol.Type_Uint8, 0})
 				b.Clone(0)
-				b.CommitCommand()
+				b.CommitCommand(ctx, false)
 			},
 			[]asm.Instruction{
 				asm.Label{Value: 10},
@@ -110,7 +110,7 @@ func TestCommitCommand(t *testing.T) {
 				b.Call(FunctionInfo{1, 123, protocol.Type_Uint8, 0})
 				b.Clone(0)
 				b.Store(value.AbsolutePointer(0x10000))
-				b.CommitCommand()
+				b.CommitCommand(ctx, false)
 			},
 			[]asm.Instruction{
 				asm.Label{Value: 10},
@@ -125,7 +125,7 @@ func TestCommitCommand(t *testing.T) {
 				b.BeginCommand(10, 0)
 				b.Call(FunctionInfo{0, 123, protocol.Type_Uint8, 0})
 				b.Clone(0)
-				b.CommitCommand()
+				b.CommitCommand(ctx, false)
 			},
 			[]asm.Instruction{
 				asm.Label{Value: 10},
@@ -143,7 +143,7 @@ func TestCommitCommand(t *testing.T) {
 				b.Call(FunctionInfo{0, 123, protocol.Type_Uint8, 0})
 				b.Clone(1)
 				b.Store(value.AbsolutePointer(0x10000))
-				b.CommitCommand()
+				b.CommitCommand(ctx, false)
 			},
 			[]asm.Instruction{
 				asm.Label{Value: 10},
@@ -186,7 +186,7 @@ func TestRevertCommand(t *testing.T) {
 				b.Push(value.U8(1))
 				b.Call(FunctionInfo{1, 123, protocol.Type_Uint8, 1})
 				b.Store(value.AbsolutePointer(0x10000))
-				b.CommitCommand()
+				b.CommitCommand(ctx, false)
 				b.BeginCommand(20, 0)
 				b.Push(value.U8(2))
 				b.Call(FunctionInfo{1, 234, protocol.Type_Uint8, 1})
@@ -253,7 +253,7 @@ func TestMapMemory(t *testing.T) {
 				b.BeginCommand(10, 0)
 				b.Push(value.ObservedPointer(0x100004))
 				b.Call(FunctionInfo{0, 123, protocol.Type_VolatilePointer, 1})
-				b.CommitCommand()
+				b.CommitCommand(ctx, false)
 			},
 			[]asm.Instruction{
 				asm.Label{Value: 10},
@@ -267,12 +267,12 @@ func TestMapMemory(t *testing.T) {
 				b.BeginCommand(10, 0)
 				b.Call(FunctionInfo{0, 100, protocol.Type_AbsolutePointer, 0})
 				b.MapMemory(memory.Range{Base: 0x100000, Size: 0x10})
-				b.CommitCommand()
+				b.CommitCommand(ctx, false)
 
 				b.BeginCommand(20, 0)
 				b.Push(value.ObservedPointer(0x100004))
 				b.Call(FunctionInfo{0, 123, protocol.Type_Void, 1})
-				b.CommitCommand()
+				b.CommitCommand(ctx, false)
 			},
 			[]asm.Instruction{
 				asm.Label{Value: 10},
@@ -292,16 +292,16 @@ func TestMapMemory(t *testing.T) {
 				b.BeginCommand(10, 0)
 				b.Call(FunctionInfo{0, 100, protocol.Type_AbsolutePointer, 0})
 				b.MapMemory(memory.Range{Base: 0x100000, Size: 0x10})
-				b.CommitCommand()
+				b.CommitCommand(ctx, false)
 
 				b.BeginCommand(20, 0)
 				b.UnmapMemory(memory.Range{Base: 0x100000, Size: 0x10})
-				b.CommitCommand()
+				b.CommitCommand(ctx, false)
 
 				b.BeginCommand(30, 0)
 				b.Push(value.ObservedPointer(0x100004))
 				b.Call(FunctionInfo{0, 123, protocol.Type_Void, 1})
-				b.CommitCommand()
+				b.CommitCommand(ctx, false)
 			},
 			[]asm.Instruction{
 				asm.Label{Value: 10},

--- a/gapis/replay/opcode/BUILD.bazel
+++ b/gapis/replay/opcode/BUILD.bazel
@@ -28,5 +28,6 @@ go_library(
         "//core/data/endian:go_default_library",
         "//core/os/device:go_default_library",
         "//gapis/replay/protocol:go_default_library",
+        "//gapis/replay/value:go_default_library",
     ],
 )

--- a/gapis/replay/protocol/opcode.go
+++ b/gapis/replay/protocol/opcode.go
@@ -20,28 +20,29 @@ import "fmt"
 type Opcode int
 
 const (
-	OpCall         = Opcode(0)
-	OpPushI        = Opcode(1)
-	OpLoadC        = Opcode(2)
-	OpLoadV        = Opcode(3)
-	OpLoad         = Opcode(4)
-	OpPop          = Opcode(5)
-	OpStoreV       = Opcode(6)
-	OpStore        = Opcode(7)
-	OpResource     = Opcode(8)
-	OpPost         = Opcode(9)
-	OpCopy         = Opcode(10)
-	OpClone        = Opcode(11)
-	OpStrcpy       = Opcode(12)
-	OpExtend       = Opcode(13)
-	OpAdd          = Opcode(14)
-	OpLabel        = Opcode(15)
-	OpSwitchThread = Opcode(16)
-	OpJumpLabel    = Opcode(17)
-	OpJumpNZ       = Opcode(18)
-	OpJumpZ        = Opcode(19)
-	OpNotification = Opcode(20)
-	OpWait         = Opcode(21)
+	OpCall           = Opcode(0)
+	OpPushI          = Opcode(1)
+	OpLoadC          = Opcode(2)
+	OpLoadV          = Opcode(3)
+	OpLoad           = Opcode(4)
+	OpPop            = Opcode(5)
+	OpStoreV         = Opcode(6)
+	OpStore          = Opcode(7)
+	OpResource       = Opcode(8)
+	OpPost           = Opcode(9)
+	OpCopy           = Opcode(10)
+	OpClone          = Opcode(11)
+	OpStrcpy         = Opcode(12)
+	OpExtend         = Opcode(13)
+	OpAdd            = Opcode(14)
+	OpLabel          = Opcode(15)
+	OpSwitchThread   = Opcode(16)
+	OpJumpLabel      = Opcode(17)
+	OpJumpNZ         = Opcode(18)
+	OpJumpZ          = Opcode(19)
+	OpNotification   = Opcode(20)
+	OpWait           = Opcode(21)
+	OpInlineResource = Opcode(22)
 )
 
 // String returns the human-readable name of the opcode.
@@ -91,6 +92,8 @@ func (t Opcode) String() string {
 		return "Notification"
 	case OpWait:
 		return "Wait"
+	case OpInlineResource:
+		return "InlineResource"
 	default:
 		panic(fmt.Errorf("Unknown Opcode %d", uint32(t)))
 	}


### PR DESCRIPTION
This stores small resources "inline" in the instruction bytecode, which is conceptually kind of nasty but highly performant. Additionally, this new instruction supports some inlined "resource patch ups" which are basically push/store and load/store instructions that can also be inlined into the compound instruction, to allow common patch-ups of the inlined resource to all be performed in a single operation.