### PR TITLE
Serialize image contents on transfer from external queue

### DIFF
--- a/gapii/cc/vulkan_external_memory.h
+++ b/gapii/cc/vulkan_external_memory.h
@@ -34,11 +34,20 @@ struct ExternalBufferMemoryStaging {
   }
 };
 
+struct ExternalImageMemoryStaging {
+  VkImage image;
+  VkImageMemoryBarrier barrier;
+  std::vector<VkBufferImageCopy> copies;
+  inline ExternalImageMemoryStaging(const VkImageMemoryBarrier& barrier)
+      : image(barrier.mimage), barrier(barrier) {}
+};
+
 struct ExternalMemoryCommandBuffer {
   std::vector<ExternalBufferMemoryStaging> buffers;
+  std::vector<ExternalImageMemoryStaging> images;
   VkCommandBuffer commandBuffer = 0;
   VkCommandBuffer stagingCommandBuffer = 0;
-  inline bool empty() const { return buffers.empty(); }
+  inline bool empty() const { return buffers.empty() && images.empty(); }
 };
 
 struct ExternalMemorySubmitInfo {

--- a/gapii/cc/vulkan_extras.h
+++ b/gapii/cc/vulkan_extras.h
@@ -29,6 +29,11 @@ extern const uint32_t kMaxMemoryTypes;
 uint32_t GetMemoryTypeIndexForStagingResources(
     const VkPhysicalDeviceMemoryProperties& phy_dev_prop,
     uint32_t requirement_type_bits);
+
+// Returns true if the resource range from |offset| with |size| is fully
+// covered in the |bindings|.
+bool IsFullyBound(VkDeviceSize offset, VkDeviceSize size,
+                  const U64ToVkSparseMemoryBind& bindings);
 };  // namespace gapii
 
 #endif

--- a/gapii/cc/vulkan_extras.inc
+++ b/gapii/cc/vulkan_extras.inc
@@ -163,6 +163,7 @@ void parseShaderModule(
     gapil::Ref<DescriptorInfo>& descriptors);
 
 std::unordered_map<VkCommandBuffer, std::vector<VkBufferMemoryBarrier>> mExternalBufferBarriers;
+std::unordered_map<VkCommandBuffer, std::vector<VkImageMemoryBarrier>> mExternalImageBarriers;
 
 void SpyOverride_vkCmdPipelineBarrier(
     CallObserver*,
@@ -203,3 +204,7 @@ uint32_t SpyOverride_vkQueueSubmit(
     VkFence                                     fence);
 
 friend struct ExternalMemoryStaging;
+
+std::vector<VkBufferImageCopy> BufferImageCopies(
+    gapil::Ref<ImageObject> img, const VkImageSubresourceRange& img_rng,
+    VkDeviceSize &offset);

--- a/gapis/api/vulkan/vulkan_pb/extras.proto
+++ b/gapis/api/vulkan/vulkan_pb/extras.proto
@@ -26,8 +26,31 @@ message ExternalBufferData {
   uint32 command_buffer_index = 6;
 }
 
+message ExternalImageDataRange {
+  uint64 data_offset = 1;
+  uint32 aspect_mask = 2;
+  uint32 mip_level = 3;
+  uint32 base_array_layer = 4;
+  uint32 layer_count = 5;
+}
+
+message ExternalImageData {
+  uint64 image = 1;
+  uint32 aspect_mask = 2;
+  uint32 base_mip_level = 3;
+  uint32 level_count = 4;
+  uint32 base_array_layer = 5;
+  uint32 layer_count = 6;
+  uint32 old_layout = 7;
+  uint32 new_layout = 8;
+  uint32 submit_index = 9;
+  uint32 command_buffer_index = 10;
+  repeated ExternalImageDataRange ranges = 11;
+}
+
 message ExternalMemoryData {
   sint64 res_index = 1;
   sint64 res_size = 2;
   repeated ExternalBufferData buffers = 3;
+  repeated ExternalImageData images = 4;
 }


### PR DESCRIPTION
This follows roughly the same strategy as buffers.

It does not cover every possible image type, but should cover the same subset that is currently supported for saving in MEC--in particular, content in multi-sample and multi-planar images is not saved.