### PR TITLE
Remove deprecated Validation Layer names.

### DIFF
--- a/gapis/api/templates/vulkan_gfx_api_extras.tmpl
+++ b/gapis/api/templates/vulkan_gfx_api_extras.tmpl
@@ -55,17 +55,7 @@
 ¶
   const char kVirtualSwapchainLayerName[] = "VirtualSwapchain";
   const char kGraphicsSpyLayerName[] = "GraphicsSpy";
-  const char* kValidationLayerNames[] = {
-    // Meta layers
-    "VK_LAYER_KHRONOS_validation",
-    "VK_LAYER_LUNARG_standard_validation",
-    // Regular layers
-    "VK_LAYER_GOOGLE_threading",
-    "VK_LAYER_LUNARG_parameter_validation",
-    "VK_LAYER_LUNARG_object_tracker",
-    "VK_LAYER_LUNARG_core_validation",
-    "VK_LAYER_GOOGLE_unique_objects",
-  };
+  const char* kValidationLayerNames[] = { "VK_LAYER_KHRONOS_validation" };
   const char kDebugReportExtensionName[] = "VK_EXT_debug_report";
 
 ¶

--- a/gapis/api/vulkan/find_issues.go
+++ b/gapis/api/vulkan/find_issues.go
@@ -29,17 +29,7 @@ import (
 	"github.com/google/gapid/gapis/service"
 )
 
-var validationLayerNames = [...]string{
-	// Meta layers
-	"VK_LAYER_KHRONOS_validation",
-	"VK_LAYER_LUNARG_standard_validation",
-	// Regular layers
-	"VK_LAYER_GOOGLE_threading",
-	"VK_LAYER_LUNARG_parameter_validation",
-	"VK_LAYER_LUNARG_object_tracker",
-	"VK_LAYER_LUNARG_core_validation",
-	"VK_LAYER_GOOGLE_unique_objects",
-}
+var validationLayerNames = [...]string{ "VK_LAYER_KHRONOS_validation" }
 
 const (
 	// Since Android NDK r21, the VK_LAYER_KHRONOS_validation meta layer


### PR DESCRIPTION
The individual validation layers have been deprecated and replaced by
a single layer called VK_LAYER_KHRONOS_validation.

See also:
https://github.com/KhronosGroup/Vulkan-ValidationLayers/blob/master/LAYER_CONFIGURATION.md