### PR TITLE
Fix crash due to missing image queue family

### DIFF
--- a/gapis/api/vulkan/state_rebuilder.go
+++ b/gapis/api/vulkan/state_rebuilder.go
@@ -1748,7 +1748,7 @@ func (sb *stateBuilder) primeImage(img ImageObjectʳ, imgPrimer *imagePrimer, op
 				if toQ.IsNil() {
 					toQ = imgLevel.LastBoundQueue()
 				}
-				if queue.Family() != toQ.Family() {
+				if !toQ.IsNil() && queue.Family() != toQ.Family() {
 					ownerTransferInfo = append(ownerTransferInfo, imageQueueFamilyTransferInfo{
 						image:      img.VulkanHandle(),
 						aspectMask: ipImageBarrierAspectFlags(aspect, img.Info().Fmt()),


### PR DESCRIPTION
When the image is not in UNDEFINED layout, and has no queue family, this can cause a null reference. This can happen for images created in PREINITIALIZED layout and never used.