### PR TITLE
Update the VkDescriptorImageInfo and VkDescriptorBufferInfo to match the vulkan headers

### DIFF
--- a/gapis/api/vulkan/api/coherent_memory.api
+++ b/gapis/api/vulkan/api/coherent_memory.api
@@ -95,11 +95,11 @@ sub void readCoherentMemoryInBufferBindings(map!(u32, ref!VkDescriptorBufferInfo
   rcb := LastBoundQueue.ReadCoherentBuffers
   for i in (0 .. n) {
     descBufferInfo := bufferBindings[as!u32(i)]
-    if descBufferInfo.Buffer != as!VkBuffer(0) {
-      if !(descBufferInfo.Buffer in rcb) {
-        if (descBufferInfo.Buffer in Buffers) {
-          rcb[descBufferInfo.Buffer] = true
-          readCoherentMemoryInBuffer(Buffers[descBufferInfo.Buffer])
+    if descBufferInfo.buffer != as!VkBuffer(0) {
+      if !(descBufferInfo.buffer in rcb) {
+        if (descBufferInfo.buffer in Buffers) {
+          rcb[descBufferInfo.buffer] = true
+          readCoherentMemoryInBuffer(Buffers[descBufferInfo.buffer])
         }
       }
     }
@@ -111,15 +111,15 @@ sub void readMemoryInBufferBindings(map!(u32, ref!VkDescriptorBufferInfo) buffer
   n := len(bufferBindings)
   for i in (0 .. n) {
     descBufferInfo := bufferBindings[as!u32(i)]
-    if descBufferInfo.Buffer != as!VkBuffer(0) {
-      if (descBufferInfo.Buffer in Buffers) {
+    if descBufferInfo.buffer != as!VkBuffer(0) {
+      if (descBufferInfo.buffer in Buffers) {
         offset := switch as!u32(i) in bufferBindingOffsets {
           case true:
             bufferBindingOffsets[as!u32(i)]
           case false:
-            descBufferInfo.Offset
+            descBufferInfo.offset
         }
-        readMemoryInBuffer(Buffers[descBufferInfo.Buffer], offset, descBufferInfo.Range)
+        readMemoryInBuffer(Buffers[descBufferInfo.buffer], offset, descBufferInfo.range)
       }
     }
   }
@@ -130,15 +130,15 @@ sub void writeMemoryInBufferBindings(map!(u32, ref!VkDescriptorBufferInfo) buffe
   n := len(bufferBindings)
   for i in (0 .. n) {
     bufferBinding := bufferBindings[as!u32(i)]
-    if bufferBinding.Buffer != as!VkBuffer(0) {
-      if (bufferBinding.Buffer in Buffers) {
+    if bufferBinding.buffer != as!VkBuffer(0) {
+      if (bufferBinding.buffer in Buffers) {
         offset := switch as!u32(i) in bufferBindingOffsets {
           case true:
             bufferBindingOffsets[as!u32(i)]
           case false:
-            bufferBinding.Offset
+            bufferBinding.offset
         }
-        writeMemoryInBuffer(Buffers[bufferBinding.Buffer], offset, bufferBinding.Range)
+        writeMemoryInBuffer(Buffers[bufferBinding.buffer], offset, bufferBinding.range)
       }
     }
   }
@@ -324,10 +324,10 @@ sub void updateImageViewQueue(ref!ImageViewObject view) {
 @server_disabled
 sub void readCoherentMemoryInImageBindings(map!(u32, ref!VkDescriptorImageInfo) imageBindings) {
   for _, _, v in imageBindings {
-    _ = Samplers[v.Sampler]
-    if v.ImageView != as!VkImageView(0) {
-      if (v.ImageView in ImageViews) {
-        view := ImageViews[v.ImageView]
+    _ = Samplers[v.sampler]
+    if v.imageView != as!VkImageView(0) {
+      if (v.imageView in ImageViews) {
+        view := ImageViews[v.imageView]
         updateImageViewQueue(view)
         imageObj := view.Image
         readCoherentMemoryInImage(imageObj)
@@ -339,10 +339,10 @@ sub void readCoherentMemoryInImageBindings(map!(u32, ref!VkDescriptorImageInfo) 
 @spy_disabled
 sub void readMemoryInImageBindings(map!(u32, ref!VkDescriptorImageInfo) imageBindings) {
   for _, _, v in imageBindings {
-    _ = Samplers[v.Sampler]
-    if v.ImageView != as!VkImageView(0) {
-      if (v.ImageView in ImageViews) {
-        view := ImageViews[v.ImageView]
+    _ = Samplers[v.sampler]
+    if v.imageView != as!VkImageView(0) {
+      if (v.imageView in ImageViews) {
+        view := ImageViews[v.imageView]
         updateImageViewQueue(view)
         readImageView(view)
       }
@@ -353,10 +353,10 @@ sub void readMemoryInImageBindings(map!(u32, ref!VkDescriptorImageInfo) imageBin
 @spy_disabled
 sub void writeMemoryInImageBindings(map!(u32, ref!VkDescriptorImageInfo) imageBindings) {
   for _, _, v in imageBindings {
-    _ = Samplers[v.Sampler]
-    if v.ImageView != as!VkImageView(0) {
-      if (v.ImageView in ImageViews) {
-        view := ImageViews[v.ImageView]
+    _ = Samplers[v.sampler]
+    if v.imageView != as!VkImageView(0) {
+      if (v.imageView in ImageViews) {
+        view := ImageViews[v.imageView]
         updateImageViewQueue(view)
         writeImageView(view)
       }

--- a/gapis/api/vulkan/api/descriptor.api
+++ b/gapis/api/vulkan/api/descriptor.api
@@ -382,9 +382,9 @@ sub map!(u32, DescriptorSetWrite) RewriteWriteDescriptorSets
             DstSet:             write.dstSet,
             Type:               write.descriptorType,
             ImageInfo:          new!VkDescriptorImageInfo(
-              Sampler:      imageInfo.Sampler,
-              ImageView:    0,
-              ImageLayout:  as!VkImageLayout(0)
+              sampler:      imageInfo.sampler,
+              imageView:    0,
+              imageLayout:  as!VkImageLayout(0)
             )
           )
         }
@@ -400,9 +400,9 @@ sub map!(u32, DescriptorSetWrite) RewriteWriteDescriptorSets
             DstSet:             write.dstSet,
             Type:               write.descriptorType,
             ImageInfo:          new!VkDescriptorImageInfo(
-              Sampler:      imageInfo.Sampler,
-              ImageView:    imageInfo.ImageView,
-              ImageLayout:  imageInfo.ImageLayout
+              sampler:      imageInfo.sampler,
+              imageView:    imageInfo.imageView,
+              imageLayout:  imageInfo.imageLayout
             )
           )
         }
@@ -430,9 +430,9 @@ sub map!(u32, DescriptorSetWrite) RewriteWriteDescriptorSets
             DstSet:             write.dstSet,
             BindingArrayIndex:  updating.ArrayIndex,
             BufferInfo:         new!VkDescriptorBufferInfo(
-              Buffer:  bufferInfo.Buffer,
-              Offset:  bufferInfo.Offset,
-              Range:   bufferInfo.Range
+              buffer:  bufferInfo.buffer,
+              offset:  bufferInfo.offset,
+              range:   bufferInfo.range
             )
           )
         }
@@ -609,14 +609,14 @@ cmd void vkUpdateDescriptorSets(
             imageBinding[arrayIndex] = w.ImageInfo
             setBinding.ImageBinding = imageBinding
 
-            if w.ImageInfo.Sampler in Samplers {
-              samObj := Samplers[w.ImageInfo.Sampler]
+            if w.ImageInfo.sampler in Samplers {
+              samObj := Samplers[w.ImageInfo.sampler]
               if samObj != null {
                 registerDescriptorUser!SamplerObject(samObj, w.DstSet, binding, arrayIndex)
               }
             }
-            if w.ImageInfo.ImageView in ImageViews {
-              viewObj := ImageViews[w.ImageInfo.ImageView]
+            if w.ImageInfo.imageView in ImageViews {
+              viewObj := ImageViews[w.ImageInfo.imageView]
               if viewObj != null {
                 registerDescriptorUser!ImageViewObject(viewObj, w.DstSet, binding, arrayIndex)
               }
@@ -644,8 +644,8 @@ cmd void vkUpdateDescriptorSets(
         bufferBindings[arrayIndex] = w.BufferInfo
         setBinding.BufferBinding = bufferBindings
         for _, _, b in setBinding.BufferBinding {
-          if !b.Buffer in Buffers {
-            vkErrorInvalidBuffer(b.Buffer)
+          if !b.buffer in Buffers {
+            vkErrorInvalidBuffer(b.buffer)
           }
         }
       }
@@ -677,7 +677,7 @@ cmd void vkUpdateDescriptorSets(
           imageBinding[c.DstArrayIndex] = srcBinding.ImageBinding[c.SrcArrayIndex]
           dstBinding.ImageBinding = imageBinding
 
-          vkSam := srcBinding.ImageBinding[c.SrcArrayIndex].Sampler
+          vkSam := srcBinding.ImageBinding[c.SrcArrayIndex].sampler
           if vkSam in Samplers {
             samObj := Samplers[vkSam]
             if samObj != null {
@@ -693,7 +693,7 @@ cmd void vkUpdateDescriptorSets(
           imageBinding[c.DstArrayIndex] = srcBinding.ImageBinding[c.SrcArrayIndex]
           dstBinding.ImageBinding = imageBinding
 
-          vkSam := srcBinding.ImageBinding[c.SrcArrayIndex].Sampler
+          vkSam := srcBinding.ImageBinding[c.SrcArrayIndex].sampler
           if vkSam in Samplers {
             samObj := Samplers[vkSam]
             if samObj != null {
@@ -701,7 +701,7 @@ cmd void vkUpdateDescriptorSets(
             }
           }
 
-          vkView := srcBinding.ImageBinding[c.SrcArrayIndex].ImageView
+          vkView := srcBinding.ImageBinding[c.SrcArrayIndex].imageView
           if vkView in ImageViews {
             viewObj := ImageViews[vkView]
             if viewObj != null {
@@ -735,8 +735,8 @@ cmd void vkUpdateDescriptorSets(
           srcBinding.BufferBinding[c.SrcArrayIndex]
           dstBinding.BufferBinding = bufferBinding
           for _, _, b in dstBinding.BufferBinding {
-            if !b.Buffer in Buffers {
-              vkErrorInvalidBuffer(b.Buffer)
+            if !b.buffer in Buffers {
+              vkErrorInvalidBuffer(b.buffer)
             }
           }
         }
@@ -815,9 +815,9 @@ sub void trackDescriptorBufferBindingOffsets(ref!vkCmdBindDescriptorSetsArgs arg
 
             binding_offset := switch binding.BindingType {
               case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC:
-                as!VkDeviceSize(args.DynamicOffsets[dynamic_offset_index.Val]) + bufferInfo.Offset
+                as!VkDeviceSize(args.DynamicOffsets[dynamic_offset_index.Val]) + bufferInfo.offset
               default:
-                bufferInfo.Offset
+                bufferInfo.offset
             }
             dynamic_offset_index.Val = switch binding.BindingType {
               case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC:

--- a/gapis/api/vulkan/api/image.api
+++ b/gapis/api/vulkan/api/image.api
@@ -549,8 +549,8 @@ cmd void vkDestroyImageView(
                 _ = indices
                 for _, index, _ in indices {
                   if index in desSetObj.Bindings[binding].ImageBinding {
-                    if desSetObj.Bindings[binding].ImageBinding[index].ImageView == imageView {
-                      desSetObj.Bindings[binding].ImageBinding[index].ImageView = as!VkImageView(0)
+                    if desSetObj.Bindings[binding].ImageBinding[index].imageView == imageView {
+                      desSetObj.Bindings[binding].ImageBinding[index].imageView = as!VkImageView(0)
                     }
                   }
                 }
@@ -696,8 +696,8 @@ cmd void vkDestroySampler(
                 case VK_DESCRIPTOR_TYPE_SAMPLER,
                   VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER: {
                   for _, index, _ in indices {
-                    if desSetObj.Bindings[binding].ImageBinding[index].Sampler == sampler {
-                      desSetObj.Bindings[binding].ImageBinding[index].Sampler = as!VkSampler(0)
+                    if desSetObj.Bindings[binding].ImageBinding[index].sampler == sampler {
+                      desSetObj.Bindings[binding].ImageBinding[index].sampler = as!VkSampler(0)
                     }
                   }
                 }

--- a/gapis/api/vulkan/api/structs.api
+++ b/gapis/api/vulkan/api/structs.api
@@ -960,15 +960,15 @@ class VkDescriptorSetAllocateInfo {
 }
 
 class VkDescriptorImageInfo {
-  VkSampler     Sampler
-  VkImageView   ImageView
-  VkImageLayout ImageLayout
+  VkSampler     sampler
+  VkImageView   imageView
+  VkImageLayout imageLayout
 }
 
 class VkDescriptorBufferInfo {
-  VkBuffer     Buffer /// Buffer used for this descriptor when the descriptor is UNIFORM_BUFFER[_DYNAMIC]
-  VkDeviceSize Offset /// Base offset from buffer start in bytes to update in the descriptor set.
-  VkDeviceSize Range  /// Size in bytes of the buffer resource for this descriptor update.
+  VkBuffer     buffer /// Buffer used for this descriptor when the descriptor is UNIFORM_BUFFER[_DYNAMIC]
+  VkDeviceSize offset /// Base offset from buffer start in bytes to update in the descriptor set.
+  VkDeviceSize range  /// Size in bytes of the buffer resource for this descriptor update.
 }
 
 class VkWriteDescriptorSet {

--- a/gapis/api/vulkan/extensions/khr_descriptor_update_template.api
+++ b/gapis/api/vulkan/extensions/khr_descriptor_update_template.api
@@ -172,13 +172,13 @@ sub void updateDescriptorSetWithTemplate(
                         inf := as!VkDescriptorImageInfo[](dat[entry.offset:entry.offset + as!size(24)])[0]
                         imageBinding := setBinding.ImageBinding
                         imageBinding[entry.dstArrayElement] = new!VkDescriptorImageInfo(
-                            Sampler: inf.Sampler,
-                            ImageView: 0,
-                            ImageLayout: as!VkImageLayout(0)
+                            sampler: inf.sampler,
+                            imageView: 0,
+                            imageLayout: as!VkImageLayout(0)
                         )
                         setBinding.ImageBinding = imageBinding
-                        if inf.Sampler in Samplers {
-                          samObj := Samplers[inf.Sampler]
+                        if inf.sampler in Samplers {
+                          samObj := Samplers[inf.sampler]
                           if samObj != null {
                             registerDescriptorUser!SamplerObject(samObj, descriptorSet, entry.dstBinding, entry.dstArrayElement)
                           }
@@ -191,19 +191,19 @@ sub void updateDescriptorSetWithTemplate(
                         inf := as!VkDescriptorImageInfo[](dat[entry.offset:entry.offset + as!size(24)])[0]
                         imageBinding := setBinding.ImageBinding
                         imageBinding[entry.dstArrayElement] = new!VkDescriptorImageInfo(
-                            Sampler: inf.Sampler,
-                            ImageView: inf.ImageView,
-                            ImageLayout: inf.ImageLayout
+                            sampler: inf.sampler,
+                            imageView: inf.imageView,
+                            imageLayout: inf.imageLayout
                         )
                         setBinding.ImageBinding = imageBinding
-                        if inf.Sampler in Samplers {
-                          samObj := Samplers[inf.Sampler]
+                        if inf.sampler in Samplers {
+                          samObj := Samplers[inf.sampler]
                           if samObj != null {
                             registerDescriptorUser!SamplerObject(samObj, descriptorSet, entry.dstBinding, entry.dstArrayElement)
                           }
                         }
-                        if inf.ImageView in ImageViews {
-                          viewObj := ImageViews[inf.ImageView]
+                        if inf.imageView in ImageViews {
+                          viewObj := ImageViews[inf.imageView]
                           if viewObj != null {
                             registerDescriptorUser!ImageViewObject(viewObj, descriptorSet, entry.dstBinding, entry.dstArrayElement)
                           }
@@ -229,9 +229,9 @@ sub void updateDescriptorSetWithTemplate(
                         bufferInfo := as!VkDescriptorBufferInfo[](dat[entry.offset:entry.offset + as!size(24)])[0]
                         bufferBindings := setBinding.BufferBinding
                         bufferBindings[entry.dstArrayElement] = new!VkDescriptorBufferInfo(
-                            Buffer: bufferInfo.Buffer,
-                            Offset: bufferInfo.Offset,
-                            Range: bufferInfo.Range
+                            buffer: bufferInfo.buffer,
+                            offset: bufferInfo.offset,
+                            range: bufferInfo.range
                         )
                         setBinding.BufferBinding = bufferBindings
                     }


### PR DESCRIPTION
This allows the template system to generate layers that using the same field name with the vulkan header. This also makes it match the style of other struct definitions.