### PR TITLE
Revert "Change API function tables from maps to flat arrays (#3769)"

### DIFF
--- a/gapir/cc/function_table.h
+++ b/gapir/cc/function_table.h
@@ -49,25 +49,20 @@ class FunctionTable {
   inline Function* lookup(Id id);
 
  private:
-  // Array of the actual function implementations by function ID
-  // This is stored as an array rather than a map because many lookups are
-  // performed at replay time and this becomes a bottleneck when stored as a
-  // map. The 64k entries (limit mandated elsewhere in the code by the vm
-  // bytecode instruction packing) are small enough that storing them as an
-  // array isn't a problem.
-  Function mFunctions[65536] = {};
+  // Map of the supported function ids to the actual function implementations
+  std::unordered_map<Id, Function> mFunctions;
 };
 
 inline FunctionTable::Function* FunctionTable::lookup(Id id) {
-  Function& ret = mFunctions[id];
-  if (ret == nullptr) {
+  auto func = mFunctions.find(id);
+  if (func == mFunctions.end()) {
     return nullptr;
   }
-  return &ret;
+  return &func->second;
 }
 
 inline void FunctionTable::insert(Id id, Function func) {
-  if (mFunctions[id] != NULL) {
+  if (mFunctions.count(id) != 0) {
     GAPID_FATAL("Duplicate functions inserted into table");
   }
   mFunctions[id] = func;

--- a/gapir/cc/interpreter.cpp
+++ b/gapir/cc/interpreter.cpp
@@ -94,7 +94,11 @@ void Interpreter::registerBuiltin(uint8_t api, FunctionTable::Id id,
 
 void Interpreter::setRendererFunctions(uint8_t api,
                                        FunctionTable* functionTable) {
-  mRendererFunctions[api] = functionTable;
+  if (functionTable != nullptr) {
+    mRendererFunctions[api] = functionTable;
+  } else {
+    mRendererFunctions.erase(api);
+  }
 }
 
 void Interpreter::resetInstructions() {
@@ -207,7 +211,7 @@ Interpreter::Result Interpreter::call(uint32_t opcode) {
     checkReplayStatusCallback(label, mInstructionCount, mCurrentInstruction);
   }
   if (func == nullptr) {
-    if (mRendererFunctions[api] != nullptr) {
+    if (mRendererFunctions.count(api) > 0) {
       func = mRendererFunctions[api]->lookup(id);
     } else {
       if (apiRequestCallback && apiRequestCallback(this, api)) {

--- a/gapir/cc/interpreter.h
+++ b/gapir/cc/interpreter.h
@@ -184,15 +184,11 @@ class Interpreter {
   // Memory manager which managing the memory used during the interpretation
   const MemoryManager* mMemoryManager;
 
-  // The builtin functions. The size of this array is specified by the number of
-  // supported APIs which in-turn is defined by the packing of the vm bytecode
-  // (4 bits = 16 values)
-  FunctionTable mBuiltins[16];
+  // The builtin functions.
+  std::unordered_map<uint8_t, FunctionTable> mBuiltins;
 
-  // The current renderer functions. The size of this array is specified by the
-  // number of supported APIs which in-turn is defined by the packing of the vm
-  // bytecode (4 bits = 16 values)
-  FunctionTable* mRendererFunctions[16] = {};
+  // The current renderer functions.
+  std::unordered_map<uint8_t, FunctionTable*> mRendererFunctions;
 
   // Callback function for requesting renderer functions for an unknown api.
   ApiRequestCallback apiRequestCallback;


### PR DESCRIPTION
This reverts commit 231c6447ae2f4f7e29f9280710246af9d5d83962.

Reverting until we can work out why this breaks windows.