### PR TITLE
Serialize buffer contents on transfer from external queue.

### DIFF
--- a/gapii/cc/BUILD.bazel
+++ b/gapii/cc/BUILD.bazel
@@ -153,6 +153,7 @@ cc_library(
         "//gapil/runtime/cc",
         "//gapis/api:api_cc_proto",
         "//gapis/api/gles/gles_pb:extras_cc_proto",
+        "//gapis/api/vulkan/vulkan_pb:extras_cc_proto",
         "//gapis/capture:capture_cc_proto",
         "//gapis/memory/memory_pb:memory_pb_cc_proto",
         "@com_google_protobuf//:protobuf",

--- a/gapii/cc/vulkan_external_memory.cpp
+++ b/gapii/cc/vulkan_external_memory.cpp
@@ -1,0 +1,484 @@
+/*
+ * Copyright (C) 2020 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "gapii/cc/vulkan_external_memory.h"
+#include "gapii/cc/vulkan_layer_extras.h"
+#include "gapii/cc/vulkan_spy.h"
+#include "gapis/api/vulkan/vulkan_pb/extras.pb.h"
+
+namespace gapii {
+
+void VulkanSpy::recordExternalBarriers(
+    VkCommandBuffer commandBuffer, uint32_t bufferMemoryBarrierCount,
+    const VkBufferMemoryBarrier* pBufferMemoryBarriers,
+    uint32_t imageMemoryBarrierCount,
+    const VkImageMemoryBarrier* pImageMemoryBarriers) {
+  static const uint32_t VK_QUEUE_FAMILY_EXTERNAL = ~0U - 1;
+
+  size_t externalBufferBarrierCount = 0;
+  for (uint32_t i = 0; i < bufferMemoryBarrierCount; ++i) {
+    if (pBufferMemoryBarriers[i].msrcQueueFamilyIndex ==
+        VK_QUEUE_FAMILY_EXTERNAL) {
+      ++externalBufferBarrierCount;
+    }
+  }
+
+  size_t externalImageBarrierCount = 0;
+  for (uint32_t i = 0; i < imageMemoryBarrierCount; ++i) {
+    if (pImageMemoryBarriers[i].msrcQueueFamilyIndex ==
+        VK_QUEUE_FAMILY_EXTERNAL) {
+      ++externalImageBarrierCount;
+    }
+  }
+
+  if (externalBufferBarrierCount == 0 && externalImageBarrierCount == 0) {
+    return;
+  }
+
+  std::vector<VkBufferMemoryBarrier>& bufBarriers =
+      mExternalBufferBarriers[commandBuffer];
+  bufBarriers.reserve(bufBarriers.size() + externalBufferBarrierCount);
+  for (uint32_t i = 0; i < bufferMemoryBarrierCount; ++i) {
+    if (pBufferMemoryBarriers[i].msrcQueueFamilyIndex ==
+        VK_QUEUE_FAMILY_EXTERNAL) {
+      bufBarriers.push_back(pBufferMemoryBarriers[i]);
+    }
+  }
+}
+
+ExternalMemoryStaging::ExternalMemoryStaging(
+    VulkanSpy* spy, CallObserver* observer, VkQueue queue, uint32_t submitCount,
+    const VkSubmitInfo* pSubmits, VkFence fence)
+    : spy(spy), observer(observer), queue(queue), origFence(fence) {
+  QueueObject& queueObj = *spy->mState.Queues[queue];
+  queueFamilyIndex = queueObj.mFamily;
+  device = queueObj.mDevice;
+  fn = &spy->mImports.mVkDeviceFunctions[device];
+
+  stagingSize = 0;
+  submits.resize(submitCount);
+  for (uint32_t i = 0; i < submitCount; ++i) {
+    submits[i].submitInfo = &pSubmits[i];
+    uint32_t commandBufferCount = pSubmits[i].mcommandBufferCount;
+    submits[i].commandBuffers.resize(commandBufferCount);
+    for (uint32_t j = 0; j < commandBufferCount; ++j) {
+      ExternalMemoryCommandBuffer& cmdBuf = submits[i].commandBuffers[j];
+      cmdBuf.commandBuffer = pSubmits[i].mpCommandBuffers[j];
+      auto bufIt = spy->mExternalBufferBarriers.find(cmdBuf.commandBuffer);
+      if (bufIt != spy->mExternalBufferBarriers.end()) {
+        for (auto barrierIt = bufIt->second.begin();
+             barrierIt != bufIt->second.end(); ++barrierIt) {
+          cmdBuf.buffers.push_back(
+              ExternalBufferMemoryStaging(*barrierIt, stagingSize));
+        }
+      }
+    }
+  }
+}
+
+uint32_t ExternalMemoryStaging::CreateResources() {
+  VkCommandPoolCreateInfo commandPoolCreateInfo{
+      VkStructureType::VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO,  // sType
+      nullptr,                                                      // pNext
+      VkCommandPoolCreateFlagBits::
+          VK_COMMAND_POOL_CREATE_TRANSIENT_BIT,  // flags
+      queueFamilyIndex,                          // queueFamilyIndex
+  };
+  uint32_t res = fn->vkCreateCommandPool(device, &commandPoolCreateInfo,
+                                         nullptr, &stagingCommandPool);
+  if (res != VkResult::VK_SUCCESS) {
+    stagingCommandPool = 0;
+    GAPID_ERROR("Error creating command pool for external memory observations");
+    return res;
+  }
+
+  VkFenceCreateInfo fenceCreateInfo{
+      VkStructureType::VK_STRUCTURE_TYPE_FENCE_CREATE_INFO,  // sType
+      nullptr,                                               // pNext
+      0,                                                     // flags
+  };
+  res = fn->vkCreateFence(device, &fenceCreateInfo, nullptr, &stagingFence);
+  if (res != VkResult::VK_SUCCESS) {
+    stagingFence = 0;
+    GAPID_ERROR("Error creating fence for external memory observations");
+    return res;
+  }
+
+  size_t commandBufferCount = 1;
+  for (auto submitIt = submits.begin(); submitIt != submits.end(); ++submitIt) {
+    for (auto cmdBufIt = submitIt->commandBuffers.begin();
+         cmdBufIt != submitIt->commandBuffers.end(); ++cmdBufIt) {
+      if (!cmdBufIt->empty()) {
+        ++commandBufferCount;
+      }
+    }
+  }
+  std::vector<VkCommandBuffer> commandBuffers(commandBufferCount);
+  VkCommandBufferAllocateInfo commandBufferAllocInfo{
+      VkStructureType::VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO,  // sType
+      nullptr,                                                          // pNext
+      stagingCommandPool,                                     // commandPool
+      VkCommandBufferLevel::VK_COMMAND_BUFFER_LEVEL_PRIMARY,  // level
+      (uint32_t)commandBuffers.size() + 1,  // commandBufferCount
+  };
+  res = fn->vkAllocateCommandBuffers(device, &commandBufferAllocInfo,
+                                     commandBuffers.data());
+  for (auto cmdBuf : commandBuffers) {
+    set_dispatch_from_parent((void*)cmdBuf, (void*)device);
+  }
+  if (res != VkResult::VK_SUCCESS) {
+    GAPID_ERROR(
+        "Error allocating command buffer for external memory observations");
+    return res;
+  }
+  stagingCommandBuffer = commandBuffers.back();
+  commandBuffers.pop_back();
+  for (auto submitIt = submits.begin(); submitIt != submits.end(); ++submitIt) {
+    for (auto cmdBufIt = submitIt->commandBuffers.begin();
+         cmdBufIt != submitIt->commandBuffers.end(); ++cmdBufIt) {
+      if (!cmdBufIt->empty()) {
+        cmdBufIt->stagingCommandBuffer = commandBuffers.back();
+        commandBuffers.pop_back();
+      }
+    }
+  }
+
+  VkBufferCreateInfo bufferCreateInfo = {
+      VkStructureType::VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO,    // sType
+      nullptr,                                                  // pNext
+      0,                                                        // flags
+      stagingSize,                                              // size
+      VkBufferUsageFlagBits::VK_BUFFER_USAGE_TRANSFER_DST_BIT,  // usage
+      VkSharingMode::VK_SHARING_MODE_EXCLUSIVE,                 // sharingMode
+      0,        // queueFamilyIndexCount
+      nullptr,  // pQueueFamilyIndices
+  };
+  res = fn->vkCreateBuffer(device, &bufferCreateInfo, nullptr, &stagingBuffer);
+  if (res != VkResult::VK_SUCCESS) {
+    stagingBuffer = 0;
+    GAPID_ERROR("Failed at creating staging buffer to read external memory");
+    return res;
+  }
+
+  VkMemoryRequirements memReqs(spy->arena());
+  fn->vkGetBufferMemoryRequirements(device, stagingBuffer, &memReqs);
+
+  VkPhysicalDevice physDevice = spy->mState.Devices[device]->mPhysicalDevice;
+  VkPhysicalDeviceMemoryProperties memProps =
+      spy->mState.PhysicalDevices[physDevice]->mMemoryProperties;
+  uint32_t memoryTypeIndex =
+      GetMemoryTypeIndexForStagingResources(memProps, memReqs.mmemoryTypeBits);
+  if (memoryTypeIndex == kInvalidMemoryTypeIndex) {
+    GAPID_ERROR(
+        "Failed at finding memory type index for staging buffer memory to read "
+        "external memory");
+    return res;
+  }
+
+  VkMemoryAllocateInfo memoryAllocInfo = {
+      VkStructureType::VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO,  // sType
+      nullptr,                                                  // pNext
+      memReqs.msize,    // allocationSize
+      memoryTypeIndex,  // memoryTypeIndex
+  };
+
+  res = VkResult::VK_SUCCESS;
+  res = fn->vkAllocateMemory(device, &memoryAllocInfo, nullptr, &stagingMemory);
+  if (res != VkResult::VK_SUCCESS) {
+    stagingMemory = 0;
+    GAPID_ERROR(
+        "Failed at allocating staging buffer memory to read external memory");
+    return res;
+  }
+
+  res = fn->vkBindBufferMemory(device, stagingBuffer, stagingMemory, 0);
+  if (res != VkResult::VK_SUCCESS) {
+    GAPID_ERROR("Failed at binding staging buffer to read external memory");
+    return res;
+  }
+
+  return VkResult::VK_SUCCESS;
+}
+
+uint32_t ExternalMemoryStaging::RecordCommandBuffers() {
+  for (auto submitIt = submits.begin(); submitIt != submits.end(); ++submitIt) {
+    for (auto cmdBufIt = submitIt->commandBuffers.begin();
+         cmdBufIt != submitIt->commandBuffers.end(); ++cmdBufIt) {
+      if (!cmdBufIt->empty()) {
+        uint32_t res = RecordStagingCommandBuffer(*cmdBufIt);
+        if (res != VkResult::VK_SUCCESS) {
+          return res;
+        }
+      }
+    }
+  }
+
+  VkCommandBufferBeginInfo beginInfo{
+      VkStructureType::VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO,  // sType
+      nullptr,                                                       // pNext
+      VkCommandBufferUsageFlagBits::
+          VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT,  // flags
+      nullptr,                                          // pInheritanceInfo
+  };
+  uint32_t res = fn->vkBeginCommandBuffer(stagingCommandBuffer, &beginInfo);
+  if (res != VkResult::VK_SUCCESS) {
+    GAPID_ERROR("Failed at begin command buffer to read external memory");
+    return res;
+  }
+
+  // Make staging buffer writes visible to the host
+  VkBufferMemoryBarrier barrier{
+      VkStructureType::VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER,  // sType
+      nullptr,                                                   // pNext
+      VkAccessFlagBits::VK_ACCESS_TRANSFER_WRITE_BIT,  // srcAccessMask
+      VkAccessFlagBits::VK_ACCESS_HOST_READ_BIT,       // dstAccessMask
+      queueFamilyIndex,                                // srcQueueFamilyIndex
+      queueFamilyIndex,                                // dstQueueFamilyIndex
+      stagingBuffer,                                   // buffer
+      0,                                               // offset
+      stagingSize,                                     // size
+  };
+
+  fn->vkCmdPipelineBarrier(
+      stagingCommandBuffer,                                     // commandBuffer
+      VkPipelineStageFlagBits::VK_PIPELINE_STAGE_TRANSFER_BIT,  // srcStageMask
+      VkPipelineStageFlagBits::VK_PIPELINE_STAGE_HOST_BIT,      // dstStageMask
+      0,         // dependencyFlags
+      0,         // memoryBarrierCount
+      nullptr,   // pMemoryBarriers
+      1,         // bufferMemoryBarrierCount
+      &barrier,  // pBufferMemoryBarriers
+      0,         // imageMemoryBarrierCount
+      nullptr    // pImageMemoryBarriers
+  );
+
+  res = fn->vkEndCommandBuffer(stagingCommandBuffer);
+  if (res != VkResult::VK_SUCCESS) {
+    GAPID_ERROR("Failed at end command buffer to read external memory");
+    return res;
+  }
+  return VkResult::VK_SUCCESS;
+}
+
+uint32_t ExternalMemoryStaging::RecordStagingCommandBuffer(
+    const ExternalMemoryCommandBuffer& cmdBuf) {
+  VkCommandBufferBeginInfo beginInfo{
+      VkStructureType::VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO,  // sType
+      nullptr,                                                       // pNext
+      VkCommandBufferUsageFlagBits::
+          VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT,  // flags
+      nullptr,                                          // pInheritanceInfo
+  };
+  uint32_t res =
+      fn->vkBeginCommandBuffer(cmdBuf.stagingCommandBuffer, &beginInfo);
+  if (res != VkResult::VK_SUCCESS) {
+    GAPID_ERROR("Failed at begin command buffer to read external memory");
+    return res;
+  }
+
+  std::vector<VkBufferMemoryBarrier> acquireBufferBarriers;
+  acquireBufferBarriers.reserve(cmdBuf.buffers.size());
+  std::vector<VkBufferMemoryBarrier> releaseBufferBarriers;
+  releaseBufferBarriers.reserve(cmdBuf.buffers.size());
+
+  for (auto bufIt = cmdBuf.buffers.begin(); bufIt != cmdBuf.buffers.end();
+       ++bufIt) {
+    VkBufferMemoryBarrier barrier = bufIt->barrier;
+    barrier.msrcAccessMask = 0;
+    barrier.mdstAccessMask = VkAccessFlagBits::VK_ACCESS_TRANSFER_READ_BIT;
+    acquireBufferBarriers.push_back(barrier);
+    std::swap(barrier.msrcAccessMask, barrier.mdstAccessMask);
+    std::swap(barrier.msrcQueueFamilyIndex, barrier.mdstQueueFamilyIndex);
+    releaseBufferBarriers.push_back(barrier);
+  }
+
+  // acquire from external queue family
+  fn->vkCmdPipelineBarrier(
+      cmdBuf.stagingCommandBuffer,  // commandBuffer
+      VkPipelineStageFlagBits::
+          VK_PIPELINE_STAGE_ALL_COMMANDS_BIT,                   // srcStageMask
+      VkPipelineStageFlagBits::VK_PIPELINE_STAGE_TRANSFER_BIT,  // dstStageMask
+      0,                                       // dependencyFlags
+      0,                                       // memoryBarrierCount
+      nullptr,                                 // pMemoryBarriers
+      (uint32_t)acquireBufferBarriers.size(),  // bufferMemoryBarrierCount
+      acquireBufferBarriers.data(),            // pBufferMemoryBarriers
+      (uint32_t)0,                             // imageMemoryBarrierCount
+      nullptr                                  // pImageMemoryBarriers
+  );
+
+  // copy external buffer barrier regions to staging buffer
+  for (auto bufIt = cmdBuf.buffers.begin(); bufIt != cmdBuf.buffers.end();
+       ++bufIt) {
+    fn->vkCmdCopyBuffer(cmdBuf.stagingCommandBuffer,  // commandBuffer
+                        bufIt->buffer,                // srcBuffer
+                        stagingBuffer,                // dstBuffer
+                        1,                            // regionCount
+                        &bufIt->copy                  // pRegions
+    );
+  }
+
+  // release external barrier regions back to external queue family
+  // (so that the original barriers run correctly when they execute later)
+  fn->vkCmdPipelineBarrier(
+      cmdBuf.stagingCommandBuffer,                              // commandBuffer
+      VkPipelineStageFlagBits::VK_PIPELINE_STAGE_TRANSFER_BIT,  // srcStageMask
+      VkPipelineStageFlagBits::
+          VK_PIPELINE_STAGE_ALL_COMMANDS_BIT,  // dstStageMask
+      0,                                       // dependencyFlags
+      0,                                       // memoryBarrierCount
+      nullptr,                                 // pMemoryBarriers
+      (uint32_t)releaseBufferBarriers.size(),  // bufferMemoryBarrierCount
+      releaseBufferBarriers.data(),            // pBufferMemoryBarriers
+      (uint32_t)0,                             // imageMemoryBarrierCount
+      nullptr                                  // pImageMemoryBarriers
+  );
+
+  res = fn->vkEndCommandBuffer(cmdBuf.stagingCommandBuffer);
+  if (res != VkResult::VK_SUCCESS) {
+    GAPID_ERROR("Failed at end command buffer to read external memory");
+    return res;
+  }
+
+  return VkResult::VK_SUCCESS;
+}
+
+uint32_t ExternalMemoryStaging::Submit() {
+  std::vector<std::vector<VkCommandBuffer>> commandBuffers;
+  std::vector<VkSubmitInfo> submitInfos;
+  for (auto submitIt = submits.begin(); submitIt != submits.end(); ++submitIt) {
+    commandBuffers.push_back({});
+    std::vector<VkCommandBuffer>& submitCmds = commandBuffers.back();
+    for (auto cmdBufIt = submitIt->commandBuffers.begin();
+         cmdBufIt != submitIt->commandBuffers.end(); ++cmdBufIt) {
+      if (!cmdBufIt->empty()) {
+        submitCmds.push_back(cmdBufIt->stagingCommandBuffer);
+      }
+      submitCmds.push_back(cmdBufIt->commandBuffer);
+    }
+    submitInfos.push_back(*submitIt->submitInfo);
+    submitInfos.back().mcommandBufferCount = (uint32_t)submitCmds.size();
+    submitInfos.back().mpCommandBuffers = submitCmds.data();
+  }
+  submitInfos.push_back({
+      VkStructureType::VK_STRUCTURE_TYPE_SUBMIT_INFO,  // sType
+      nullptr,                                         // pNext
+      0,                                               // waitSemaphoreCount
+      nullptr,                                         // pWaitSemaphores
+      nullptr,                                         // pWaitDstStageMask
+      1,                                               // commandBufferCount
+      &stagingCommandBuffer,                           // pCommandBuffers
+      0,                                               // signalSemaphoreCount
+      nullptr,                                         // pSignalSemaphores
+  });
+  uint32_t res = fn->vkQueueSubmit(queue, submitInfos.size(),
+                                   submitInfos.data(), stagingFence);
+  if (res != VkResult::VK_SUCCESS) {
+    return res;
+  }
+  if (origFence != 0) {
+    res = fn->vkQueueSubmit(queue, 0, nullptr, origFence);
+    if (res != VkResult::VK_SUCCESS) {
+      GAPID_ERROR(
+          "Error submitting original fence after external memory observations");
+      return res;
+    }
+  }
+  return VkResult::VK_SUCCESS;
+}
+
+void ExternalMemoryStaging::SendData() {
+  uint32_t res = fn->vkWaitForFences(device, 1, &stagingFence, 0, UINT64_MAX);
+  if (res != VkResult::VK_SUCCESS) {
+    GAPID_ERROR("Error waiting for fence to save external memory observations");
+    return;
+  }
+
+  static const VkDeviceSize VK_WHOLE_SIZE = ~0ULL;
+
+  uint8_t* data = nullptr;
+  res = fn->vkMapMemory(device, stagingMemory, 0, VK_WHOLE_SIZE, 0,
+                        (void**)&data);
+  if (res != VkResult::VK_SUCCESS) {
+    GAPID_ERROR("Failed at mapping staging memory to save external memory");
+    return;
+  }
+
+  VkMappedMemoryRange range{
+      VkStructureType::VK_STRUCTURE_TYPE_MAPPED_MEMORY_RANGE,  // sType
+      nullptr,                                                 // pNext
+      stagingMemory,                                           // memory
+      0,                                                       // offset
+      VK_WHOLE_SIZE,                                           // size
+  };
+  if (VkResult::VK_SUCCESS !=
+      fn->vkInvalidateMappedMemoryRanges(device, 1, &range)) {
+    GAPID_ERROR("Failed at invalidating mapped memory to save external memory");
+  } else {
+    auto resIndex = spy->sendResource(VulkanSpy::kApiIndex, data, stagingSize);
+
+    auto extra = new vulkan_pb::ExternalMemoryData();
+    extra->set_res_index(resIndex);
+    extra->set_res_size(stagingSize);
+    for (uint32_t submitIndex = 0; submitIndex < submits.size();
+         ++submitIndex) {
+      const ExternalMemorySubmitInfo& submit = submits[submitIndex];
+      for (uint32_t commandBufferIndex = 0;
+           commandBufferIndex < submit.commandBuffers.size();
+           ++commandBufferIndex) {
+        const ExternalMemoryCommandBuffer& cmdBuf =
+            submit.commandBuffers[commandBufferIndex];
+        for (auto bufIt = cmdBuf.buffers.begin(); bufIt != cmdBuf.buffers.end();
+             ++bufIt) {
+          auto bufMsg = extra->add_buffers();
+          bufMsg->set_buffer(bufIt->buffer);
+          bufMsg->set_buffer_offset(bufIt->copy.msrcOffset);
+          bufMsg->set_data_offset(bufIt->copy.mdstOffset);
+          bufMsg->set_size(bufIt->copy.msize);
+          bufMsg->set_submit_index(submitIndex);
+          bufMsg->set_command_buffer_index(commandBufferIndex);
+        }
+      }
+    }
+    observer->encodeAndDelete(extra);
+  }
+
+  fn->vkUnmapMemory(device, stagingMemory);
+}
+
+void ExternalMemoryStaging::Cleanup() {
+  if (stagingCommandPool != 0) {
+    fn->vkDestroyCommandPool(device, stagingCommandPool, nullptr);
+    stagingCommandPool = 0;
+  }
+
+  if (stagingFence != 0) {
+    fn->vkDestroyFence(device, stagingFence, nullptr);
+    stagingFence = 0;
+  }
+
+  if (stagingBuffer != 0) {
+    fn->vkDestroyBuffer(device, stagingBuffer, nullptr);
+    stagingBuffer = 0;
+  }
+
+  if (stagingMemory != 0) {
+    fn->vkFreeMemory(device, stagingMemory, nullptr);
+    stagingMemory = 0;
+  }
+}
+
+}  // namespace gapii

--- a/gapii/cc/vulkan_external_memory.h
+++ b/gapii/cc/vulkan_external_memory.h
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2020 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "gapii/cc/vulkan_spy.h"
+
+#ifndef GAPII_VULKAN_EXTERNAL_MEMORY_H_
+#define GAPII_VULKAN_EXTERNAL_MEMORY_H_
+
+namespace gapii {
+
+struct ExternalBufferMemoryStaging {
+  VkBuffer buffer;
+  VkBufferMemoryBarrier barrier;
+  VkBufferCopy copy;
+  inline ExternalBufferMemoryStaging(const VkBufferMemoryBarrier& barrier,
+                                     VkDeviceSize& stagingOffset)
+      : buffer(barrier.mbuffer),
+        barrier(barrier),
+        copy(barrier.moffset, stagingOffset, barrier.msize) {
+    stagingOffset += barrier.msize;
+  }
+};
+
+struct ExternalMemoryCommandBuffer {
+  std::vector<ExternalBufferMemoryStaging> buffers;
+  VkCommandBuffer commandBuffer = 0;
+  VkCommandBuffer stagingCommandBuffer = 0;
+  inline bool empty() const { return buffers.empty(); }
+};
+
+struct ExternalMemorySubmitInfo {
+  const VkSubmitInfo* submitInfo;
+  std::vector<ExternalMemoryCommandBuffer> commandBuffers;
+};
+
+struct ExternalMemoryStaging {
+  VulkanSpy* spy = nullptr;
+  CallObserver* observer = nullptr;
+  VkQueue queue = 0;
+  uint32_t queueFamilyIndex = 0;
+  VkFence origFence = 0;
+  VkFence stagingFence = 0;
+  VkDevice device = 0;
+  const VulkanImports::VkDeviceFunctions* fn = nullptr;
+
+  std::vector<ExternalMemorySubmitInfo> submits;
+
+  VkBuffer stagingBuffer = 0;
+  VkDeviceMemory stagingMemory = 0;
+  VkDeviceSize stagingSize = 0;
+  VkCommandPool stagingCommandPool = 0;
+  VkCommandBuffer stagingCommandBuffer = 0;
+
+  ExternalMemoryStaging(VulkanSpy* spy, CallObserver* observer, VkQueue queue,
+                        uint32_t submitCount, const VkSubmitInfo* pSubmits,
+                        VkFence fence);
+  inline ~ExternalMemoryStaging() { Cleanup(); }
+  uint32_t CreateResources();
+  uint32_t RecordCommandBuffers();
+  uint32_t RecordStagingCommandBuffer(
+      const ExternalMemoryCommandBuffer& cmdBuf);
+  uint32_t Submit();
+  void SendData();
+  void Cleanup();
+};
+
+}  // namespace gapii
+
+#endif  // GAPII_VULKAN_EXTERNAL_MEMORY_H_

--- a/gapii/cc/vulkan_extras.cpp
+++ b/gapii/cc/vulkan_extras.cpp
@@ -147,7 +147,7 @@ bool VulkanSpy::observeFramebuffer(CallObserver* observer, uint32_t* w,
   fn.vkGetImageMemoryRequirements(device, resolve_image, &image_reqs);
 
   uint32_t image_memory_req = 0xFFFFFFFF;
-  for (size_t i = 0; i < 32; ++i) {
+  for (size_t i = 0; i < kMaxMemoryTypes; ++i) {
     if (image_reqs.mmemoryTypeBits & (1 << i)) {
       image_memory_req = i;
       break;
@@ -197,7 +197,8 @@ bool VulkanSpy::observeFramebuffer(CallObserver* observer, uint32_t* w,
   fn.vkGetBufferMemoryRequirements(device, buffer, &buffer_reqs);
 
   uint32_t buffer_memory_req = 0;
-  while (buffer_reqs.mmemoryTypeBits) {
+  while (buffer_reqs.mmemoryTypeBits &&
+         buffer_memory_req < memory_properties.mmemoryTypeCount) {
     if (buffer_reqs.mmemoryTypeBits & 0x1) {
       if (memory_properties.mmemoryTypes[buffer_memory_req].mpropertyFlags &
           VkMemoryPropertyFlagBits::VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT) {

--- a/gapii/cc/vulkan_extras.h
+++ b/gapii/cc/vulkan_extras.h
@@ -17,4 +17,18 @@
 #ifndef GAPII_VULKAN_EXTRAS_H_
 #define GAPII_VULKAN_EXTRAS_H_
 
+namespace gapii {
+
+// An invalid value of memory type index
+extern const uint32_t kInvalidMemoryTypeIndex;
+// The queue family value when it is ignored
+extern const uint32_t kQueueFamilyIgnore;
+// The maxmimum number of memory types
+extern const uint32_t kMaxMemoryTypes;
+
+uint32_t GetMemoryTypeIndexForStagingResources(
+    const VkPhysicalDeviceMemoryProperties& phy_dev_prop,
+    uint32_t requirement_type_bits);
+};  // namespace gapii
+
 #endif

--- a/gapii/cc/vulkan_extras.inc
+++ b/gapii/cc/vulkan_extras.inc
@@ -161,3 +161,45 @@ void walkImageSubRng(
 void parseShaderModule(
     StageData* stage,
     gapil::Ref<DescriptorInfo>& descriptors);
+
+std::unordered_map<VkCommandBuffer, std::vector<VkBufferMemoryBarrier>> mExternalBufferBarriers;
+
+void SpyOverride_vkCmdPipelineBarrier(
+    CallObserver*,
+    VkCommandBuffer                             commandBuffer,
+    VkPipelineStageFlags                        srcStageMask,
+    VkPipelineStageFlags                        dstStageMask,
+    VkDependencyFlags                           dependencyFlags,
+    uint32_t                                    memoryBarrierCount,
+    const VkMemoryBarrier*                      pMemoryBarriers,
+    uint32_t                                    bufferMemoryBarrierCount,
+    const VkBufferMemoryBarrier*                pBufferMemoryBarriers,
+    uint32_t                                    imageMemoryBarrierCount,
+    const VkImageMemoryBarrier*                 pImageMemoryBarriers);
+
+void recordExternalBarriers(
+    VkCommandBuffer                             commandBuffer,
+    uint32_t                                    bufferMemoryBarrierCount,
+    const VkBufferMemoryBarrier*                pBufferMemoryBarriers,
+    uint32_t                                    imageMemoryBarrierCount,
+    const VkImageMemoryBarrier*                 pImageMemoryBarriers);
+
+void SpyOverride_vkCmdExecuteCommands(
+    CallObserver*,
+    VkCommandBuffer                             commandBuffer,
+    uint32_t                                    commandBufferCount,
+    const VkCommandBuffer*                      pCommandBuffers);
+
+uint32_t SpyOverride_vkBeginCommandBuffer(
+    CallObserver*,
+    VkCommandBuffer                             commandBuffer,
+    const VkCommandBufferBeginInfo*             pBeginInfo);
+
+uint32_t SpyOverride_vkQueueSubmit(
+    CallObserver*                               observer,
+    VkQueue                                     queue,
+    uint32_t                                    submitCount,
+    const VkSubmitInfo*                         pSubmits,
+    VkFence                                     fence);
+
+friend struct ExternalMemoryStaging;

--- a/gapii/cc/vulkan_layer_extras.h
+++ b/gapii/cc/vulkan_layer_extras.h
@@ -46,6 +46,10 @@
 namespace gapii {
 namespace {
 
+static inline void set_dispatch_from_parent(void* child, void* parent) {
+  *((const void**)child) = *((const void**)parent);
+}
+
 // ------------------------------------------------------------------------------------------------
 // CreateInstance and CreateDevice support structures
 

--- a/gapii/cc/vulkan_mid_execution.cpp
+++ b/gapii/cc/vulkan_mid_execution.cpp
@@ -16,6 +16,7 @@
 
 #include "gapii/cc/state_serializer.h"
 #include "gapii/cc/vulkan_exports.h"
+#include "gapii/cc/vulkan_extras.h"
 #include "gapii/cc/vulkan_spy.h"
 
 #include "gapis/memory/memory_pb/memory.pb.h"
@@ -52,6 +53,8 @@ gapil::Ref<QueueObject> GetQueue(const VkQueueToQueueObject__R& queues,
 const uint32_t kInvalidMemoryTypeIndex = 0xFFFFFFFF;
 // The queue family value when it is ignored
 const uint32_t kQueueFamilyIgnore = 0xFFFFFFFF;
+// The maxmimum number of memory types
+const uint32_t kMaxMemoryTypes = 32;
 
 // Try to find memory type within the types specified in
 // |requirement_type_bits| which is host-visible and non-host-coherent. If a
@@ -63,7 +66,7 @@ uint32_t GetMemoryTypeIndexForStagingResources(
     uint32_t requirement_type_bits) {
   uint32_t index = 0;
   uint32_t backup_index = kInvalidMemoryTypeIndex;
-  while (requirement_type_bits) {
+  while (requirement_type_bits && index < phy_dev_prop.mmemoryTypeCount) {
     if (requirement_type_bits & 0x1) {
       VkMemoryPropertyFlags prop_flags =
           phy_dev_prop.mmemoryTypes[index].mpropertyFlags;

--- a/gapis/api/vulkan/BUILD.bazel
+++ b/gapis/api/vulkan/BUILD.bazel
@@ -65,6 +65,7 @@ go_library(
         "doc.go",
         "drawCall.go",
         "draw_call_mesh.go",
+        "external_memory.go",
         "externs.go",
         "find_issues.go",
         "frame_loop.go",

--- a/gapis/api/vulkan/api/command_buffer_control.api
+++ b/gapis/api/vulkan/api/command_buffer_control.api
@@ -450,6 +450,7 @@ extern void recordEndCommandBuffer(VkCommandBuffer commandBuffer)
 
 @threadSafety("app")
 @indirect("VkCommandBuffer", "VkDevice")
+@override
 cmd VkResult vkBeginCommandBuffer(
     VkCommandBuffer                 commandBuffer,
     const VkCommandBufferBeginInfo* pBeginInfo) {
@@ -644,6 +645,7 @@ sub void dovkCmdExecuteCommands(ref!vkCmdExecuteCommandsArgs cmds) {
 }
 
 @indirect("VkCommandBuffer", "VkDevice")
+@override
 cmd void vkCmdExecuteCommands(
     VkCommandBuffer        commandBuffer,
     u32                    commandBufferCount,

--- a/gapis/api/vulkan/api/queue.api
+++ b/gapis/api/vulkan/api/queue.api
@@ -112,6 +112,8 @@ cmd void vkGetDeviceQueue2(
 @threadSafety("app")
 @indirect("VkQueue", "VkDevice")
 @submission
+@custom
+@override
 cmd VkResult vkQueueSubmit(
     VkQueue             queue,
     u32                 submitCount,

--- a/gapis/api/vulkan/api/synchronization.api
+++ b/gapis/api/vulkan/api/synchronization.api
@@ -575,6 +575,8 @@ sub void handleImageMemoryBarriersPNext(const VkImageMemoryBarrier* pBarriers, u
 
 @threadSafety("app")
 @indirect("VkCommandBuffer", "VkDevice")
+@custom
+@override
 cmd void vkCmdPipelineBarrier(
     VkCommandBuffer              commandBuffer,
     VkPipelineStageFlags         srcStageMask,

--- a/gapis/api/vulkan/external_memory.go
+++ b/gapis/api/vulkan/external_memory.go
@@ -1,0 +1,629 @@
+// Copyright (C) 2020 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vulkan
+
+import (
+	"context"
+	"math"
+
+	"github.com/google/gapid/core/data/id"
+	"github.com/google/gapid/core/data/protoconv"
+	"github.com/google/gapid/gapis/api"
+	"github.com/google/gapid/gapis/api/vulkan/vulkan_pb"
+	"github.com/google/gapid/gapis/memory"
+)
+
+type ExternalBufferData struct {
+	Buffer             VkBuffer
+	BufferOffset       VkDeviceSize
+	DataOffset         VkDeviceSize
+	Size               VkDeviceSize
+	SubmitIndex        uint32
+	CommandBufferIndex uint32
+}
+
+type ExternalImageDataRange struct {
+	DataOffset  VkDeviceSize
+	Subresource VkImageSubresourceLayers
+}
+
+type ExternalMemoryData struct {
+	ID      id.ID
+	Size    VkDeviceSize
+	Buffers []ExternalBufferData
+}
+
+// ExternalMemoryData returns a pointer to the ExternalMemoryData structure in the
+// CmdExtras, or nil if there are no observations in the CmdExtras.
+func GetExternalMemoryData(e *api.CmdExtras) *ExternalMemoryData {
+	for _, o := range e.All() {
+		if o, ok := o.(*ExternalMemoryData); ok {
+			return o
+		}
+	}
+	return nil
+}
+
+type externalMemoryCommandBuffer struct {
+	commandBuffer        VkCommandBuffer
+	stagingCommandBuffer VkCommandBuffer
+	buffers              []ExternalBufferData
+}
+
+type externalMemorySubmitInfo struct {
+	submitInfo     VkSubmitInfo
+	commandBuffers []externalMemoryCommandBuffer
+}
+
+type externalMemoryStaging struct {
+	h *vkQueueSubmitHijack
+
+	queueFamilyIndex uint32
+	device           VkDevice
+
+	stagingBufferSize VkDeviceSize
+	stagingMemorySize VkDeviceSize
+	stagingData       id.ID
+
+	submits []externalMemorySubmitInfo
+
+	stagingBuffer        VkBuffer
+	stagingMemory        VkDeviceMemory
+	stagingCommandPool   VkCommandPool
+	stagingCommandBuffer VkCommandBuffer
+}
+
+func (e *externalMemoryStaging) initialize(h *vkQueueSubmitHijack, externalData *ExternalMemoryData) {
+	e.h = h
+	e.stagingData = externalData.ID
+	e.stagingBufferSize = externalData.Size
+	e.stagingMemorySize = 2 * e.stagingBufferSize
+
+	queueObj := e.h.c.Queues().Get(h.get().Queue())
+	e.device = queueObj.Device()
+	e.queueFamilyIndex = queueObj.Family()
+
+	submitInfos := e.h.submitInfos()
+	e.submits = make([]externalMemorySubmitInfo, len(submitInfos))
+
+	for i, submitInfo := range submitInfos {
+		e.submits[i].submitInfo = submitInfo
+		e.submits[i].commandBuffers = make([]externalMemoryCommandBuffer, submitInfo.CommandBufferCount())
+		commandBufferCount := uint64(submitInfo.CommandBufferCount())
+		commandBuffers := submitInfo.PCommandBuffers().Slice(0, commandBufferCount, e.h.s.MemoryLayout).MustRead(e.h.ctx, e.h.origSubmit, e.h.s, nil)
+		for j, commandBuffer := range commandBuffers {
+			e.submits[i].commandBuffers[j].commandBuffer = commandBuffer
+		}
+	}
+
+	for _, extBuf := range externalData.Buffers {
+		buffers := &e.submits[extBuf.SubmitIndex].commandBuffers[extBuf.CommandBufferIndex].buffers
+		*buffers = append(*buffers, extBuf)
+	}
+}
+
+func (e *externalMemoryStaging) createCommandPool() error {
+	commandPool := VkCommandPool(newUnusedID(false, func(x uint64) bool { return e.h.c.CommandPools().Contains(VkCommandPool(x)) }))
+	pCommandPool := e.h.mustAllocData(commandPool)
+	pCommandPoolCreateInfo := e.h.mustAllocData(NewVkCommandPoolCreateInfo(
+		e.h.s.Arena,
+		VkStructureType_VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO,                                 // sType
+		NewVoidᶜᵖ(memory.Nullptr),                                                                  // pNext
+		VkCommandPoolCreateFlags(VkCommandPoolCreateFlagBits_VK_COMMAND_POOL_CREATE_TRANSIENT_BIT), // flags
+		e.queueFamilyIndex, // queueFamilyIndex
+	))
+	err := e.h.cb.VkCreateCommandPool(
+		e.device,
+		pCommandPoolCreateInfo.Ptr(),
+		memory.Nullptr,
+		pCommandPool.Ptr(),
+		VkResult_VK_SUCCESS,
+	).AddRead(
+		pCommandPoolCreateInfo.Data(),
+	).AddWrite(
+		pCommandPool.Data(),
+	).Mutate(
+		e.h.ctx, api.CmdNoID, e.h.s, e.h.b, nil,
+	)
+	if err != nil {
+		return err
+	}
+	e.stagingCommandPool = commandPool
+	return nil
+}
+
+func (e *externalMemoryStaging) allocCommandBuffer() (VkCommandBuffer, error) {
+	commandBuffer := VkCommandBuffer(newUnusedID(false, func(x uint64) bool { return e.h.c.CommandBuffers().Contains(VkCommandBuffer(x)) }))
+	pCommandBuffer := e.h.mustAllocData(commandBuffer)
+	pCommandBufferAllocInfo := e.h.mustAllocData(NewVkCommandBufferAllocateInfo(
+		e.h.s.Arena,
+		VkStructureType_VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO, // sType
+		NewVoidᶜᵖ(memory.Nullptr),                                      // pNext
+		e.stagingCommandPool,                                           // commandPool
+		VkCommandBufferLevel_VK_COMMAND_BUFFER_LEVEL_PRIMARY,           // level
+		1, // commandBufferCount
+	))
+
+	err := e.h.cb.VkAllocateCommandBuffers(
+		e.device,
+		pCommandBufferAllocInfo.Ptr(),
+		pCommandBuffer.Ptr(),
+		VkResult_VK_SUCCESS,
+	).AddRead(
+		pCommandBufferAllocInfo.Data(),
+	).AddWrite(
+		pCommandBuffer.Data(),
+	).Mutate(
+		e.h.ctx, api.CmdNoID, e.h.s, e.h.b, nil,
+	)
+	if err != nil {
+		return VkCommandBuffer(0), err
+	}
+
+	return commandBuffer, nil
+}
+
+func (e *externalMemoryStaging) createBuffer() error {
+	bufferID := VkBuffer(newUnusedID(false, func(x uint64) bool { ok := e.h.c.Buffers().Contains(VkBuffer(x)); return ok }))
+	pBuffer := e.h.mustAllocData(bufferID)
+	pCreateInfo := e.h.mustAllocData(NewVkBufferCreateInfo(
+		e.h.s.Arena,
+		VkStructureType_VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO, // sType
+		NewVoidᶜᵖ(memory.Nullptr),                            // pNext
+		0,                                                    // flags
+		VkDeviceSize(e.stagingBufferSize),                    // size
+		VkBufferUsageFlags(VkBufferUsageFlagBits_VK_BUFFER_USAGE_TRANSFER_SRC_BIT), // usage
+		VkSharingMode_VK_SHARING_MODE_EXCLUSIVE,                                    // sharingMode
+		0,                                                                          // queueFamilyIndexCount
+		NewU32ᶜᵖ(memory.Nullptr),                                                   // pQueueFamilyIndices
+	))
+
+	err := e.h.cb.VkCreateBuffer(
+		e.device,
+		pCreateInfo.Ptr(),
+		memory.Nullptr,
+		pBuffer.Ptr(),
+		VkResult_VK_SUCCESS,
+	).AddRead(
+		pCreateInfo.Data(),
+	).AddWrite(
+		pBuffer.Data(),
+	).Mutate(
+		e.h.ctx, api.CmdNoID, e.h.s, e.h.b, nil,
+	)
+	if err != nil {
+		return err
+	}
+	e.stagingBuffer = bufferID
+	return nil
+}
+
+func (e *externalMemoryStaging) allocMemory() error {
+	deviceObj := e.h.c.Devices().Get(e.device)
+	physicalDeviceObj := e.h.c.PhysicalDevices().Get(deviceObj.PhysicalDevice())
+	memProps := physicalDeviceObj.MemoryProperties()
+
+	memoryID := VkDeviceMemory(newUnusedID(false, func(x uint64) bool { ok := e.h.c.DeviceMemories().Contains(VkDeviceMemory(x)); return ok }))
+	pStagingMemory := e.h.mustAllocData(memoryID)
+
+	stagingMemoryTypeIndex := uint32(math.MaxUint32)
+	for i := uint32(0); i < memProps.MemoryTypeCount(); i++ {
+		t := memProps.MemoryTypes().Get(int(i))
+		if 0 != (t.PropertyFlags() & VkMemoryPropertyFlags(
+			VkMemoryPropertyFlagBits_VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT)) {
+			stagingMemoryTypeIndex = i
+			break
+		}
+	}
+
+	pAllocInfo := e.h.mustAllocData(NewVkMemoryAllocateInfo(
+		e.h.s.Arena,
+		VkStructureType_VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO, // sType
+		NewVoidᶜᵖ(memory.Nullptr),                              // pNext
+		VkDeviceSize(e.stagingMemorySize),                      // allocationSize
+		stagingMemoryTypeIndex,                                 // memoryTypeIndex
+	))
+
+	err := e.h.cb.VkAllocateMemory(
+		e.device,
+		pAllocInfo.Ptr(),
+		memory.Nullptr,
+		pStagingMemory.Ptr(),
+		VkResult_VK_SUCCESS,
+	).AddRead(
+		pAllocInfo.Data(),
+	).AddWrite(
+		pStagingMemory.Data(),
+	).Mutate(
+		e.h.ctx, api.CmdNoID, e.h.s, e.h.b, nil,
+	)
+	if err != nil {
+		return err
+	}
+	e.stagingMemory = memoryID
+	return nil
+}
+
+func (e *externalMemoryStaging) bindBufferMemory() error {
+	err := e.h.cb.VkBindBufferMemory(
+		e.device,
+		e.stagingBuffer,
+		e.stagingMemory,
+		VkDeviceSize(0),
+		VkResult_VK_SUCCESS,
+	).Mutate(
+		e.h.ctx, api.CmdNoID, e.h.s, e.h.b, nil,
+	)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (e *externalMemoryStaging) createResources() error {
+	if err := e.createCommandPool(); err != nil {
+		return err
+	}
+	if cmdBuf, err := e.allocCommandBuffer(); err != nil {
+		return err
+	} else {
+		e.stagingCommandBuffer = cmdBuf
+	}
+	for i := range e.submits {
+		for j := range e.submits[i].commandBuffers {
+			cmdBuf := &e.submits[i].commandBuffers[j]
+			if len(cmdBuf.buffers) > 0 {
+				if stagingCommandBuffer, err := e.allocCommandBuffer(); err != nil {
+					return err
+				} else {
+					cmdBuf.stagingCommandBuffer = stagingCommandBuffer
+				}
+			}
+		}
+	}
+	if err := e.createBuffer(); err != nil {
+		return err
+	}
+	if err := e.allocMemory(); err != nil {
+		return err
+	}
+	if err := e.bindBufferMemory(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (e *externalMemoryStaging) beginCommandBuffer(commandBuffer VkCommandBuffer) error {
+	pBeginInfo := e.h.mustAllocData(NewVkCommandBufferBeginInfo(
+		e.h.s.Arena,
+		VkStructureType_VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO,                                         // sType
+		NewVoidᶜᵖ(memory.Nullptr),                                                                           // pNext
+		VkCommandBufferUsageFlags(VkCommandBufferUsageFlagBits_VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT), // flags
+		NewVkCommandBufferInheritanceInfoᶜᵖ(memory.Nullptr),                                                 // pInheritanceInfo
+	))
+
+	return e.h.cb.VkBeginCommandBuffer(
+		commandBuffer,
+		pBeginInfo.Ptr(),
+		VkResult_VK_SUCCESS,
+	).AddRead(
+		pBeginInfo.Data(),
+	).Mutate(
+		e.h.ctx, api.CmdNoID, e.h.s, e.h.b, nil,
+	)
+}
+
+func (e *externalMemoryStaging) endCommandBuffer(commandBuffer VkCommandBuffer) error {
+	return e.h.cb.VkEndCommandBuffer(
+		commandBuffer,
+		VkResult_VK_SUCCESS,
+	).Mutate(
+		e.h.ctx, api.CmdNoID, e.h.s, e.h.b, nil,
+	)
+}
+
+func (e *externalMemoryStaging) cmdPipelineBarrier(
+	commandBuffer VkCommandBuffer,
+	srcStageMask VkPipelineStageFlags,
+	dstStageMask VkPipelineStageFlags,
+	bufferBarriers []VkBufferMemoryBarrier,
+	imageBarriers []VkImageMemoryBarrier) error {
+	pBufferBarriers := e.h.mustAllocData(bufferBarriers)
+	pImageBarriers := e.h.mustAllocData(imageBarriers)
+
+	return e.h.cb.VkCmdPipelineBarrier(
+		commandBuffer,               // commandBuffer
+		srcStageMask,                // srcStageMask
+		dstStageMask,                // dstStageMask
+		0,                           // dependencyFlags
+		0,                           // memoryBarrierCount
+		memory.Nullptr,              // pMemoryBarriers
+		uint32(len(bufferBarriers)), // bufferMemoryBarrierCount
+		pBufferBarriers.Ptr(),       // pBufferMemoryBarriers
+		uint32(len(imageBarriers)),  // imageMemoryBarrierCount
+		pImageBarriers.Ptr(),        // pImageMemoryBarriers
+	).AddRead(
+		pBufferBarriers.Data(),
+	).AddRead(
+		pImageBarriers.Data(),
+	).mutate(
+		e.h.ctx, api.CmdNoID, e.h.s, e.h.b, nil,
+	)
+}
+
+func (e *externalMemoryStaging) cmdCopyBuffer(
+	commandBuffer VkCommandBuffer,
+	srcBuffer VkBuffer,
+	dstBuffer VkBuffer,
+	regions []VkBufferCopy) error {
+	pRegions := e.h.mustAllocData(regions)
+
+	return e.h.cb.VkCmdCopyBuffer(
+		commandBuffer,        // commandBuffer
+		srcBuffer,            // srcBuffer
+		dstBuffer,            // dstBuffer
+		uint32(len(regions)), // regionCount
+		pRegions.Ptr(),       // pRegions
+	).AddRead(
+		pRegions.Data(),
+	).Mutate(
+		e.h.ctx, api.CmdNoID, e.h.s, e.h.b, nil,
+	)
+}
+
+func (e *externalMemoryStaging) recordCommandBuffers() error {
+	if err := e.beginCommandBuffer(e.stagingCommandBuffer); err != nil {
+		return err
+	}
+	err := e.cmdPipelineBarrier(
+		e.stagingCommandBuffer, // commandBuffer
+		VkPipelineStageFlags(VkPipelineStageFlagBits_VK_PIPELINE_STAGE_HOST_BIT),     // srcStageMask
+		VkPipelineStageFlags(VkPipelineStageFlagBits_VK_PIPELINE_STAGE_TRANSFER_BIT), // dstStageMask
+		[]VkBufferMemoryBarrier{
+			NewVkBufferMemoryBarrier(
+				e.h.s.Arena,
+				VkStructureType_VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER,     // sType
+				NewVoidᶜᵖ(memory.Nullptr),                                   // pNext
+				VkAccessFlags(VkAccessFlagBits_VK_ACCESS_HOST_WRITE_BIT),    // srcAccessMask
+				VkAccessFlags(VkAccessFlagBits_VK_ACCESS_TRANSFER_READ_BIT), // dstAccessMask
+				e.queueFamilyIndex,  // srcQueueFamilyIndex
+				e.queueFamilyIndex,  // dstQueueFamilyIndex
+				e.stagingBuffer,     // buffer
+				0,                   // offset
+				e.stagingBufferSize, // size
+			),
+		},
+		[]VkImageMemoryBarrier{},
+	)
+	if err != nil {
+		return err
+	}
+	if err := e.endCommandBuffer(e.stagingCommandBuffer); err != nil {
+		return err
+	}
+
+	for _, submit := range e.submits {
+		for _, cmdBuf := range submit.commandBuffers {
+			if cmdBuf.stagingCommandBuffer == VkCommandBuffer(0) {
+				continue
+			}
+			if err := e.beginCommandBuffer(cmdBuf.stagingCommandBuffer); err != nil {
+				return err
+			}
+			for _, buf := range cmdBuf.buffers {
+				err := e.cmdCopyBuffer(
+					cmdBuf.stagingCommandBuffer, // commandBuffer
+					e.stagingBuffer,             // srcBuffer
+					buf.Buffer,                  // dstBuffer
+					[]VkBufferCopy{
+						NewVkBufferCopy(
+							e.h.s.Arena,
+							buf.DataOffset,   // srcOffset
+							buf.BufferOffset, // dstOffset
+							buf.Size,         // size
+						),
+					},
+				)
+				if err != nil {
+					return err
+				}
+			}
+			if err := e.endCommandBuffer(cmdBuf.stagingCommandBuffer); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (e *externalMemoryStaging) mapMemory() (memory.Range, error) {
+	VK_WHOLE_SIZE := VkDeviceSize(0xFFFFFFFFFFFFFFFF)
+
+	at := e.h.mustAlloc(uint64(e.stagingMemorySize))
+	mappedPointer := e.h.mustAllocData(at.Address())
+
+	err := e.h.cb.VkMapMemory(
+		e.device,
+		e.stagingMemory,
+		0,
+		VK_WHOLE_SIZE,
+		VkMemoryMapFlags(0),
+		mappedPointer.Ptr(),
+		VkResult_VK_SUCCESS,
+	).AddWrite(
+		mappedPointer.Data(),
+	).Mutate(
+		e.h.ctx, api.CmdNoID, e.h.s, e.h.b, nil,
+	)
+	if err != nil {
+		return memory.Range{}, err
+	}
+	return at.Range(), nil
+}
+
+func (e *externalMemoryStaging) flushMappedMemory(at memory.Range) error {
+	VK_WHOLE_SIZE := VkDeviceSize(0xFFFFFFFFFFFFFFFF)
+
+	pRange := e.h.mustAllocData(NewVkMappedMemoryRange(
+		e.h.s.Arena,
+		VkStructureType_VK_STRUCTURE_TYPE_MAPPED_MEMORY_RANGE, // sType
+		NewVoidᶜᵖ(memory.Nullptr),                             // pNext
+		e.stagingMemory,                                       // memory
+		VkDeviceSize(0),                                       // offset
+		VK_WHOLE_SIZE,                                         // size
+	))
+
+	return e.h.cb.VkFlushMappedMemoryRanges(
+		e.device,
+		1,
+		pRange.Ptr(),
+		VkResult_VK_SUCCESS,
+	).AddRead(
+		memory.Range{
+			Base: at.Base,
+			Size: uint64(e.stagingBufferSize),
+		},
+		e.stagingData,
+	).AddRead(
+		pRange.Data(),
+	).Mutate(
+		e.h.ctx, api.CmdNoID, e.h.s, e.h.b, nil,
+	)
+}
+
+func (e *externalMemoryStaging) unmapMemory() error {
+	return e.h.cb.VkUnmapMemory(
+		e.device,
+		e.stagingMemory,
+	).Mutate(
+		e.h.ctx, api.CmdNoID, e.h.s, e.h.b, nil,
+	)
+}
+
+func (e *externalMemoryStaging) stageData() error {
+	at, err := e.mapMemory()
+	if err != nil {
+		return err
+	}
+	err = e.flushMappedMemory(at)
+	if err != nil {
+		return err
+	}
+	return e.unmapMemory()
+}
+
+func (e *externalMemoryStaging) updateCall() {
+	newSubmitInfos := make([]VkSubmitInfo, 0, len(e.submits)+1)
+	hijack := e.h.hijack()
+	pStagingCommandBuffer := e.h.mustAllocData(e.stagingCommandBuffer)
+	newSubmitInfos = append(newSubmitInfos, NewVkSubmitInfo(
+		e.h.s.Arena,
+		VkStructureType_VK_STRUCTURE_TYPE_SUBMIT_INFO, // sType
+		NewVoidᶜᵖ(memory.Nullptr),                     // pNext
+		0,                                             // waitSemaphoreCount
+		NewVkSemaphoreᶜᵖ(memory.Nullptr),              // pWaitSemaphores
+		NewVkPipelineStageFlagsᶜᵖ(memory.Nullptr), // pWaitDstStageMask
+		1, // commandBufferCount
+		NewVkCommandBufferᶜᵖ(pStagingCommandBuffer.Ptr()), // pCommandBuffers
+		0,                                // signalSemaphoreCount
+		NewVkSemaphoreᶜᵖ(memory.Nullptr), // pSignalSemaphores
+	))
+	hijack.AddRead(pStagingCommandBuffer.Data())
+	for _, submit := range e.submits {
+		commandBuffers := make([]VkCommandBuffer, 0, 2*len(submit.commandBuffers))
+		for _, cmdBuf := range submit.commandBuffers {
+			if cmdBuf.stagingCommandBuffer != VkCommandBuffer(0) {
+				commandBuffers = append(commandBuffers, cmdBuf.stagingCommandBuffer)
+			}
+			commandBuffers = append(commandBuffers, cmdBuf.commandBuffer)
+		}
+		pCommandBuffers := e.h.mustAllocData(commandBuffers)
+		submit.submitInfo.SetCommandBufferCount(uint32(len(commandBuffers)))
+		submit.submitInfo.SetPCommandBuffers(NewVkCommandBufferᶜᵖ(pCommandBuffers.Ptr()))
+		hijack.AddRead(pCommandBuffers.Data())
+		newSubmitInfos = append(newSubmitInfos, submit.submitInfo)
+	}
+	e.h.setSubmitInfos(newSubmitInfos)
+}
+
+func (h *vkQueueSubmitHijack) processExternalMemory() error {
+	externalData := GetExternalMemoryData(h.origSubmit.Extras())
+	if externalData == nil {
+		return nil
+	}
+	staging := externalMemoryStaging{}
+	staging.initialize(h, externalData)
+	if err := staging.createResources(); err != nil {
+		return err
+	}
+	if err := staging.recordCommandBuffers(); err != nil {
+		return err
+	}
+	if err := staging.stageData(); err != nil {
+		return err
+	}
+	staging.updateCall()
+	return nil
+}
+
+func init() {
+	protoconv.Register(
+		func(ctx context.Context, a *ExternalMemoryData) (*vulkan_pb.ExternalMemoryData, error) {
+			resIndex, err := id.GetRemapper(ctx).RemapID(ctx, a.ID)
+			if err != nil {
+				return nil, err
+			}
+
+			res := &vulkan_pb.ExternalMemoryData{
+				ResIndex: resIndex,
+				ResSize:  int64(a.Size),
+			}
+			for _, b := range a.Buffers {
+				res.Buffers = append(res.Buffers, &vulkan_pb.ExternalBufferData{
+					Buffer:             uint64(b.Buffer),
+					BufferOffset:       uint64(b.BufferOffset),
+					DataOffset:         uint64(b.DataOffset),
+					Size:               uint64(b.Size),
+					SubmitIndex:        b.SubmitIndex,
+					CommandBufferIndex: b.CommandBufferIndex,
+				})
+			}
+			return res, nil
+		},
+		func(ctx context.Context, from *vulkan_pb.ExternalMemoryData) (*ExternalMemoryData, error) {
+			id, err := id.GetRemapper(ctx).RemapIndex(ctx, from.ResIndex)
+			if err != nil {
+				return nil, err
+			}
+			o := &ExternalMemoryData{
+				ID:   id,
+				Size: VkDeviceSize(from.ResSize),
+			}
+			o.Buffers = make([]ExternalBufferData, 0, len(from.Buffers))
+			for _, b := range from.Buffers {
+				o.Buffers = append(o.Buffers, ExternalBufferData{
+					Buffer:             VkBuffer(b.Buffer),
+					BufferOffset:       VkDeviceSize(b.BufferOffset),
+					DataOffset:         VkDeviceSize(b.DataOffset),
+					Size:               VkDeviceSize(b.Size),
+					SubmitIndex:        b.SubmitIndex,
+					CommandBufferIndex: b.CommandBufferIndex,
+				})
+			}
+			return o, nil
+		},
+	)
+}

--- a/gapis/api/vulkan/vulkan.api
+++ b/gapis/api/vulkan/vulkan.api
@@ -281,6 +281,12 @@ sub ref!ExtensionSet supportedDeviceExtensions() {
   supported.ExtensionNames["VK_KHR_shader_float16_int8"] = true
   supported.ExtensionNames["VK_KHR_shader_atomic_int64"] = true
   supported.ExtensionNames["VK_KHR_driver_properties"] = true
+  supported.ExtensionNames["VK_KHR_external_memory"] = true
+  supported.ExtensionNames["VK_KHR_external_memory_fd"] = true
+  supported.ExtensionNames["VK_KHR_external_fence"] = true
+  supported.ExtensionNames["VK_KHR_external_fence_fd"] = true
+  supported.ExtensionNames["VK_KHR_external_semaphore"] = true
+  supported.ExtensionNames["VK_KHR_external_semaphore_fd"] = true
   return supported
 }
 

--- a/gapis/api/vulkan/vulkan_pb/BUILD.bazel
+++ b/gapis/api/vulkan/vulkan_pb/BUILD.bazel
@@ -33,9 +33,25 @@ go_library(
 
 proto_library(
     name = "vulkan_pb_proto",
-    srcs = [":api_proto"],  # keep
+    srcs = [
+        "extras.proto",
+        ":api_proto",  # keep
+    ],
     visibility = ["//visibility:public"],
     deps = ["//gapis/memory/memory_pb:memory_pb_proto"],  # keep
+)
+
+proto_library(
+    name = "extras_proto",
+    srcs = ["extras.proto"],
+    visibility = ["//visibility:public"],
+    deps = ["//gapis/memory/memory_pb:memory_pb_proto"],  # keep
+)
+
+cc_proto_library(
+    name = "extras_cc_proto",
+    visibility = ["//visibility:public"],
+    deps = [":extras_proto"],
 )
 
 cc_proto_library(

--- a/gapis/api/vulkan/vulkan_pb/extras.proto
+++ b/gapis/api/vulkan/vulkan_pb/extras.proto
@@ -1,0 +1,33 @@
+// Copyright (C) 2020 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package vulkan_pb;
+option go_package = "github.com/google/gapid/gapis/api/vulkan/vulkan_pb";
+
+message ExternalBufferData {
+  uint64 buffer = 1;
+  uint64 buffer_offset = 2;
+  uint64 data_offset = 3;
+  uint64 size = 4;
+  uint32 submit_index = 5;
+  uint32 command_buffer_index = 6;
+}
+
+message ExternalMemoryData {
+  sint64 res_index = 1;
+  sint64 res_size = 2;
+  repeated ExternalBufferData buffers = 3;
+}


### PR DESCRIPTION
This PR is work toward supporting external memory (https://github.com/bjoeris/gapid/tree/extern-mem).

When a `VkBufferMemoryBarrier` (in a `vkCmdPipelineBarrier` or `vkCmdWaitEvents` call) has `srcQueueFamilyIndex = VK_QUEUE_FAMILY_EXTERNAL`, this indicates that the buffer contents may have been changed by an external process. This PR saves the contents when tracing, and restores the contents when replaying.

Capture:
  - Command buffer recording: maintain a map (`mExternalMemoryBarriers`) from command buffers to the `VkBufferMemoryBarrier`s recorded in the command buffers that acquire from `VK_QUEUE_FAMILY_EXTERNAL`.
  - Queue submission:
    1. Insert new command buffers to:
        1. acquire the buffers from the external queue family
        2. copy the contents into a staging buffer, and
        3. transfer the buffer back to the external queue family (so that the original acquire operation is valid).
      These new command buffers are inserted *before* the command buffers containing the corresponding `VkBufferMemoryBarrier`s.
    2. When the queue submission is complete, map the staging memory, and record the contents as an `ExternalMemoryData` extra.

Replay:
  - Command buffer recording: remove all queue family transfers to/from `VK_QUEUE_FAMILY_EXTERNAL`; for queue family transfers from `VK_QUEUE_FAMILY_EXTERNAL`, add `VK_ACCESS_TRANSFER_WRITE_BIT` to `srcAccessMask` and add `VK_PIPELINE_STAGE_TRANSFER_BIT` to the `srcStageMask`.
  - Queue submission:
    1. Load the contents into a staging buffer
    2. Insert new command buffers to:
        1. copy the contents from the staging buffer into the corresponding buffers.